### PR TITLE
Update README with docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,69 @@
 # Hardened.Framework
-A C# framework for .net 6.0, focused primarily on servless compute.
 
+The core framework for the [Hardened](https://ipjohnson-org.github.io/Hardened.Docs) ecosystem — a compile-time, source-generated .NET framework for building web APIs, AWS Lambda functions, and canary tests.
 
+Hardened uses C# source generators to wire up dependency injection, request routing, configuration, and more at compile time — eliminating runtime reflection and delivering fast startup, small binaries, and strong type safety.
 
+## Packages
 
+| Package | Description |
+|---|---|
+| `Hardened.Shared.Runtime` | Core: DI attributes (`[Expose]`, `[Singleton]`, `[Scoped]`), configuration, environment, application lifecycle |
+| `Hardened.Shared.Testing` | Test framework: `[HardenedTest]`, `[Mock]`, `ITestContext` |
+| `Hardened.Requests.Abstract` | Request/response abstractions, execution pipeline interfaces |
+| `Hardened.Requests.Runtime` | Execution pipeline implementation, filters |
+| `Hardened.Requests.Testing` | Request testing utilities |
+| `Hardened.Web.Runtime` | Web routing: `[Get]`, `[Post]`, `[Put]`, `[Delete]`, `[BasePath]` |
+| `Hardened.Web.AspNetCore.Runtime` | ASP.NET Core integration bridge |
+| `Hardened.Web.Testing` | `ITestWebApp`, `TestWebRequest`, `TestWebResponse` |
+| `Hardened.Templates.Abstract` | Template abstractions: `[TemplatePackage]`, `[TemplateHelper]` |
+| `Hardened.Templates.Runtime` | Mustache-style template engine |
+| `Hardened.SourceGenerator` | Core source generator (DI, modules, configuration) |
+| `Hardened.Web.SourceGenerator` | Web routing source generator |
+| `Hardened.Web.AspNetCore.SourceGenerator` | ASP.NET Core source generator |
+| `Hardened.Library.SourceGenerator` | Library/module source generator |
+| `Hardened.Templates.SourceGenerator` | Template compilation source generator |
+| `Hardened.Console.SourceGenerator` | Console application source generator |
+
+## Quick Start
+
+```csharp
+using Hardened.Shared.Runtime.Attributes;
+using Hardened.Web.Runtime.Attributes;
+
+[HardenedModule]
+[AspNetCoreRuntime.Module]
+public partial class Application { }
+
+public class HelloController {
+    [Get("/hello/{name}")]
+    public string Hello(string name) {
+        return $"Hello, {name}!";
+    }
+}
+```
+
+```csharp
+// Program.cs
+var builder = Application.CreateBuilder(args);
+var app = builder.Build();
+app.UseHardened();
+app.Run();
+```
+
+## Documentation
+
+Full documentation is available at **[ipjohnson-org.github.io/Hardened.Docs](https://ipjohnson-org.github.io/Hardened.Docs)**.
+
+- [Getting Started](https://ipjohnson-org.github.io/Hardened.Docs/getting-started/installation/)
+- [Architecture Overview](https://ipjohnson-org.github.io/Hardened.Docs/architecture/overview/)
+- [Dependency Injection](https://ipjohnson-org.github.io/Hardened.Docs/framework/shared/dependency-injection/)
+- [Web Routing](https://ipjohnson-org.github.io/Hardened.Docs/framework/web/routing/)
+- [Testing](https://ipjohnson-org.github.io/Hardened.Docs/framework/testing/hardened-test/)
+- [Recipes](https://ipjohnson-org.github.io/Hardened.Docs/recipes/web-api-crud/)
+
+## Related Repositories
+
+- [Hardened.Amz](https://github.com/ipjohnson-org/Hardened.Amz) — AWS Lambda runtimes, DynamoDB/SQS clients, CDK support
+- [Hardened.Canaries](https://github.com/ipjohnson-org/Hardened.Canaries) — Canary testing framework
+- [Hardened.Docs](https://github.com/ipjohnson-org/Hardened.Docs) — Documentation site


### PR DESCRIPTION
## Summary
- Replace minimal README stub with comprehensive package table, quick start snippet, and links to the new docs site at ipjohnson-org.github.io/Hardened.Docs

## Test plan
- [x] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)