### PR TITLE
Compute the preview build number in the shell, not an expression

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-          source-url: https://nuget.pkg.github.com/ipjohnson-org/index.json
+          source-url: https://nuget.pkg.github.com/ipjohnson/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -65,10 +65,17 @@ jobs:
           name: coverage-report
           path: coverage-report
 
+      # GitHub Actions expressions have no arithmetic operators, so the 10000 offset
+      # is applied in the shell. The offset keeps the build number at five digits:
+      # NuGet compares alphanumeric prerelease labels lexically, so preview9999 would
+      # sort above preview10000.
       - name: Pack
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet pack src/Hardened.Framework.sln --configuration Release --no-build /p:PackageVersion=1.0.0-preview${{ 10000 + github.run_number }}
+        run: |
+          BUILD=$(( 10000 + GITHUB_RUN_NUMBER ))
+          echo "Packing 1.0.0-preview$BUILD"
+          dotnet pack src/Hardened.Framework.sln --configuration Release --no-build /p:PackageVersion=1.0.0-preview$BUILD
 
       - name: Push
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push src/**/bin/Release/*.nupkg --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/ipjohnson-org/index.json" --skip-duplicate
+        run: dotnet nuget push src/**/bin/Release/*.nupkg --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/ipjohnson/index.json" --skip-duplicate


### PR DESCRIPTION
`1.0.0-preview${{ 10000 + github.run_number }}` is **not a valid GitHub Actions expression** — expressions have no arithmetic operators. The workflow failed to load entirely: the run reported a *workflow file issue* rather than a step failure, and nothing was published.

The offset now happens in the shell, where arithmetic works:

```bash
BUILD=$(( 10000 + GITHUB_RUN_NUMBER ))
dotnet pack ... /p:PackageVersion=1.0.0-preview$BUILD
```

The offset itself matters: NuGet compares alphanumeric prerelease labels lexically, not numerically, so `preview9999` sorts *above* `preview10000`. Five digits keeps lexical and numeric order aligned.

Also **restores the publish target to the `ipjohnson` feed** — it had reverted to `ipjohnson-org` because I copied the workflow file across branches from a point before that fix landed. My error, caught before it published anywhere wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd