### PR TITLE
Add transport conformance suite and fix the ASP.NET Core adapter

### DIFF
--- a/src/Hardened.Framework.sln
+++ b/src/Hardened.Framework.sln
@@ -93,6 +93,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.DependencyModules.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Function.SourceGenerator", "SourceGenerators\Hardened.Function.SourceGenerator\Hardened.Function.SourceGenerator.csproj", "{06999170-205C-49C4-8F0D-81481F558819}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Web.AspNetCore.Runtime.Tests", "Web\Hardened.Web.AspNetCore.Runtime.Tests\Hardened.Web.AspNetCore.Runtime.Tests.csproj", "{7D8DED0A-72BA-483B-9B78-8182113238B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -235,6 +237,10 @@ Global
 		{06999170-205C-49C4-8F0D-81481F558819}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06999170-205C-49C4-8F0D-81481F558819}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06999170-205C-49C4-8F0D-81481F558819}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D8DED0A-72BA-483B-9B78-8182113238B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D8DED0A-72BA-483B-9B78-8182113238B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D8DED0A-72BA-483B-9B78-8182113238B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D8DED0A-72BA-483B-9B78-8182113238B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -278,6 +284,7 @@ Global
 		{B2941D10-F532-485E-AC98-D5D8A989B7CA} = {3692338C-6161-4EC7-826E-53FB6DD8114C}
 		{76585983-2ECC-4BDA-85C6-19A35993796D} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
 		{06999170-205C-49C4-8F0D-81481F558819} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
+		{7D8DED0A-72BA-483B-9B78-8182113238B9} = {7DC696BF-0B4E-4B03-B309-ABDC7A502538}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF6CD1AB-6B41-427D-BA1B-C4803CF67E97}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Conformance/InMemoryExecutionRequestConformanceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Conformance/InMemoryExecutionRequestConformanceTests.cs
@@ -1,0 +1,42 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.QueryString;
+using Hardened.Requests.Testing;
+using Hardened.Requests.Testing.Conformance;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Runtime.Tests.Conformance;
+
+/// <summary>
+/// Runs the shared transport conformance suite against the in-memory transport used by the
+/// test harness. This transport has no wire format of its own - values are supplied
+/// directly - so it acts as the reference implementation the real transports are held to.
+/// </summary>
+public class InMemoryExecutionRequestConformanceTests : ExecutionRequestConformanceTests {
+
+    protected override IExecutionRequestConformanceAdapter Adapter { get; } = new InMemoryAdapter();
+
+    private class InMemoryAdapter : IExecutionRequestConformanceAdapter {
+        public string TransportName => "In-memory";
+
+        public IExecutionRequest CreateRequest(ConformanceRequestSpec spec) {
+            var headers = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var header in spec.Headers) {
+                headers[header.Key] = new StringValues(header.Value);
+            }
+
+            // Accept is a constructor parameter on this transport rather than being parsed
+            // out of a header block, so translating the spec means passing it through.
+            spec.Headers.TryGetValue("Accept", out var accept);
+
+            var queryString = new SimpleQueryStringCollection(
+                spec.QueryString.ToDictionary(q => q.Key, q => q.Value));
+
+            return new TestExecutionRequest(spec.Method, spec.Path, accept, queryString) {
+                Headers = headers,
+                Cookies = spec.Cookies.ToList(),
+                Body = spec.Body is null ? Stream.Null : new MemoryStream(spec.Body)
+            };
+        }
+    }
+}

--- a/src/Requests/Hardened.Requests.Testing/Conformance/ConformanceRequestSpec.cs
+++ b/src/Requests/Hardened.Requests.Testing/Conformance/ConformanceRequestSpec.cs
@@ -1,0 +1,32 @@
+namespace Hardened.Requests.Testing.Conformance;
+
+/// <summary>
+/// A request described in transport-neutral terms.
+///
+/// Each transport adapter translates one of these into its own native representation
+/// (an <c>HttpContext</c>, an <c>APIGatewayHttpApiV2ProxyRequest</c>, an SQS message, and
+/// so on) and then into an <see cref="Hardened.Requests.Abstract.Execution.IExecutionRequest"/>.
+/// The conformance suite then asserts that what comes out the far side is the same
+/// regardless of which transport carried it.
+/// </summary>
+public class ConformanceRequestSpec {
+    public string Method { get; set; } = "GET";
+
+    public string Path { get; set; } = "/";
+
+    /// <summary>
+    /// Header names are matched case-insensitively, as they are over the wire.
+    /// </summary>
+    public IDictionary<string, string> Headers { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    public IDictionary<string, string> QueryString { get; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Raw cookie strings in <c>name=value</c> form, matching the shape API Gateway v2
+    /// delivers them in.
+    /// </summary>
+    public IList<string> Cookies { get; } = new List<string>();
+
+    public byte[]? Body { get; set; }
+}

--- a/src/Requests/Hardened.Requests.Testing/Conformance/ExecutionRequestConformanceTests.cs
+++ b/src/Requests/Hardened.Requests.Testing/Conformance/ExecutionRequestConformanceTests.cs
@@ -1,0 +1,232 @@
+using Hardened.Requests.Abstract.Execution;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Hardened.Requests.Testing.Conformance;
+
+/// <summary>
+/// The behaviour every <see cref="IExecutionRequest"/> implementation must exhibit,
+/// expressed once and executed against every transport.
+///
+/// Hardened's central claim is that it is transport agnostic: a handler should not be able
+/// to tell whether its request arrived over ASP.NET Core, API Gateway, Lambda streaming or
+/// an in-memory test harness. That claim is only true if every adapter maps its native
+/// request onto this contract the same way. This suite is what makes that checkable rather
+/// than assumed.
+///
+/// To enrol a transport, derive from this class and supply an adapter:
+///
+/// <code>
+/// public class MyTransportConformanceTests : ExecutionRequestConformanceTests {
+///     protected override IExecutionRequestConformanceAdapter Adapter { get; } = new MyAdapter();
+/// }
+/// </code>
+///
+/// Deliberately not asserted yet: that <c>Clone</c> replaces query string and cookies when
+/// those arguments are supplied. Implementations currently diverge on it, and tightening
+/// that is a separate change from establishing the contract.
+/// </summary>
+public abstract class ExecutionRequestConformanceTests {
+
+    protected abstract IExecutionRequestConformanceAdapter Adapter { get; }
+
+    private IExecutionRequest Create(Action<ConformanceRequestSpec>? configure = null) {
+        var spec = new ConformanceRequestSpec();
+        configure?.Invoke(spec);
+        return Adapter.CreateRequest(spec);
+    }
+
+    private string Because(string what) => $"[{Adapter.TransportName}] {what}";
+
+    // ---------------------------------------------------------------- request surface
+
+    [Fact]
+    public void MethodIsSurfaced() {
+        var request = Create(s => s.Method = "POST");
+
+        Assert.True("POST".Equals(request.Method, StringComparison.OrdinalIgnoreCase),
+            Because($"expected Method 'POST' but got '{request.Method}'"));
+    }
+
+    [Fact]
+    public void PathIsSurfaced() {
+        var request = Create(s => s.Path = "/orders/42");
+
+        Assert.Equal("/orders/42", request.Path);
+    }
+
+    [Fact]
+    public void HeadersAreSurfaced() {
+        var request = Create(s => s.Headers["X-Correlation-Id"] = "abc-123");
+
+        Assert.True(request.Headers.TryGetValue("X-Correlation-Id", out var value),
+            Because("expected header 'X-Correlation-Id' to be present"));
+        Assert.Equal("abc-123", value.ToString());
+    }
+
+    [Fact]
+    public void ContentTypeComesFromTheContentTypeHeader() {
+        var request = Create(s => s.Headers["Content-Type"] = "application/json");
+
+        Assert.Equal("application/json", request.ContentType);
+    }
+
+    /// <summary>
+    /// Accept is read by every response serializer to decide whether it can handle the
+    /// response (<c>context.Request.Accept?.Contains("application/json")</c>). A transport
+    /// that fails to surface it silently disables content negotiation.
+    /// </summary>
+    [Fact]
+    public void AcceptComesFromTheAcceptHeader() {
+        var request = Create(s => s.Headers["Accept"] = "application/json");
+
+        Assert.NotNull(request.Accept);
+        Assert.Contains("application/json", request.Accept!);
+    }
+
+    [Fact]
+    public void AcceptReflectsANonJsonValue() {
+        var request = Create(s => s.Headers["Accept"] = "text/html");
+
+        Assert.NotNull(request.Accept);
+        Assert.Contains("text/html", request.Accept!);
+        Assert.DoesNotContain("application/json", request.Accept!);
+    }
+
+    [Fact]
+    public void QueryStringIsSurfaced() {
+        var request = Create(s => {
+            s.QueryString["page"] = "2";
+            s.QueryString["size"] = "50";
+        });
+
+        Assert.Equal("2", request.QueryString.Get("page").ToString());
+        Assert.Equal("50", request.QueryString.Get("size").ToString());
+    }
+
+    [Fact]
+    public void CookiesAreSurfaced() {
+        var request = Create(s => {
+            s.Cookies.Add("session=abc123");
+            s.Cookies.Add("theme=dark");
+        });
+
+        Assert.Contains(request.Cookies, c => c.Contains("session=abc123"));
+        Assert.Contains(request.Cookies, c => c.Contains("theme=dark"));
+    }
+
+    [Fact]
+    public void CookiesAreEmptyRatherThanNullWhenNoneWereSent() {
+        var request = Create();
+
+        Assert.NotNull(request.Cookies);
+        Assert.Empty(request.Cookies);
+    }
+
+    [Fact]
+    public void BodyIsReadable() {
+        var payload = "{\"name\":\"conformance\"}"u8.ToArray();
+        var request = Create(s => s.Body = payload);
+
+        request.Body.Position = 0;
+        using var reader = new StreamReader(request.Body);
+
+        Assert.Equal("{\"name\":\"conformance\"}", reader.ReadToEnd());
+    }
+
+    /// <summary>
+    /// Handlers index into PathTokens without null-checking, so an unrouted request must
+    /// yield an empty collection rather than null.
+    /// </summary>
+    [Fact]
+    public void PathTokensAreEmptyRatherThanNullBeforeRouting() {
+        var request = Create();
+
+        Assert.NotNull(request.PathTokens);
+    }
+
+    // ------------------------------------------------------------------ clone contract
+    //
+    // Settled semantics, already asserted for LambdaExecutionRequest in Hardened.Amz:
+    // a null argument keeps the current value, a non-null argument replaces it.
+
+    [Fact]
+    public void ClonePreservesMethodWhenMethodIsNull() {
+        var request = Create(s => s.Method = "PATCH");
+
+        var clone = request.Clone(method: null, path: "/somewhere-else");
+
+        Assert.True("PATCH".Equals(clone.Method, StringComparison.OrdinalIgnoreCase),
+            Because($"Clone(method: null) must keep 'PATCH' but got '{clone.Method}'"));
+    }
+
+    [Fact]
+    public void CloneReplacesMethodWhenMethodIsProvided() {
+        var request = Create(s => s.Method = "GET");
+
+        var clone = request.Clone(method: "DELETE");
+
+        Assert.True("DELETE".Equals(clone.Method, StringComparison.OrdinalIgnoreCase),
+            Because($"Clone(method: \"DELETE\") must replace the method but got '{clone.Method}'"));
+    }
+
+    [Fact]
+    public void ClonePreservesPathWhenPathIsNull() {
+        var request = Create(s => s.Path = "/original");
+
+        var clone = request.Clone(method: "PUT", path: null);
+
+        Assert.Equal("/original", clone.Path);
+    }
+
+    [Fact]
+    public void CloneReplacesPathWhenPathIsProvided() {
+        var request = Create(s => s.Path = "/original");
+
+        var clone = request.Clone(path: "/replaced");
+
+        Assert.Equal("/replaced", clone.Path);
+    }
+
+    [Fact]
+    public void CloneReplacesHeadersWhenHeadersAreProvided() {
+        var request = Create(s => s.Headers["X-Original"] = "yes");
+
+        var replacement = new Dictionary<string, StringValues> {
+            { "X-Replaced", new StringValues("also-yes") }
+        };
+
+        var clone = request.Clone(headers: replacement);
+
+        Assert.True(clone.Headers.TryGetValue("X-Replaced", out var value),
+            Because("Clone(headers: ...) must expose the supplied headers"));
+        Assert.Equal("also-yes", value.ToString());
+    }
+
+    [Fact]
+    public void ClonePreservesBody() {
+        var payload = "conformance-body"u8.ToArray();
+        var request = Create(s => s.Body = payload);
+
+        var clone = request.Clone(method: "POST");
+
+        clone.Body.Position = 0;
+        using var reader = new StreamReader(clone.Body);
+
+        Assert.Equal("conformance-body", reader.ReadToEnd());
+    }
+
+    [Fact]
+    public void CloneDoesNotMutateTheOriginal() {
+        var request = Create(s => {
+            s.Method = "GET";
+            s.Path = "/original";
+        });
+
+        request.Clone(method: "DELETE", path: "/replaced");
+
+        Assert.True("GET".Equals(request.Method, StringComparison.OrdinalIgnoreCase),
+            Because($"Clone must not mutate the original, but Method became '{request.Method}'"));
+        Assert.Equal("/original", request.Path);
+    }
+}

--- a/src/Requests/Hardened.Requests.Testing/Conformance/IExecutionRequestConformanceAdapter.cs
+++ b/src/Requests/Hardened.Requests.Testing/Conformance/IExecutionRequestConformanceAdapter.cs
@@ -1,0 +1,20 @@
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.Requests.Testing.Conformance;
+
+/// <summary>
+/// Implemented once per transport to plug it into <see cref="ExecutionRequestConformanceTests"/>.
+///
+/// The implementation should do the least work possible beyond building the transport's
+/// native request and wrapping it in that transport's <see cref="IExecutionRequest"/> - the
+/// point of the suite is to test the adapter, so anything the adapter gets wrong should
+/// reach the assertions rather than being smoothed over here.
+/// </summary>
+public interface IExecutionRequestConformanceAdapter {
+    /// <summary>
+    /// Name used in assertion messages so a failure identifies the transport.
+    /// </summary>
+    string TransportName { get; }
+
+    IExecutionRequest CreateRequest(ConformanceRequestSpec spec);
+}

--- a/src/Requests/Hardened.Requests.Testing/Hardened.Requests.Testing.csproj
+++ b/src/Requests/Hardened.Requests.Testing/Hardened.Requests.Testing.csproj
@@ -18,6 +18,10 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <!-- Referenced directly rather than relied on transitively through
+             Hardened.Shared.Testing, because the Conformance suite exposes xUnit types
+             (Fact, Assert) as part of this package's public surface. -->
+        <PackageReference Include="xunit.v3" Version="1.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Conformance/AspNetExecutionRequestConformanceTests.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Conformance/AspNetExecutionRequestConformanceTests.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Testing.Conformance;
+using Hardened.Web.AspNetCore.Runtime.Impl;
+using Microsoft.AspNetCore.Http;
+
+namespace Hardened.Web.AspNetCore.Runtime.Tests.Conformance;
+
+/// <summary>
+/// Runs the shared transport conformance suite against the ASP.NET Core adapter.
+///
+/// The adapter is exercised through a real <see cref="DefaultHttpContext"/> populated the
+/// way Kestrel would populate it, so what is under test is genuinely the mapping from
+/// ASP.NET Core's request onto <see cref="IExecutionRequest"/>.
+/// </summary>
+public class AspNetExecutionRequestConformanceTests : ExecutionRequestConformanceTests {
+
+    protected override IExecutionRequestConformanceAdapter Adapter { get; } = new AspNetAdapter();
+
+    private class AspNetAdapter : IExecutionRequestConformanceAdapter {
+        public string TransportName => "ASP.NET Core";
+
+        public IExecutionRequest CreateRequest(ConformanceRequestSpec spec) {
+            var httpContext = new DefaultHttpContext();
+            var httpRequest = httpContext.Request;
+
+            httpRequest.Method = spec.Method;
+            httpRequest.Path = spec.Path;
+
+            foreach (var header in spec.Headers) {
+                httpRequest.Headers[header.Key] = header.Value;
+            }
+
+            if (spec.QueryString.Count > 0) {
+                httpRequest.QueryString = QueryString.Create(
+                    spec.QueryString.ToDictionary(q => q.Key, q => (string?)q.Value));
+            }
+
+            // Cookies arrive over the wire in a single Cookie header, which is how Kestrel
+            // delivers them before ASP.NET parses them into HttpRequest.Cookies.
+            if (spec.Cookies.Count > 0) {
+                httpRequest.Headers.Cookie = string.Join("; ", spec.Cookies);
+            }
+
+            if (spec.Body is not null) {
+                httpRequest.Body = new MemoryStream(spec.Body);
+                httpRequest.ContentLength = spec.Body.Length;
+            }
+
+            return new AspNetExecutionRequest(httpRequest);
+        }
+    }
+}

--- a/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Hardened.Web.AspNetCore.Runtime.Tests.csproj
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Hardened.Web.AspNetCore.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -7,25 +7,27 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="xunit.v3" Version="1.*" />
-        <PackageReference Include="SimpleFixture.NSubstitute" Version="4.0.0-RC191"/>
-        <PackageReference Include="SimpleFixture.xUnit" Version="4.0.0-RC191"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Shared\Hardened.Shared.Runtime.Tests\Hardened.Shared.Runtime.Tests.csproj"/>
+        <ProjectReference Include="..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
+        <ProjectReference Include="..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <ProjectReference Include="..\..\Requests\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
         <ProjectReference Include="..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
-        <ProjectReference Include="..\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
-        <ProjectReference Include="..\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
-        <ProjectReference Include="..\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
+        <ProjectReference Include="..\Hardened.Web.AspNetCore.Runtime\Hardened.Web.AspNetCore.Runtime.csproj"/>
+        <ProjectReference Include="..\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
@@ -4,7 +4,9 @@ using Hardened.Requests.Abstract.PathTokens;
 using Hardened.Requests.Abstract.QueryString;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.Headers;
+using Hardened.Requests.Runtime.PathTokens;
 using Hardened.Requests.Runtime.QueryString;
+using Hardened.Shared.Runtime.Collections;
 using Hardened.Shared.Runtime.Diagnostics;
 using Hardened.Shared.Runtime.Metrics;
 using Microsoft.AspNetCore.Http;
@@ -72,32 +74,67 @@ public class AspNetExecutionContext : IExecutionContext {
 }
 
 public class AspNetExecutionRequest : IExecutionRequest {
-    private HttpRequest _httpRequest;
+    private readonly HttpRequest _httpRequest;
+
+    // Values supplied by Clone. Null means "fall through to the underlying HttpRequest",
+    // which is what keeps Clone(x: null) preserving the current value.
+    private readonly string? _methodOverride;
+    private readonly string? _pathOverride;
+    private readonly IDictionary<string, StringValues>? _headersOverride;
+    private readonly IQueryStringCollection? _queryStringOverride;
+    private readonly IReadOnlyList<string>? _cookiesOverride;
+
+    private IPathTokenCollection? _pathTokens;
+    private IQueryStringCollection? _queryString;
+    private IReadOnlyList<string>? _cookies;
 
     public AspNetExecutionRequest(HttpRequest httpRequest) {
         _httpRequest = httpRequest;
     }
 
+    private AspNetExecutionRequest(
+        HttpRequest httpRequest,
+        string? methodOverride,
+        string? pathOverride,
+        IDictionary<string, StringValues>? headersOverride,
+        IQueryStringCollection? queryStringOverride,
+        IReadOnlyList<string>? cookiesOverride) {
+        _httpRequest = httpRequest;
+        _methodOverride = methodOverride;
+        _pathOverride = pathOverride;
+        _headersOverride = headersOverride;
+        _queryStringOverride = queryStringOverride;
+        _cookiesOverride = cookiesOverride;
+    }
+
+    /// <summary>
+    /// A null argument keeps the current value, a non-null argument replaces it.
+    /// </summary>
     public IExecutionRequest Clone(
-        string? method,
-        string? path,
-        IDictionary<string, StringValues> headers,
-        IQueryStringCollection queryString,
-        IReadOnlyList<string> cookies) {
-        return new AspNetExecutionRequest(_httpRequest) {
+        string? method = null,
+        string? path = null,
+        IDictionary<string, StringValues>? headers = null,
+        IQueryStringCollection? queryString = null,
+        IReadOnlyList<string>? cookies = null) {
+        return new AspNetExecutionRequest(
+            _httpRequest,
+            method ?? _methodOverride,
+            path ?? _pathOverride,
+            headers ?? _headersOverride,
+            queryString ?? _queryStringOverride,
+            cookies ?? _cookiesOverride) {
             Parameters = Parameters,
-            Body = Body,
             PathTokens = PathTokens,
         };
     }
 
-    public string Method => _httpRequest.Method;
+    public string Method => _methodOverride ?? _httpRequest.Method;
 
-    public string Path => _httpRequest.Path;
+    public string Path => _pathOverride ?? _httpRequest.Path;
 
-    public string? ContentType => _httpRequest.ContentType;
+    public string? ContentType => Headers.GetOrDefault(KnownHeaders.ContentType);
 
-    public string? Accept => null;
+    public string? Accept => Headers.GetOrDefault(KnownHeaders.Accept);
 
     public IExecutionRequestParameters? Parameters { get; set; }
 
@@ -106,15 +143,24 @@ public class AspNetExecutionRequest : IExecutionRequest {
         set => _httpRequest.Body = value;
     }
 
-    public IDictionary<string, StringValues> Headers => _httpRequest.Headers;
+    public IDictionary<string, StringValues> Headers => _headersOverride ?? _httpRequest.Headers;
 
     public IQueryStringCollection QueryString =>
-        new SimpleQueryStringCollection(
-            _httpRequest.Query.ToDictionary(q => q.Key, q => q.Value.ToString()));
+        _queryStringOverride ?? (_queryString ??= new SimpleQueryStringCollection(
+            _httpRequest.Query.ToDictionary(q => q.Key, q => q.Value.ToString())));
 
-    public IPathTokenCollection PathTokens { get; set; }
+    public IPathTokenCollection PathTokens {
+        get => _pathTokens ?? PathTokenCollection.Empty;
+        set => _pathTokens = value;
+    }
 
-    public IReadOnlyList<string> Cookies => new List<string>();
+    /// <summary>
+    /// ASP.NET Core parses the Cookie header into name/value pairs; the framework contract
+    /// is the raw <c>name=value</c> form that API Gateway v2 delivers, so reassemble it.
+    /// </summary>
+    public IReadOnlyList<string> Cookies =>
+        _cookiesOverride ?? (_cookies ??=
+            _httpRequest.Cookies.Select(cookie => $"{cookie.Key}={cookie.Value}").ToList());
 }
 
 public class AspNetExecutionResponse : IExecutionResponse {


### PR DESCRIPTION
## Why

Hardened's central claim is that it's transport agnostic — a handler shouldn't be able to tell whether its request arrived over ASP.NET Core, API Gateway, Lambda streaming, or an in-memory harness. That's only true if every adapter maps its native request onto `IExecutionRequest` the same way, and nothing was checking. **They had diverged.**

## The suite

`Hardened.Requests.Testing.Conformance` states the behaviour every `IExecutionRequest` implementation must exhibit, written once. A transport enrols by implementing `IExecutionRequestConformanceAdapter` and deriving from `ExecutionRequestConformanceTests`:

```csharp
public class MyTransportConformanceTests : ExecutionRequestConformanceTests {
    protected override IExecutionRequestConformanceAdapter Adapter { get; } = new MyAdapter();
}
```

It lives in `Hardened.Requests.Testing`, not `Hardened.Web.Testing`, because `IExecutionRequest` is the Requests-layer contract — SQS and DynamoDB stream transports implement it too, not just HTTP ones.

**The `Clone` semantics aren't invented here.** `LambdaExecutionRequest` in Hardened.Amz already implements them and `Hardened.Amz.Shared.Lambda.Runtime.Tests` already asserts them: null keeps, non-null replaces. The suite just makes that binding on everyone.

## Validated before it was trusted

Run first against the **in-memory transport** — no wire format of its own, so it acts as the reference implementation: **18/18 passed.** That confirms the suite doesn't assert anything unreasonable before it's used to indict anything.

Run then against **ASP.NET Core**: **7/18 failed.**

## What it caught

| Behaviour | Was | Now |
|---|---|---|
| `Accept` | hardcoded `null` | reads the Accept header |
| `Cookies` | always empty | reassembled `name=value` from parsed cookies |
| `Clone(method:)` | argument ignored | replaces |
| `Clone(path:)` | argument ignored | replaces |
| `Clone(headers:)` | argument ignored | replaces |
| `PathTokens` before routing | **null** (declared non-nullable) | `PathTokenCollection.Empty` |
| `ContentType` | direct off `HttpRequest` | header lookup, so `Clone(headers:)` is reflected |

### The `Accept` one had live consequences

All three response serializers decide whether they can handle a response with:

```csharp
return context.Request.Accept?.Contains("application/json") ?? false;
```

With `Accept` hardcoded `null` on ASP.NET, that returned **false on every request**, and `SerializationLocatorService` always fell through to `IsDefaultSerializer`. Content negotiation was silently dead on ASP.NET while working on API Gateway — same request, different selection path. That's the transport-agnostic claim failing in production code, not a latent API wart.

`Clone` and `Cookies`, by contrast, are currently latent: nothing in Framework calls `IExecutionRequest.Clone` or reads `Request.Cookies` yet.

## Result

All 18 behaviours now pass on **both** transports. Full suite **383 → 419 tests**, no regressions — the `WebApp.SUT` integration tests still pass because they send no Accept header and so still resolve to the default serializer.

| | Before | After |
|---|---|---|
| `Hardened.Web.AspNetCore.Runtime` | **0.0%** | **38.2%** |
| `Hardened.Requests.Testing` | 19.5% | **84.8%** |
| Repository | 37.2% | 38.3% |
| Solution warnings | 44 | **39** |

## Scope notes

- **Not yet asserted:** that `Clone` replaces query string and cookies when supplied. Implementations diverge and tightening it is a separate change — called out in the suite's doc comment rather than left implicit.
- **Browser-visible behaviour is unchanged.** Worth stating explicitly, since "content negotiation now works" sounds riskier than it is. A browser sending `Accept: text/html,...,*/*;q=0.8` still receives JSON, exactly as before: that string doesn't contain `application/json`, so `CanProcessContext` returns false just as it did when `Accept` was hardcoded `null`, and selection falls through to `IsDefaultSerializer`. All three registered response serializers are JSON serializers and all three are marked default, so a JSON serializer runs either way.

  HTML is never reached through `Accept` in this framework at all — `ContextSerializationService.SerializeResponse` checks `context.DefaultOutput` *before* consulting serializer selection, so templates short-circuit it. HTML is selected by `[Template("name")]` on a handler, not by a request header.

  The only case that changes is a request whose `Accept` genuinely contains `application/json`. With a single serializer registered there is no observable difference. With several (say Newtonsoft alongside System.Text.Json), the user-registered one now wins instead of the framework default — which is what `SerializationLocatorService`'s existing `// reverse lists so user registered serializers are tested first` was always meant to do, and which was dead code on ASP.NET until now.

- **Pre-existing limitation, not addressed here:** `Accept?.Contains("application/json")` is substring matching rather than content negotiation — it ignores q-values and doesn't understand `*/*`, so curl's default `Accept: */*` also misses and lands on the fallback. Left alone deliberately; it deserves its own change.
- **Follow-up:** Hardened.Amz can adopt this once the package publishes. `ApiGatewayV2ExecutionRequest` has the same `Clone` defect this suite caught in ASP.NET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
