### PR TITLE
Rename validation error types to avoid STJ AOT name collision

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime.Tests/Validation/ValidationFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Validation/ValidationFilterTests.cs
@@ -61,7 +61,7 @@ public class ValidationFilterTests {
         await filter.Execute(chain);
 
         response.Received(1).Status = 400;
-        Assert.IsType<ValidationErrorModel>(response.ResponseValue);
+        Assert.IsType<RequestValidationError>(response.ResponseValue);
         await chain.DidNotReceive().Next();
     }
 
@@ -94,7 +94,7 @@ public class ValidationFilterTests {
         await filter.Execute(chain);
 
         response.Received(1).Status = 400;
-        var errorModel = (ValidationErrorModel)response.ResponseValue!;
+        var errorModel = (RequestValidationError)response.ResponseValue!;
         Assert.Equal(2, errorModel.Errors.Count);
         await chain.DidNotReceive().Next();
     }

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -9,10 +9,10 @@ namespace Hardened.Requests.Runtime.Errors;
 public class ExceptionToModelConverter : IExceptionToModelConverter {
     public (int, object) ConvertExceptionToModel(IExecutionContext context, Exception exp) {
         if (exp is ValidationException validationException) {
-            var errorModel = new ValidationErrorModel {
+            var errorModel = new RequestValidationError {
                 Type = "ValidationError",
                 Message = validationException.Message,
-                Errors = validationException.ValidationResult.Errors.Select(e => new ValidationFieldError {
+                Errors = validationException.ValidationResult.Errors.Select(e => new RequestValidationFieldError {
                     Field = e.Field,
                     Code = e.Code,
                     Message = e.Message

--- a/src/Requests/Hardened.Requests.Runtime/Validation/ValidationErrorModel.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Validation/ValidationErrorModel.cs
@@ -1,14 +1,14 @@
 namespace Hardened.Requests.Runtime.Validation;
 
-public class ValidationErrorModel {
+public class RequestValidationError {
     public string Type { get; set; } = "";
 
     public string Message { get; set; } = "";
 
-    public List<ValidationFieldError> Errors { get; set; } = new();
+    public List<RequestValidationFieldError> Errors { get; set; } = new();
 }
 
-public class ValidationFieldError {
+public class RequestValidationFieldError {
     public string Field { get; set; } = "";
 
     public string Code { get; set; } = "";

--- a/src/Requests/Hardened.Requests.Runtime/Validation/ValidationFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Validation/ValidationFilter.cs
@@ -76,12 +76,12 @@ public class ValidationFilter : IExecutionFilter {
             }
         }
 
-        // 4. If errors: set 400 + ValidationErrorModel, return
+        // 4. If errors: set 400 + RequestValidationError, return
         if (!result.IsValid) {
-            var errorModel = new ValidationErrorModel {
+            var errorModel = new RequestValidationError {
                 Type = "ValidationError",
                 Message = "One or more validation errors occurred.",
-                Errors = result.Errors.Select(e => new ValidationFieldError {
+                Errors = result.Errors.Select(e => new RequestValidationFieldError {
                     Field = e.Field,
                     Code = e.Code,
                     Message = e.Message


### PR DESCRIPTION
## Summary
- Renamed `ValidationErrorModel` → `RequestValidationError`
- Renamed `ValidationFieldError` → `RequestValidationFieldError`
- The STJ source generator deduplicates by short name, so consuming projects with their own `ValidationFieldError` caused the framework type to be silently dropped from the AOT serializer context

## Test plan
- [x] Existing `ValidationFilterTests` updated and passing
- [ ] Verify BackEndApi deploys without serialization errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)