### PR TITLE
Prove incremental generator caching, and cover the model equality it rests on

### DIFF
--- a/src/Hardened.Framework.sln
+++ b/src/Hardened.Framework.sln
@@ -95,6 +95,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Function.SourceGen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Web.AspNetCore.Runtime.Tests", "Web\Hardened.Web.AspNetCore.Runtime.Tests\Hardened.Web.AspNetCore.Runtime.Tests.csproj", "{7D8DED0A-72BA-483B-9B78-8182113238B9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Web.SourceGenerator.Tests", "SourceGenerators\Hardened.Web.SourceGenerator.Tests\Hardened.Web.SourceGenerator.Tests.csproj", "{6C04C9AB-EB75-4594-94C2-ADBF1C908FC3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -241,6 +243,10 @@ Global
 		{7D8DED0A-72BA-483B-9B78-8182113238B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7D8DED0A-72BA-483B-9B78-8182113238B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D8DED0A-72BA-483B-9B78-8182113238B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C04C9AB-EB75-4594-94C2-ADBF1C908FC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C04C9AB-EB75-4594-94C2-ADBF1C908FC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C04C9AB-EB75-4594-94C2-ADBF1C908FC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C04C9AB-EB75-4594-94C2-ADBF1C908FC3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -285,6 +291,7 @@ Global
 		{76585983-2ECC-4BDA-85C6-19A35993796D} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
 		{06999170-205C-49C4-8F0D-81481F558819} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
 		{7D8DED0A-72BA-483B-9B78-8182113238B9} = {7DC696BF-0B4E-4B03-B309-ABDC7A502538}
+		{6C04C9AB-EB75-4594-94C2-ADBF1C908FC3} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF6CD1AB-6B41-427D-BA1B-C4803CF67E97}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelEqualityCachingTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelEqualityCachingTests.cs
@@ -1,0 +1,131 @@
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Requests;
+using Hardened.SourceGenerator.Shared;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Caching;
+
+/// <summary>
+/// Incremental generator caching is built on model equality. Roslyn keeps a cached result
+/// and reuses it only when the model produced by the new run compares equal to the previous
+/// one. Any model that falls back to reference equality is never equal to its successor, so
+/// the pipeline re-runs on every keystroke - output stays correct, nothing fails, the IDE
+/// just gets slower for no visible reason.
+///
+/// These assert the property caching actually depends on: a model rebuilt from identical
+/// inputs equals the original, and differing inputs do not.
+/// </summary>
+public class ModelEqualityCachingTests {
+
+    private static ITypeDefinition Type(string ns, string name) => TypeDefinition.Get(ns, name);
+
+    private static RequestHandlerModel Model(
+        string path = "/orders/{id}",
+        string method = "GET",
+        string handlerMethod = "GetOrder",
+        string returnTypeName = "String") =>
+        new(
+            new RequestHandlerNameModel(path, method),
+            Type("TestApp", "OrderController"),
+            handlerMethod,
+            Type("TestApp", "OrderController_GetOrder"),
+            new List<RequestParameterInformation> {
+                new(
+                    parameterType: Type("System", "String"),
+                    name: "id",
+                    required: true,
+                    defaultValue: null,
+                    bindingType: ParameterBindType.Path,
+                    bindingName: "id",
+                    parameterIndex: 0)
+            },
+            new ResponseInformationModel { ReturnType = Type("System", returnTypeName) },
+            new List<AttributeModel> {
+                new(Type("TestApp", "AuthorizeAttribute"), "", "")
+            });
+
+    /// <summary>
+    /// Everything else rests on this. ITypeDefinition comes from CSharpAuthor and appears in
+    /// nearly every model; if it compared by reference, no model built on it could ever
+    /// cache.
+    /// </summary>
+    [Fact]
+    public void TypeDefinitionComparesStructurally() {
+        Assert.Equal(Type("System", "String"), Type("System", "String"));
+        Assert.Equal(Type("System", "String").GetHashCode(), Type("System", "String").GetHashCode());
+        Assert.NotEqual(Type("System", "String"), Type("System", "Int32"));
+    }
+
+    [Fact]
+    public void IdenticallyBuiltModelsAreEqual() {
+        Assert.True(Model().Equals(Model()),
+            "two models built from identical inputs must compare equal or the generator " +
+            "pipeline re-runs on every edit");
+    }
+
+    [Fact]
+    public void IdenticallyBuiltModelsShareAHashCode() {
+        Assert.Equal(Model().GetHashCode(), Model().GetHashCode());
+    }
+
+    [Theory]
+    [InlineData("/orders/{id}", "POST", "GetOrder", "String")]
+    [InlineData("/other/{id}", "GET", "GetOrder", "String")]
+    [InlineData("/orders/{id}", "GET", "DeleteOrder", "String")]
+    [InlineData("/orders/{id}", "GET", "GetOrder", "Int32")]
+    public void ModelsDifferingInAnyMemberAreNotEqual(
+        string path, string method, string handlerMethod, string returnTypeName) {
+        Assert.False(Model().Equals(Model(path, method, handlerMethod, returnTypeName)),
+            "a model that differs must not compare equal, or a real code change would be " +
+            "cached away and never regenerated");
+    }
+
+    [Fact]
+    public void ModelIsNotEqualToAnUnrelatedObject() {
+        Assert.False(Model().Equals("not a model"));
+        Assert.False(Model().Equals(null!));
+    }
+
+    [Fact]
+    public void ComparerAgreesWithTheModel() {
+        var comparer = new RequestHandlerModelComparer();
+
+        Assert.True(comparer.Equals(Model(), Model()));
+        Assert.Equal(comparer.GetHashCode(Model()), comparer.GetHashCode(Model()));
+        Assert.False(comparer.Equals(Model(), Model(method: "DELETE")));
+    }
+
+    [Fact]
+    public void RequestHandlerNameModelComparesStructurally() {
+        var a = new RequestHandlerNameModel("/a", "GET");
+        var b = new RequestHandlerNameModel("/a", "GET");
+
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.False(a.Equals(new RequestHandlerNameModel("/a", "POST")));
+        Assert.False(a.Equals(new RequestHandlerNameModel("/b", "GET")));
+    }
+
+    /// <summary>
+    /// ResponseInformationModel and AttributeModel are records, so equality is generated
+    /// member-wise. That is only structural while their members are - a collection member
+    /// would silently revert them to reference equality.
+    /// </summary>
+    [Fact]
+    public void RecordModelsCompareStructurally() {
+        var responseA = new ResponseInformationModel { ReturnType = Type("System", "String"), IsAsync = true };
+        var responseB = new ResponseInformationModel { ReturnType = Type("System", "String"), IsAsync = true };
+
+        Assert.Equal(responseA, responseB);
+        Assert.Equal(responseA.GetHashCode(), responseB.GetHashCode());
+        Assert.NotEqual(responseA, new ResponseInformationModel { ReturnType = Type("System", "String") });
+
+        var attributeA = new AttributeModel(Type("TestApp", "AuthorizeAttribute"), "args", "props");
+        var attributeB = new AttributeModel(Type("TestApp", "AuthorizeAttribute"), "args", "props");
+
+        Assert.Equal(attributeA, attributeB);
+        Assert.Equal(attributeA.GetHashCode(), attributeB.GetHashCode());
+        Assert.NotEqual(attributeA, attributeA with { Arguments = "different" });
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Caching/GeneratorTestHarness.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Caching/GeneratorTestHarness.cs
@@ -1,0 +1,67 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Hardened.Web.SourceGenerator.Tests.Caching;
+
+/// <summary>
+/// Runs an <see cref="IIncrementalGenerator"/> through a real <see cref="GeneratorDriver"/>
+/// so that both its output and its incremental caching behaviour can be asserted.
+/// </summary>
+internal static class GeneratorTestHarness {
+
+    /// <summary>
+    /// Reference set wide enough for a Hardened controller to compile: the framework
+    /// assemblies plus everything currently loaded, which covers the BCL.
+    /// </summary>
+    private static readonly Lazy<ImmutableArray<MetadataReference>> References = new(() =>
+        AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => (MetadataReference)MetadataReference.CreateFromFile(a.Location))
+            .ToImmutableArray());
+
+    public static CSharpCompilation CreateCompilation(string source, string assemblyName = "GeneratorCacheTests") =>
+        CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            References.Value,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+    /// <summary>
+    /// Creates a driver with step tracking enabled. Tracking is what makes
+    /// <see cref="GeneratorRunResult.TrackedOutputSteps"/> populated, and therefore what
+    /// makes cache behaviour observable at all.
+    /// </summary>
+    public static GeneratorDriver CreateDriver(IIncrementalGenerator generator) =>
+        CSharpGeneratorDriver.Create(
+            generators: new[] { generator.AsSourceGenerator() },
+            driverOptions: new GeneratorDriverOptions(
+                disabledOutputs: IncrementalGeneratorOutputKind.None,
+                trackIncrementalGeneratorSteps: true));
+
+    /// <summary>
+    /// Every reason recorded against the driver's output steps for a run.
+    /// </summary>
+    public static IReadOnlyList<IncrementalStepRunReason> OutputStepReasons(GeneratorDriver driver) =>
+        driver.GetRunResult().Results
+            .SelectMany(result => result.TrackedOutputSteps)
+            .SelectMany(step => step.Value)
+            .SelectMany(step => step.Outputs)
+            .Select(output => output.Reason)
+            .ToList();
+
+    public static IReadOnlyList<string> GeneratedSources(GeneratorDriver driver) =>
+        driver.GetRunResult().Results
+            .SelectMany(result => result.GeneratedSources)
+            .OrderBy(source => source.HintName, StringComparer.Ordinal)
+            .Select(source => source.SourceText.ToString())
+            .ToList();
+
+    public static IReadOnlyList<string> GeneratedHintNames(GeneratorDriver driver) =>
+        driver.GetRunResult().Results
+            .SelectMany(result => result.GeneratedSources)
+            .Select(source => source.HintName)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Caching/WebGeneratorCachingTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Caching/WebGeneratorCachingTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Caching;
+
+/// <summary>
+/// Incremental generators are re-run by the IDE on every keystroke. They stay cheap only if
+/// their pipeline caches - which requires every model flowing through it to compare equal
+/// when the underlying code has not meaningfully changed. A model that falls back to
+/// reference equality still produces correct output, so nothing fails; the generator just
+/// silently re-runs every time and the IDE gets slower.
+///
+/// These tests make that observable: the driver is created with step tracking enabled, run
+/// twice, and the reasons recorded on the second run are asserted.
+/// </summary>
+public class WebGeneratorCachingTests {
+
+    private const string ControllerSource = """
+        using Hardened.Web.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [BasePath("/api/orders")]
+        public class OrderController {
+            [Get("/{id}")]
+            public string GetOrder(string id) => id;
+
+            [Post("/")]
+            public string CreateOrder(string name) => name;
+        }
+        """;
+
+    private static WebLibrarySourceGenerator Generator() => new();
+
+    [Fact]
+    public void GeneratorProducesOutputForAController() {
+        var compilation = GeneratorTestHarness.CreateCompilation(ControllerSource);
+        var driver = GeneratorTestHarness.CreateDriver(Generator()).RunGenerators(compilation);
+
+        var diagnostics = driver.GetRunResult().Diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+
+        Assert.Empty(diagnostics);
+    }
+
+    /// <summary>
+    /// The core caching assertion. Running the same compilation through the driver a second
+    /// time must not re-execute the pipeline: every recorded output step should be Cached or
+    /// Unchanged. A New or Modified reason means something in the model chain compared
+    /// unequal to itself.
+    /// </summary>
+    [Fact]
+    public void SecondRunOverAnUnchangedCompilationIsFullyCached() {
+        var compilation = GeneratorTestHarness.CreateCompilation(ControllerSource);
+
+        var driver = GeneratorTestHarness.CreateDriver(Generator());
+        driver = driver.RunGenerators(compilation);
+
+        // Re-run against the very same compilation.
+        driver = driver.RunGenerators(compilation);
+
+        var reasons = GeneratorTestHarness.OutputStepReasons(driver);
+
+        Assert.All(reasons, reason =>
+            Assert.True(
+                reason is IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged,
+                $"expected every output step to be Cached or Unchanged on an unchanged re-run, " +
+                $"but one was {reason}. The generator is re-running its pipeline on every edit."));
+    }
+
+    /// <summary>
+    /// The realistic IDE case: the user edits an unrelated part of the file. The syntax tree
+    /// is a different instance and the compilation is new, but nothing the generator cares
+    /// about changed, so its output should still come from cache.
+    /// </summary>
+    [Fact]
+    public void EditingAnUnrelatedDeclarationStillCachesGeneratorOutput() {
+        var first = GeneratorTestHarness.CreateCompilation(ControllerSource);
+
+        var edited = ControllerSource.Replace(
+            "public class OrderController {",
+            "public class OrderController {\n    private int _unrelatedField;");
+
+        var second = GeneratorTestHarness.CreateCompilation(edited);
+
+        var driver = GeneratorTestHarness.CreateDriver(Generator());
+        driver = driver.RunGenerators(first);
+        var firstSources = GeneratorTestHarness.GeneratedSources(driver);
+
+        driver = driver.RunGenerators(second);
+        var secondSources = GeneratorTestHarness.GeneratedSources(driver);
+
+        Assert.Equal(firstSources, secondSources);
+    }
+
+    /// <summary>
+    /// The other half of the contract: caching must not be so aggressive that a real change
+    /// is missed. Adding a route has to change the generated output.
+    /// </summary>
+    [Fact]
+    public void AddingARouteChangesGeneratedOutput() {
+        var withExtraRoute = ControllerSource.Replace(
+            "    [Post(\"/\")]",
+            """
+                [Delete("/{id}")]
+                public string DeleteOrder(string id) => id;
+
+                [Post("/")]
+            """);
+
+        var driver = GeneratorTestHarness.CreateDriver(Generator());
+
+        driver = driver.RunGenerators(GeneratorTestHarness.CreateCompilation(ControllerSource));
+        var before = GeneratorTestHarness.GeneratedSources(driver);
+
+        driver = driver.RunGenerators(GeneratorTestHarness.CreateCompilation(withExtraRoute));
+        var after = GeneratorTestHarness.GeneratedSources(driver);
+
+        Assert.NotEqual(before, after);
+    }
+
+    /// <summary>
+    /// Generation must be deterministic: two independent drivers over identical input have
+    /// to produce byte-identical source. Non-determinism here would show up downstream as
+    /// spurious rebuilds and unstable diffs in committed generated output.
+    /// </summary>
+    [Fact]
+    public void GenerationIsDeterministicAcrossIndependentDrivers() {
+        var one = GeneratorTestHarness.CreateDriver(Generator())
+            .RunGenerators(GeneratorTestHarness.CreateCompilation(ControllerSource));
+
+        var two = GeneratorTestHarness.CreateDriver(Generator())
+            .RunGenerators(GeneratorTestHarness.CreateCompilation(ControllerSource));
+
+        Assert.Equal(
+            GeneratorTestHarness.GeneratedSources(one),
+            GeneratorTestHarness.GeneratedSources(two));
+
+        Assert.Equal(
+            GeneratorTestHarness.GeneratedHintNames(one),
+            GeneratorTestHarness.GeneratedHintNames(two));
+    }
+
+    [Fact]
+    public void GeneratorDoesNotThrowOnAFileWithNoControllers() {
+        var compilation = GeneratorTestHarness.CreateCompilation(
+            "namespace TestApp; public class NotAController { public int Value { get; set; } }");
+
+        var driver = GeneratorTestHarness.CreateDriver(Generator()).RunGenerators(compilation);
+
+        Assert.Empty(driver.GetRunResult().Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="1.*" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!--
+          Hardened.Web.SourceGenerator is referenced as a normal assembly rather than an
+          analyzer so a GeneratorDriver can drive it directly.
+
+          Hardened.SourceGenerator is deliberately NOT referenced here. It is compiled into
+          Hardened.Web.SourceGenerator via linked Compile items, so referencing both puts
+          two copies of RequestHandlerModel, RouteTreeNode<T> and friends in scope and every
+          use becomes ambiguous (CS0433).
+        -->
+        <ProjectReference Include="..\Hardened.Web.SourceGenerator\Hardened.Web.SourceGenerator.csproj"/>
+        <ProjectReference Include="..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
+        <ProjectReference Include="..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
+        <ProjectReference Include="..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## The answer up front: caching works

Verified rather than assumed — the web generator's pipeline caches correctly today.

## Why this needed testing at all

Incremental generators are re-run by the IDE on **every keystroke**. They stay cheap only if their pipeline caches, and caching depends on every model flowing through it comparing equal when the underlying code hasn't meaningfully changed.

The failure mode is invisible. A model that falls back to reference equality still produces **correct output** — nothing fails, no test goes red. The generator just re-runs every time and the IDE gets slower for no discoverable reason. Nothing was checking it.

## Driver-level caching tests

`Hardened.Web.SourceGenerator.Tests` drives `WebLibrarySourceGenerator` through a real `CSharpGeneratorDriver` with `trackIncrementalGeneratorSteps` enabled, which is what makes cache behaviour observable at all.

| Behaviour | |
|---|---|
| Produces output for a controller | no error diagnostics |
| **Re-run over unchanged compilation** | **every output step `Cached` or `Unchanged`** |
| Unrelated edit elsewhere in the file | generated sources still identical |
| Adding a route | output **does** change — caching isn't so aggressive it misses real edits |
| Two independent drivers, same input | byte-identical source |
| File with no controllers | doesn't throw |

### The assertion was checked for vacuity

`Assert.All` over an empty sequence passes trivially, so a caching test that observes nothing looks identical to one that passes. I inspected the tracked step counts directly rather than trusting the green:

```
generatedSources=1  trackedSteps=1  trackedOutputSteps=1  outputStepReasons=1 -> Cached
```

One real output step, reason `Cached`. The assertion is observing something.

## Model equality — the primitives caching rests on

Tested directly in `Hardened.SourceGenerator.Tests`, no driver needed:

- **`ITypeDefinition` compares structurally.** Everything rests on this. It comes from CSharpAuthor and appears in nearly every model, so if it compared by reference nothing built on it could ever cache.
- `RequestHandlerModel` equals itself when rebuilt from identical inputs, shares a hash code, and differs when any member differs.
- `RequestHandlerModelComparer` agrees with the model it wraps.
- `RequestHandlerNameModel` compares structurally.
- `ResponseInformationModel` and `AttributeModel` are records — their generated equality is **member-wise**, so it's only structural while their members are. A collection member would silently revert them to reference equality. Currently they hold only scalars and `ITypeDefinition`, so they're fine; the test locks that in.

## A finding: the generator assemblies are mutually exclusive as references

These tests couldn't live in `Hardened.SourceGenerator.Tests`. Referencing both `Hardened.SourceGenerator` and `Hardened.Web.SourceGenerator` puts **two copies** of `RequestHandlerModel`, `RouteTreeNode<T>` and the rest in scope — the web generator compiles that shared source into itself via linked `Compile` items — and every use becomes ambiguous:

```
error CS0433: The type 'RequestHandlerModel' exists in both
  'Hardened.SourceGenerator' and 'Hardened.Web.SourceGenerator'
```

That's a concrete cost of the linked-source duplication flagged in the original review: **each generator wanting driver-level tests needs its own test project.** `Hardened.DependencyModules.SourceGenerator` links no shared source and wouldn't collide.

## Coverage accounting — the number goes down, and that's honest

Reported line coverage moves **39.6% → 38.6%**. That is measuring *more* code, not testing less:

- `Hardened.Web.SourceGenerator` now appears in the report at **34.7%**. It was previously invisible because no test project referenced it.
- Total measured branches: **4,885 → 6,354**.
- `Hardened.SourceGenerator`: 27.0% → **28.4%**.

**506 → 523 tests**, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
