### PR TITLE
Add request validation system with filter wiring fix

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/RequestModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/RequestModelBuilder.cs
@@ -38,7 +38,8 @@ internal static class RequestModelBuilder {
         foreach (var model in models) {
             var handlerInfo = FindHandlerInfo(model, handlerInfos);
             if (handlerInfo != null) {
-                var filters = new List<AttributeModel>(handlerInfo.ClassFilters);
+                var filters = new List<AttributeModel>(model.Filters);
+                filters.AddRange(handlerInfo.ClassFilters);
 
                 // Find method-level filters matching this handler's method
                 foreach (var methodFilter in handlerInfo.MethodFilters) {


### PR DESCRIPTION
## Summary
- Adds OpenAPI-driven request validation system: source generator reads constraints from `openapi.yaml` and emits `ValidationFilterProvider` classes per endpoint
- Validation rules: required, string length, range, pattern, enum, array bounds
- `ValidationFilter` runs at `FilterOrder.Validation`, validates parameters + body properties, then resolves `ICustomRequestValidator<T>` from DI
- Returns HTTP 400 with structured `ValidationErrorModel` on failure
- **Bug fix**: `EnrichWithHandlerFilters()` was dropping validation filters when merging handler-level filters — now preserves `model.Filters`

## Test plan
- [x] Unit tests for all validation rules (ArrayBounds, Enum, Pattern, Range, Required, StringLength)
- [x] Integration test for ValidationFilter end-to-end
- [x] ValidationFilterEmitter source generator tests
- [x] Validation parsing tests for OpenAPI spec constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)