### PR TITLE
Use global type output mode in all source generators

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime/AotSerializerModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/AotSerializerModule.cs
@@ -17,6 +17,14 @@ public class AotSerializerModule : IDependencyModule {
 
     public override bool Equals(object? obj) => obj is AotSerializerModule;
     public override int GetHashCode() => typeof(AotSerializerModule).GetHashCode();
+    
+    public void InternalApplyServices(IServiceCollection services) {
+        // Register AOT serializers first; RequestRuntimeDI uses TryAddSingleton
+        // so its reflection-based serializers will be skipped (last in wins).
+        services.AddSingleton<IResponseSerializer, AotResponseSerializer>();
+        services.AddSingleton<IRequestDeserializer, AotRequestDeserializer>();
+        services.AddSingleton<IJsonSerializer, AotJsonSerializer>();
+    }
 }
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]

--- a/src/SourceGenerators/Hardened.Console.SourceGenerator/Impl/CommandDefinitionRegistrationGenerator.cs
+++ b/src/SourceGenerators/Hardened.Console.SourceGenerator/Impl/CommandDefinitionRegistrationGenerator.cs
@@ -15,7 +15,10 @@ public class CommandDefinitionRegistrationGenerator {
         GeneratedCode(sourceProductionContext, commandData.Left, commandData.Right,
             commandsFile);
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         commandsFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiRoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiRoutingTableGenerator.cs
@@ -31,7 +31,10 @@ internal static class OpenApiRoutingTableGenerator {
 
         CreateRoutingTable(appModel, handlers, handlerInfos, applicationFile, cancellationToken);
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
         applicationFile.WriteOutput(outputContext);
         return outputContext.Output();
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Configuration/ConfigurationEntryPointGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Configuration/ConfigurationEntryPointGenerator.cs
@@ -19,7 +19,10 @@ public static class ConfigurationEntryPointGenerator {
 
         GenerateConfiguration(classDefinition, arg2.AppModel, arg2.ConfigFiles);
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         cSharpFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Configuration/ConfigurationPropertyImplementationGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Configuration/ConfigurationPropertyImplementationGenerator.cs
@@ -19,7 +19,10 @@ public static class ConfigurationPropertyImplementationGenerator {
 
         ProcessModelDefinition(arg2, modelDefinition, interfaceDefinition);
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         csharpFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/DependencyInjection/DependencyInjectionFileGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/DependencyInjection/DependencyInjectionFileGenerator.cs
@@ -22,7 +22,10 @@ public class DependencyInjectionFileGenerator {
 
         GeneratedCode(dependencyData.Left, dependencyData.Right, diFile);
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         diFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Module/ModuleEntryPointFileWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Module/ModuleEntryPointFileWriter.cs
@@ -14,7 +14,10 @@ public class ModuleEntryPointFileWriter {
 
             GenerateClassDefinition(context, model, csharpFile);
 
-            var outputContext = new OutputContext();
+            var outputContext = new OutputContext(
+                new OutputContextOptions {
+                    TypeOutputMode = TypeOutputMode.Global
+                });
 
             csharpFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
@@ -149,7 +149,7 @@ public static class KnownTypes {
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, "System", "IServiceProvider");
 
         public static readonly ITypeDefinition ServiceProvider =
-            TypeDefinition.Get("System", "ServiceProvider");
+            TypeDefinition.Get(Namespace.Microsoft.Extensions.DependencyInjection, "ServiceProvider");
 
         public static readonly ITypeDefinition ExposeAttribute =
             TypeDefinition.Get(Namespace.Hardened.Shared.Runtime.Attributes, "ExposeAttribute");

--- a/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateClassGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateClassGenerator.cs
@@ -49,7 +49,10 @@ public class TemplateClassGenerator {
 
         _executionMethodGenerator.GenerateImplementation(classDefinition, templateExtension, templateNodes.ToList());
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         csharpFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateEntryPointGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateEntryPointGenerator.cs
@@ -24,7 +24,10 @@ public static class TemplateEntryPointGenerator {
 
         var templateFileName = templateData.applicationModel.EntryPointType.Name + ".Templates.cs";
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         applicationFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateHelperGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateHelperGenerator.cs
@@ -28,7 +28,10 @@ public static class TemplateHelperGenerator {
 
         var fileName = helperData.applicationModel.EntryPointType.Name + ".TemplateHelpers.cs";
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         helperFile.WriteOutput(outputContext);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
@@ -20,7 +20,10 @@ public class WebExecutionHandlerCodeGenerator {
 
         InvokeClassGenerator.GenerateInvokeClass(requestHandlerModel, csharpFile, cancellationToken);
 
-        var outputContext = new OutputContext();
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
 
         csharpFile.WriteOutput(outputContext);
 


### PR DESCRIPTION
## Summary
- All source generators now use `TypeOutputMode.Global` when creating `OutputContext`, ensuring generated code uses fully-qualified type names (e.g. `global::Microsoft.Extensions.DependencyInjection.ServiceProvider` instead of `ServiceProvider`)
- Fixes `KnownTypes.ServiceProvider` namespace from `System` to `Microsoft.Extensions.DependencyInjection`
- Adds `InternalApplyServices` to `AotSerializerModule`
- Required for Native AOT compatibility where `using` directives in generated code may not resolve correctly

## Test plan
- [ ] Build source generators
- [ ] Build downstream projects (AuthenticationApi) with AOT enabled
- [ ] Verify generated code uses fully-qualified type names

🤖 Generated with [Claude Code](https://claude.com/claude-code)