### PR TITLE
TestWebApp.SetupBodyStream: use configured IJsonSerializer

### DIFF
--- a/src/Web/Hardened.Web.Testing/TestWebApp.cs
+++ b/src/Web/Hardened.Web.Testing/TestWebApp.cs
@@ -10,6 +10,7 @@ using Hardened.Requests.Runtime.QueryString;
 using Hardened.Requests.Testing;
 using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Runtime.Diagnostics;
+using Hardened.Shared.Runtime.Json;
 using Hardened.Shared.Testing.Impl;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -103,10 +104,15 @@ public class TestWebApp : TestContext, ITestWebApp {
         if (bodyValue == null)
             return Stream.Null;
 
+        // Resolve IJsonSerializer first so its constructor populates the
+        // shared JsonSerializerConfiguration.Options TypeInfoResolverChain
+        // with the source-gen contexts the application has registered. The
+        // options instance held by IJsonSerializerConfiguration is the same
+        // one mutated by AotJsonSerializer/JsonSerializerImpl on construction.
+        var serializer = _applicationRoot.Provider.GetRequiredService<IJsonSerializer>();
         var memoryStream = new MemoryStream();
-
-        JsonSerializer.Serialize(memoryStream, bodyValue);
-
+        serializer.SerializeAsync(memoryStream, bodyValue, false, CancellationToken.None)
+            .GetAwaiter().GetResult();
         memoryStream.Position = 0;
 
         return memoryStream;


### PR DESCRIPTION
## Summary
\`TestWebApp.SetupBodyStream\` was building request bodies via \`JsonSerializer.Serialize(memoryStream, bodyValue)\` with no options — falling through to STJ's default reflection-based resolver. The application under test registers source-generated \`JsonSerializerContext\` instances via DI, but they were never used to write the request bodies that round-trip through the system.

This change resolves \`IJsonSerializer\` from the application's service provider and serializes through it. The bytes written are now the same shape the application's configured serializer would produce, and constructing \`IJsonSerializer\` populates the shared \`JsonSerializerConfiguration.Options\` chain with the registered \`IJsonTypeInfoResolver\` instances — so any consumer that wants to lock down their tests with \`IsReflectionEnabledByDefault=false\` now can.

Side effect: test bodies that use anonymous types (e.g. \`new { }\` to send "any body") will fail because anon types can't be source-gen registered. That's the intended behavior — those tests were leaning on reflection. Replacing them with a real registered type (e.g. an existing request DTO) is a one-line fix per call site.

## Test plan
- [x] Hardened.Web.Testing builds clean
- [x] Verified downstream (FriendsWithRecipes.Search) tests pass after replacing one \`new { }\` with a real \`ShardSearchRequest\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)