### PR TITLE
Support x-codegen-exclude extension on OpenAPI parameters

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/OpenApiSpecParser.cs
@@ -295,6 +295,13 @@ internal static class OpenApiSpecParser {
 
             if (operation.Parameters != null) {
                 foreach (var param in operation.Parameters) {
+                    // Skip parameters marked with x-codegen-exclude
+                    if (param.Extensions != null &&
+                        param.Extensions.TryGetValue("x-codegen-exclude", out var excludeExt) &&
+                        excludeExt is OpenApiBoolean excludeBool && excludeBool.Value) {
+                        continue;
+                    }
+
                     var paramModel = new ParameterModel {
                         Name = param.Name,
                         In = param.In?.ToString()?.ToLowerInvariant() ?? "query",


### PR DESCRIPTION
## Summary
- Skip parameters with `x-codegen-exclude: true` at parse time
- Prevents infrastructure headers from being passed as service method arguments

## Test plan
- [x] Generator builds
- [x] BackEndApi builds with `contentSha256` excluded from generated handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)