### PR TITLE
Disable auto-approve CompilationUnit in HardenedSourceGenerator

### DIFF
--- a/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/HardenedSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/HardenedSourceGenerator.cs
@@ -14,6 +14,8 @@ public class HardenedSourceGenerator : BaseSourceGenerator {
         TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition,
             "Hardened.Shared.Runtime.Attributes", "HardenedModuleAttribute");
 
+    protected override bool ShouldAutoApproveCompilationUnit => false;
+
     protected override ITypeDefinition[] ModuleAttributeTypes() {
         return new[] { HardenedModuleAttribute };
     }


### PR DESCRIPTION
## Summary
- Overrides `ShouldAutoApproveCompilationUnit => false` in `HardenedSourceGenerator`
- Prevents duplicate `ApplicationModule` generation when both the standalone `DependencyModules.SourceGenerator` (from `Hardened.Shared.Runtime`) and the embedded `Hardened.DependencyModules.SourceGenerator` are present in a consumer project

## Context
After embedding the DM generator DLL in `Hardened.Library.SourceGenerator` (PR #48), consumers like Hardened.Amz get two DM-based generators. Both were auto-generating `ApplicationModule` from `Program.cs`, causing duplicate member errors. This fix makes the Hardened generator skip `Program.cs` auto-approval, leaving that to the standalone DM generator.

Depends on: https://github.com/ipjohnson/DependencyModules/pull/11 (merged, package publishing via AppVeyor)

## Test plan
- [ ] CI passes (requires new `DependencyModules.SourceGenerator.Impl` package from AppVeyor)
- [ ] Hardened.Amz builds without duplicate generation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)