### PR TITLE
Fix floating versions for prerelease packages

### DIFF
--- a/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
+++ b/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.*" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-*" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />


### PR DESCRIPTION
## Summary
- Change `DependencyModules.*` package references from `Version="1.0.*"` to `Version="1.0.0-*"` to match prerelease NuGet packages

NuGet floating version `major.minor.*` only matches stable releases. The `major.minor.patch-*` pattern is required for prerelease packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)