### PR TITLE
Fix empty streaming response hanging on Lambda Function URLs

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
@@ -67,6 +67,12 @@ public class AsyncEnumerableIoFilter<TItem> : IExecutionFilter {
                     context.Response.Body.WriteByte((byte)'\n');
                     await context.Response.Body.FlushAsync(context.CancellationToken);
                 }
+
+                // Write a trailing newline so the streaming response body is never
+                // empty. Lambda Function URLs don't close the body stream promptly
+                // for zero-byte responses, causing downstream readers to hang.
+                context.Response.Body.WriteByte((byte)'\n');
+                await context.Response.Body.FlushAsync(context.CancellationToken);
             }
             else if (chain.Context.Response.ShouldSerialize) {
                 await _serializeResponse(chain.Context);


### PR DESCRIPTION
## Summary
- When an `IAsyncEnumerable` handler yields zero results, the response body had zero bytes written
- Lambda Function URLs with `RESPONSE_STREAM` don't close the HTTP body stream for zero-byte responses, causing downstream readers to hang for 10+ seconds
- Added a trailing newline after the async enumerable loop so the body is never empty

## Test plan
- [x] Deployed to beta and verified browse endpoints: 10.5s → ~0.2s (warm)
- [x] Empty result sets now return immediately instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)