### PR TITLE
Use camelCase JSON property names and add uint32 support

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime.Tests/Validation/ValidationFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Validation/ValidationFilterTests.cs
@@ -61,7 +61,7 @@ public class ValidationFilterTests {
         await filter.Execute(chain);
 
         response.Received(1).Status = 400;
-        Assert.IsType<ValidationErrorModel>(response.ResponseValue);
+        Assert.IsType<RequestValidationError>(response.ResponseValue);
         await chain.DidNotReceive().Next();
     }
 
@@ -94,7 +94,7 @@ public class ValidationFilterTests {
         await filter.Execute(chain);
 
         response.Received(1).Status = 400;
-        var errorModel = (ValidationErrorModel)response.ResponseValue!;
+        var errorModel = (RequestValidationError)response.ResponseValue!;
         Assert.Equal(2, errorModel.Errors.Count);
         await chain.DidNotReceive().Next();
     }

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -9,10 +9,10 @@ namespace Hardened.Requests.Runtime.Errors;
 public class ExceptionToModelConverter : IExceptionToModelConverter {
     public (int, object) ConvertExceptionToModel(IExecutionContext context, Exception exp) {
         if (exp is ValidationException validationException) {
-            var errorModel = new ValidationErrorModel {
+            var errorModel = new RequestValidationError {
                 Type = "ValidationError",
                 Message = validationException.Message,
-                Errors = validationException.ValidationResult.Errors.Select(e => new ValidationFieldError {
+                Errors = validationException.ValidationResult.Errors.Select(e => new RequestValidationFieldError {
                     Field = e.Field,
                     Code = e.Code,
                     Message = e.Message

--- a/src/Requests/Hardened.Requests.Runtime/Validation/ValidationErrorModel.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Validation/ValidationErrorModel.cs
@@ -1,14 +1,14 @@
 namespace Hardened.Requests.Runtime.Validation;
 
-public class ValidationErrorModel {
+public class RequestValidationError {
     public string Type { get; set; } = "";
 
     public string Message { get; set; } = "";
 
-    public List<ValidationFieldError> Errors { get; set; } = new();
+    public List<RequestValidationFieldError> Errors { get; set; } = new();
 }
 
-public class ValidationFieldError {
+public class RequestValidationFieldError {
     public string Field { get; set; } = "";
 
     public string Code { get; set; } = "";

--- a/src/Requests/Hardened.Requests.Runtime/Validation/ValidationFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Validation/ValidationFilter.cs
@@ -76,12 +76,12 @@ public class ValidationFilter : IExecutionFilter {
             }
         }
 
-        // 4. If errors: set 400 + ValidationErrorModel, return
+        // 4. If errors: set 400 + RequestValidationError, return
         if (!result.IsValid) {
-            var errorModel = new ValidationErrorModel {
+            var errorModel = new RequestValidationError {
                 Type = "ValidationError",
                 Message = "One or more validation errors occurred.",
-                Errors = result.Errors.Select(e => new ValidationFieldError {
+                Errors = result.Errors.Select(e => new RequestValidationFieldError {
                     Field = e.Field,
                     Code = e.Code,
                     Message = e.Message

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/JsonTypeInfoEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/JsonTypeInfoEmitterTests.cs
@@ -51,9 +51,9 @@ public class JsonTypeInfoEmitterTests {
 
         Assert.Contains("CreatePropertyInfo<string>(options", result);
         Assert.Contains("DeclaringType = typeof(Pet)", result);
-        Assert.Contains("PropertyName = \"Id\"", result);
-        Assert.Contains("PropertyName = \"Name\"", result);
-        Assert.Contains("PropertyName = \"Tag\"", result);
+        Assert.Contains("PropertyName = \"id\"", result);
+        Assert.Contains("PropertyName = \"name\"", result);
+        Assert.Contains("PropertyName = \"tag\"", result);
         Assert.Contains("((Pet)obj).Id", result);
         Assert.Contains("((Pet)obj).Name", result);
         Assert.Contains("((Pet)obj).Tag", result);
@@ -78,9 +78,9 @@ public class JsonTypeInfoEmitterTests {
         var result = JsonTypeInfoEmitter.Emit(schemas, "Test.Api");
 
         Assert.Contains("ConstructorParameterMetadataInitializer", result);
-        Assert.Contains("Name = \"Id\"", result);
-        Assert.Contains("Name = \"Name\"", result);
-        Assert.Contains("Name = \"Tag\"", result);
+        Assert.Contains("Name = \"id\"", result);
+        Assert.Contains("Name = \"name\"", result);
+        Assert.Contains("Name = \"tag\"", result);
         // Required params: HasDefaultValue = false
         Assert.Contains("Position = 0", result);
         Assert.Contains("Position = 1", result);
@@ -509,7 +509,7 @@ public class JsonTypeInfoEmitterTests {
     }
 
     [Fact]
-    public void Emit_PascalCasePropertyNames() {
+    public void Emit_PreservesOriginalJsonPropertyNames() {
         var schemas = new List<SchemaModel> {
             new() {
                 Name = "user-profile",
@@ -523,12 +523,14 @@ public class JsonTypeInfoEmitterTests {
 
         var result = JsonTypeInfoEmitter.Emit(schemas, "Test.Api");
 
+        // C# type and property names are PascalCase
         Assert.Contains("typeof(UserProfile)", result);
         Assert.Contains("CreateUserProfileTypeInfo", result);
-        Assert.Contains("PropertyName = \"FirstName\"", result);
-        Assert.Contains("PropertyName = \"LastName\"", result);
         Assert.Contains("((UserProfile)obj).FirstName", result);
         Assert.Contains("((UserProfile)obj).LastName", result);
+        // JSON property names preserve original OpenAPI casing
+        Assert.Contains("PropertyName = \"first_name\"", result);
+        Assert.Contains("PropertyName = \"last-name\"", result);
     }
 
     [Fact]

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/JsonTypeInfoEmitter.cs
@@ -65,6 +65,7 @@ internal static class JsonTypeInfoEmitter {
         sb.AppendLine("        if (type == typeof(string)) return JsonMetadataServices.CreateValueInfo<string>(options, JsonMetadataServices.StringConverter);");
         sb.AppendLine("        if (type == typeof(bool)) return JsonMetadataServices.CreateValueInfo<bool>(options, JsonMetadataServices.BooleanConverter);");
         sb.AppendLine("        if (type == typeof(int)) return JsonMetadataServices.CreateValueInfo<int>(options, JsonMetadataServices.Int32Converter);");
+        sb.AppendLine("        if (type == typeof(uint)) return JsonMetadataServices.CreateValueInfo<uint>(options, JsonMetadataServices.UInt32Converter);");
         sb.AppendLine("        if (type == typeof(long)) return JsonMetadataServices.CreateValueInfo<long>(options, JsonMetadataServices.Int64Converter);");
         sb.AppendLine("        if (type == typeof(float)) return JsonMetadataServices.CreateValueInfo<float>(options, JsonMetadataServices.SingleConverter);");
         sb.AppendLine("        if (type == typeof(double)) return JsonMetadataServices.CreateValueInfo<double>(options, JsonMetadataServices.DoubleConverter);");
@@ -76,6 +77,7 @@ internal static class JsonTypeInfoEmitter {
         sb.AppendLine("        // Nullable value types");
         sb.AppendLine("        if (type == typeof(bool?)) return JsonMetadataServices.CreateValueInfo<bool?>(options, JsonMetadataServices.GetNullableConverter<bool>(options));");
         sb.AppendLine("        if (type == typeof(int?)) return JsonMetadataServices.CreateValueInfo<int?>(options, JsonMetadataServices.GetNullableConverter<int>(options));");
+        sb.AppendLine("        if (type == typeof(uint?)) return JsonMetadataServices.CreateValueInfo<uint?>(options, JsonMetadataServices.GetNullableConverter<uint>(options));");
         sb.AppendLine("        if (type == typeof(long?)) return JsonMetadataServices.CreateValueInfo<long?>(options, JsonMetadataServices.GetNullableConverter<long>(options));");
         sb.AppendLine("        if (type == typeof(float?)) return JsonMetadataServices.CreateValueInfo<float?>(options, JsonMetadataServices.GetNullableConverter<float>(options));");
         sb.AppendLine("        if (type == typeof(double?)) return JsonMetadataServices.CreateValueInfo<double?>(options, JsonMetadataServices.GetNullableConverter<double>(options));");
@@ -145,7 +147,7 @@ internal static class JsonTypeInfoEmitter {
         sb.AppendLine("                    IsProperty = true,");
         sb.AppendLine("                    IsPublic = true,");
         sb.AppendLine($"                    DeclaringType = typeof({declaringTypeName}),");
-        sb.AppendLine($"                    PropertyName = \"{propName}\",");
+        sb.AppendLine($"                    PropertyName = \"{prop.Name}\",");
         sb.AppendLine($"                    Getter = static obj => (({declaringTypeName})obj).{propName},");
         sb.AppendLine("                    Setter = null,");
         sb.AppendLine("                }),");
@@ -162,7 +164,7 @@ internal static class JsonTypeInfoEmitter {
 
         sb.AppendLine("                new()");
         sb.AppendLine("                {");
-        sb.AppendLine($"                    Name = \"{propName}\",");
+        sb.AppendLine($"                    Name = \"{prop.Name}\",");
         sb.AppendLine($"                    ParameterType = typeof({paramType}),");
         sb.AppendLine($"                    Position = {position},");
         sb.AppendLine($"                    HasDefaultValue = {(prop.IsRequired ? "false" : "true")},");
@@ -251,6 +253,7 @@ internal static class JsonTypeInfoEmitter {
     private static bool IsValueType(string csType, PropertyModel prop, List<SchemaModel> allSchemas) {
         switch (csType) {
             case "int":
+            case "uint":
             case "long":
             case "float":
             case "double":

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/TypeMapper.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/TypeMapper.cs
@@ -17,6 +17,7 @@ internal static class TypeMapper {
             ("string", "binary") => "byte[]",
             ("string", _) => "string",
             ("integer", "int64") => "long",
+            ("integer", "uint32") => "uint",
             ("integer", _) => "int",
             ("number", "float") => "float",
             ("number", "double") => "double",
@@ -103,6 +104,7 @@ internal static class TypeMapper {
         return csType switch {
             "string" => TypeDefinition.Get(typeof(string)),
             "int" => TypeDefinition.Get(typeof(int)),
+            "uint" => TypeDefinition.Get(typeof(uint)),
             "long" => TypeDefinition.Get(typeof(long)),
             "float" => TypeDefinition.Get(typeof(float)),
             "double" => TypeDefinition.Get(typeof(double)),


### PR DESCRIPTION
## Summary
- OpenAPI source generator now emits `PropertyName` and parameter `Name` using original OpenAPI casing (camelCase) instead of PascalCase
- Adds `uint32` format mapping to C# `uint` (was falling through to `int`, causing overflow for IDs > 2B)
- Adds `uint`/`uint?` primitive type entries in the generated resolver

## Test plan
- [x] All 31 JsonTypeInfoEmitter tests pass
- [x] Backend deployed to beta and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)