### PR TITLE
Add DynamicDependency to static DI registration fields

### DIFF
--- a/src/SourceGenerators/Hardened.Console.SourceGenerator/Impl/CommandDefinitionRegistrationGenerator.cs
+++ b/src/SourceGenerators/Hardened.Console.SourceGenerator/Impl/CommandDefinitionRegistrationGenerator.cs
@@ -52,6 +52,7 @@ public class CommandDefinitionRegistrationGenerator {
             .DependencyInjection);
         templateField.InitializeValue =
             new CodeOutputComponent($"DependencyRegistry<{classDefinition.Name}>.Register(RegisterCommands)");
+        templateField.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"), "nameof(RegisterCommands)");
     }
 
     private void GenerateConstructors(

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiRoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiRoutingTableGenerator.cs
@@ -84,6 +84,7 @@ internal static class OpenApiRoutingTableGenerator {
         templateField.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;
         templateField.AddUsingNamespace(KnownTypes.Namespace.Hardened.Shared.Runtime.DependencyInjection);
         templateField.InitializeValue = new CodeOutputComponent($"DependencyRegistry<{classDefinition.Name}>.Register(OpenApiRoutingTableDI)");
+        templateField.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"), "nameof(OpenApiRoutingTableDI)");
 
         var diMethod = classDefinition.AddMethod("OpenApiRoutingTableDI");
         diMethod.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;

--- a/src/SourceGenerators/Hardened.SourceGenerator/Configuration/ConfigurationEntryPointGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Configuration/ConfigurationEntryPointGenerator.cs
@@ -50,6 +50,7 @@ public static class ConfigurationEntryPointGenerator {
         templateField.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;
         templateField.AddUsingNamespace(KnownTypes.Namespace.Hardened.Shared.Runtime.DependencyInjection);
         templateField.InitializeValue = new CodeOutputComponent($"DependencyRegistry<{classDefinition.Name}>.Register(ConfigurationDI)");
+        templateField.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"), "nameof(ConfigurationDI)");
 
         var diMethod = classDefinition.AddMethod("ConfigurationDI");
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateEntryPointGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateEntryPointGenerator.cs
@@ -42,6 +42,7 @@ public static class TemplateEntryPointGenerator {
         templateField.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;
         templateField.AddUsingNamespace(KnownTypes.Namespace.Hardened.Shared.Runtime.DependencyInjection);
         templateField.InitializeValue = new CodeOutputComponent($"DependencyRegistry<{classDefinition.Name}>.Register(HardenedTemplateDI)");
+        templateField.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"), "nameof(HardenedTemplateDI)");
 
         var diMethod = classDefinition.AddMethod("HardenedTemplateDI");
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateHelperGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateHelperGenerator.cs
@@ -45,6 +45,7 @@ public static class TemplateHelperGenerator {
         templateField.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;
         templateField.AddUsingNamespace(KnownTypes.Namespace.Hardened.Shared.Runtime.DependencyInjection);
         templateField.InitializeValue = new CodeOutputComponent($"DependencyRegistry<{appClass.Name}>.Register(HardenedTemplateHelperDI)");
+        templateField.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"), "nameof(HardenedTemplateHelperDI)");
 
         var diMethod = appClass.AddMethod("HardenedTemplateHelperDI");
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
@@ -81,6 +81,7 @@ public static class RoutingTableGenerator {
         templateField.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;
         templateField.AddUsingNamespace(KnownTypes.Namespace.Hardened.Shared.Runtime.DependencyInjection);
         templateField.InitializeValue = new CodeOutputComponent($"DependencyRegistry<{classDefinition.Name}>.Register(RoutingTableDI)");
+        templateField.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"), "nameof(RoutingTableDI)");
 
         var diMethod = classDefinition.AddMethod("RoutingTableDI");
 


### PR DESCRIPTION
## Summary
- Adds `[DynamicDependency(nameof(...))]` to all 6 source generators that emit static DI registration fields
- Prevents the AOT trimmer from removing fields whose side-effect (`Register()` call) is the important part
- Fixes silent 404s in trimmed/AOT builds caused by routing and other DI registrations being stripped

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` passes (10/10)
- [ ] Verify generated output includes `[DynamicDependency]` on static fields
- [ ] Deploy and test AOT Lambda

🤖 Generated with [Claude Code](https://claude.com/claude-code)