### PR TITLE
Add unit tests for critical runtime components

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RetryFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RetryFilterTests.cs
@@ -1,0 +1,125 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.Shared.Runtime.Collections;
+using NSubstitute;
+using SimpleFixture.NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Filters;
+
+[SubFixtureInitialize]
+public class RetryFilterTests {
+    [Fact]
+    public async Task SucceedsOnFirstTry_CallsChainOnce() {
+        var memoryStreamPool = new MemoryStreamPool();
+        var filter = new RetryFilter(memoryStreamPool, 3, 0);
+
+        var chain = Substitute.For<IExecutionChain>();
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+
+        request.Body.Returns(new MemoryStream());
+        context.Request.Returns(request);
+        chain.Context.Returns(context);
+
+        var callCount = 0;
+        chain.Next().Returns(_ => {
+            callCount++;
+            return Task.CompletedTask;
+        });
+
+        await filter.Execute(chain);
+
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task RetriesOnFailure_SucceedsOnSecondTry() {
+        var memoryStreamPool = new MemoryStreamPool();
+        var filter = new RetryFilter(memoryStreamPool, 3, 0);
+
+        var chain = Substitute.For<IExecutionChain>();
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+
+        request.Body.Returns(new MemoryStream());
+        context.Request.Returns(request);
+        chain.Context.Returns(context);
+
+        var callCount = 0;
+        chain.Next().Returns(_ => {
+            callCount++;
+            if (callCount == 1) {
+                throw new InvalidOperationException("transient failure");
+            }
+            return Task.CompletedTask;
+        });
+
+        await filter.Execute(chain);
+
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task ThrowsLastException_AfterAllRetriesExhausted() {
+        var memoryStreamPool = new MemoryStreamPool();
+        var filter = new RetryFilter(memoryStreamPool, 3, 0);
+
+        var chain = Substitute.For<IExecutionChain>();
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+
+        request.Body.Returns(new MemoryStream());
+        context.Request.Returns(request);
+        chain.Context.Returns(context);
+
+        var callCount = 0;
+        chain.Next().Returns(_ => {
+            callCount++;
+            throw new InvalidOperationException($"failure {callCount}");
+        });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => filter.Execute(chain));
+
+        Assert.Equal(3, callCount);
+        Assert.Equal("failure 3", ex.Message);
+    }
+
+    [Fact]
+    public async Task RequestBody_IsReplayableAcrossRetries() {
+        var memoryStreamPool = new MemoryStreamPool();
+        var filter = new RetryFilter(memoryStreamPool, 3, 0);
+
+        var bodyContent = new byte[] { 1, 2, 3, 4, 5 };
+        var bodyStream = new MemoryStream(bodyContent);
+
+        var chain = Substitute.For<IExecutionChain>();
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+
+        request.Body.Returns(bodyStream);
+        context.Request.Returns(request);
+        chain.Context.Returns(context);
+
+        var bodiesRead = new List<byte[]>();
+        var callCount = 0;
+
+        chain.Next().Returns(async _ => {
+            callCount++;
+
+            var ms = new MemoryStream();
+            await request.Body.CopyToAsync(ms);
+            bodiesRead.Add(ms.ToArray());
+
+            if (callCount < 2) {
+                throw new InvalidOperationException("transient");
+            }
+        });
+
+        await filter.Execute(chain);
+
+        Assert.Equal(2, bodiesRead.Count);
+        Assert.Equal(bodyContent, bodiesRead[0]);
+        Assert.Equal(bodyContent, bodiesRead[1]);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/StringConverterServiceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/StringConverterServiceTests.cs
@@ -1,0 +1,115 @@
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Errors;
+using Hardened.Requests.Runtime.Serializer;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Serializer;
+
+public class StringConverterServiceTests {
+    private readonly StringConverterService _service;
+
+    public StringConverterServiceTests() {
+        _service = new StringConverterService(Array.Empty<IStringConverter>());
+    }
+
+    [Fact]
+    public void ParseRequired_ReturnsParsedInt() {
+        var result = _service.ParseRequired<int>("42", "testValue");
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void ParseRequired_ReturnsParsedLong() {
+        var result = _service.ParseRequired<long>("9999999999", "testValue");
+        Assert.Equal(9999999999L, result);
+    }
+
+    [Fact]
+    public void ParseRequired_ReturnsParsedGuid() {
+        var guid = Guid.NewGuid();
+        var result = _service.ParseRequired<Guid>(guid.ToString(), "testValue");
+        Assert.Equal(guid, result);
+    }
+
+    [Fact]
+    public void ParseRequired_ReturnsParsedDateTime() {
+        var result = _service.ParseRequired<DateTime>("2024-01-15", "testValue");
+        Assert.Equal(new DateTime(2024, 1, 15), result);
+    }
+
+    [Fact]
+    public void ParseRequired_ReturnsParsedString() {
+        var result = _service.ParseRequired<string>("hello", "testValue");
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public void ParseRequired_ThrowsBadRequestException_ForEmptyValue() {
+        Assert.Throws<BadRequestException>(() =>
+            _service.ParseRequired<int>("", "testValue"));
+    }
+
+    [Fact]
+    public void ParseRequired_ThrowsBadRequestException_ForNullValue() {
+        Assert.Throws<BadRequestException>(() =>
+            _service.ParseRequired<int>(null!, "testValue"));
+    }
+
+    [Fact]
+    public void ParseRequired_ThrowsBadRequestException_ForMalformedValue() {
+        var ex = Assert.Throws<BadRequestException>(() =>
+            _service.ParseRequired<int>("not-a-number", "testValue"));
+        Assert.Contains("malformed", ex.Message);
+    }
+
+    [Fact]
+    public void ParseWithDefault_ReturnsDefault_ForEmptyString() {
+        var result = _service.ParseWithDefault("", "testValue", 99);
+        Assert.Equal(99, result);
+    }
+
+    [Fact]
+    public void ParseWithDefault_ReturnsDefault_ForMalformedValue() {
+        var result = _service.ParseWithDefault("not-a-number", "testValue", 99);
+        Assert.Equal(99, result);
+    }
+
+    [Fact]
+    public void ParseWithDefault_ReturnsParsedValue_WhenValid() {
+        var result = _service.ParseWithDefault("42", "testValue", 99);
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsNull_ForEmptyString() {
+        var result = _service.ParseOptional<int>("", "testValue");
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsNull_ForMalformedValue() {
+        var result = _service.ParseOptional<int>("not-a-number", "testValue");
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsParsedValue_WhenValid() {
+        var result = _service.ParseOptional<int>("42", "testValue");
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void CustomStringConverter_IsUsedWhenRegistered() {
+        var converter = Substitute.For<IStringConverter>();
+        converter.ConvertType.Returns(typeof(int));
+        converter.Convert<int>("custom-42").Returns(42);
+
+        var service = new StringConverterService(new[] { converter });
+
+        var result = service.ParseRequired<int>("custom-42", "testValue");
+
+        Assert.Equal(42, result);
+        converter.Received(1).Convert<int>("custom-42");
+    }
+}

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Collections/ItemPoolTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Collections/ItemPoolTests.cs
@@ -1,0 +1,86 @@
+using Hardened.Shared.Runtime.Collections;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Collections;
+
+public class ItemPoolTests {
+    [Fact]
+    public void Get_ReturnsNewItem_WhenPoolIsEmpty() {
+        var created = 0;
+        using var pool = new ItemPool<int>(() => ++created, _ => { });
+
+        using var reservation = pool.Get();
+
+        Assert.Equal(1, reservation.Item);
+        Assert.Equal(1, created);
+    }
+
+    [Fact]
+    public void Get_ReturnsPooledItem_AfterDisposal() {
+        var created = 0;
+        using var pool = new ItemPool<string>(() => $"item-{++created}", _ => { });
+
+        string firstItem;
+        using (var reservation = pool.Get()) {
+            firstItem = reservation.Item;
+        }
+
+        using var secondReservation = pool.Get();
+        Assert.Same(firstItem, secondReservation.Item);
+        Assert.Equal(1, created);
+    }
+
+    [Fact]
+    public void Get_CreatesNewItem_WhenAllPooledItemsInUse() {
+        var created = 0;
+        using var pool = new ItemPool<int>(() => ++created, _ => { });
+
+        using var first = pool.Get();
+        using var second = pool.Get();
+
+        Assert.Equal(1, first.Item);
+        Assert.Equal(2, second.Item);
+        Assert.Equal(2, created);
+    }
+
+    [Fact]
+    public void ConcurrentGetDispose_IsSafe() {
+        var created = 0;
+        using var pool = new ItemPool<int>(() => Interlocked.Increment(ref created), _ => { });
+
+        var tasks = Enumerable.Range(0, 100).Select(_ => Task.Run(() => {
+            for (var i = 0; i < 100; i++) {
+                using var reservation = pool.Get();
+                var _ = reservation.Item;
+            }
+        }));
+
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.True(created > 0);
+        Assert.True(created <= 10000);
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllPooledItems_ViaDisposeAction() {
+        var disposed = new List<int>();
+        var pool = new ItemPool<int>(() => disposed.Count + 1, _ => { }, i => disposed.Add(i));
+
+        using (var r1 = pool.Get()) { }
+        using (var r2 = pool.Get()) { }
+
+        pool.Dispose();
+
+        Assert.Contains(1, disposed);
+    }
+
+    [Fact]
+    public void CleanupAction_IsCalledWhenItemReturnedToPool() {
+        var cleanupCount = 0;
+        using var pool = new ItemPool<int>(() => 42, _ => cleanupCount++);
+
+        using (var reservation = pool.Get()) { }
+
+        Assert.Equal(1, cleanupCount);
+    }
+}

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Configuration/ConfigurationManagerTests.cs
@@ -1,0 +1,131 @@
+using Hardened.Shared.Runtime.Application;
+using Hardened.Shared.Runtime.Configuration;
+using NSubstitute;
+using SimpleFixture.NSubstitute;
+using SimpleFixture.xUnit;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Configuration;
+
+[SubFixtureInitialize]
+public class ConfigurationManagerTests {
+    public interface ITestConfig { }
+
+    public class TestConfig : ITestConfig { }
+
+    public interface IOtherConfig { }
+
+    public class OtherConfig : IOtherConfig { }
+
+    [Fact]
+    public void GetConfiguration_ReturnsValueFromProvider() {
+        var env = Substitute.For<IHardenedEnvironment>();
+        var config = new TestConfig();
+
+        var provider = Substitute.For<IConfigurationValueProvider>();
+        provider.InterfaceType.Returns(typeof(ITestConfig));
+        provider.ProvideValue(env, Arg.Any<Action<IHardenedEnvironment, object>>()).Returns(config);
+
+        var package = Substitute.For<IConfigurationPackage>();
+        package.ConfigurationValueProviders(env).Returns(new[] { provider });
+        package.ConfigurationValueAmenders(env).Returns(Array.Empty<IConfigurationValueAmender>());
+
+        var manager = new ConfigurationManager(env, new[] { package });
+
+        var result = manager.GetConfiguration<ITestConfig>();
+
+        Assert.Same(config, result);
+    }
+
+    [Fact]
+    public void GetConfiguration_CachesResultOnSecondCall() {
+        var env = Substitute.For<IHardenedEnvironment>();
+        var config = new TestConfig();
+
+        var provider = Substitute.For<IConfigurationValueProvider>();
+        provider.InterfaceType.Returns(typeof(ITestConfig));
+        provider.ProvideValue(env, Arg.Any<Action<IHardenedEnvironment, object>>()).Returns(config);
+
+        var package = Substitute.For<IConfigurationPackage>();
+        package.ConfigurationValueProviders(env).Returns(new[] { provider });
+        package.ConfigurationValueAmenders(env).Returns(Array.Empty<IConfigurationValueAmender>());
+
+        var manager = new ConfigurationManager(env, new[] { package });
+
+        var first = manager.GetConfiguration<ITestConfig>();
+        var second = manager.GetConfiguration<ITestConfig>();
+
+        Assert.Same(first, second);
+        provider.Received(1).ProvideValue(env, Arg.Any<Action<IHardenedEnvironment, object>>());
+    }
+
+    [Fact]
+    public void GetConfiguration_ThrowsForUnregisteredType() {
+        var env = Substitute.For<IHardenedEnvironment>();
+
+        var package = Substitute.For<IConfigurationPackage>();
+        package.ConfigurationValueProviders(env).Returns(Array.Empty<IConfigurationValueProvider>());
+        package.ConfigurationValueAmenders(env).Returns(Array.Empty<IConfigurationValueAmender>());
+
+        var manager = new ConfigurationManager(env, new[] { package });
+
+        var ex = Assert.Throws<Exception>(() => manager.GetConfiguration<ITestConfig>());
+        Assert.Contains("ITestConfig", ex.Message);
+    }
+
+    [Fact]
+    public void Amenders_AreAppliedToConfigurationValues() {
+        var env = Substitute.For<IHardenedEnvironment>();
+        var config = new TestConfig();
+
+        var provider = Substitute.For<IConfigurationValueProvider>();
+        provider.InterfaceType.Returns(typeof(ITestConfig));
+        provider.ProvideValue(env, Arg.Any<Action<IHardenedEnvironment, object>>())
+            .Returns(ci => {
+                var amender = ci.Arg<Action<IHardenedEnvironment, object>>();
+                amender(env, config);
+                return config;
+            });
+
+        var valueAmender = Substitute.For<IConfigurationValueAmender>();
+        valueAmender.ApplyConfiguration(env, config).Returns(config);
+
+        var package = Substitute.For<IConfigurationPackage>();
+        package.ConfigurationValueProviders(env).Returns(new[] { provider });
+        package.ConfigurationValueAmenders(env).Returns(new[] { valueAmender });
+
+        var manager = new ConfigurationManager(env, new[] { package });
+
+        manager.GetConfiguration<ITestConfig>();
+
+        valueAmender.Received(1).ApplyConfiguration(env, config);
+    }
+
+    [Fact]
+    public void MultiplePackages_RegisterProvidersCorrectly() {
+        var env = Substitute.For<IHardenedEnvironment>();
+        var testConfig = new TestConfig();
+        var otherConfig = new OtherConfig();
+
+        var provider1 = Substitute.For<IConfigurationValueProvider>();
+        provider1.InterfaceType.Returns(typeof(ITestConfig));
+        provider1.ProvideValue(env, Arg.Any<Action<IHardenedEnvironment, object>>()).Returns(testConfig);
+
+        var provider2 = Substitute.For<IConfigurationValueProvider>();
+        provider2.InterfaceType.Returns(typeof(IOtherConfig));
+        provider2.ProvideValue(env, Arg.Any<Action<IHardenedEnvironment, object>>()).Returns(otherConfig);
+
+        var package1 = Substitute.For<IConfigurationPackage>();
+        package1.ConfigurationValueProviders(env).Returns(new[] { provider1 });
+        package1.ConfigurationValueAmenders(env).Returns(Array.Empty<IConfigurationValueAmender>());
+
+        var package2 = Substitute.For<IConfigurationPackage>();
+        package2.ConfigurationValueProviders(env).Returns(new[] { provider2 });
+        package2.ConfigurationValueAmenders(env).Returns(Array.Empty<IConfigurationValueAmender>());
+
+        var manager = new ConfigurationManager(env, new[] { package1, package2 });
+
+        Assert.Same(testConfig, manager.GetConfiguration<ITestConfig>());
+        Assert.Same(otherConfig, manager.GetConfiguration<IOtherConfig>());
+    }
+}

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Utilities/FileExtToMimeTypeHelperTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Utilities/FileExtToMimeTypeHelperTests.cs
@@ -1,0 +1,73 @@
+using Hardened.Shared.Runtime.Utilities;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Utilities;
+
+public class FileExtToMimeTypeHelperTests {
+    private readonly FileExtToMimeTypeHelper _helper = new();
+
+    [Theory]
+    [InlineData("css", "text/css", false)]
+    [InlineData("js", "text/javascript", false)]
+    [InlineData("json", "application/json", false)]
+    [InlineData("html", "text/html", false)]
+    [InlineData("png", "image/png", true)]
+    [InlineData("jpg", "image/jpeg", true)]
+    [InlineData("pdf", "application/pdf", true)]
+    [InlineData("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", true)]
+    [InlineData("pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", true)]
+    [InlineData("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", true)]
+    [InlineData("zip", "application/zip", true)]
+    public void ReturnsCorrectMimeType_ForKnownExtensions(string ext, string expectedMime, bool expectedBinary) {
+        var (mimeType, isBinary) = _helper.GetMimeTypeInfo(ext);
+
+        Assert.Equal(expectedMime, mimeType);
+        Assert.Equal(expectedBinary, isBinary);
+    }
+
+    [Theory]
+    [InlineData("css", false)]
+    [InlineData("js", false)]
+    [InlineData("json", false)]
+    [InlineData("html", false)]
+    [InlineData("xml", false)]
+    [InlineData("png", true)]
+    [InlineData("jpg", true)]
+    [InlineData("pdf", true)]
+    [InlineData("zip", true)]
+    [InlineData("gif", true)]
+    public void ReturnsCorrectIsBinaryFlag(string ext, bool expectedBinary) {
+        var (_, isBinary) = _helper.GetMimeTypeInfo(ext);
+
+        Assert.Equal(expectedBinary, isBinary);
+    }
+
+    [Fact]
+    public void ReturnsDefault_ForUnknownExtension() {
+        var (mimeType, isBinary) = _helper.GetMimeTypeInfo("xyz");
+
+        Assert.Equal("application/bin", mimeType);
+        Assert.True(isBinary);
+    }
+
+    [Theory]
+    [InlineData(".css", "text/css")]
+    [InlineData("css", "text/css")]
+    [InlineData(".json", "application/json")]
+    [InlineData("json", "application/json")]
+    public void HandlesExtensions_WithAndWithoutLeadingDot(string ext, string expectedMime) {
+        var (mimeType, _) = _helper.GetMimeTypeInfo(ext);
+
+        Assert.Equal(expectedMime, mimeType);
+    }
+
+    [Theory]
+    [InlineData("CSS")]
+    [InlineData("Css")]
+    [InlineData("cSs")]
+    public void IsCaseInsensitive(string ext) {
+        var (mimeType, _) = _helper.GetMimeTypeInfo(ext);
+
+        Assert.Equal("text/css", mimeType);
+    }
+}

--- a/src/Web/Hardened.Web.Runtime.Tests/StaticContent/GZipStaticContentCompressorTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/StaticContent/GZipStaticContentCompressorTests.cs
@@ -1,0 +1,57 @@
+using System.IO.Compression;
+using Hardened.Shared.Runtime.Collections;
+using Hardened.Web.Runtime.StaticContent;
+using Xunit;
+
+namespace Hardened.Web.Runtime.Tests.StaticContent;
+
+public class GZipStaticContentCompressorTests {
+    private readonly GZipStaticContentCompressor _compressor;
+
+    public GZipStaticContentCompressorTests() {
+        _compressor = new GZipStaticContentCompressor(new MemoryStreamPool());
+    }
+
+    [Fact]
+    public void CompressedOutput_CanBeDecompressed_ToOriginalContent() {
+        var original = "Hello, World! This is a test of GZip compression."u8.ToArray();
+
+        var compressed = _compressor.CompressContent(original, CompressionLevel.Fastest);
+
+        using var compressedStream = new MemoryStream(compressed);
+        using var gzipStream = new GZipStream(compressedStream, CompressionMode.Decompress);
+        using var resultStream = new MemoryStream();
+        gzipStream.CopyTo(resultStream);
+
+        Assert.Equal(original, resultStream.ToArray());
+    }
+
+    [Fact]
+    public void EmptyInput_ProducesValidGzipOutput() {
+        var compressed = _compressor.CompressContent(Array.Empty<byte>(), CompressionLevel.Fastest);
+
+        using var compressedStream = new MemoryStream(compressed);
+        using var gzipStream = new GZipStream(compressedStream, CompressionMode.Decompress);
+        using var resultStream = new MemoryStream();
+        gzipStream.CopyTo(resultStream);
+
+        Assert.Empty(resultStream.ToArray());
+    }
+
+    [Theory]
+    [InlineData(CompressionLevel.Fastest)]
+    [InlineData(CompressionLevel.Optimal)]
+    [InlineData(CompressionLevel.SmallestSize)]
+    public void DifferentCompressionLevels_ProduceValidOutput(CompressionLevel level) {
+        var original = "Test content for compression level validation."u8.ToArray();
+
+        var compressed = _compressor.CompressContent(original, level);
+
+        using var compressedStream = new MemoryStream(compressed);
+        using var gzipStream = new GZipStream(compressedStream, CompressionMode.Decompress);
+        using var resultStream = new MemoryStream();
+        gzipStream.CopyTo(resultStream);
+
+        Assert.Equal(original, resultStream.ToArray());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 40+ unit tests across 6 critical runtime classes: ItemPool, ConfigurationManager, StringConverterService, RetryFilter, FileExtToMimeTypeHelper, GZipStaticContentCompressor
- Tests cover thread safety, caching, error handling, retry logic, MIME mapping, and compression
- All tests pass, zero build errors

## Test plan
- [x] `dotnet build src/Hardened.Framework.sln` — 0 errors
- [x] `dotnet test src/Hardened.Framework.sln` — all 185 tests pass (was ~121)

🤖 Generated with [Claude Code](https://claude.com/claude-code)