### PR TITLE
Version as 1.0.0-preview, with a five digit build number

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-          source-url: https://nuget.pkg.github.com/ipjohnson/index.json
+          source-url: https://nuget.pkg.github.com/ipjohnson-org/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -67,8 +67,8 @@ jobs:
 
       - name: Pack
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet pack src/Hardened.Framework.sln --configuration Release --no-build /p:PackageVersion=0.2.0-Alpha${{ github.run_number }}
+        run: dotnet pack src/Hardened.Framework.sln --configuration Release --no-build /p:PackageVersion=1.0.0-preview${{ 10000 + github.run_number }}
 
       - name: Push
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push src/**/bin/Release/*.nupkg --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/ipjohnson/index.json" --skip-duplicate
+        run: dotnet nuget push src/**/bin/Release/*.nupkg --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/ipjohnson-org/index.json" --skip-duplicate


### PR DESCRIPTION
Both repositories move to `1.0.0-preview${{ 10000 + github.run_number }}`, giving one scheme across the framework and the AWS packages ahead of a first public release. Previously the framework packed `0.2.0-Alpha{run}` and the AWS packages packed `1.0.{run}` — a *stable* scheme.

**The 10000 offset is not cosmetic.** NuGet compares alphanumeric prerelease labels lexically, not numerically, so `preview9999` sorts *above* `preview10000`. Keeping the build number at five digits keeps lexical and numeric order aligned, and the offset guarantees it stays there until 99999.

First version will be `1.0.0-preview10128` — the offset applies to the existing run number rather than restarting the counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd