### PR TITLE
Include DM generator transitively via Library.SourceGenerator

### DIFF
--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
@@ -37,6 +37,12 @@
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="../Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj"
+                          ReferenceOutputAssembly="false"
+                          PrivateAssets="none" />
+    </ItemGroup>
+
     <PropertyGroup>
         <IncludeBuildOutput>false</IncludeBuildOutput>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- Adds a `ProjectReference` to `Hardened.DependencyModules.SourceGenerator` in `Hardened.Library.SourceGenerator.csproj` with `ReferenceOutputAssembly="false"` and `PrivateAssets="none"`
- This ensures NuGet consumers (Hardened.Amz, Auth API, etc.) get the DM generator transitively, fixing CS1061 errors for the missing `PopulateServiceCollection` method
- No other changes needed — Hardened.Framework internal projects already have explicit references to both generators

## Test plan
- [x] Hardened.Framework solution builds (0 errors)
- [x] All 265 tests pass
- [ ] After package publish, verify Hardened.Amz CI builds without CS1061 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)