### PR TITLE
Cover the core pipeline; fix gzip compression, path traversal, and cookie attributes

### DIFF
--- a/src/Requests/Hardened.Requests.Abstract/Headers/ICookieSetCollection.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Headers/ICookieSetCollection.cs
@@ -21,7 +21,10 @@ public record CookieSetOptions(
 
     public void AppendSettings(StringBuilder builder) {
         if (Expires.HasValue) {
-            builder.AppendFormat("; Expire={0:ddd, dd MMM yyyy HH:mm:ss}", Expires);
+            // RFC 6265 names the attribute "Expires" and requires an RFC 1123 date in GMT.
+            // The "R" format specifier produces exactly that, but only reads correctly if
+            // the value is already UTC.
+            builder.AppendFormat("; Expires={0:R}", Expires.Value.ToUniversalTime());
         }
 
         if (MaxAge.HasValue) {
@@ -32,6 +35,11 @@ public record CookieSetOptions(
         if (!string.IsNullOrEmpty(Domain)) {
             builder.Append("; Domain=");
             builder.Append(Domain);
+        }
+
+        if (!string.IsNullOrEmpty(Path)) {
+            builder.Append("; Path=");
+            builder.Append(Path);
         }
 
         if (SameSite.HasValue) {

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
@@ -1,0 +1,128 @@
+using Hardened.Requests.Abstract.Errors;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Validation;
+using Hardened.Requests.Runtime.Errors;
+using Hardened.Requests.Runtime.Validation;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Errors;
+
+/// <summary>
+/// This converter decides both the status code a caller sees and how much of the
+/// exception is echoed back to them, so its mapping is worth pinning precisely.
+/// </summary>
+public class ExceptionToModelConverterTests {
+
+    private static readonly ExceptionToModelConverter Converter = new();
+
+    private static IExecutionContext Context() => Substitute.For<IExecutionContext>();
+
+    [Fact]
+    public void ValidationExceptionMapsTo400WithFieldErrors() {
+        var result = new ValidationResult();
+        result.AddError("email", "Required", "email is required");
+        result.AddError("age", "Range", "age must be between 0 and 120");
+
+        var (status, model) = Converter.ConvertExceptionToModel(Context(), new ValidationException(result));
+
+        Assert.Equal(400, status);
+
+        var validationError = Assert.IsType<RequestValidationError>(model);
+        Assert.Equal("ValidationError", validationError.Type);
+        Assert.Equal(2, validationError.Errors.Count);
+
+        Assert.Equal("email", validationError.Errors[0].Field);
+        Assert.Equal("Required", validationError.Errors[0].Code);
+        Assert.Equal("email is required", validationError.Errors[0].Message);
+
+        Assert.Equal("age", validationError.Errors[1].Field);
+        Assert.Equal("Range", validationError.Errors[1].Code);
+    }
+
+    [Fact]
+    public void ValidationExceptionWithNoErrorsStillMapsTo400() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(), new ValidationException(new ValidationResult()));
+
+        Assert.Equal(400, status);
+        Assert.Empty(Assert.IsType<RequestValidationError>(model).Errors);
+    }
+
+    [Fact]
+    public void FormatExceptionMapsTo400() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(), new FormatException("not a number"));
+
+        Assert.Equal(400, status);
+        var error = Assert.IsType<ErrorModel>(model);
+        Assert.Equal(nameof(FormatException), error.Type);
+        Assert.Equal("not a number", error.Message);
+    }
+
+    [Fact]
+    public void BadRequestExceptionMapsTo400() {
+        var (status, _) = Converter.ConvertExceptionToModel(
+            Context(), new BadRequestException("malformed"));
+
+        Assert.Equal(400, status);
+    }
+
+    [Fact]
+    public void UnrecognisedExceptionMapsTo500() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(), new InvalidOperationException("something went wrong"));
+
+        Assert.Equal(500, status);
+        var error = Assert.IsType<ErrorModel>(model);
+        Assert.Equal(nameof(InvalidOperationException), error.Type);
+        Assert.Equal("something went wrong", error.Message);
+    }
+
+    private class CustomValidationProblemException : Exception {
+        public CustomValidationProblemException() : base("custom") { }
+    }
+
+    private class BadgeNotFoundException : Exception {
+        public BadgeNotFoundException() : base("no badge") { }
+    }
+
+    /// <summary>
+    /// Classification is done by substring match on the exception type name rather than by
+    /// type hierarchy, so any type whose name contains "Validation" is treated as a client
+    /// error without deriving from anything.
+    /// </summary>
+    [Fact]
+    public void ExceptionNamedForValidationMapsTo400WithoutInheritance() {
+        var (status, _) = Converter.ConvertExceptionToModel(
+            Context(), new CustomValidationProblemException());
+
+        Assert.Equal(400, status);
+    }
+
+    /// <summary>
+    /// The same substring matching catches "Bad" anywhere in the name, so BadgeNotFound is
+    /// classified as a 400. Pinned deliberately: this is current behaviour, and a test
+    /// failing here means the classification strategy changed.
+    /// </summary>
+    [Fact]
+    public void SubstringMatchingAlsoCatchesUnrelatedNamesContainingBad() {
+        var (status, _) = Converter.ConvertExceptionToModel(
+            Context(), new BadgeNotFoundException());
+
+        Assert.Equal(400, status);
+    }
+
+    /// <summary>
+    /// The exception message is echoed to the caller verbatim for unrecognised exceptions.
+    /// Worth pinning so that a change to message handling is a deliberate decision.
+    /// </summary>
+    [Fact]
+    public void UnrecognisedExceptionMessageIsEchoedVerbatim() {
+        var (_, model) = Converter.ConvertExceptionToModel(
+            Context(), new Exception("connection string 'Server=db;Password=hunter2' failed"));
+
+        Assert.Equal("connection string 'Server=db;Password=hunter2' failed",
+            Assert.IsType<ErrorModel>(model).Message);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Headers/CookieSetOptionsTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Headers/CookieSetOptionsTests.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using Hardened.Requests.Abstract.Headers;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Headers;
+
+/// <summary>
+/// Cookie attributes are a security surface - Secure, HttpOnly and SameSite are what keep a
+/// session cookie out of reach of script and cross-site requests - so the emitted string is
+/// asserted exactly.
+/// </summary>
+public class CookieSetOptionsTests {
+
+    private static string Render(CookieSetOptions options) {
+        var builder = new StringBuilder();
+        options.AppendSettings(builder);
+        return builder.ToString();
+    }
+
+    [Fact]
+    public void DefaultsAreSecureAndHttpOnly() {
+        var options = new CookieSetOptions();
+
+        Assert.True(options.Secure);
+        Assert.True(options.HttpOnly);
+
+        var rendered = Render(options);
+        Assert.Contains("; Secure", rendered);
+        Assert.Contains("; HttpOnly", rendered);
+    }
+
+    [Fact]
+    public void SecureAndHttpOnlyAreOmittedWhenDisabled() {
+        var rendered = Render(new CookieSetOptions(Secure: false, HttpOnly: false));
+
+        Assert.DoesNotContain("Secure", rendered);
+        Assert.DoesNotContain("HttpOnly", rendered);
+    }
+
+    [Theory]
+    [InlineData(SameSite.Strict, "; SameSite=Strict")]
+    [InlineData(SameSite.Lax, "; SameSite=Lax")]
+    [InlineData(SameSite.None, "; SameSite=None")]
+    public void SameSiteIsEmittedWhenSet(SameSite sameSite, string expected) {
+        Assert.Contains(expected, Render(new CookieSetOptions(SameSite: sameSite)));
+    }
+
+    [Fact]
+    public void SameSiteIsOmittedWhenNull() {
+        Assert.DoesNotContain("SameSite", Render(new CookieSetOptions()));
+    }
+
+    [Fact]
+    public void MaxAgeIsEmittedWhenSet() {
+        Assert.Contains("; Max-Age=3600", Render(new CookieSetOptions(MaxAge: 3600)));
+    }
+
+    [Fact]
+    public void DomainIsEmittedWhenSet() {
+        Assert.Contains("; Domain=example.com", Render(new CookieSetOptions(Domain: "example.com")));
+    }
+
+    [Fact]
+    public void DomainIsOmittedWhenEmpty() {
+        Assert.DoesNotContain("Domain", Render(new CookieSetOptions(Domain: "")));
+    }
+
+    [Fact]
+    public void EmptyIsAReusableDefaultInstance() {
+        Assert.NotNull(CookieSetOptions.Empty);
+        Assert.True(CookieSetOptions.Empty.Secure);
+        Assert.True(CookieSetOptions.Empty.HttpOnly);
+    }
+
+    /// <summary>
+    /// A cookie scoped to a path must actually carry that scope, otherwise the browser
+    /// applies it to the whole origin and it is sent on requests it was never meant for.
+    /// </summary>
+    [Fact]
+    public void PathIsEmittedWhenSet() {
+        Assert.Contains("; Path=/admin", Render(new CookieSetOptions(Path: "/admin")));
+    }
+
+    [Fact]
+    public void PathIsOmittedWhenNotSet() {
+        Assert.DoesNotContain("Path=", Render(new CookieSetOptions()));
+    }
+
+    /// <summary>
+    /// RFC 6265 names the attribute "Expires" and requires an RFC 1123 date in GMT. Anything
+    /// else is ignored by the browser, which silently turns an expiring cookie into a
+    /// session cookie.
+    /// </summary>
+    [Fact]
+    public void ExpiresUsesTheRfcAttributeNameAndGmtFormat() {
+        var rendered = Render(new CookieSetOptions(
+            Expires: new DateTime(2026, 6, 9, 10, 18, 14, DateTimeKind.Utc)));
+
+        Assert.Contains("; Expires=", rendered);
+        Assert.Contains("GMT", rendered);
+        Assert.Contains("Tue, 09 Jun 2026 10:18:14 GMT", rendered);
+    }
+
+    [Fact]
+    public void ExpiresIsConvertedToUtcBeforeFormatting() {
+        var local = new DateTime(2026, 6, 9, 10, 18, 14, DateTimeKind.Utc).ToLocalTime();
+
+        var rendered = Render(new CookieSetOptions(Expires: local));
+
+        Assert.Contains("Tue, 09 Jun 2026 10:18:14 GMT", rendered);
+    }
+
+    [Fact]
+    public void ExpiresIsOmittedWhenNotSet() {
+        Assert.DoesNotContain("Expires", Render(new CookieSetOptions()));
+    }
+
+    [Fact]
+    public void AttributesCombineInASingleRender() {
+        var rendered = Render(new CookieSetOptions(
+            MaxAge: 600,
+            Domain: "example.com",
+            SameSite: SameSite.Strict));
+
+        Assert.Contains("; Max-Age=600", rendered);
+        Assert.Contains("; Domain=example.com", rendered);
+        Assert.Contains("; SameSite=Strict", rendered);
+        Assert.Contains("; HttpOnly", rendered);
+        Assert.Contains("; Secure", rendered);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Headers/HeaderCollectionStringValuesTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Headers/HeaderCollectionStringValuesTests.cs
@@ -1,0 +1,223 @@
+using Hardened.Requests.Runtime.Headers;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Headers;
+
+/// <summary>
+/// The header collection backing the API Gateway and streaming transports. Lookups that
+/// miss must yield <see cref="StringValues.Empty"/> rather than throwing, because callers
+/// index into it directly.
+/// </summary>
+public class HeaderCollectionStringValuesTests {
+
+    [Fact]
+    public void ConstructsFromStringDictionary() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> {
+            { "Content-Type", "application/json" },
+            { "Accept", "text/plain" }
+        });
+
+        Assert.Equal("application/json", headers.Get("Content-Type").ToString());
+        Assert.Equal("text/plain", headers.Get("Accept").ToString());
+        Assert.Equal(2, headers.Count);
+    }
+
+    [Fact]
+    public void ConstructsEmptyFromNullDictionary() {
+        var headers = new HeaderCollectionStringValues((IDictionary<string, string>?)null);
+
+        Assert.Equal(0, headers.Count);
+    }
+
+    [Fact]
+    public void DefaultConstructorStartsEmpty() {
+        Assert.Equal(0, new HeaderCollectionStringValues().Count);
+    }
+
+    [Fact]
+    public void WrapsAnExistingStringValuesDictionaryByReference() {
+        var backing = new Dictionary<string, StringValues> { { "X-Trace", "abc" } };
+        var headers = new HeaderCollectionStringValues(backing);
+
+        headers.Set("X-Extra", "value");
+
+        Assert.True(backing.ContainsKey("X-Extra"));
+    }
+
+    [Fact]
+    public void GetReturnsEmptyForMissingKey() {
+        Assert.Equal(StringValues.Empty, new HeaderCollectionStringValues().Get("Nope"));
+    }
+
+    [Fact]
+    public void IndexerReturnsEmptyForMissingKeyRatherThanThrowing() {
+        Assert.Equal(StringValues.Empty, new HeaderCollectionStringValues()["Nope"]);
+    }
+
+    [Fact]
+    public void IndexerSetThenGetRoundTrips() {
+        var headers = new HeaderCollectionStringValues();
+
+        headers["X-Custom"] = "one";
+
+        Assert.Equal("one", headers["X-Custom"].ToString());
+    }
+
+    [Fact]
+    public void TryGetReportsPresenceAndAbsence() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> { { "A", "1" } });
+
+        Assert.True(headers.TryGet("A", out var found));
+        Assert.Equal("1", found.ToString());
+
+        Assert.False(headers.TryGet("B", out var missing));
+        Assert.Equal(StringValues.Empty, missing);
+    }
+
+    [Fact]
+    public void AppendCreatesTheHeaderWhenAbsent() {
+        var headers = new HeaderCollectionStringValues();
+
+        var result = headers.Append("Set-Cookie", "a=1");
+
+        Assert.Equal("a=1", result.ToString());
+        Assert.Equal("a=1", headers.Get("Set-Cookie").ToString());
+    }
+
+    [Fact]
+    public void AppendConcatenatesOntoAnExistingHeader() {
+        var headers = new HeaderCollectionStringValues();
+
+        headers.Append("Set-Cookie", "a=1");
+        var result = headers.Append("Set-Cookie", "b=2");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new[] { "a=1", "b=2" }, result.ToArray());
+    }
+
+    [Fact]
+    public void AppendTreatsNullAsEmptyString() {
+        var headers = new HeaderCollectionStringValues();
+
+        var result = headers.Append("X-Null", null!);
+
+        Assert.Equal("", result.ToString());
+    }
+
+    [Fact]
+    public void SetWithNullRemovesTheHeader() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> { { "X-Gone", "here" } });
+
+        var result = headers.Set("X-Gone", (object?)null);
+
+        Assert.Equal(StringValues.Empty, result);
+        Assert.False(headers.ContainsKey("X-Gone"));
+    }
+
+    [Fact]
+    public void SetConvertsNonStringValues() {
+        var headers = new HeaderCollectionStringValues();
+
+        headers.Set("Content-Length", 1234);
+
+        Assert.Equal("1234", headers.Get("Content-Length").ToString());
+    }
+
+    [Fact]
+    public void RemoveReportsWhetherTheKeyWasPresent() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> { { "A", "1" } });
+
+        Assert.True(headers.Remove("A"));
+        Assert.False(headers.Remove("A"));
+    }
+
+    [Fact]
+    public void ClearEmptiesTheCollection() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> {
+            { "A", "1" }, { "B", "2" }
+        });
+
+        headers.Clear();
+
+        Assert.Equal(0, headers.Count);
+    }
+
+    [Fact]
+    public void KeysAndValuesExposeContents() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> { { "A", "1" } });
+
+        Assert.Contains("A", headers.Keys);
+        Assert.Contains(headers.Values, v => v.ToString() == "1");
+    }
+
+    [Fact]
+    public void IsEnumerable() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> {
+            { "A", "1" }, { "B", "2" }
+        });
+
+        var seen = headers.ToDictionary(pair => pair.Key, pair => pair.Value.ToString());
+
+        Assert.Equal("1", seen["A"]);
+        Assert.Equal("2", seen["B"]);
+    }
+
+    [Fact]
+    public void ToStringDictionaryFlattensValues() {
+        var headers = new HeaderCollectionStringValues();
+        headers.Append("Set-Cookie", "a=1");
+        headers.Append("Set-Cookie", "b=2");
+
+        var flattened = headers.ToStringDictionary();
+
+        Assert.Equal("a=1,b=2", flattened["Set-Cookie"]);
+    }
+
+    [Fact]
+    public void IsNotReadOnly() {
+        Assert.False(new HeaderCollectionStringValues().IsReadOnly);
+    }
+
+    [Fact]
+    public void ContainsMatchesOnKeyAndValue() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> { { "A", "1" } });
+
+        Assert.True(headers.Contains(new KeyValuePair<string, StringValues>("A", "1")));
+        Assert.False(headers.Contains(new KeyValuePair<string, StringValues>("A", "2")));
+    }
+
+    [Fact]
+    public void AddAndRemoveKeyValuePairRoundTrip() {
+        var headers = new HeaderCollectionStringValues();
+
+        headers.Add(new KeyValuePair<string, StringValues>("A", "1"));
+        Assert.Equal("1", headers.Get("A").ToString());
+
+        Assert.True(headers.Remove(new KeyValuePair<string, StringValues>("A", "1")));
+        Assert.Equal(0, headers.Count);
+    }
+
+    [Fact]
+    public void CopyToWritesIntoTheTargetArray() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> { { "A", "1" } });
+        var target = new KeyValuePair<string, StringValues>[1];
+
+        headers.CopyTo(target, 0);
+
+        Assert.Equal("A", target[0].Key);
+    }
+
+    /// <summary>
+    /// Add(string, StringValues) is unimplemented and throws. Pinned so the behaviour is
+    /// visible rather than discovered at runtime - callers should use Set or the
+    /// KeyValuePair overload. A failure here means it was implemented, which is an
+    /// improvement worth updating this test for.
+    /// </summary>
+    [Fact]
+    public void AddByKeyAndValueIsNotImplemented() {
+        var headers = new HeaderCollectionStringValues();
+
+        Assert.Throws<NotImplementedException>(() => headers.Add("A", new StringValues("1")));
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResponseSerializerCompressionTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResponseSerializerCompressionTests.cs
@@ -1,0 +1,152 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Configuration;
+using Hardened.Requests.Runtime.Serializer;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Serializer;
+
+/// <summary>
+/// Both JSON response serializers share a compression branch. These tests cover it for each
+/// of them, since the implementations are duplicated rather than shared.
+/// </summary>
+public class ResponseSerializerCompressionTests {
+
+    private record Payload(string Name, int Value);
+
+    private static IOptions<IJsonSerializerConfiguration> Config() =>
+        Options.Create<IJsonSerializerConfiguration>(new JsonSerializerConfiguration {
+            SerializeOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        });
+
+    private static (IExecutionContext context, MemoryStream body) Context(
+        object? responseValue, bool shouldCompress, string? accept = "application/json") {
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+        var response = Substitute.For<IExecutionResponse>();
+        var body = new MemoryStream();
+
+        request.Accept.Returns(accept);
+        response.Body.Returns(body);
+        response.ResponseValue.Returns(responseValue);
+        response.ShouldCompress.Returns(shouldCompress);
+        context.Request.Returns(request);
+        context.Response.Returns(response);
+
+        return (context, body);
+    }
+
+    private static IEnumerable<IResponseSerializer> Serializers() {
+        yield return new SystemTextJsonResponseSerializer(Config());
+        yield return new AotResponseSerializer(Config(), Array.Empty<IJsonTypeInfoResolver>());
+    }
+
+    public static TheoryData<string> SerializerNames => new() {
+        nameof(SystemTextJsonResponseSerializer),
+        nameof(AotResponseSerializer)
+    };
+
+    private static IResponseSerializer SerializerNamed(string name) =>
+        Serializers().First(s => s.GetType().Name == name);
+
+    [Theory]
+    [MemberData(nameof(SerializerNames))]
+    public async Task UncompressedResponseIsPlainJson(string serializerName) {
+        var (context, body) = Context(new Payload("hello", 42), shouldCompress: false);
+
+        await SerializerNamed(serializerName).SerializeResponse(context);
+
+        var json = System.Text.Encoding.UTF8.GetString(body.ToArray());
+        var payload = JsonSerializer.Deserialize<Payload>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.Equal("hello", payload!.Name);
+        Assert.Equal(42, payload.Value);
+    }
+
+    [Theory]
+    [MemberData(nameof(SerializerNames))]
+    public async Task NullResponseValueWritesNothing(string serializerName) {
+        var (context, body) = Context(responseValue: null, shouldCompress: false);
+
+        await SerializerNamed(serializerName).SerializeResponse(context);
+
+        Assert.Empty(body.ToArray());
+    }
+
+    [Theory]
+    [MemberData(nameof(SerializerNames))]
+    public async Task ContentTypeIsSetToApplicationJson(string serializerName) {
+        var (context, _) = Context(new Payload("x", 1), shouldCompress: false);
+
+        await SerializerNamed(serializerName).SerializeResponse(context);
+
+        context.Response.Received().ContentType = "application/json";
+    }
+
+    /// <summary>
+    /// When ShouldCompress is set the body must actually be gzip data. Writing plain JSON
+    /// while a GZipStream is open over the same body produces output that is not
+    /// decompressible, so this asserts the bytes round-trip through GZipStream.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(SerializerNames))]
+    public async Task CompressedResponseIsActuallyGzipped(string serializerName) {
+        var (context, body) = Context(new Payload("compress me", 7), shouldCompress: true);
+
+        await SerializerNamed(serializerName).SerializeResponse(context);
+
+        var written = body.ToArray();
+        Assert.NotEmpty(written);
+
+        // gzip magic number - if the body is plain JSON this fails immediately with a
+        // clearer signal than a decompression exception.
+        Assert.True(written.Length >= 2 && written[0] == 0x1f && written[1] == 0x8b,
+            $"{serializerName}: response body is not gzip data (first bytes: " +
+            $"{string.Join(" ", written.Take(4).Select(b => b.ToString("x2")))})");
+
+        using var input = new MemoryStream(written);
+        using var gzip = new GZipStream(input, CompressionMode.Decompress);
+        using var reader = new StreamReader(gzip);
+
+        var payload = JsonSerializer.Deserialize<Payload>(
+            await reader.ReadToEndAsync(), new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.Equal("compress me", payload!.Name);
+        Assert.Equal(7, payload.Value);
+    }
+
+    [Theory]
+    [MemberData(nameof(SerializerNames))]
+    public async Task CompressionIsSkippedForNullResponseValue(string serializerName) {
+        var (context, body) = Context(responseValue: null, shouldCompress: true);
+
+        await SerializerNamed(serializerName).SerializeResponse(context);
+
+        Assert.Empty(body.ToArray());
+    }
+
+    [Theory]
+    [MemberData(nameof(SerializerNames))]
+    public void CanProcessContextRequiresJsonInAccept(string serializerName) {
+        var serializer = SerializerNamed(serializerName);
+
+        var (jsonContext, _) = Context(new Payload("x", 1), false, accept: "application/json");
+        var (htmlContext, _) = Context(new Payload("x", 1), false, accept: "text/html");
+        var (nullContext, _) = Context(new Payload("x", 1), false, accept: null);
+
+        Assert.True(serializer.CanProcessContext(jsonContext));
+        Assert.False(serializer.CanProcessContext(htmlContext));
+        Assert.False(serializer.CanProcessContext(nullContext));
+    }
+
+    [Theory]
+    [MemberData(nameof(SerializerNames))]
+    public void BothAreRegisteredAsDefaultSerializers(string serializerName) {
+        Assert.True(SerializerNamed(serializerName).IsDefaultSerializer);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
@@ -38,7 +38,10 @@ public class AotResponseSerializer : IResponseSerializer {
         if (context.Response.ShouldCompress) {
             await using var gzipStream = new GZipStream(context.Response.Body, CompressionLevel.Fastest, true);
 
-            await System.Text.Json.JsonSerializer.SerializeAsync(context.Response.Body, context.Response.ResponseValue,
+            // Serialize into the gzip stream, not the response body underneath it - writing
+            // to the body directly leaves the payload uncompressed while a GZipStream is
+            // open over it.
+            await System.Text.Json.JsonSerializer.SerializeAsync(gzipStream, context.Response.ResponseValue,
                 _serializerOptions);
 
             await gzipStream.FlushAsync();

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonResponseSerializer.cs
@@ -34,7 +34,10 @@ public class SystemTextJsonResponseSerializer : IResponseSerializer {
         if (context.Response.ShouldCompress) {
             await using var gzipStream = new GZipStream(context.Response.Body, CompressionLevel.Fastest, true);
 
-            await System.Text.Json.JsonSerializer.SerializeAsync(context.Response.Body, context.Response.ResponseValue,
+            // Serialize into the gzip stream, not the response body underneath it - writing
+            // to the body directly leaves the payload uncompressed while a GZipStream is
+            // open over it.
+            await System.Text.Json.JsonSerializer.SerializeAsync(gzipStream, context.Response.ResponseValue,
                 _serializerOptions);
 
             await gzipStream.FlushAsync();

--- a/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsConfigurationTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsConfigurationTests.cs
@@ -1,0 +1,126 @@
+using Hardened.Web.Runtime.Cors;
+using Xunit;
+
+namespace Hardened.Web.Runtime.Tests.Cors;
+
+public class CorsConfigurationTests {
+
+    [Fact]
+    public void AllowedOriginIsMatched() {
+        var config = new CorsConfiguration();
+        config.AllowOrigin("https://app.example.com");
+
+        Assert.True(config.IsOriginAllowed("https://app.example.com"));
+    }
+
+    [Fact]
+    public void UnknownOriginIsNotMatched() {
+        var config = new CorsConfiguration();
+        config.AllowOrigin("https://app.example.com");
+
+        Assert.False(config.IsOriginAllowed("https://evil.example.com"));
+    }
+
+    [Fact]
+    public void MatchingIsCaseInsensitive() {
+        var config = new CorsConfiguration();
+        config.AllowOrigin("https://App.Example.com");
+
+        Assert.True(config.IsOriginAllowed("https://app.example.COM"));
+    }
+
+    /// <summary>
+    /// Trailing slashes are normalised on both sides, so a configured
+    /// "https://app.example.com/" matches a browser-sent "https://app.example.com".
+    /// </summary>
+    [Theory]
+    [InlineData("https://app.example.com/", "https://app.example.com")]
+    [InlineData("https://app.example.com", "https://app.example.com/")]
+    [InlineData("https://app.example.com/", "https://app.example.com/")]
+    public void TrailingSlashesAreNormalisedOnBothSides(string configured, string requested) {
+        var config = new CorsConfiguration();
+        config.AllowOrigin(configured);
+
+        Assert.True(config.IsOriginAllowed(requested));
+    }
+
+    [Fact]
+    public void NothingIsAllowedByDefault() {
+        Assert.False(new CorsConfiguration().IsOriginAllowed("https://app.example.com"));
+        Assert.Empty(new CorsConfiguration().AllowedOrigins);
+    }
+
+    [Fact]
+    public void DefaultsAreSensible() {
+        var config = new CorsConfiguration();
+
+        Assert.Equal(86400, config.MaxAgeSec);
+        Assert.Contains("GET", config.AllowedMethods);
+        Assert.Contains("OPTIONS", config.AllowedMethods);
+        Assert.Contains("Authorization", config.AllowedHeaders);
+        Assert.Equal(CorsConfiguration.DefaultEnvironmentVariable, config.EnvironmentVariable);
+    }
+
+    [Fact]
+    public void LoadFromEnvironmentReadsCommaSeparatedOrigins() {
+        var variable = "CORS_TEST_" + Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(variable,
+            "https://a.example.com, https://b.example.com ,https://c.example.com");
+
+        try {
+            var config = new CorsConfiguration { EnvironmentVariable = variable };
+            config.LoadFromEnvironment();
+
+            Assert.True(config.IsOriginAllowed("https://a.example.com"));
+            Assert.True(config.IsOriginAllowed("https://b.example.com"));
+            Assert.True(config.IsOriginAllowed("https://c.example.com"));
+            Assert.Equal(3, config.AllowedOrigins.Count);
+        }
+        finally {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
+    public void LoadFromEnvironmentIsANoOpWhenUnset() {
+        var config = new CorsConfiguration {
+            EnvironmentVariable = "CORS_TEST_UNSET_" + Guid.NewGuid().ToString("N")
+        };
+
+        config.LoadFromEnvironment();
+
+        Assert.Empty(config.AllowedOrigins);
+    }
+
+    [Fact]
+    public void LoadFromEnvironmentIsANoOpWhenBlank() {
+        var variable = "CORS_TEST_" + Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(variable, "   ");
+
+        try {
+            var config = new CorsConfiguration { EnvironmentVariable = variable };
+            config.LoadFromEnvironment();
+
+            Assert.Empty(config.AllowedOrigins);
+        }
+        finally {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
+    public void LoadFromEnvironmentSkipsEmptyEntries() {
+        var variable = "CORS_TEST_" + Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(variable, "https://a.example.com,,https://b.example.com,");
+
+        try {
+            var config = new CorsConfiguration { EnvironmentVariable = variable };
+            config.LoadFromEnvironment();
+
+            Assert.Equal(2, config.AllowedOrigins.Count);
+        }
+        finally {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+}

--- a/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsFilterTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsFilterTests.cs
@@ -1,0 +1,160 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Web.Runtime.Cors;
+using Microsoft.Extensions.Primitives;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Web.Runtime.Tests.Cors;
+
+/// <summary>
+/// CORS headers are a security boundary: emitting Access-Control-Allow-Origin for an origin
+/// that was never allowed hands that origin read access to authenticated responses. Each
+/// case is therefore asserted for what it does emit and what it must not.
+/// </summary>
+public class CorsFilterTests {
+
+    private const string Allowed = "https://app.example.com";
+    private const string Denied = "https://evil.example.com";
+
+    private static CorsConfiguration ConfigAllowing(params string[] origins) {
+        var config = new CorsConfiguration();
+        foreach (var origin in origins) {
+            config.AllowOrigin(origin);
+        }
+        return config;
+    }
+
+    private static (IExecutionChain chain, IDictionary<string, StringValues> responseHeaders, IExecutionResponse response)
+        Chain(string method, string? origin) {
+        var chain = Substitute.For<IExecutionChain>();
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+        var response = Substitute.For<IExecutionResponse>();
+
+        var requestHeaders = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+        if (origin is not null) {
+            requestHeaders["Origin"] = origin;
+        }
+
+        var responseHeaders = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        request.Method.Returns(method);
+        request.Headers.Returns(requestHeaders);
+        response.Headers.Returns(responseHeaders);
+        context.Request.Returns(request);
+        context.Response.Returns(response);
+        chain.Context.Returns(context);
+
+        return (chain, responseHeaders, response);
+    }
+
+    [Fact]
+    public async Task AllowedOriginReceivesCorsHeaders() {
+        var (chain, headers, _) = Chain("GET", Allowed);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        Assert.Equal(Allowed, headers[KnownHeaders.Cors.AccessControlAllowOrigin].ToString());
+        Assert.False(StringValues.IsNullOrEmpty(headers[KnownHeaders.Cors.AccessControlAllowHeaders]));
+        Assert.False(StringValues.IsNullOrEmpty(headers[KnownHeaders.Cors.AccessControlAllowMethods]));
+        Assert.Equal("86400", headers[KnownHeaders.Cors.AccessControlMaxAge].ToString());
+    }
+
+    [Fact]
+    public async Task DisallowedOriginReceivesNoCorsHeaders() {
+        var (chain, headers, _) = Chain("GET", Denied);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        Assert.Empty(headers);
+    }
+
+    [Fact]
+    public async Task RequestWithoutAnOriginReceivesNoCorsHeaders() {
+        var (chain, headers, _) = Chain("GET", origin: null);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        Assert.Empty(headers);
+    }
+
+    [Fact]
+    public async Task EmptyOriginHeaderReceivesNoCorsHeaders() {
+        var (chain, headers, _) = Chain("GET", "");
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        Assert.Empty(headers);
+    }
+
+    [Fact]
+    public async Task NonPreflightRequestContinuesDownTheChain() {
+        var (chain, _, _) = Chain("GET", Allowed);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        await chain.Received(1).Next();
+    }
+
+    [Fact]
+    public async Task PreflightShortCircuitsWith204AndDoesNotContinue() {
+        var (chain, _, response) = Chain("OPTIONS", Allowed);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        response.Received().Status = 204;
+        response.Received().ShouldSerialize = false;
+        await chain.DidNotReceive().Next();
+    }
+
+    [Fact]
+    public async Task PreflightFromAnAllowedOriginStillCarriesCorsHeaders() {
+        var (chain, headers, _) = Chain("OPTIONS", Allowed);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        Assert.Equal(Allowed, headers[KnownHeaders.Cors.AccessControlAllowOrigin].ToString());
+    }
+
+    /// <summary>
+    /// A preflight from a denied origin is still answered 204, but without the CORS headers,
+    /// so the browser rejects the actual request. The important half of that is the absence
+    /// of Access-Control-Allow-Origin.
+    /// </summary>
+    [Fact]
+    public async Task PreflightFromADeniedOriginIsAnsweredWithoutCorsHeaders() {
+        var (chain, headers, response) = Chain("OPTIONS", Denied);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        response.Received().Status = 204;
+        Assert.Empty(headers);
+    }
+
+    [Fact]
+    public async Task MethodMatchingForPreflightIsCaseInsensitive() {
+        var (chain, _, response) = Chain("options", Allowed);
+
+        await new CorsFilter(ConfigAllowing(Allowed)).Execute(chain);
+
+        response.Received().Status = 204;
+        await chain.DidNotReceive().Next();
+    }
+
+    [Fact]
+    public async Task ConfiguredMethodsAndHeadersAreEmittedVerbatim() {
+        var config = ConfigAllowing(Allowed);
+        config.AllowedMethods = "GET, POST";
+        config.AllowedHeaders = "Authorization";
+        config.MaxAgeSec = 60;
+
+        var (chain, headers, _) = Chain("GET", Allowed);
+
+        await new CorsFilter(config).Execute(chain);
+
+        Assert.Equal("GET, POST", headers[KnownHeaders.Cors.AccessControlAllowMethods].ToString());
+        Assert.Equal("Authorization", headers[KnownHeaders.Cors.AccessControlAllowHeaders].ToString());
+        Assert.Equal("60", headers[KnownHeaders.Cors.AccessControlMaxAge].ToString());
+    }
+}

--- a/src/Web/Hardened.Web.Runtime.Tests/StaticContent/StaticContentPathTraversalTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/StaticContent/StaticContentPathTraversalTests.cs
@@ -1,0 +1,136 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Shared.Runtime.Collections;
+using Hardened.Shared.Runtime.Utilities;
+using Hardened.Web.Runtime.Configuration;
+using Hardened.Web.Runtime.StaticContent;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Web.Runtime.Tests.StaticContent;
+
+/// <summary>
+/// StaticContentHandler maps a request path onto the filesystem with
+/// Path.Combine(root, requestPath.TrimStart('/')) and no canonicalisation, so whether a
+/// traversal sequence can escape the configured root depends entirely on the transport
+/// having normalised the path first.
+///
+/// These tests exercise the handler directly, which is the position a transport that does
+/// not normalise leaves it in.
+/// </summary>
+public class StaticContentPathTraversalTests : IDisposable {
+
+    private readonly string _tempRoot;
+    private readonly string _staticRoot;
+    private readonly string _secretFile;
+    private readonly string _originalCurrentDirectory;
+
+    public StaticContentPathTraversalTests() {
+        _originalCurrentDirectory = Directory.GetCurrentDirectory();
+
+        _tempRoot = Path.Combine(Path.GetTempPath(), "hardened-static-" + Guid.NewGuid().ToString("N"));
+        _staticRoot = Path.Combine(_tempRoot, "wwwroot");
+        Directory.CreateDirectory(_staticRoot);
+
+        File.WriteAllText(Path.Combine(_staticRoot, "public.txt"), "public content");
+
+        // A file a sibling of the static root, standing in for anything outside the
+        // directory the server is meant to expose.
+        _secretFile = Path.Combine(_tempRoot, "secret.txt");
+        File.WriteAllText(_secretFile, "SECRET-CONTENT");
+
+        Directory.SetCurrentDirectory(_tempRoot);
+    }
+
+    public void Dispose() {
+        Directory.SetCurrentDirectory(_originalCurrentDirectory);
+        try { Directory.Delete(_tempRoot, true); } catch { /* best effort */ }
+    }
+
+    private static StaticContentHandler Handler() {
+        var configuration = Substitute.For<IStaticContentConfiguration>();
+        configuration.Path.Returns("wwwroot");
+        configuration.EnableETag.Returns(false);
+        configuration.CompressTextContent.Returns(false);
+        configuration.FallBackFile.Returns((string?)null);
+        configuration.CacheMaxAge.Returns((int?)null);
+
+        var mimeHelper = Substitute.For<IFileExtToMimeTypeHelper>();
+        mimeHelper.GetMimeTypeInfo(Arg.Any<string>()).Returns(("text/plain", false));
+
+        var etag = Substitute.For<IETagProvider>();
+        etag.GenerateETag(Arg.Any<byte[]>()).Returns("etag");
+
+        return new StaticContentHandler(
+            Options.Create(configuration),
+            mimeHelper,
+            Substitute.For<IGZipStaticContentCompressor>(),
+            etag,
+            new MemoryStreamPool(),
+            NullLogger<StaticContentHandler>.Instance);
+    }
+
+    private static (IExecutionContext context, MemoryStream body) Context(string path) {
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+        var response = Substitute.For<IExecutionResponse>();
+        var body = new MemoryStream();
+
+        request.Path.Returns(path);
+        request.Headers.Returns(new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase));
+        response.Body.Returns(body);
+        response.Headers.Returns(new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase));
+        context.Request.Returns(request);
+        context.Response.Returns(response);
+
+        return (context, body);
+    }
+
+    [Fact]
+    public async Task ServesAFileInsideTheConfiguredRoot() {
+        var (context, body) = Context("/public.txt");
+
+        var handled = await Handler().Handle(context);
+
+        Assert.True(handled);
+        Assert.Equal("public content", System.Text.Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    [Fact]
+    public async Task DoesNotHandleAMissingFile() {
+        var (context, _) = Context("/does-not-exist.txt");
+
+        Assert.False(await Handler().Handle(context));
+    }
+
+    /// <summary>
+    /// A traversal sequence must not reach a file outside the configured root. If this
+    /// fails, an unnormalised request path is able to read arbitrary files the process can
+    /// see.
+    /// </summary>
+    [Fact]
+    public async Task TraversalOutsideTheRootIsNotServed() {
+        var (context, body) = Context("/../secret.txt");
+
+        var handled = await Handler().Handle(context);
+        var served = System.Text.Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.False(handled,
+            "a path traversal escaped the configured static root and was served");
+        Assert.DoesNotContain("SECRET-CONTENT", served);
+    }
+
+    [Fact]
+    public async Task DeepTraversalOutsideTheRootIsNotServed() {
+        var (context, body) = Context("/assets/../../secret.txt");
+
+        var handled = await Handler().Handle(context);
+        var served = System.Text.Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.False(handled,
+            "a nested path traversal escaped the configured static root and was served");
+        Assert.DoesNotContain("SECRET-CONTENT", served);
+    }
+}

--- a/src/Web/Hardened.Web.Runtime/StaticContent/StaticContentHandler.cs
+++ b/src/Web/Hardened.Web.Runtime/StaticContent/StaticContentHandler.cs
@@ -53,7 +53,9 @@ public class StaticContentHandler : IStaticContentHandler {
         _configuration = configuration.Value;
         _cachedStaticContentEntries = new ConcurrentDictionary<string, CachedStaticContentEntry>();
 
-        _rootPath = Path.Combine(Directory.GetCurrentDirectory(), _configuration.Path);
+        // Fully qualified so that containment checks in ResolveWithinRoot compare
+        // canonical paths on both sides.
+        _rootPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), _configuration.Path));
         _pathExists = Directory.Exists(_rootPath);
 
         if (!_pathExists) {
@@ -61,7 +63,7 @@ public class StaticContentHandler : IStaticContentHandler {
                 Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "";
 
             if (!string.IsNullOrEmpty(_rootPath)) {
-                _rootPath = Path.Combine(_rootPath, _configuration.Path);
+                _rootPath = Path.GetFullPath(Path.Combine(_rootPath, _configuration.Path));
                 _pathExists = Directory.Exists(_rootPath);
             }
         }
@@ -81,12 +83,53 @@ public class StaticContentHandler : IStaticContentHandler {
         return HandleRequestForPath(context, context.Request.Path);
     }
 
+    /// <summary>
+    /// Maps a request path onto the filesystem and confirms the result is still inside the
+    /// configured root, returning null when it is not.
+    ///
+    /// Path.Combine does not resolve traversal sequences, so "/../secret" combined with the
+    /// root points outside it. Hardened is transport agnostic and not every transport
+    /// normalises the request path the way Kestrel does - API Gateway delivers RawPath - so
+    /// the handler cannot assume that has already happened.
+    /// </summary>
+    private string? ResolveWithinRoot(string requestPath) {
+        string candidate;
+
+        try {
+            candidate = Path.GetFullPath(Path.Combine(_rootPath, requestPath.TrimStart('/')));
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException or NotSupportedException or PathTooLongException) {
+            // Malformed path - treat exactly like one that escapes the root.
+            return null;
+        }
+
+        var relative = Path.GetRelativePath(_rootPath, candidate);
+
+        if (relative == ".." ||
+            relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+            Path.IsPathRooted(relative)) {
+            _logger.LogWarning(
+                "Static content request {RequestPath} resolved outside the configured root and was refused",
+                requestPath);
+
+            return null;
+        }
+
+        return candidate;
+    }
+
     private Task<bool> HandleRequestForPath(IExecutionContext context, string requestPath) {
+        var filePath = ResolveWithinRoot(requestPath);
+
+        // Outside the configured root - refuse before touching the filesystem or the cache.
+        if (filePath == null) {
+            return FalseComplete;
+        }
+
         if (_cachedStaticContentEntries.TryGetValue(requestPath, out var cacheEntry)) {
             return RespondWithContent(context, cacheEntry);
         }
-
-        var filePath = Path.Combine(_rootPath, requestPath.TrimStart('/'));
 
         if (File.Exists(filePath)) {
             return ReturnFile(context, filePath);


### PR DESCRIPTION
## Summary

67 tests across the request pipeline and web runtime, targeting the classes at or near zero where being wrong has consequences a caller can see. One of them turned up a real defect.

## Gzip response compression never compressed anything

Both JSON response serializers had the same flaw:

```csharp
await using var gzipStream = new GZipStream(context.Response.Body, CompressionLevel.Fastest, true);

await JsonSerializer.SerializeAsync(context.Response.Body, ...);   // ← the body, not the gzip stream

await gzipStream.FlushAsync();
```

The `GZipStream` is opened over the response body, then disposed without ever being written to. The payload serializes straight to the body underneath it, so setting `ShouldCompress` produced **plain JSON**.

The test asserts the gzip magic number and reports the observed bytes on failure:

```
SystemTextJsonResponseSerializer: response body is not gzip data (first bytes: 7b 22 6e 61)
AotResponseSerializer:            response body is not gzip data (first bytes: 7b 22 6e 61)
```

`7b 22 6e 61` is `{"na`.

**Severity is limited**, and worth stating plainly: nothing in the framework ever assigns `ShouldCompress`. It's read in these two places and declared on `IExecutionResponse`, and no production path sets it. `Content-Encoding` is likewise only set by `StaticContentHandler`, a separate path for pre-compressed files. So a consumer opting in got silently uncompressed output rather than a corrupt response labelled gzip. Fixed in both by serializing into the gzip stream.

## `ExceptionToModelConverter` — was 0%

Decides the status code a caller sees and how much of the exception is echoed back. Covers `ValidationException` → 400 with per-field errors, `FormatException`/`BadRequestException` → 400, everything else → 500.

Two behaviours are **pinned rather than changed**, since they're current behaviour and a failure there should be a decision rather than a surprise:

- Classification is a substring match on the type *name*, not the type hierarchy — so `BadgeNotFoundException` is classified 400 because it contains "Bad".
- The exception message is echoed to the caller verbatim on a 500.

Neither is touched here. Both now have a test that will fail loudly if the strategy changes.

## `CorsFilter` — was 0%

CORS headers are a security boundary: emitting `Access-Control-Allow-Origin` for an origin that was never allowed hands that origin read access to authenticated responses. Every case asserts both what is emitted and what must not be:

| Case | Asserted |
|---|---|
| Allowed origin | all four CORS headers present |
| Disallowed origin | **no headers at all** |
| Absent / empty Origin | **no headers at all** |
| Preflight (OPTIONS) | 204, `ShouldSerialize=false`, chain **not** continued |
| Preflight from denied origin | answered 204, **without** CORS headers |

`CorsConfiguration` adds trailing-slash normalisation on both sides, case-insensitive matching, and environment loading including unset, blank, and empty-entry cases.

## `HeaderCollectionStringValues` — was 0% across 49 lines

The header collection backing the API Gateway and streaming transports. Covers all three constructors, misses returning `StringValues.Empty` rather than throwing, `Append` creating and concatenating, `Set` removing on null, and the dictionary surface.

`Add(string, StringValues)` throws `NotImplementedException` — pinned so it's visible rather than discovered at runtime. Callers should use `Set` or the `KeyValuePair` overload.

## Result

**419 → 486 tests**, all passing.

| | Before | After |
|---|---|---|
| `Hardened.Requests.Runtime` | 53.8% | **66.1%** |
| `Hardened.Web.Runtime` | 38.8% | **54.8%** |
| Repository | 38.3% | 39.2% |


---

# Second batch: a path traversal, and cookie attributes

## 🔴 Path traversal in `StaticContentHandler`

The handler mapped a request onto the filesystem with no canonicalisation:

```csharp
var filePath = Path.Combine(_rootPath, requestPath.TrimStart('/'));
if (File.Exists(filePath)) { return ReturnFile(context, filePath); }
```

`Path.Combine` does not resolve traversal sequences, so `/../secret.txt` resolved **outside** the static root and the file was served.

**Demonstrated, not inferred.** The test builds a real static root with a sibling file outside it and drives the handler directly. Before the fix:

```
a path traversal escaped the configured static root and was served
a nested path traversal escaped the configured static root and was served
```

**Reachability depends on the transport.** Kestrel normalises traversal sequences before the framework sees them, so ASP.NET Core hosts were probably not exposed. API Gateway delivers `RawPath`, and a custom transport need not normalise at all. Since Hardened is explicitly transport agnostic, the handler cannot assume normalisation has happened — so it now checks itself.

`ResolveWithinRoot` fully qualifies the candidate and confirms containment via `Path.GetRelativePath`, refusing anything that escapes and logging a warning. Malformed paths are refused identically. **The check runs before the filesystem or the entry cache is touched**, so a traversal path can never be cached. The root is now fully qualified in the constructor so both sides of the comparison are canonical.

## Cookie attributes were emitted incorrectly

Two defects in `CookieSetOptions.AppendSettings`, each silently producing a different cookie than the one requested:

| | Was | Now |
|---|---|---|
| `Path` | **accepted and never written** — cookie applied to the whole origin, sent on requests it was never scoped for | emitted when set |
| `Expires` | **`Expire=` with no timezone** — not an RFC 6265 attribute, so browsers ignored it and the cookie silently became a session cookie | `Expires=` in RFC 1123 GMT, converted to UTC first |

Both fixed. Also covered: `Secure`/`HttpOnly` defaulting on, `SameSite` across all three values, and the omission cases.

## Running total

**419 → 506 tests**, all passing.

| | Start of phase | Now |
|---|---|---|
| `Hardened.Requests.Runtime` | 53.8% | **66.1%** |
| `Hardened.Web.Runtime` | 38.8% | **71.4%** |
| `Hardened.Requests.Abstract` | 51.1% | **70.9%** |
| Repository | 38.3% | 39.6% |

Three real defects found and fixed across the phase: gzip compression that never compressed, a path traversal, and two cookie attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
