### PR TITLE
Embed DM generator DLL in Library.SourceGenerator package

### DIFF
--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
@@ -35,12 +35,14 @@
 
     <ItemGroup>
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+        <None Include="../Hardened.DependencyModules.SourceGenerator/bin/$(Configuration)/$(TargetFramework)/Hardened.DependencyModules.SourceGenerator.dll"
+              Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="../Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj"
                           ReferenceOutputAssembly="false"
-                          PrivateAssets="none" />
+                          PrivateAssets="all" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
## Summary
- `ReferenceOutputAssembly="false"` on ProjectReference causes `dotnet pack` to exclude the reference from nuspec dependencies — so the previous transitive dependency approach didn't work
- Instead, embed the `Hardened.DependencyModules.SourceGenerator.dll` directly in `analyzers/dotnet/cs` alongside the Library generator DLL
- Consumers get both generators from a single package, no transitive resolution needed

## Test plan
- [x] Verified nupkg contains both DLLs in `analyzers/dotnet/cs`
- [x] Hardened.Framework builds (0 errors)
- [x] All 265 tests pass
- [ ] After publish, re-run Hardened.Amz CI to confirm CS1061 resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)