### PR TITLE
Run startup services in test framework

### DIFF
--- a/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
+++ b/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
@@ -22,15 +22,18 @@ public class WebTestingAttribute : Attribute, ITestStartupAttribute {
         });
     }
 
-    public Task StartupAsync(IXunitTestMethod testMethod, IServiceProvider serviceProvider) {
+    public async Task StartupAsync(IXunitTestMethod testMethod, IServiceProvider serviceProvider) {
         var entryPoint = testMethod.Method.GetTestAttribute<HardenedTestEntryPointAttribute>();
+
+        // Run registered startup services (CORS, filters, etc.)
+        foreach (var startupService in serviceProvider.GetServices<IStartupService>()) {
+            await startupService.Startup(serviceProvider);
+        }
 
         if (entryPoint != null && !typeof(IApplicationRoot).IsAssignableFrom(entryPoint.EntryPoint)) {
             var handler = serviceProvider.GetRequiredService<IWebExecutionHandlerService>();
             var middleware = serviceProvider.GetRequiredService<IMiddlewareService>();
             middleware.Use(_ => handler);
         }
-
-        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
IStartupService instances were not executed in WebTestingAttribute, so CORS middleware and other startup-registered services didn't work in tests.