### PR TITLE
Use floating version for DependencyModules

### DIFF
--- a/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
+++ b/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-RC9153" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.*" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />


### PR DESCRIPTION
## Summary
- Switch DependencyModules.Runtime from `1.0.0-RC9153` to `1.0.*` in Hardened.Shared.Runtime

## Test plan
- [ ] `dotnet restore` resolves floating version
- [ ] `dotnet build` succeeds
- [ ] `dotnet test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)