### PR TITLE
Embed analyzer deps as resources, make generated types partial

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/RecordEmitter.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/RecordEmitter.cs
@@ -31,14 +31,14 @@ internal static class RecordEmitter {
             if (excludeFromCoverage) {
                 sb.AppendLine("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
             }
-            sb.AppendLine($"public record {recordName};");
+            sb.AppendLine($"public partial record {recordName};");
             return sb.ToString();
         }
 
         if (excludeFromCoverage) {
             sb.AppendLine("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]");
         }
-        sb.Append($"public record {recordName}(");
+        sb.Append($"public partial record {recordName}(");
         sb.AppendLine();
 
         // Required parameters must precede optional ones in C# record constructors.

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/ServiceInterfaceEmitter.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/ServiceInterfaceEmitter.cs
@@ -15,7 +15,7 @@ internal static class ServiceInterfaceEmitter {
 
         var interfaceName = NamingHelper.ToInterfaceName(service.Tag);
 
-        sb.AppendLine($"public interface {interfaceName}");
+        sb.AppendLine($"public partial interface {interfaceName}");
         sb.AppendLine("{");
 
         foreach (var op in service.Operations) {

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
@@ -43,12 +43,9 @@
         </Content>
     </ItemGroup>
 
-    <!-- Pack the analyzer DLL and its dependencies into the correct NuGet folder -->
+    <!-- Pack the analyzer DLL (now self-contained with embedded dependencies) into the NuGet folder -->
     <ItemGroup>
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
-        <None Include="$(PkgMicrosoft_OpenApi_Readers)\lib\netstandard2.0\Microsoft.OpenApi.Readers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
-        <None Include="$(PkgMicrosoft_OpenApi)\lib\netstandard2.0\Microsoft.OpenApi.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
-        <None Include="$(PkgSharpYaml)\lib\netstandard2.0\SharpYaml.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
     </ItemGroup>
 
     <!-- Bundle OpenAPI dependencies with the analyzer so they're available at compile time -->
@@ -59,6 +56,13 @@
             <TargetPathWithTargetPlatformMoniker Include="$(PkgSharpYaml)\lib\netstandard2.0\SharpYaml.dll" IncludeRuntimeDependency="false" />
         </ItemGroup>
     </Target>
+
+    <!-- Embed dependency DLLs as resources so the AssemblyResolve hook can load them in any host -->
+    <ItemGroup>
+        <EmbeddedResource Include="$(PkgMicrosoft_OpenApi_Readers)\lib\netstandard2.0\Microsoft.OpenApi.Readers.dll" LogicalName="Microsoft.OpenApi.Readers.dll" Visible="false" />
+        <EmbeddedResource Include="$(PkgMicrosoft_OpenApi)\lib\netstandard2.0\Microsoft.OpenApi.dll" LogicalName="Microsoft.OpenApi.dll" Visible="false" />
+        <EmbeddedResource Include="$(PkgSharpYaml)\lib\netstandard2.0\SharpYaml.dll" LogicalName="SharpYaml.dll" Visible="false" />
+    </ItemGroup>
 
     <PropertyGroup>
         <PackageCSharpAuthorIncludeSource>true</PackageCSharpAuthorIncludeSource>

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiSourceGenerator.cs
@@ -13,18 +13,26 @@ namespace Hardened.OpenApi.SourceGenerator;
 
 [Generator]
 public class OpenApiSourceGenerator : IIncrementalGenerator {
+    private static readonly Dictionary<string, Assembly> _embeddedAssemblies = new();
+
     static OpenApiSourceGenerator() {
-        // Rider's Roslyn host doesn't probe the analyzer directory for co-located
-        // dependencies (Microsoft.OpenApi, SharpYaml). Register a resolver that
-        // loads them from the same directory as this generator DLL.
+        // Some Roslyn hosts (Rider, older VS) don't resolve co-located analyzer
+        // dependencies. Pre-load all embedded dependencies so they share a single
+        // loading context and avoid type-identity mismatches.
+        var generatorAssembly = typeof(OpenApiSourceGenerator).Assembly;
+        foreach (var dllName in new[] { "Microsoft.OpenApi", "Microsoft.OpenApi.Readers", "SharpYaml" }) {
+            using var stream = generatorAssembly.GetManifestResourceStream(dllName + ".dll");
+            if (stream == null) continue;
+            var bytes = new byte[stream.Length];
+            stream.Read(bytes, 0, bytes.Length);
+#pragma warning disable RS1035 // Load embedded dependency DLLs for hosts that can't resolve co-located assemblies
+            _embeddedAssemblies[dllName] = Assembly.Load(bytes);
+#pragma warning restore RS1035
+        }
+
         AppDomain.CurrentDomain.AssemblyResolve += (_, args) => {
             var name = new AssemblyName(args.Name).Name;
-            var directory = Path.GetDirectoryName(typeof(OpenApiSourceGenerator).Assembly.Location);
-            if (directory == null) return null;
-#pragma warning disable RS1035 // Resolver must probe the file system to load co-located analyzer dependencies
-            var candidate = Path.Combine(directory, name + ".dll");
-            return File.Exists(candidate) ? Assembly.LoadFrom(candidate) : null;
-#pragma warning restore RS1035
+            return _embeddedAssemblies.TryGetValue(name!, out var asm) ? asm : null;
         };
     }
 


### PR DESCRIPTION
## Summary
- Embed Microsoft.OpenApi, Microsoft.OpenApi.Readers, and SharpYaml as resources inside the generator DLL — eliminates co-located DLL resolution issues across all Roslyn hosts and reference styles
- Pre-load all three in the static constructor so they share a single loading context (avoids type-identity mismatches)
- Remove separate DLL packing into `analyzers/dotnet/cs` since the generator is now self-contained
- Mark generated records as `public partial record` and interfaces as `public partial interface`

## Test plan
- [x] SUT builds from CLI
- [x] BackEndApi builds from CLI
- [ ] Verify in Rider: generated types visible, no red squiggles
- [ ] Verify partial types can be extended in consuming projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)