### PR TITLE
Add built-in CORS support to HardenedWebModule

### DIFF
--- a/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
@@ -21,5 +21,9 @@ public static class KnownHeaders {
         public const string AccessControlAllowOrigin = "Access-Control-Allow-Origin";
 
         public const string AccessControlAllowHeaders = "Access-Control-Allow-Headers";
+
+        public const string AccessControlAllowMethods = "Access-Control-Allow-Methods";
+
+        public const string AccessControlMaxAge = "Access-Control-Max-Age";
     }
 }

--- a/src/Web/Hardened.Web.Runtime/Cors/CorsConfiguration.cs
+++ b/src/Web/Hardened.Web.Runtime/Cors/CorsConfiguration.cs
@@ -1,0 +1,38 @@
+namespace Hardened.Web.Runtime.Cors;
+
+public class CorsConfiguration {
+    public const string DefaultEnvironmentVariable = "CORS_ALLOWED_ORIGINS";
+
+    private readonly HashSet<string> _allowedOrigins = new(StringComparer.OrdinalIgnoreCase);
+
+    public string EnvironmentVariable { get; set; } = DefaultEnvironmentVariable;
+
+    public IReadOnlySet<string> AllowedOrigins => _allowedOrigins;
+
+    public string AllowedMethods { get; set; } = "GET, POST, PUT, DELETE, OPTIONS";
+
+    public string AllowedHeaders { get; set; } = "Authorization, Content-Type, Accept";
+
+    public int MaxAgeSec { get; set; } = 86400;
+
+    public void AllowOrigin(string origin) {
+        _allowedOrigins.Add(origin.TrimEnd('/'));
+    }
+
+    /// <summary>
+    /// Reads comma-separated origins from the configured environment variable
+    /// and adds them to the allowed set.
+    /// </summary>
+    public void LoadFromEnvironment() {
+        var value = Environment.GetEnvironmentVariable(EnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(value)) return;
+
+        foreach (var origin in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) {
+            AllowOrigin(origin);
+        }
+    }
+
+    public bool IsOriginAllowed(string origin) {
+        return _allowedOrigins.Contains(origin.TrimEnd('/'));
+    }
+}

--- a/src/Web/Hardened.Web.Runtime/Cors/CorsFilter.cs
+++ b/src/Web/Hardened.Web.Runtime/Cors/CorsFilter.cs
@@ -1,0 +1,38 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Web.Runtime.Cors;
+
+public class CorsFilter : IExecutionFilter {
+    private readonly CorsConfiguration _config;
+
+    public CorsFilter(CorsConfiguration config) {
+        _config = config;
+    }
+
+    public Task Execute(IExecutionChain chain) {
+        var context = chain.Context;
+        var request = context.Request;
+
+        if (request.Headers.TryGetValue("Origin", out var originValues)) {
+            var origin = originValues.ToString();
+
+            if (!string.IsNullOrEmpty(origin) && _config.IsOriginAllowed(origin)) {
+                var headers = context.Response.Headers;
+                headers[KnownHeaders.Cors.AccessControlAllowOrigin] = origin;
+                headers[KnownHeaders.Cors.AccessControlAllowHeaders] = _config.AllowedHeaders;
+                headers[KnownHeaders.Cors.AccessControlAllowMethods] = _config.AllowedMethods;
+                headers[KnownHeaders.Cors.AccessControlMaxAge] = _config.MaxAgeSec.ToString();
+            }
+        }
+
+        if (string.Equals(request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase)) {
+            context.Response.Status = 204;
+            context.Response.ShouldSerialize = false;
+            return Task.CompletedTask;
+        }
+
+        return chain.Next();
+    }
+}

--- a/src/Web/Hardened.Web.Runtime/Cors/CorsStartupService.cs
+++ b/src/Web/Hardened.Web.Runtime/Cors/CorsStartupService.cs
@@ -1,0 +1,20 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hardened.Web.Runtime.Cors;
+
+internal class CorsStartupService : IStartupService {
+    public Task<bool> Startup(IServiceProvider rootProvider) {
+        var config = rootProvider.GetRequiredService<CorsConfiguration>();
+        var filter = rootProvider.GetRequiredService<CorsFilter>();
+        var registry = rootProvider.GetRequiredService<IGlobalFilterRegistry>();
+
+        if (config.AllowedOrigins.Count > 0) {
+            registry.RegisterFilter(filter, (int)ExecutionFilterOrder.Init + 1);
+        }
+
+        return Task.FromResult(true);
+    }
+}

--- a/src/Web/Hardened.Web.Runtime/DependencyInjection/HardenedWebModule.cs
+++ b/src/Web/Hardened.Web.Runtime/DependencyInjection/HardenedWebModule.cs
@@ -1,8 +1,10 @@
 using DependencyModules.Runtime.Attributes;
 using DependencyModules.Runtime.Interfaces;
 using Hardened.Requests.Runtime.DependencyInjection;
+using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Runtime.Configuration;
 using Hardened.Web.Runtime.Configuration;
+using Hardened.Web.Runtime.Cors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -22,5 +24,13 @@ public partial class HardenedWebModule : IServiceCollectionConfiguration {
             serviceProvider => Microsoft.Extensions.Options.Options.Create(
                 serviceProvider.GetRequiredService<IConfigurationManager>()
                     .GetConfiguration<IStaticContentConfiguration>()));
+
+        services.AddSingleton<CorsConfiguration>(sp => {
+            var config = new CorsConfiguration();
+            config.LoadFromEnvironment();
+            return config;
+        });
+        services.AddSingleton<CorsFilter>();
+        services.AddSingleton<IStartupService, CorsStartupService>();
     }
 }


### PR DESCRIPTION
## Summary
- Add CORS support built into `HardenedWebModule` — no extra module attribute needed
- Reads comma-separated origins from `CORS_ALLOWED_ORIGINS` env var at startup
- Global filter sets `Access-Control-Allow-Origin/Methods/Headers/Max-Age` for matching requests
- `OPTIONS` preflight requests short-circuited with 204
- Zero overhead when env var is not set — filter is never registered

## Usage
Set the env var per stage (CDK, CloudFormation, etc.):
```
CORS_ALLOWED_ORIGINS=https://gamma.friendswithrecipes.com,http://localhost:3000
```

Devs can also add origins programmatically:
```csharp
config.Amend((CorsConfiguration cors) => cors.AllowOrigin("http://localhost:8080"));
```

## Files
- `Cors/CorsConfiguration.cs` — allowed origins, env var name, methods/headers config
- `Cors/CorsFilter.cs` — IExecutionFilter for CORS headers + OPTIONS handling
- `Cors/CorsStartupService.cs` — registers filter at startup if origins are configured
- `KnownHeaders.cs` — added `AccessControlAllowMethods` and `AccessControlMaxAge`

## Test plan
- [ ] Verify build passes
- [ ] Set `CORS_ALLOWED_ORIGINS` on BackEndApi beta Lambda, verify CORS headers in response
- [ ] Verify no CORS headers when env var is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)