### PR TITLE
Add opt-in AOT serializer module

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime/AotSerializerModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/AotSerializerModule.cs
@@ -1,0 +1,27 @@
+using DependencyModules.Runtime.Interfaces;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Serializer;
+using Hardened.Shared.Runtime.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Hardened.Requests.Runtime;
+
+public class AotSerializerModule : IDependencyModule {
+    public void PopulateServiceCollection(IServiceCollection services) {
+        services.Replace(new ServiceDescriptor(
+            typeof(IResponseSerializer), typeof(AotResponseSerializer), ServiceLifetime.Singleton));
+        services.Replace(new ServiceDescriptor(
+            typeof(IRequestDeserializer), typeof(AotRequestDeserializer), ServiceLifetime.Singleton));
+        services.Replace(new ServiceDescriptor(
+            typeof(IJsonSerializer), typeof(AotJsonSerializer), ServiceLifetime.Singleton));
+    }
+
+    public override bool Equals(object? obj) => obj is AotSerializerModule;
+    public override int GetHashCode() => typeof(AotSerializerModule).GetHashCode();
+}
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class AotSerializerModuleAttribute : Attribute, IDependencyModuleProvider {
+    public IDependencyModule GetModule() => new AotSerializerModule();
+}

--- a/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
+++ b/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
@@ -15,6 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-*" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotJsonSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotJsonSerializer.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Shared.Runtime.Json;
+using Microsoft.Extensions.Options;
+
+namespace Hardened.Requests.Runtime.Serializer;
+
+public class AotJsonSerializer : IJsonSerializer {
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly JsonSerializerOptions _prettyOptions;
+
+    public AotJsonSerializer(IOptions<Hardened.Shared.Runtime.Json.IJsonSerializerConfiguration> configuration,
+        IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        _serializerOptions = configuration.Value.Options;
+        _prettyOptions = new JsonSerializerOptions(_serializerOptions) { WriteIndented = true };
+
+        foreach (var resolver in resolvers) {
+            _serializerOptions.TypeInfoResolverChain.Add(resolver);
+            _prettyOptions.TypeInfoResolverChain.Add(resolver);
+        }
+    }
+
+    public async Task<T> DeserializeAsync<T>(Stream jsonStream, CancellationToken cancellationToken = default) {
+        using var streamReader = new StreamReader(jsonStream);
+
+        return await JsonSerializer.DeserializeAsync<T>(jsonStream, _serializerOptions, cancellationToken) ??
+               throw new Exception("Deserialized to null instance");
+    }
+
+    public T Deserialize<T>(string json) {
+        return JsonSerializer.Deserialize<T>(json, _serializerOptions) ??
+               throw new Exception("Deserialized to null instance");
+    }
+
+    public string Serialize(object obj, bool pretty) {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(
+            obj,
+            pretty ? _prettyOptions : _serializerOptions);
+
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    public Task SerializeAsync(Stream jsonStream, object obj, bool pretty, CancellationToken cancellationToken) {
+        return JsonSerializer.SerializeAsync(
+            jsonStream,
+            obj,
+            pretty ? _prettyOptions : _serializerOptions,
+            cancellationToken);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotRequestDeserializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotRequestDeserializer.cs
@@ -1,0 +1,62 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Configuration;
+using Hardened.Requests.Runtime.Errors;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Runtime.Serializer;
+
+public class AotRequestDeserializer : IRequestDeserializer {
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly ILogger<AotRequestDeserializer> _logger;
+
+    public AotRequestDeserializer(IOptions<IJsonSerializerConfiguration> configuration,
+        ILogger<AotRequestDeserializer> logger,
+        IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        _logger = logger;
+        _serializerOptions =
+            configuration.Value.DeSerializerOptions ??
+            new(JsonSerializerDefaults.Web);
+
+        foreach (var resolver in resolvers) {
+            _serializerOptions.TypeInfoResolverChain.Add(resolver);
+        }
+    }
+
+    public bool IsDefaultSerializer => true;
+
+    public bool CanProcessContext(IExecutionContext context) {
+        return context.Request.ContentType?.Contains("application/json") ?? false;
+    }
+
+    public async ValueTask<T?> DeserializeRequestBody<T>(IExecutionContext context) {
+        if (context.Request.Headers.TryGetValue("Content-Encoding", out var contentEncoding)) {
+            return await DeserializeEncodedContent<T>(context, contentEncoding);
+        }
+
+        _logger.LogInformation($"Deserialize with option convert count {_serializerOptions.Converters.Count}");
+        return await System.Text.Json.JsonSerializer.DeserializeAsync<T>(context.Request.Body, _serializerOptions);
+    }
+
+    private async ValueTask<T?> DeserializeEncodedContent<T>(IExecutionContext context, StringValues contentEncoding) {
+        if (contentEncoding.Contains(KnownEncoding.GZip)) {
+            await using var decompressStream = new GZipStream(context.Request.Body, CompressionMode.Decompress);
+
+            return await System.Text.Json.JsonSerializer.DeserializeAsync<T>(decompressStream, _serializerOptions);
+        }
+
+        if (contentEncoding.Contains(KnownEncoding.Br)) {
+            await using var decompressStream = new BrotliStream(context.Request.Body, CompressionMode.Decompress);
+
+            return await System.Text.Json.JsonSerializer.DeserializeAsync<T>(decompressStream, _serializerOptions);
+        }
+
+        throw new BadContentEncodingException(contentEncoding.ToString());
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
@@ -1,0 +1,51 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Hardened.Requests.Runtime.Serializer;
+
+public class AotResponseSerializer : IResponseSerializer {
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    public AotResponseSerializer(IOptions<IJsonSerializerConfiguration> configuration,
+        IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        _serializerOptions =
+            configuration.Value.SerializeOptions ??
+            new(JsonSerializerDefaults.Web);
+
+        foreach (var resolver in resolvers) {
+            _serializerOptions.TypeInfoResolverChain.Add(resolver);
+        }
+    }
+
+    public bool IsDefaultSerializer => true;
+
+    public bool CanProcessContext(IExecutionContext context) {
+        return context.Request.Accept?.Contains("application/json") ?? false;
+    }
+
+    public async Task SerializeResponse(IExecutionContext context) {
+        context.Response.ContentType = "application/json";
+
+        if (context.Response.ResponseValue == null) {
+            return;
+        }
+
+        if (context.Response.ShouldCompress) {
+            await using var gzipStream = new GZipStream(context.Response.Body, CompressionLevel.Fastest, true);
+
+            await System.Text.Json.JsonSerializer.SerializeAsync(context.Response.Body, context.Response.ResponseValue,
+                _serializerOptions);
+
+            await gzipStream.FlushAsync();
+        }
+        else {
+            await System.Text.Json.JsonSerializer.SerializeAsync(context.Response.Body, context.Response.ResponseValue,
+                _serializerOptions);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AotSerializerModule` / `[AotSerializerModule]` attribute to `Hardened.Requests.Runtime`
- Replaces reflection-based `IResponseSerializer`, `IRequestDeserializer`, and `IJsonSerializer` with AOT-compatible versions that inject `IEnumerable<IJsonTypeInfoResolver>` into `TypeInfoResolverChain`
- Opt-in only — existing consumers are unaffected

## Test plan
- [x] `dotnet build` Hardened.Framework — 0 errors
- [x] `dotnet test` Hardened.Framework — 265 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)