### PR TITLE
Follow the move to ipjohnson, and pin DependencyModules to rc9200

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hardened.Framework
 
-The core framework for the [Hardened](https://ipjohnson-org.github.io/Hardened.Docs) ecosystem — a compile-time, source-generated .NET framework for building web APIs, AWS Lambda functions, and canary tests.
+The core framework for the [Hardened](https://ipjohnson.github.io/Hardened.Docs) ecosystem — a compile-time, source-generated .NET framework for building web APIs, AWS Lambda functions, and canary tests.
 
 Hardened uses C# source generators to wire up dependency injection, request routing, configuration, and more at compile time — eliminating runtime reflection and delivering fast startup, small binaries, and strong type safety.
 
@@ -53,17 +53,17 @@ app.Run();
 
 ## Documentation
 
-Full documentation is available at **[ipjohnson-org.github.io/Hardened.Docs](https://ipjohnson-org.github.io/Hardened.Docs)**.
+Full documentation is available at **[ipjohnson.github.io/Hardened.Docs](https://ipjohnson.github.io/Hardened.Docs)**.
 
-- [Getting Started](https://ipjohnson-org.github.io/Hardened.Docs/getting-started/installation/)
-- [Architecture Overview](https://ipjohnson-org.github.io/Hardened.Docs/architecture/overview/)
-- [Dependency Injection](https://ipjohnson-org.github.io/Hardened.Docs/framework/shared/dependency-injection/)
-- [Web Routing](https://ipjohnson-org.github.io/Hardened.Docs/framework/web/routing/)
-- [Testing](https://ipjohnson-org.github.io/Hardened.Docs/framework/testing/hardened-test/)
-- [Recipes](https://ipjohnson-org.github.io/Hardened.Docs/recipes/web-api-crud/)
+- [Getting Started](https://ipjohnson.github.io/Hardened.Docs/getting-started/installation/)
+- [Architecture Overview](https://ipjohnson.github.io/Hardened.Docs/architecture/overview/)
+- [Dependency Injection](https://ipjohnson.github.io/Hardened.Docs/framework/shared/dependency-injection/)
+- [Web Routing](https://ipjohnson.github.io/Hardened.Docs/framework/web/routing/)
+- [Testing](https://ipjohnson.github.io/Hardened.Docs/framework/testing/hardened-test/)
+- [Recipes](https://ipjohnson.github.io/Hardened.Docs/recipes/web-api-crud/)
 
 ## Related Repositories
 
-- [Hardened.Amz](https://github.com/ipjohnson-org/Hardened.Amz) — AWS Lambda runtimes, DynamoDB/SQS clients, CDK support
-- [Hardened.Canaries](https://github.com/ipjohnson-org/Hardened.Canaries) — Canary testing framework
-- [Hardened.Docs](https://github.com/ipjohnson-org/Hardened.Docs) — Documentation site
+- [Hardened.Amz](https://github.com/ipjohnson/Hardened.Amz) — AWS Lambda runtimes, DynamoDB/SQS clients, CDK support
+- [Hardened.Canaries](https://github.com/ipjohnson/Hardened.Canaries) — Canary testing framework
+- [Hardened.Docs](https://github.com/ipjohnson/Hardened.Docs) — Documentation site

--- a/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
+++ b/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
@@ -15,8 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-*" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-*" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
+++ b/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
@@ -15,8 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-*" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-*" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />

--- a/src/Shared/Hardened.Shared.Testing/Hardened.Shared.Testing.csproj
+++ b/src/Shared/Hardened.Shared.Testing/Hardened.Shared.Testing.csproj
@@ -27,7 +27,7 @@
         <ProjectReference Include="..\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\..\DependencyModules\src\DependencyModules.xUnit\DependencyModules.xUnit.csproj"
                           Condition="Exists('..\..\..\..\DependencyModules\src\DependencyModules.xUnit\DependencyModules.xUnit.csproj')"/>
-        <PackageReference Include="DependencyModules.xUnit" Version="1.0.0-*"
+        <PackageReference Include="DependencyModules.xUnit" Version="1.0.0-rc9200"
                           Condition="!Exists('..\..\..\..\DependencyModules\src\DependencyModules.xUnit\DependencyModules.xUnit.csproj')"/>
     </ItemGroup>
 

--- a/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
@@ -47,7 +47,7 @@
 
     <!-- DependencyModules source: NuGet package or local linked files -->
     <ItemGroup Condition="'$(UseLocalDependencyModules)' != 'true'">
-        <PackageReference Include="DependencyModules.SourceGenerator.Impl" Version="1.0.0-*">
+        <PackageReference Include="DependencyModules.SourceGenerator.Impl" Version="1.0.0-rc9200">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>build</IncludeAssets>
         </PackageReference>

--- a/src/Templates/Hardened.Templates.Runtime/Hardened.Templates.Runtime.csproj
+++ b/src/Templates/Hardened.Templates.Runtime/Hardened.Templates.Runtime.csproj
@@ -15,8 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-*" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-*" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/Web/Hardened.Web.Runtime/Hardened.Web.Runtime.csproj
+++ b/src/Web/Hardened.Web.Runtime/Hardened.Web.Runtime.csproj
@@ -15,8 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-*" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-*" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,12 +3,12 @@
     <packageSources>
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-        <add key="github-ipjohnson-org" value="https://nuget.pkg.github.com/ipjohnson-org/index.json" />
+        <add key="github-ipjohnson" value="https://nuget.pkg.github.com/ipjohnson/index.json" />
     </packageSources>
     <packageSourceCredentials>
-        <github-ipjohnson-org>
-            <add key="Username" value="ipjohnson-org" />
+        <github-ipjohnson>
+            <add key="Username" value="ipjohnson" />
             <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
-        </github-ipjohnson-org>
+        </github-ipjohnson>
     </packageSourceCredentials>
 </configuration>


### PR DESCRIPTION
Updates the package feed, its credential entry and the documentation links from `ipjohnson-org` to `ipjohnson`, following the repository transfer. The workflow was already updated separately.

Also pins DependencyModules from the floating `1.0.0-*` to an explicit `1.0.0-rc9200`.

**Pinning is deliberate.** NuGet compares prerelease labels as strings, so `1.0.0-rel9` — which exists on the GitHub feed — sorts *above* `1.0.0-rc9200`, and the float would have quietly stayed on `rel9` rather than taking the newly published version. The float had already moved the framework onto an in-progress `rel` build without anyone choosing it, which is a poor property for the dependency that decides whether tests get discovered at all.

Builds clean and **all 506 tests pass** on `rc9200`, with no duplicate test-case IDs skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd