### PR TITLE
Fix 9 critical bugs in source generators, web, and shared

### DIFF
--- a/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
@@ -15,6 +15,8 @@ public static class KnownHeaders {
 
     public const string IfMatch = "If-Match";
 
+    public const string IfNoneMatch = "If-None-Match";
+
     public static class Cors {
         public const string AccessControlAllowOrigin = "Access-Control-Allow-Origin";
 

--- a/src/Shared/Hardened.Shared.Runtime/Collections/ItemPool.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Collections/ItemPool.cs
@@ -36,15 +36,17 @@ public class ItemPool<T> : IItemPool<T>, IDisposable {
     }
 
     public IPoolItemReservation<T> Get() {
-        if (_reservations != null) {
+        for (var i = 0; i < 5; i++) {
             var currentReservation = _reservations;
 
-            for (var i = 0; i < 5; i++) {
-                if (Interlocked.CompareExchange(ref _reservations, currentReservation.Next, currentReservation) ==
-                    currentReservation) {
-                    currentReservation.Next = null;
-                    return currentReservation;
-                }
+            if (currentReservation == null) {
+                break;
+            }
+
+            if (Interlocked.CompareExchange(ref _reservations, currentReservation.Next, currentReservation) ==
+                currentReservation) {
+                currentReservation.Next = null;
+                return currentReservation;
             }
         }
 

--- a/src/Shared/Hardened.Shared.Runtime/Utilities/FileExtToMimeTypeHelper.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Utilities/FileExtToMimeTypeHelper.cs
@@ -17,7 +17,7 @@ public class FileExtToMimeTypeHelper : IFileExtToMimeTypeHelper {
                 return ("text/csv", false);
 
             case "docx":
-                return ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", false);
+                return ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", true);
 
             case "gz":
                 return ("application/gzip", true);
@@ -46,7 +46,7 @@ public class FileExtToMimeTypeHelper : IFileExtToMimeTypeHelper {
                 return ("image/png", true);
 
             case "pptx":
-                return ("image/pptx", true);
+                return ("application/vnd.openxmlformats-officedocument.presentationml.presentation", true);
 
             case "txt":
             case "text":

--- a/src/SourceGenerators/Hardened.SourceGenerator/Module/ModuleEntryPointFileWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Module/ModuleEntryPointFileWriter.cs
@@ -20,8 +20,8 @@ public class ModuleEntryPointFileWriter {
 
             context.AddSource(model.EntryPointType.Name + ".Module.cs", outputContext.Output());
         }
-        catch (Exception exp) {
-            throw exp;
+        catch (Exception) {
+            throw;
         }
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BindRequestParametersMethodGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BindRequestParametersMethodGenerator.cs
@@ -125,7 +125,7 @@ public static class BindRequestParametersMethodGenerator {
         if (parameterInformation.BindingType == ParameterBindType.ExecutionRequest) {
             invokeStatement = context.Property("Request");
         }
-        else if (parameterInformation.BindingType != ParameterBindType.ExecutionResponse) {
+        else if (parameterInformation.BindingType == ParameterBindType.ExecutionResponse) {
             invokeStatement = context.Property("Response");
         }
 

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
@@ -80,7 +80,9 @@ public class AspNetExecutionRequest : IExecutionRequest {
 
     public IDictionary<string, StringValues> Headers => _httpRequest.Headers;
     
-    public IQueryStringCollection QueryString => new EmptyQueryStringCollection();
+    public IQueryStringCollection QueryString =>
+        new SimpleQueryStringCollection(
+            _httpRequest.Query.ToDictionary(q => q.Key, q => q.Value.ToString()));
     
     public IPathTokenCollection PathTokens { get; set; }
 
@@ -127,7 +129,7 @@ public class AspNetExecutionResponse : IExecutionResponse {
     
     public bool IsBinary { get; set; }
     
-    public ICookieSetCollection Cookies { get; }
+    public ICookieSetCollection Cookies { get; } = new CookieSetCollectionImpl();
 
     public bool ShouldSerialize { get; set; } = true;
 }

--- a/src/Web/Hardened.Web.Runtime/StaticContent/GZipStaticContentCompressor.cs
+++ b/src/Web/Hardened.Web.Runtime/StaticContent/GZipStaticContentCompressor.cs
@@ -16,10 +16,10 @@ public class GZipStaticContentCompressor : IGZipStaticContentCompressor {
 
     public byte[] CompressContent(byte[] bytes, CompressionLevel compressionLevel) {
         using var memoryStreamRes = _memoryStreamPool.Get();
-        using var gzipStream = new GZipStream(memoryStreamRes.Item, compressionLevel, true);
 
-        gzipStream.Write(bytes, 0, bytes.Length);
-        gzipStream.Flush();
+        using (var gzipStream = new GZipStream(memoryStreamRes.Item, compressionLevel, true)) {
+            gzipStream.Write(bytes, 0, bytes.Length);
+        }
 
         return memoryStreamRes.Item.ToArray();
     }

--- a/src/Web/Hardened.Web.Runtime/StaticContent/StaticContentHandler.cs
+++ b/src/Web/Hardened.Web.Runtime/StaticContent/StaticContentHandler.cs
@@ -252,7 +252,7 @@ public class StaticContentHandler : IStaticContentHandler {
     }
 
     private StringValues GetRequestETag(IExecutionContext context) {
-        if (context.Request.Headers.TryGetValue(KnownHeaders.IfMatch, out var ifMatch)) {
+        if (context.Request.Headers.TryGetValue(KnownHeaders.IfNoneMatch, out var ifMatch)) {
             return ifMatch;
         }
 


### PR DESCRIPTION
## Summary
- Fix `throw exp` destroying stack trace in `ModuleEntryPointFileWriter` (changed to `throw;`)
- Fix logic inversion in `BindRequestParametersMethodGenerator` where `ExecutionResponse` binding incorrectly assigned `context` instead of `context.Response`
- Fix ASP.NET `QueryString` always returning empty collection by wrapping `HttpRequest.Query` in `SimpleQueryStringCollection`
- Fix ETag cache validation using `If-Match` instead of `If-None-Match` header, which prevented browsers from ever receiving 304 responses
- Fix GZip compression output truncation by disposing `GZipStream` before calling `ToArray()` to ensure the gzip footer is written
- Fix race condition in `ItemPool.Get()` where `currentReservation` was never re-read inside the CAS retry loop
- Initialize `Cookies` on `AspNetExecutionResponse` to prevent `NullReferenceException`
- Fix PPTX MIME type from `image/pptx` to correct OOXML type
- Fix `.docx` incorrectly marked as non-binary (DOCX files are ZIP archives)

## Test plan
- [ ] Verify solution builds with zero errors
- [ ] Verify all 121 existing tests pass
- [ ] Verify ASP.NET query string parameters are correctly parsed from incoming requests
- [ ] Verify ETag-based caching returns 304 for unchanged resources
- [ ] Verify GZip-compressed static content is not corrupted
- [ ] Verify `ExecutionResponse` parameter binding generates correct code
- [ ] Verify PPTX and DOCX files are served with correct MIME types

🤖 Generated with [Claude Code](https://claude.com/claude-code)