### PR TITLE
Add Hardened.Function.SourceGenerator

### DIFF
--- a/src/Hardened.Framework.sln
+++ b/src/Hardened.Framework.sln
@@ -97,6 +97,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.O
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.DependencyModules.SourceGenerator", "SourceGenerators\Hardened.DependencyModules.SourceGenerator\Hardened.DependencyModules.SourceGenerator.csproj", "{76585983-2ECC-4BDA-85C6-19A35993796D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Function.SourceGenerator", "SourceGenerators\Hardened.Function.SourceGenerator\Hardened.Function.SourceGenerator.csproj", "{06999170-205C-49C4-8F0D-81481F558819}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +245,10 @@ Global
 		{76585983-2ECC-4BDA-85C6-19A35993796D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76585983-2ECC-4BDA-85C6-19A35993796D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76585983-2ECC-4BDA-85C6-19A35993796D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06999170-205C-49C4-8F0D-81481F558819}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06999170-205C-49C4-8F0D-81481F558819}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06999170-205C-49C4-8F0D-81481F558819}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06999170-205C-49C4-8F0D-81481F558819}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -287,6 +293,7 @@ Global
 		{10C9842A-FBBA-400F-9D3B-B4350C79D49C} = {3692338C-6161-4EC7-826E-53FB6DD8114C}
 		{B2941D10-F532-485E-AC98-D5D8A989B7CA} = {3692338C-6161-4EC7-826E-53FB6DD8114C}
 		{76585983-2ECC-4BDA-85C6-19A35993796D} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
+		{06999170-205C-49C4-8F0D-81481F558819} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF6CD1AB-6B41-427D-BA1B-C4803CF67E97}

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IFunctionHandlerProvider.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IFunctionHandlerProvider.cs
@@ -1,0 +1,5 @@
+namespace Hardened.Requests.Abstract.Execution;
+
+public interface IFunctionHandlerProvider {
+    IExecutionRequestHandler? GetFunctionHandler(string functionName, IServiceProvider serviceProvider);
+}

--- a/src/SourceGenerators/Hardened.Function.SourceGenerator/FunctionLibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Function.SourceGenerator/FunctionLibrarySourceGenerator.cs
@@ -1,0 +1,17 @@
+using Microsoft.CodeAnalysis;
+using Hardened.SourceGenerator.Shared;
+using Hardened.SourceGenerator.Function;
+
+namespace Hardened.Function.SourceGenerator;
+
+[Generator]
+public class FunctionLibrarySourceGenerator : IIncrementalGenerator {
+    public void Initialize(IncrementalGeneratorInitializationContext context) {
+        var applicationModel = context.SyntaxProvider.CreateSyntaxProvider(
+            EntryPointSelector.UsingAttribute(),
+            EntryPointSelector.TransformModel(false)
+        ).WithComparer(new EntryPointSelector.Comparer());
+
+        FunctionIncrementalGenerator.Setup(context, applicationModel);
+    }
+}

--- a/src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj
@@ -1,0 +1,90 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <_CSharpAuthorRoot>$(MSBuildThisFileDirectory)../../../CSharpAuthor</_CSharpAuthorRoot>
+        <CSharpAuthorProject>$(_CSharpAuthorRoot)/CSharpAuthor/CSharpAuthor.csproj</CSharpAuthorProject>
+        <UseLocalCSharpAuthor Condition="Exists('$(CSharpAuthorProject)')">true</UseLocalCSharpAuthor>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>10</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>True</IsPackable>
+        <PackageId>Hardened.Function.SourceGenerator</PackageId>
+        <Authors>Ian Johnson</Authors>
+        <PackageTags>Hardened.Framework</PackageTags>
+        <PackageProjectUrl>https://github.com/ipjohnson/Hardened.Framework</PackageProjectUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/ipjohnson/Hardened.Framework</RepositoryUrl>
+        <IsRoslynComponent>true</IsRoslynComponent>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <PackageCSharpAuthorIncludeSource Condition="'$(UseLocalCSharpAuthor)' != 'true'">true</PackageCSharpAuthorIncludeSource>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Condition="'$(UseLocalCSharpAuthor)' != 'true'" Include="CSharpAuthor" Version="1.1.1006">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>build</IncludeAssets>
+        </PackageReference>
+        <ProjectReference Condition="'$(UseLocalCSharpAuthor)' == 'true'" Include="$(CSharpAuthorProject)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="../Hardened.SourceGenerator/Configuration/**/*">
+            <Link>Configuration\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/DependencyInjection/**/*">
+            <Link>DependencyInjection\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Models/**/*">
+            <Link>Models\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Module/**/*">
+            <Link>Module\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Requests/**/*">
+            <Link>Requests\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Shared/**/*">
+            <Link>Shared\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Templates/**/*">
+            <Link>Templates\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Function/**/*">
+            <Link>Function\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+    </ItemGroup>
+
+</Project>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Function/FunctionIncrementalGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Function/FunctionIncrementalGenerator.cs
@@ -1,0 +1,177 @@
+using System.Collections.Immutable;
+using CSharpAuthor;
+using static CSharpAuthor.SyntaxHelpers;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Requests;
+using Hardened.SourceGenerator.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Hardened.SourceGenerator.Function;
+
+public static class FunctionIncrementalGenerator {
+    public static void Setup(
+        IncrementalGeneratorInitializationContext initializationContext,
+        IncrementalValuesProvider<EntryPointSelector.Model> entryPointProvider) {
+        var methodSelector =
+            new SyntaxSelector<MethodDeclarationSyntax>(KnownTypes.Requests.HardenedFunctionAttribute);
+        var modelGenerator = new FunctionModelGenerator();
+
+        var modelProvider = initializationContext.SyntaxProvider.CreateSyntaxProvider(
+            methodSelector.Where,
+            modelGenerator.GenerateRequestModel
+        ).WithComparer(new RequestHandlerModelComparer());
+
+        // Invoker stage - generate invoker classes (one per handler)
+        initializationContext.RegisterSourceOutput(
+            modelProvider,
+            SourceGeneratorWrapper.Wrap<RequestHandlerModel>(GenerateInvokerSource)
+        );
+
+        // Registration stage - generate FunctionHandlerProvider + DI
+        var collection = modelProvider.Collect();
+
+        var combined = entryPointProvider.Combine(collection).WithComparer(new CombinedComparer());
+        initializationContext.RegisterSourceOutput(combined,
+            SourceGeneratorWrapper.Wrap<
+                (EntryPointSelector.Model Left, ImmutableArray<RequestHandlerModel> Right)>(
+                GenerateFunctionHandlerProvider));
+    }
+
+    private static void GenerateInvokerSource(SourceProductionContext context, RequestHandlerModel model) {
+        context.CancellationToken.ThrowIfCancellationRequested();
+
+        var csharpFile = new CSharpFileDefinition(model.InvokeHandlerType.Namespace);
+
+        InvokeClassGenerator.GenerateInvokeClass(model, csharpFile, context.CancellationToken);
+
+        var outputContext = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
+
+        csharpFile.WriteOutput(outputContext);
+
+        context.AddSource(model.Name.Path + ".FunctionHandler.cs", outputContext.Output());
+    }
+
+    private static void GenerateFunctionHandlerProvider(SourceProductionContext context,
+        (EntryPointSelector.Model Left, ImmutableArray<RequestHandlerModel> Right) models) {
+        context.CancellationToken.ThrowIfCancellationRequested();
+
+        var appModel = models.Left;
+        var requestHandlers = models.Right;
+
+        var csharpFile = new CSharpFileDefinition(appModel.EntryPointType.Namespace);
+
+        var appClass = csharpFile.AddClass(appModel.EntryPointType.Name);
+        appClass.Modifiers = ComponentModifier.Public | ComponentModifier.Partial;
+
+        CreateFunctionHandlerProviderClass(requestHandlers, appClass, context.CancellationToken);
+        SetupDiForFunctionHandlers(requestHandlers, appClass, context.CancellationToken);
+
+        var output = new OutputContext(
+            new OutputContextOptions {
+                TypeOutputMode = TypeOutputMode.Global
+            });
+
+        csharpFile.WriteOutput(output);
+
+        context.AddSource(appModel.EntryPointType.Name + ".FunctionHandlers.cs", output.Output());
+    }
+
+    private static void CreateFunctionHandlerProviderClass(
+        ImmutableArray<RequestHandlerModel> requestHandlers, ClassDefinition appClass,
+        CancellationToken cancellationToken) {
+        var providerClass = appClass.AddClass("FunctionHandlerProvider");
+        providerClass.Modifiers = ComponentModifier.Private;
+        providerClass.AddBaseType(KnownTypes.Requests.IFunctionHandlerProvider);
+
+        // Constructor with IServiceProvider
+        var field = providerClass.AddField(typeof(IServiceProvider), "_serviceProvider");
+
+        var constructor = providerClass.AddConstructor();
+        var spParam = constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+        constructor.Assign(spParam).To(field.Instance);
+
+        // GetFunctionHandler method
+        var method = providerClass.AddMethod("GetFunctionHandler");
+        method.SetReturnType(KnownTypes.Requests.IExecutionRequestHandler.MakeNullable());
+        var functionNameParam = method.AddParameter(typeof(string), "functionName");
+        var serviceProviderParam = method.AddParameter(KnownTypes.DI.IServiceProvider, "serviceProvider");
+
+        if (requestHandlers.Length > 0) {
+            // Handlers with explicit function names go in the switch.
+            // Handlers without explicit names (Name.Path == HandlerMethod) are catch-all.
+            var namedHandlers = requestHandlers.Where(h => h.Name.Path != h.HandlerMethod).ToList();
+            var defaultHandlers = requestHandlers.Where(h => h.Name.Path == h.HandlerMethod).ToList();
+
+            if (namedHandlers.Count > 0) {
+                var switchBlock = method.Switch(functionNameParam);
+
+                foreach (var handler in namedHandlers) {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var caseBlock = switchBlock.AddCase($"\"{handler.Name.Path}\"");
+                    caseBlock.Return(New(handler.InvokeHandlerType, serviceProviderParam));
+                }
+            }
+
+            // Unnamed handlers match any function name (catch-all)
+            if (defaultHandlers.Count > 0) {
+                method.Return(New(defaultHandlers[0].InvokeHandlerType, serviceProviderParam));
+                return;
+            }
+        }
+
+        method.Return(new CodeOutputComponent("null"));
+    }
+
+    private static void SetupDiForFunctionHandlers(
+        ImmutableArray<RequestHandlerModel> requestHandlers, ClassDefinition appClass,
+        CancellationToken cancellationToken) {
+        var templateField = appClass.AddField(typeof(int), "_functionHandlersDi");
+
+        templateField.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;
+        templateField.AddUsingNamespace(KnownTypes.Namespace.DependencyModules.Runtime.Helpers);
+        templateField.InitializeValue =
+            new CodeOutputComponent($"DependencyRegistry<{appClass.Name}>.Add(FunctionHandlersDI)");
+        templateField.AddAttribute(
+            TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"),
+            "nameof(FunctionHandlersDI)");
+
+        var diMethod = appClass.AddMethod("FunctionHandlersDI");
+        diMethod.Modifiers |= ComponentModifier.Static | ComponentModifier.Private;
+
+        var serviceCollection = diMethod.AddParameter(KnownTypes.DI.IServiceCollection, "serviceCollection");
+
+        diMethod.AddIndentedStatement(serviceCollection.InvokeGeneric("AddSingleton",
+            new[] {
+                KnownTypes.Requests.IFunctionHandlerProvider,
+                TypeDefinition.Get("", "FunctionHandlerProvider")
+            }));
+
+        var handlerTypes = requestHandlers.Select(m => m.ControllerType).Distinct();
+
+        foreach (var handlerType in handlerTypes) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            diMethod.AddIndentedStatement(
+                serviceCollection.InvokeGeneric("AddTransient", new[] { handlerType }));
+        }
+    }
+
+    public class CombinedComparer : IEqualityComparer<(EntryPointSelector.Model Left,
+        ImmutableArray<RequestHandlerModel> Right)> {
+        public bool Equals((EntryPointSelector.Model Left, ImmutableArray<RequestHandlerModel> Right) x,
+            (EntryPointSelector.Model Left, ImmutableArray<RequestHandlerModel> Right) y) {
+            return x.Item1.Equals(y.Item1) && ((Object)x.Item2).Equals(y.Item2);
+        }
+
+        public int GetHashCode((EntryPointSelector.Model Left, ImmutableArray<RequestHandlerModel> Right) obj) {
+            unchecked {
+                return (obj.Item1.GetHashCode() * 397) ^ obj.Item2.GetHashCodeAggregation();
+            }
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Function/FunctionModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Function/FunctionModelGenerator.cs
@@ -1,0 +1,114 @@
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Requests;
+using Hardened.SourceGenerator.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Hardened.SourceGenerator.Function;
+
+public class FunctionModelGenerator : BaseRequestModelGenerator {
+    private readonly List<string> _attributeNames = new() {
+        "HardenedFunction"
+    };
+
+    protected override RequestHandlerNameModel GetRequestNameModel(GeneratorSyntaxContext context,
+        MethodDeclarationSyntax methodDeclaration, CancellationToken cancellation) {
+        var attribute =
+            methodDeclaration.GetAttribute(
+                KnownTypes.Requests.HardenedFunctionAttribute.Name.Replace("Attribute", ""))!;
+        var argument = attribute.ArgumentList?.Arguments.FirstOrDefault();
+
+        var functionName = methodDeclaration.Identifier.Text;
+
+        if (argument != null) {
+            var constantValue = context.SemanticModel.GetConstantValue(argument.Expression);
+
+            if (constantValue.HasValue && constantValue.Value != null) {
+                functionName = constantValue.Value.ToString();
+            } else {
+                functionName = argument.Expression.ToString().Trim('"');
+            }
+        }
+
+        return new RequestHandlerNameModel(functionName, "POST");
+    }
+
+    protected override ITypeDefinition GetInvokeHandlerType(GeneratorSyntaxContext context,
+        MethodDeclarationSyntax methodDeclaration, CancellationToken cancellation) {
+        var classDeclarationSyntax =
+            methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>().First();
+
+        var namespaceSyntax = classDeclarationSyntax.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().First();
+
+        var className = classDeclarationSyntax.Identifier + "_" + methodDeclaration.Identifier.Text;
+
+        if (methodDeclaration.ParameterList.Parameters.Count > 0) {
+            var parameterString = "";
+
+            foreach (var parameter in methodDeclaration.ParameterList.Parameters) {
+                parameterString += '|' + parameter.Identifier.Text;
+            }
+
+            className += "_" + parameterString.Select(c => (int)c).Aggregate((total, c) => total + c);
+        }
+
+        return TypeDefinition.Get(namespaceSyntax.Name.ToFullString().TrimEnd() + ".Generated", className);
+    }
+
+    protected override RequestParameterInformation? GetParameterInfoFromAttributes(
+        GeneratorSyntaxContext generatorSyntaxContext, MethodDeclarationSyntax methodDeclarationSyntax,
+        RequestHandlerNameModel requestHandlerNameModel,
+        ParameterSyntax parameter, int parameterIndex) {
+        foreach (var attributeList in parameter.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                var attributeName = attribute.Name.ToString().Replace("Attribute", "");
+
+                switch (attributeName) {
+                    case "FromContext":
+                        var headerName =
+                            attribute.ArgumentList?.Arguments.FirstOrDefault()?.ToFullString() ?? "";
+
+                        return GetParameterInfoWithBinding(generatorSyntaxContext, parameter,
+                            ParameterBindType.Header, headerName, parameterIndex);
+
+                    default:
+                        return DefaultGetParameterFromAttribute(
+                            attribute, generatorSyntaxContext, parameter, parameterIndex);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected override bool IsFilterAttribute(AttributeSyntax attribute) {
+        var attributeName = attribute.Name.ToString().Replace("Attribute", "");
+
+        switch (attributeName) {
+            case "Template":
+            case "RawResponse":
+            case "HardenedFunction":
+                return false;
+
+            default:
+                return !_attributeNames.Contains(attributeName);
+        }
+    }
+
+    private static RequestParameterInformation GetParameterInfoWithBinding(
+        GeneratorSyntaxContext generatorSyntaxContext,
+        ParameterSyntax parameter,
+        ParameterBindType bindingType,
+        string bindingName,
+        int parameterIndex) {
+        var parameterType = parameter.Type?.GetTypeDefinition(generatorSyntaxContext)!;
+
+        return CreateRequestParameterInformation(parameter,
+            parameterType,
+            bindingType,
+            parameterIndex,
+            null,
+            bindingName);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
@@ -228,6 +228,10 @@ public static class KnownTypes {
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Execution,
                 "IExecutionRequestHandler");
 
+        public static readonly ITypeDefinition IFunctionHandlerProvider =
+            TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Execution,
+                "IFunctionHandlerProvider");
+
         public static readonly ITypeDefinition IExecutionRequestHandlerInfo =
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Execution,
                 "IExecutionRequestHandlerInfo");


### PR DESCRIPTION
## Summary
- Add `IFunctionHandlerProvider` interface for core projects to expose `[HardenedFunction]` handlers via DI
- Add `FunctionModelGenerator` and `FunctionIncrementalGenerator` shared source (mirrors Web pattern)
- Add `Hardened.Function.SourceGenerator` project that runs in core library projects to discover handlers, generate invokers, and register `IFunctionHandlerProvider`
- Add `IFunctionHandlerProvider` to `KnownTypes` for Lambda source generator

## Test plan
- [x] Build Hardened.Function.SourceGenerator project
- [x] Verified generated output (invokers + FunctionHandlerProvider) in consumer projects
- [x] Full solution build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)