### PR TITLE
Classify client errors by type, not by the shape of the name

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
@@ -87,28 +87,56 @@ public class ExceptionToModelConverterTests {
         public BadgeNotFoundException() : base("no badge") { }
     }
 
-    /// <summary>
-    /// Classification is done by substring match on the exception type name rather than by
-    /// type hierarchy, so any type whose name contains "Validation" is treated as a client
-    /// error without deriving from anything.
-    /// </summary>
-    [Fact]
-    public void ExceptionNamedForValidationMapsTo400WithoutInheritance() {
-        var (status, _) = Converter.ConvertExceptionToModel(
-            Context(), new CustomValidationProblemException());
-
-        Assert.Equal(400, status);
+    private class TenantMismatchException : BadRequestException {
+        public TenantMismatchException() : base("tenant does not match") { }
     }
 
     /// <summary>
-    /// The same substring matching catches "Bad" anywhere in the name, so BadgeNotFound is
-    /// classified as a 400. Pinned deliberately: this is current behaviour, and a test
-    /// failing here means the classification strategy changed.
+    /// Classification is by type, not by the shape of the name. A type merely named for
+    /// validation, without deriving from BadRequestException, is not a client error.
     /// </summary>
     [Fact]
-    public void SubstringMatchingAlsoCatchesUnrelatedNamesContainingBad() {
+    public void ExceptionMerelyNamedForValidationIsNotAClientError() {
+        var (status, _) = Converter.ConvertExceptionToModel(
+            Context(), new CustomValidationProblemException());
+
+        Assert.Equal(500, status);
+    }
+
+    /// <summary>
+    /// The case that motivated the change: substring matching on "Bad" classified
+    /// BadgeNotFoundException - an unrelated type - as a client error.
+    /// </summary>
+    [Fact]
+    public void UnrelatedNameContainingBadIsNotAClientError() {
         var (status, _) = Converter.ConvertExceptionToModel(
             Context(), new BadgeNotFoundException());
+
+        Assert.Equal(500, status);
+    }
+
+    /// <summary>
+    /// The supported way to have an exception treated as a client error: derive it from
+    /// BadRequestException. The name is irrelevant.
+    /// </summary>
+    [Fact]
+    public void DerivingFromBadRequestExceptionMakesItAClientError() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(), new TenantMismatchException());
+
+        Assert.Equal(400, status);
+        Assert.Equal(nameof(TenantMismatchException), Assert.IsType<ErrorModel>(model).Type);
+    }
+
+    /// <summary>
+    /// BadContentEncodingException is raised when a client sends an unsupported
+    /// Content-Encoding, so it is a client error. It previously reached 400 only because
+    /// its name contains "Bad"; it now derives from BadRequestException and earns it.
+    /// </summary>
+    [Fact]
+    public void UnsupportedContentEncodingIsAClientError() {
+        var (status, _) = Converter.ConvertExceptionToModel(
+            Context(), new BadContentEncodingException("deflate"));
 
         Assert.Equal(400, status);
     }

--- a/src/Requests/Hardened.Requests.Runtime/Errors/BadContentEncodingException.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/BadContentEncodingException.cs
@@ -1,6 +1,11 @@
-﻿namespace Hardened.Requests.Runtime.Errors;
+namespace Hardened.Requests.Runtime.Errors;
 
-public class BadContentEncodingException : Exception {
+/// <summary>
+/// Thrown when a request arrives with a Content-Encoding the deserializers do not support.
+/// That is a client error, so it derives from <see cref="BadRequestException"/> and is
+/// classified as a 400 by type rather than by the shape of its name.
+/// </summary>
+public class BadContentEncodingException : BadRequestException {
     public BadContentEncodingException(string contentEncoding) : base(
         $"{contentEncoding} is not a supported Content-Encoding") { }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -21,14 +21,17 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
             return (400, errorModel);
         }
 
-        var statusCode = 500;
         var model = new ErrorModel { Type = exp.GetType().Name, Message = exp.Message };
 
-        if (exp.GetType().Name.Contains("Validation") ||
-            exp.GetType().Name.Contains("Bad") ||
-            exp is FormatException) {
-            statusCode = 400;
-        }
+        // Client errors are identified by type, not by the shape of the type's name.
+        //
+        // This previously matched any exception whose name contained "Validation" or "Bad",
+        // which classified unrelated types - a BadgeNotFoundException became a 400 - while
+        // missing any client error that happened not to be named that way.
+        //
+        // To have an exception treated as a client error, derive it from
+        // BadRequestException.
+        var statusCode = exp is BadRequestException or FormatException ? 400 : 500;
 
         return (statusCode, model);
     }


### PR DESCRIPTION
`ExceptionToModelConverter` decided between 400 and 500 with a substring match on the exception **type name**:

```csharp
if (exp.GetType().Name.Contains("Validation") ||
    exp.GetType().Name.Contains("Bad") ||
    exp is FormatException)
```

Wrong in both directions — it classified unrelated types as client errors (a `BadgeNotFoundException` became a **400** because its name contains "Bad") and missed genuine client errors not named that way. It also meant **renaming an exception silently changed the status code callers saw**.

Classification is now by type: `BadRequestException` or `FormatException`. To have an exception treated as a client error, derive it from `BadRequestException`.

## `BadContentEncodingException` needed fixing alongside it

It's raised when a request arrives with an unsupported `Content-Encoding`, so 400 is correct — but it derived from `Exception` and reached 400 **only because its name contains "Bad"**. Under type-based classification it would have silently become a 500. It now derives from `BadRequestException` and earns the status properly.

That's the kind of thing the old heuristic hid: a correct status code resting on an accident of naming.

## Behaviour change

An exception that relied on the name heuristic *without* deriving from `BadRequestException` now returns **500 rather than 400**. That was never a deliberate contract, but it was reachable — a consumer naming an exception for validation and expecting a 400 will see a difference.

Nothing in either repository catches `BadRequestException` or `BadContentEncodingException`, so the hierarchy change affects no existing catch blocks.

**525 tests pass, zero warnings under `ContinuousIntegrationBuild`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
