### PR TITLE
Fix CORS: use middleware instead of global filter

### DIFF
--- a/src/Web/Hardened.Web.Runtime/Cors/CorsStartupService.cs
+++ b/src/Web/Hardened.Web.Runtime/Cors/CorsStartupService.cs
@@ -1,5 +1,4 @@
-using Hardened.Requests.Abstract.Execution;
-using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Abstract.Middleware;
 using Hardened.Shared.Runtime.Application;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,11 +7,11 @@ namespace Hardened.Web.Runtime.Cors;
 internal class CorsStartupService : IStartupService {
     public Task<bool> Startup(IServiceProvider rootProvider) {
         var config = rootProvider.GetRequiredService<CorsConfiguration>();
-        var filter = rootProvider.GetRequiredService<CorsFilter>();
-        var registry = rootProvider.GetRequiredService<IGlobalFilterRegistry>();
 
         if (config.AllowedOrigins.Count > 0) {
-            registry.RegisterFilter(filter, (int)ExecutionFilterOrder.Init + 1);
+            var middleware = rootProvider.GetRequiredService<IMiddlewareService>();
+            var filter = rootProvider.GetRequiredService<CorsFilter>();
+            middleware.Use(_ => filter);
         }
 
         return Task.FromResult(true);


### PR DESCRIPTION
## Summary
- Register CorsFilter as middleware instead of a global filter
- Global filters only run for matched routes — OPTIONS preflight gets 404 without headers
- Middleware runs at the event processor level before route matching, handling all requests

## Test plan
- [ ] OPTIONS preflight returns 204 with CORS headers
- [ ] Non-OPTIONS requests get CORS headers on response

🤖 Generated with [Claude Code](https://claude.com/claude-code)