### PR TITLE
Fix critical bugs and implement missing Clone() methods

### DIFF
--- a/src/Requests/Hardened.Requests.Testing/TestExecutionContext.cs
+++ b/src/Requests/Hardened.Requests.Testing/TestExecutionContext.cs
@@ -27,7 +27,16 @@ public class TestExecutionContext : IExecutionContext {
         IExecutionResponse? response,
         IServiceProvider? serviceProvider,
         IMetricLogger? metricLogger) {
-        throw new NotImplementedException();
+        return new TestExecutionContext(
+            RootServiceProvider,
+            serviceProvider ?? RequestServices,
+            KnownServices,
+            request ?? Request,
+            response ?? Response,
+            CancellationToken) {
+            HandlerInstance = HandlerInstance,
+            HandlerInfo = HandlerInfo,
+        };
     }
 
     public IServiceProvider RootServiceProvider { get; }

--- a/src/Requests/Hardened.Requests.Testing/TestExecutionRequest.cs
+++ b/src/Requests/Hardened.Requests.Testing/TestExecutionRequest.cs
@@ -27,7 +27,17 @@ public class TestExecutionRequest : IExecutionRequest {
         IDictionary<string, StringValues> headers,
         IQueryStringCollection queryString,
         IReadOnlyList<string> cookies) {
-        throw new NotImplementedException();
+        return new TestExecutionRequest(
+            method ?? Method,
+            path ?? Path,
+            Accept,
+            queryString ?? QueryString) {
+            Parameters = Parameters,
+            Body = Body,
+            Headers = headers ?? Headers,
+            PathTokens = PathTokens,
+            Cookies = cookies ?? Cookies,
+        };
     }
 
     public string Method { get; }

--- a/src/Requests/Hardened.Requests.Testing/TestExecutionResponse.cs
+++ b/src/Requests/Hardened.Requests.Testing/TestExecutionResponse.cs
@@ -13,7 +13,15 @@ public class TestExecutionResponse : IExecutionResponse {
     }
 
     public IExecutionResponse Clone(IHeaderCollection? headerCollection) {
-        throw new NotImplementedException();
+        return new TestExecutionResponse(Body) {
+            ResponseValue = ResponseValue,
+            TemplateName = TemplateName,
+            Status = Status,
+            ShouldCompress = ShouldCompress,
+            Headers = headerCollection as IDictionary<string, StringValues> ?? Headers,
+            IsBinary = IsBinary,
+            ShouldSerialize = ShouldSerialize,
+        };
     }
 
     public string? ContentType {

--- a/src/Shared/Hardened.Shared.Runtime/Collections/ItemPool.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Collections/ItemPool.cs
@@ -24,7 +24,9 @@ public class ItemPool<T> : IItemPool<T>, IDisposable {
     public void Dispose() {
         if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0) {
             if (this._disposeAction != null) {
-                var current = _reservations;
+                // Atomically detach the entire list to prevent concurrent returns
+                // from corrupting the iteration.
+                var current = Interlocked.Exchange(ref _reservations, null);
 
                 while (current != null) {
                     _disposeAction(current.Item);
@@ -65,9 +67,20 @@ public class ItemPool<T> : IItemPool<T>, IDisposable {
 
         public void Dispose() {
             if (Next == null) {
+                // Don't return items to a disposed pool.
+                if (_pool._disposed != 0) {
+                    return;
+                }
+
                 _pool._cleanupAction(Item);
 
                 while (true) {
+                    // Re-check disposal status before each CAS attempt
+                    // to avoid pushing onto a pool that's being torn down.
+                    if (_pool._disposed != 0) {
+                        return;
+                    }
+
                     var current = _pool._reservations;
 
                     Next = current;

--- a/src/Shared/Hardened.Shared.Runtime/DependencyInjection/DependencyRegistry.cs
+++ b/src/Shared/Hardened.Shared.Runtime/DependencyInjection/DependencyRegistry.cs
@@ -53,7 +53,7 @@ public class DependencyRegistry<T> where T : class {
     /// <param name="entryPoint"></param>
     public static void ApplyRegistration(IHardenedEnvironment environment, IServiceCollection serviceCollection, T entryPoint) {
         foreach (var registration in _registrations) {
-            if (registration.LastServiceCollection.TryGetTarget(out var collection) && ReferenceEquals(collection, entryPoint)){
+            if (registration.LastServiceCollection.TryGetTarget(out var collection) && ReferenceEquals(collection, serviceCollection)){
                 continue;
             }
             

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
@@ -1,4 +1,4 @@
-﻿using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.PathTokens;
 using Hardened.Requests.Abstract.QueryString;
@@ -15,7 +15,7 @@ namespace Hardened.Web.AspNetCore.Runtime.Impl;
 
 public class AspNetExecutionContext : IExecutionContext {
     private HttpContext _httpContext;
-    
+
     public AspNetExecutionContext(HttpContext httpContext, IMetricLogger logger) {
         _httpContext = httpContext;
         KnownServices = httpContext.RequestServices.GetRequiredService<IKnownServices>();
@@ -25,16 +25,40 @@ public class AspNetExecutionContext : IExecutionContext {
         RequestMetrics = logger;
     }
 
+    private AspNetExecutionContext(
+        HttpContext httpContext,
+        IKnownServices knownServices,
+        IExecutionRequest request,
+        IExecutionResponse response,
+        IMetricLogger metricLogger,
+        MachineTimestamp startTime) {
+        _httpContext = httpContext;
+        KnownServices = knownServices;
+        Request = request;
+        Response = response;
+        RequestMetrics = metricLogger;
+        StartTime = startTime;
+    }
+
     public IExecutionContext Clone(
         IExecutionRequest? request,
         IExecutionResponse? response,
         IServiceProvider? serviceProvider,
         IMetricLogger? metricLogger) {
-        throw new NotImplementedException();
+        return new AspNetExecutionContext(
+            _httpContext,
+            KnownServices,
+            request ?? Request,
+            response ?? Response,
+            metricLogger ?? RequestMetrics,
+            StartTime) {
+            HandlerInstance = HandlerInstance,
+            HandlerInfo = HandlerInfo,
+        };
     }
 
     public IServiceProvider RootServiceProvider => _httpContext.RequestServices;
-    
+
     public IKnownServices KnownServices { get; }
     public IServiceProvider RequestServices => _httpContext.RequestServices;
     public IExecutionRequest Request { get; }
@@ -49,7 +73,7 @@ public class AspNetExecutionContext : IExecutionContext {
 
 public class AspNetExecutionRequest : IExecutionRequest {
     private HttpRequest _httpRequest;
-    
+
     public AspNetExecutionRequest(HttpRequest httpRequest) {
         _httpRequest = httpRequest;
     }
@@ -60,7 +84,11 @@ public class AspNetExecutionRequest : IExecutionRequest {
         IDictionary<string, StringValues> headers,
         IQueryStringCollection queryString,
         IReadOnlyList<string> cookies) {
-        throw new NotImplementedException();
+        return new AspNetExecutionRequest(_httpRequest) {
+            Parameters = Parameters,
+            Body = Body,
+            PathTokens = PathTokens,
+        };
     }
 
     public string Method => _httpRequest.Method;
@@ -70,7 +98,7 @@ public class AspNetExecutionRequest : IExecutionRequest {
     public string? ContentType => _httpRequest.ContentType;
 
     public string? Accept => null;
-    
+
     public IExecutionRequestParameters? Parameters { get; set; }
 
     public Stream Body {
@@ -79,11 +107,11 @@ public class AspNetExecutionRequest : IExecutionRequest {
     }
 
     public IDictionary<string, StringValues> Headers => _httpRequest.Headers;
-    
+
     public IQueryStringCollection QueryString =>
         new SimpleQueryStringCollection(
             _httpRequest.Query.ToDictionary(q => q.Key, q => q.Value.ToString()));
-    
+
     public IPathTokenCollection PathTokens { get; set; }
 
     public IReadOnlyList<string> Cookies => new List<string>();
@@ -91,13 +119,19 @@ public class AspNetExecutionRequest : IExecutionRequest {
 
 public class AspNetExecutionResponse : IExecutionResponse {
     private HttpResponse _httpResponse;
-    
+
     public AspNetExecutionResponse(HttpResponse httpResponse) {
         _httpResponse = httpResponse;
     }
 
     public IExecutionResponse Clone(IHeaderCollection? headerCollection) {
-        throw new NotImplementedException();
+        return new AspNetExecutionResponse(_httpResponse) {
+            ResponseValue = ResponseValue,
+            TemplateName = TemplateName,
+            ShouldCompress = ShouldCompress,
+            IsBinary = IsBinary,
+            ShouldSerialize = ShouldSerialize,
+        };
     }
 
     public string? ContentType {
@@ -106,29 +140,29 @@ public class AspNetExecutionResponse : IExecutionResponse {
     }
 
     public object? ResponseValue { get; set; }
-    
+
     public string? TemplateName { get; set; }
 
     public int? Status {
-        get => _httpResponse.StatusCode; 
+        get => _httpResponse.StatusCode;
         set => _httpResponse.StatusCode = value ?? 200;
     }
-    
+
     public bool ShouldCompress { get; set; }
 
     public Stream Body {
-        get => _httpResponse.Body; 
+        get => _httpResponse.Body;
         set => _httpResponse.Body = value;
     }
 
     public IDictionary<string, StringValues> Headers => _httpResponse.Headers;
-    
+
     public Exception? ExceptionValue { get; set; }
 
     public bool ResponseStarted => _httpResponse.HasStarted;
-    
+
     public bool IsBinary { get; set; }
-    
+
     public ICookieSetCollection Cookies { get; } = new CookieSetCollectionImpl();
 
     public bool ShouldSerialize { get; set; } = true;


### PR DESCRIPTION
## Summary
- Fix **ItemPool<T>.Dispose() race condition** using Interlocked.Exchange to atomically detach the linked list, and prevent returning items to a disposed pool
- Fix **DependencyRegistry<T>.ApplyRegistration()** comparing IServiceCollection to generic T instead of the actual serviceCollection parameter (dedup guard never worked)
- Implement **Clone()** for AspNetExecutionContext/Request/Response and TestExecutionContext/Request/Response (all previously threw NotImplementedException)

## Test plan
- [x] All 185 Framework tests pass (10 SourceGenerator + 45 Shared.Runtime + 88 Templates.Runtime + 5 Web.Runtime + 27 Requests.Runtime + 6 Commands + 4 WebApp.SUT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)