### PR TITLE
Add IAsyncEnumerable<T> streaming IO filter

### DIFF
--- a/src/Requests/Hardened.Requests.Abstract/RequestFilter/IIOFilterProvider.cs
+++ b/src/Requests/Hardened.Requests.Abstract/RequestFilter/IIOFilterProvider.cs
@@ -6,4 +6,8 @@ public interface IIOFilterProvider {
     IExecutionFilter ProvideFilter(
         IExecutionRequestHandlerInfo handlerInfo,
         Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequest);
+
+    IExecutionFilter ProvideAsyncEnumerableFilter<TItem>(
+        IExecutionRequestHandlerInfo handlerInfo,
+        Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequest);
 }

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
@@ -131,6 +131,57 @@ public static class ExecutionHelper {
 
     #endregion
 
+    #region async enumerable with parameters
+
+    public static Func<IExecutionContext, IExecutionFilter>[]
+        AsyncEnumerableFilterWithParameters<TController, TParameter, TItem>(
+            IServiceProvider serviceProvider,
+            IExecutionRequestHandlerInfo handlerInfo,
+            Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequestFunc,
+            InvokeWithParameters<TController, TParameter> invokeMethod,
+            IEnumerable<IRequestFilterProvider> filterProviders) where TController : class {
+        var ioFilterProvider = serviceProvider.GetRequiredService<IIOFilterProvider>();
+
+        var ioFilter = ioFilterProvider.ProvideAsyncEnumerableFilter<TItem>(
+            handlerInfo,
+            deserializeRequestFunc
+        );
+
+        var invokeFilter = new InvokeWithParametersFilter<TController, TParameter>(invokeMethod);
+
+        var instanceFilter = serviceProvider.GetRequiredService<IInstanceFilterProvider>()
+            .ProvideFilter<TController>(serviceProvider);
+
+        return CreateFilterArray(serviceProvider, handlerInfo, filterProviders, ioFilter, invokeFilter, instanceFilter);
+    }
+
+    #endregion
+
+    #region async enumerable no parameters
+
+    public static Func<IExecutionContext, IExecutionFilter>[]
+        AsyncEnumerableFilterEmptyParameters<TController, TItem>(
+            IServiceProvider serviceProvider,
+            IExecutionRequestHandlerInfo handlerInfo,
+            InvokeNoParameters<TController> invokeMethod,
+            IEnumerable<IRequestFilterProvider> filterProviders) {
+        var ioFilterProvider = serviceProvider.GetRequiredService<IIOFilterProvider>();
+
+        var ioFilter = ioFilterProvider.ProvideAsyncEnumerableFilter<TItem>(
+            handlerInfo,
+            _emptyDeserializeRequest
+        );
+
+        var invokeFilter = new InvokeNoParametersFilter<TController>(invokeMethod);
+
+        var instanceFilter = serviceProvider.GetRequiredService<IInstanceFilterProvider>()
+            .ProvideFilter<TController>(serviceProvider);
+
+        return CreateFilterArray(serviceProvider, handlerInfo, filterProviders, ioFilter, invokeFilter, instanceFilter);
+    }
+
+    #endregion
+
     #region create filter array
 
     private static Func<IExecutionContext, IExecutionFilter>[] CreateFilterArray(

--- a/src/Requests/Hardened.Requests.Runtime/Execution/IOFilterProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/IOFilterProvider.cs
@@ -62,4 +62,14 @@ public class IOFilterProvider : IIOFilterProvider {
             _headerActions
         );
     }
+
+    public IExecutionFilter ProvideAsyncEnumerableFilter<TItem>(
+        IExecutionRequestHandlerInfo handlerInfo,
+        Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequest) {
+        return new AsyncEnumerableIoFilter<TItem>(
+            deserializeRequest,
+            _contextSerializationService.SerializeResponse,
+            _headerActions
+        );
+    }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
@@ -1,0 +1,79 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Logging;
+using Hardened.Requests.Abstract.Metrics;
+using Hardened.Shared.Runtime.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hardened.Requests.Runtime.Filters;
+
+public class AsyncEnumerableIoFilter<TItem> : IExecutionFilter {
+    private readonly Func<IExecutionContext, Task<IExecutionRequestParameters>> _deserializeRequest;
+    private readonly Func<IExecutionContext, Task> _serializeResponse;
+    private readonly Action<IExecutionContext>? _headerActions;
+
+    public AsyncEnumerableIoFilter(
+        Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequest,
+        Func<IExecutionContext, Task> serializeResponse,
+        Action<IExecutionContext>? headerActions) {
+        _deserializeRequest = deserializeRequest;
+        _serializeResponse = serializeResponse;
+        _headerActions = headerActions;
+    }
+
+    public async Task Execute(IExecutionChain chain) {
+        var context = chain.Context;
+        var bindParameterStartTimestamp = MachineTimestamp.Now;
+
+        try {
+            if (context.Request.Parameters == null) {
+                context.Request.Parameters = await _deserializeRequest(chain.Context);
+            }
+        }
+        catch (Exception exp) {
+            chain.Context.RequestServices.GetRequiredService<IRequestLogger>()
+                .RequestParameterBindFailed(chain.Context, exp);
+
+            chain.Context.Response.ExceptionValue = exp;
+        }
+        finally {
+            context.RequestMetrics.Record(RequestMetrics.ParameterBindDuration,
+                bindParameterStartTimestamp.GetElapsedMilliseconds());
+        }
+
+        if (chain.Context.Response.ExceptionValue == null) {
+            try {
+                await chain.Next();
+            }
+            catch (Exception exp) {
+                chain.Context.Response.ExceptionValue = exp;
+            }
+        }
+
+        var responseTimestamp = MachineTimestamp.Now;
+
+        try {
+            _headerActions?.Invoke(chain.Context);
+
+            if (chain.Context.Response.ExceptionValue != null) {
+                await _serializeResponse(chain.Context);
+            }
+            else if (chain.Context.Response.ResponseValue is IAsyncEnumerable<TItem> asyncEnumerable) {
+                context.Response.ContentType = "application/x-ndjson";
+                context.Response.ShouldSerialize = false;
+
+                await foreach (var item in asyncEnumerable.WithCancellation(context.CancellationToken)) {
+                    context.Response.ResponseValue = item;
+                    await _serializeResponse(context);
+                    context.Response.Body.WriteByte((byte)'\n');
+                    await context.Response.Body.FlushAsync(context.CancellationToken);
+                }
+            }
+            else if (chain.Context.Response.ShouldSerialize) {
+                await _serializeResponse(chain.Context);
+            }
+        }
+        finally {
+            context.RequestMetrics.Record(RequestMetrics.ResponseDuration, responseTimestamp.GetElapsedMilliseconds());
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
@@ -5,6 +5,10 @@ namespace Hardened.SourceGenerator.Models.Request;
 public record ResponseInformationModel {
     public bool IsAsync { get; set; }
 
+    public bool IsAsyncEnumerable { get; set; }
+
+    public ITypeDefinition? AsyncEnumerableItemType { get; set; }
+
     public ITypeDefinition? ReturnType { get; set; }
 
     public string? TemplateName { get; set; }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -212,9 +212,16 @@ public abstract class BaseRequestModelGenerator {
         var returnType = methodDeclaration.ReturnType.GetTypeDefinition(context);
 
         var isAsync = false;
+        var isAsyncEnumerable = false;
+        ITypeDefinition? asyncEnumerableItemType = null;
 
         if (returnType is GenericTypeDefinition genericType) {
-            isAsync = genericType.Name.Equals("Task") || genericType.Name.Equals("ValueTask");
+            if (genericType.Name.Equals("Task") || genericType.Name.Equals("ValueTask")) {
+                isAsync = true;
+            } else if (genericType.Name.Equals("IAsyncEnumerable")) {
+                isAsyncEnumerable = true;
+                asyncEnumerableItemType = genericType.TypeArguments[0];
+            }
         } else if (returnType?.Name == "Task") {
             isAsync = true;
             returnType = TypeDefinition.Get(typeof(void));
@@ -231,6 +238,8 @@ public abstract class BaseRequestModelGenerator {
 
         return new ResponseInformationModel {
             IsAsync = isAsync,
+            IsAsyncEnumerable = isAsyncEnumerable,
+            AsyncEnumerableItemType = asyncEnumerableItemType,
             TemplateName = template,
             ReturnType = returnType,
             RawResponseContentType = rawResponse

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeClassGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeClassGenerator.cs
@@ -67,7 +67,15 @@ public static class InvokeClassGenerator {
                 contentType);
         }
 
-        if (handlerModel.RequestParameterInformationList.Count == 0) {
+        if (handlerModel.ResponseInformation.IsAsyncEnumerable) {
+            if (handlerModel.RequestParameterInformationList.Count == 0) {
+                CreateAsyncEnumerableNoParameterConstructor(handlerModel, classDefinition, defaultOutput);
+            }
+            else {
+                CreateAsyncEnumerableParametersConstructor(handlerModel, classDefinition, defaultOutput);
+            }
+        }
+        else if (handlerModel.RequestParameterInformationList.Count == 0) {
             if (handlerModel.ResponseInformation.IsAsync) {
                 CreateAsyncNoParameterConstructor(handlerModel, classDefinition, defaultOutput);
             }
@@ -149,6 +157,46 @@ public static class InvokeClassGenerator {
             "StandardFilterWithParameters",
             new[] {
                 handlerModel.ControllerType, GenericParameters
+            },
+            "serviceProvider",
+            "_handlerInfo",
+            "BindRequestParameters",
+            "InvokeMethod",
+            GenerateFilterEnumerable(handlerModel, classDefinition)
+        );
+        var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
+
+        constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+    }
+
+    private static void CreateAsyncEnumerableNoParameterConstructor(RequestHandlerModel handlerModel,
+        ClassDefinition classDefinition,
+        IOutputComponent defaultOutput) {
+        var filterMethod = InvokeGeneric(
+            KnownTypes.Requests.ExecutionHelper,
+            "AsyncEnumerableFilterEmptyParameters",
+            new[] {
+                handlerModel.ControllerType,
+                handlerModel.ResponseInformation.AsyncEnumerableItemType!
+            },
+            "serviceProvider",
+            "_handlerInfo",
+            "InvokeMethod",
+            GenerateFilterEnumerable(handlerModel, classDefinition)
+        );
+        var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
+
+        constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+    }
+
+    private static void CreateAsyncEnumerableParametersConstructor(RequestHandlerModel handlerModel,
+        ClassDefinition classDefinition, IOutputComponent defaultOutput) {
+        var filterMethod = InvokeGeneric(
+            KnownTypes.Requests.ExecutionHelper,
+            "AsyncEnumerableFilterWithParameters",
+            new[] {
+                handlerModel.ControllerType, GenericParameters,
+                handlerModel.ResponseInformation.AsyncEnumerableItemType!
             },
             "serviceProvider",
             "_handlerInfo",

--- a/src/Web/Hardened.Web.Testing/TestWebResponse.cs
+++ b/src/Web/Hardened.Web.Testing/TestWebResponse.cs
@@ -23,6 +23,18 @@ public class TestWebResponse {
 
     public IWebAssertThat Assert => _assertThat ??= new WebAssertThat(this);
 
+    public async IAsyncEnumerable<T> DeserializeAsyncEnumerable<T>() {
+        Body.Position = 0;
+        using var reader = new StreamReader(Body, leaveOpen: true);
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        while (await reader.ReadLineAsync() is { } line) {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            yield return JsonSerializer.Deserialize<T>(line, options) ??
+                         throw new Exception("Could not deserialize NDJSON line");
+        }
+    }
+
     public T Deserialize<T>() {
         if (Headers.TryGetValue(KnownHeaders.ContentEncoding, out var contentEncoding)) {
             if (contentEncoding.Contains(KnownEncoding.GZip)) {


### PR DESCRIPTION
## Summary
- Source generator detects `IAsyncEnumerable<T>` return types and emits `AsyncEnumerableFilter` constructor calls
- New `AsyncEnumerableIoFilter<TItem>` streams each item as NDJSON using the Hardened serializer (not raw `JsonSerializer`)
- `IIOFilterProvider` / `IOFilterProvider` gain `ProvideAsyncEnumerableFilter<TItem>()` method
- `ExecutionHelper` gains `AsyncEnumerableFilterWithParameters` / `AsyncEnumerableFilterEmptyParameters`
- `TestWebResponse` gains `DeserializeAsyncEnumerable<T>()` for NDJSON test responses

## Test plan
- [x] `dotnet build` Hardened.Framework — compiles clean
- [x] Downstream builds (Search, BackEndApi) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)