### PR TITLE
Fix AOT enum serialization and auto-register resolver in DI

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Emitters/JsonTypeInfoEmitter.cs
@@ -178,8 +178,7 @@ internal static class JsonTypeInfoEmitter {
         sb.AppendLine();
         sb.AppendLine($"    private static JsonTypeInfo<{typeName}> Create{typeName}TypeInfo(JsonSerializerOptions options)");
         sb.AppendLine("    {");
-        sb.AppendLine($"        var converter = new JsonStringEnumConverter<{typeName}>();");
-        sb.AppendLine($"        return JsonMetadataServices.CreateValueInfo<{typeName}>(options, converter);");
+        sb.AppendLine($"        return JsonMetadataServices.CreateValueInfo<{typeName}>(options, JsonMetadataServices.GetEnumConverter<{typeName}>(options));");
         sb.AppendLine("    }");
     }
 


### PR DESCRIPTION
## Summary
- Replace `new JsonStringEnumConverter<T>()` with AOT-safe `JsonMetadataServices.GetEnumConverter<T>(options)`
- Auto-register `OpenApiJsonTypeInfoResolver` as `IJsonTypeInfoResolver` in generated DI

## Test plan
- [x] BackEndApi builds and deploys
- [x] Recipe GET no longer throws `NotSupportedException` for enum types

🤖 Generated with [Claude Code](https://claude.com/claude-code)