### PR TITLE
Fix OpenAPI source generator NuGet packaging

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/RecordEmitter.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/RecordEmitter.cs
@@ -21,8 +21,11 @@ internal static class RecordEmitter {
         sb.Append($"public record {recordName}(");
         sb.AppendLine();
 
-        for (var i = 0; i < schema.Properties.Count; i++) {
-            var prop = schema.Properties[i];
+        // Required parameters must precede optional ones in C# record constructors.
+        var sorted = schema.Properties.OrderByDescending(p => p.IsRequired).ToList();
+
+        for (var i = 0; i < sorted.Count; i++) {
+            var prop = sorted[i];
             var csType = TypeMapper.MapPropertyToCSharpType(prop);
             var propName = NamingHelper.ToPascalCase(prop.Name);
             var nullable = !prop.IsRequired ? "?" : "";
@@ -33,7 +36,7 @@ internal static class RecordEmitter {
                 sb.Append(" = default");
             }
 
-            if (i < schema.Properties.Count - 1) {
+            if (i < sorted.Count - 1) {
                 sb.AppendLine(",");
             } else {
                 sb.Append(")");

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
@@ -5,7 +5,17 @@
         <LangVersion>10</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsRoslynComponent>true</IsRoslynComponent>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <IsPackable>True</IsPackable>
+        <PackageId>Hardened.OpenApi.SourceGenerator</PackageId>
+        <Authors>Ian Johnson</Authors>
+        <PackageTags>Hardened.Framework</PackageTags>
+        <PackageProjectUrl>https://github.com/ipjohnson/CSharpAuthor</PackageProjectUrl>
+        <PackageLicenseUrl>https://github.com/ipjohnson/CSharpAuthor/blob/main/LICENSE</PackageLicenseUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ipjohnson/CSharpAuthor</RepositoryUrl>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
     </PropertyGroup>
 
     <ItemGroup>
@@ -23,6 +33,14 @@
         <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.22" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="Microsoft.OpenApi" Version="1.6.22" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="SharpYaml" Version="2.1.1" GeneratePathProperty="true" PrivateAssets="all" />
+    </ItemGroup>
+
+    <!-- Pack the analyzer DLL and its dependencies into the correct NuGet folder -->
+    <ItemGroup>
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+        <None Include="$(PkgMicrosoft_OpenApi_Readers)\lib\netstandard2.0\Microsoft.OpenApi.Readers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+        <None Include="$(PkgMicrosoft_OpenApi)\lib\netstandard2.0\Microsoft.OpenApi.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+        <None Include="$(PkgSharpYaml)\lib\netstandard2.0\SharpYaml.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
     </ItemGroup>
 
     <!-- Bundle OpenAPI dependencies with the analyzer so they're available at compile time -->

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiSpecParser.cs
@@ -137,7 +137,7 @@ internal static class OpenApiSpecParser {
             Name = name,
             Kind = SchemaKind.Dictionary,
             DictionaryValueType = addlProps?.Type,
-            DictionaryValueRef = addlProps?.Reference?.ReferenceV3
+            DictionaryValueRef = GetNonPrimitiveRef(addlProps)
         };
     }
 
@@ -145,7 +145,7 @@ internal static class OpenApiSpecParser {
         return new SchemaModel {
             Name = name,
             Kind = SchemaKind.Array,
-            ArrayItemsRef = schema.Items?.Reference?.ReferenceV3,
+            ArrayItemsRef = GetNonPrimitiveRef(schema.Items),
             ArrayItemsType = schema.Items?.Type,
             ArrayItemsFormat = schema.Items?.Format
         };
@@ -157,8 +157,11 @@ internal static class OpenApiSpecParser {
             IsRequired = isRequired
         };
 
-        if (prop.Reference != null) {
-            model.Ref = prop.Reference.ReferenceV3;
+        // Only keep $ref when it points to an object or enum that gets a generated C# type.
+        // Primitive refs (e.g. CustomId → string) are inlined to their underlying type.
+        var nonPrimitiveRef = GetNonPrimitiveRef(prop);
+        if (nonPrimitiveRef != null) {
+            model.Ref = nonPrimitiveRef;
             return model;
         }
 
@@ -173,7 +176,7 @@ internal static class OpenApiSpecParser {
 
         if (prop.Type == "array") {
             model.IsArray = true;
-            model.ArrayItemsRef = prop.Items?.Reference?.ReferenceV3;
+            model.ArrayItemsRef = GetNonPrimitiveRef(prop.Items);
             model.ArrayItemsType = prop.Items?.Type;
             model.ArrayItemsFormat = prop.Items?.Format;
             return model;
@@ -182,13 +185,31 @@ internal static class OpenApiSpecParser {
         if (prop.Type == "object" && prop.AdditionalProperties != null) {
             model.IsDictionary = true;
             model.DictionaryValueType = prop.AdditionalProperties.Type;
-            model.DictionaryValueRef = prop.AdditionalProperties.Reference?.ReferenceV3;
+            model.DictionaryValueRef = GetNonPrimitiveRef(prop.AdditionalProperties);
             return model;
         }
 
         model.Type = prop.Type;
         model.Format = prop.Format;
         return model;
+    }
+
+    /// <summary>
+    /// Returns the ReferenceV3 string only if the schema references an object or enum
+    /// (types that get generated C# classes). Returns null for primitive type refs
+    /// so that the caller inlines the underlying type instead.
+    /// </summary>
+    private static string? GetNonPrimitiveRef(OpenApiSchema? schema) {
+        if (schema?.Reference == null) return null;
+
+        // Enums and objects get generated C# types — keep the ref.
+        if (schema.Enum is { Count: > 0 }) return schema.Reference.ReferenceV3;
+        if (schema.Type == "object" || schema.Properties is { Count: > 0 }) return schema.Reference.ReferenceV3;
+        if (schema.Type == "array") return schema.Reference.ReferenceV3;
+        if (schema.AllOf is { Count: > 0 }) return schema.Reference.ReferenceV3;
+
+        // Primitive types (string, integer, number, boolean) — inline them.
+        return null;
     }
 
     private static void ParsePath(string path, OpenApiPathItem pathItem,
@@ -215,10 +236,10 @@ internal static class OpenApiSpecParser {
                         IsRequired = param.Required,
                         Type = param.Schema?.Type,
                         Format = param.Schema?.Format,
-                        Ref = param.Schema?.Reference?.ReferenceV3,
+                        Ref = GetNonPrimitiveRef(param.Schema),
                         IsArray = param.Schema?.Type == "array",
                         ArrayItemsType = param.Schema?.Items?.Type,
-                        ArrayItemsRef = param.Schema?.Items?.Reference?.ReferenceV3
+                        ArrayItemsRef = GetNonPrimitiveRef(param.Schema?.Items)
                     });
                 }
             }

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
         <add key="github-ipjohnson-org" value="https://nuget.pkg.github.com/ipjohnson-org/index.json" />
     </packageSources>
     <packageSourceCredentials>
         <github-ipjohnson-org>
-            <add key="Username" value="ipjohnson" />
+            <add key="Username" value="ipjohnson-org" />
             <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
         </github-ipjohnson-org>
     </packageSourceCredentials>


### PR DESCRIPTION
## Summary
- Fix NuGet package to place analyzer DLL in `analyzers/dotnet/cs/` instead of `lib/` so IDEs (Rider) properly recognize the source generator
- Added `IsRoslynComponent`, `IncludeBuildOutput=false`, and `None` pack items for the main DLL and its dependencies (Microsoft.OpenApi, Microsoft.OpenApi.Readers, SharpYaml)
- Fix record constructor parameter ordering (required before optional)
- Fix primitive type ref inlining (e.g. CustomId → string instead of generating a ref)
- Fix nuget.config to include nuget.org and correct username

## Test plan
- [ ] Verify `dotnet pack` places DLLs in `analyzers/dotnet/cs/` in the .nupkg
- [ ] Verify consuming projects can use the NuGet package reference instead of local project reference
- [ ] Verify Rider recognizes the source generator from the NuGet package

🤖 Generated with [Claude Code](https://claude.com/claude-code)