### PR TITLE
Add AppVeyor NuGet source for DependencyModules package

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -17,8 +17,6 @@ jobs:
           source-url: https://nuget.pkg.github.com/ipjohnson-org/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Add ipjohnson package source
-        run: dotnet nuget add source "https://nuget.pkg.github.com/ipjohnson/index.json" --name github-ipjohnson --username ipjohnson --password ${{secrets.GITHUB_TOKEN}} --store-password-in-clear-text
       - run: dotnet restore src/Hardened.Framework.sln
       - run: dotnet build src/Hardened.Framework.sln --no-restore --configuration Release
       - run: dotnet test src/Hardened.Framework.sln --no-build --configuration Release

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,6 +3,7 @@
     <packageSources>
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+        <add key="appveyor-dependencymodules" value="https://ci.appveyor.com/nuget/dependencymodules" />
         <add key="github-ipjohnson-org" value="https://nuget.pkg.github.com/ipjohnson-org/index.json" />
     </packageSources>
     <packageSourceCredentials>


### PR DESCRIPTION
## Summary
- Add AppVeyor public NuGet feed (`https://ci.appveyor.com/nuget/dependencymodules`) to `nuget.config` so CI can resolve `DependencyModules.SourceGenerator.Impl` without cross-account GitHub Packages auth
- Remove redundant `dotnet nuget add source` step from CI workflow (now handled by `nuget.config`)

## Test plan
- [x] Local build succeeds with NuGet package (DependencyModules repo not present)
- [x] Local build succeeds with local DependencyModules repo
- [x] All 265 tests pass
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)