### PR TITLE
Update tests for partial type declarations

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/RecordEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/RecordEmitterTests.cs
@@ -21,7 +21,7 @@ public class RecordEmitterTests {
         var result = RecordEmitter.Emit(schema, "Test.Api");
 
         Assert.Contains("namespace Test.Api.Models;", result);
-        Assert.Contains("public record Pet(", result);
+        Assert.Contains("public partial record Pet(", result);
         Assert.Contains("string Id,", result);
         Assert.Contains("string Name,", result);
         Assert.Contains("string? Tag = default)", result);
@@ -37,7 +37,7 @@ public class RecordEmitterTests {
 
         var result = RecordEmitter.Emit(schema, "Test.Api");
 
-        Assert.Contains("public record EmptyModel;", result);
+        Assert.Contains("public partial record EmptyModel;", result);
     }
 
     [Fact]

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ServiceInterfaceEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ServiceInterfaceEmitterTests.cs
@@ -42,7 +42,7 @@ public class ServiceInterfaceEmitterTests {
         var result = ServiceInterfaceEmitter.Emit(service, "Test.Api");
 
         Assert.Contains("namespace Test.Api.Services;", result);
-        Assert.Contains("public interface IPetService", result);
+        Assert.Contains("public partial interface IPetService", result);
         Assert.Contains("Task<PetList> ListPets(int? limit);", result);
         Assert.Contains("Task<Pet> CreatePet(CreatePetRequest body);", result);
     }


### PR DESCRIPTION
## Summary
- Fix 3 failing tests that expected `public record` / `public interface` instead of `public partial record` / `public partial interface`

## Test plan
- [x] All 116 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)