### PR TITLE
Remove legacy DI attributes, expose DM generator transitively

### DIFF
--- a/src/Shared/Hardened.Shared.Runtime/Attributes/ScopedAttribute.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Attributes/ScopedAttribute.cs
@@ -1,6 +1,0 @@
-﻿namespace Hardened.Shared.Runtime.Attributes;
-
-/// <summary>
-/// Expose service as scoped
-/// </summary>
-public class ScopedAttribute : Attribute { }

--- a/src/Shared/Hardened.Shared.Runtime/Attributes/SingletonAttribute.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Attributes/SingletonAttribute.cs
@@ -1,6 +1,0 @@
-﻿namespace Hardened.Shared.Runtime.Attributes;
-
-/// <summary>
-/// Expose service as singleton
-/// </summary>
-public class SingletonAttribute : Attribute { }

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
@@ -42,7 +42,7 @@
     <ItemGroup>
         <ProjectReference Include="../Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj"
                           ReferenceOutputAssembly="false"
-                          PrivateAssets="all" />
+                          PrivateAssets="none" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
## Summary
- Remove `ScopedAttribute` and `SingletonAttribute` from `Hardened.Shared.Runtime` (replaced by DependencyModules equivalents)
- Change `Library.SourceGenerator` DM reference to `PrivateAssets="none"` so downstream consumers get the generator transitively

## Test plan
- [x] Verified downstream repos (Search, Amz) build successfully with these changes
- [x] Deployed to beta and confirmed all Lambda functions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)