### PR TITLE
Fix NRE in SimpleQueryStringCollection when query params are null

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime/QueryString/SimpleQueryStringCollection.cs
+++ b/src/Requests/Hardened.Requests.Runtime/QueryString/SimpleQueryStringCollection.cs
@@ -6,8 +6,8 @@ namespace Hardened.Requests.Runtime.QueryString;
 public class SimpleQueryStringCollection : IQueryStringCollection {
     private readonly IDictionary<string, string> _queryParameters;
 
-    public SimpleQueryStringCollection(IDictionary<string, string> queryParameters) {
-        _queryParameters = queryParameters;
+    public SimpleQueryStringCollection(IDictionary<string, string>? queryParameters) {
+        _queryParameters = queryParameters ?? new Dictionary<string, string>();
     }
 
     public int Count => _queryParameters.Count;


### PR DESCRIPTION
## Summary
- Null-guard `SimpleQueryStringCollection` constructor so endpoints with optional query parameters don't throw `NullReferenceException` when called without a query string
- Defaults to an empty dictionary when `null` is passed

## Test plan
- [x] `dotnet build` passes
- [ ] Verify endpoints like ListNotifications, ListFriends, ListCommunities work when called without query params

🤖 Generated with [Claude Code](https://claude.com/claude-code)