### PR TITLE
Cover the request pipeline end to end, and fix three generator defects it found

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ErrorHandlingTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ErrorHandlingTests.cs
@@ -1,0 +1,75 @@
+using Hardened.Requests.Abstract.Errors;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// Exception-to-status mapping driven through the real pipeline: routing, handler
+/// invocation, the exception filter, the converter and response serialization together.
+/// Unit tests cover the converter in isolation; these confirm the wiring around it.
+/// </summary>
+public class ErrorHandlingTests {
+
+    [HardenedTest]
+    public async Task BadRequestExceptionBecomes400(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/bad-request");
+
+        response.Assert.BadRequest();
+    }
+
+    /// <summary>
+    /// A consumer-defined exception is a client error because of what it derives from, not
+    /// what it is called.
+    /// </summary>
+    [HardenedTest]
+    public async Task ExceptionDerivedFromBadRequestBecomes400(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/derived-client-error");
+
+        response.Assert.BadRequest();
+    }
+
+    [HardenedTest]
+    public async Task FormatExceptionBecomes400(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/format");
+
+        response.Assert.BadRequest();
+    }
+
+    [HardenedTest]
+    public async Task UnsupportedContentEncodingBecomes400(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/bad-encoding");
+
+        response.Assert.BadRequest();
+    }
+
+    [HardenedTest]
+    public async Task UnrecognisedExceptionBecomes500(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/server");
+
+        Assert.Equal(500, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The regression this guards: classification used to be a substring match on the type
+    /// name, so BadgeNotFoundException was served as a 400 purely because its name contains
+    /// "Bad". It derives from Exception, so it must be a 500.
+    /// </summary>
+    [HardenedTest]
+    public async Task ExceptionMerelyNamedLikeAClientErrorBecomes500(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/badge-missing");
+
+        Assert.Equal(500, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The response body carries a serialized ErrorModel, not just a status code.
+    /// </summary>
+    [HardenedTest]
+    public async Task ErrorResponseCarriesASerialisedModel(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/server");
+
+        var error = response.Deserialize<ErrorModel>();
+
+        Assert.Equal(nameof(InvalidOperationException), error.Type);
+        Assert.Equal("the widget was not ready", error.Message);
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/OverlappingRouteTokenNamesTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/OverlappingRouteTokenNamesTests.cs
@@ -1,0 +1,53 @@
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// A known routing defect, captured as a runnable reproduction rather than left in a
+/// tracker.
+///
+/// When two routes share a prefix and both have a path token in the same position, the
+/// route tree stores the token name on the tree *node* - that is, on the position - rather
+/// than on the individual route. Both routes therefore share whichever name was registered
+/// first, and the other one fails to bind.
+///
+/// BindingController declares:
+///
+///     [Get("/path/{id}")]                  FromPath
+///     [Get("/path/{first}/{second}")]      OverlappingPathTokens
+///
+/// A request to /binding/path/a/b routes correctly to OverlappingPathTokens - the log shows
+/// the right handler - and then fails binding with BadRequestException "first was missing",
+/// returning 400. The generated binding code is correct; it asks PathTokens for "first",
+/// and the collection was populated under the name from the shorter route.
+///
+/// This fails at runtime rather than at build time, which makes it more dangerous than the
+/// generator defects fixed alongside it: nothing surfaces until someone calls the route.
+///
+/// Fixing it means moving the token name from RouteTreeNode onto the leaf so each route
+/// carries its own, and updating the routing table emitter to match. That is a structural
+/// change to the route tree, so it is recorded here rather than bundled into this work.
+///
+/// Remove the Skip when the token name moves to the route.
+/// </summary>
+public class OverlappingRouteTokenNamesTests {
+
+    [HardenedTest(Skip = "Known defect: route tree stores path token names per position, " +
+                         "so overlapping routes with differently named tokens cannot both bind.")]
+    public async Task OverlappingRoutesBindTheirOwnTokenNames(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/path/alpha/beta");
+
+        response.Assert.Ok();
+        Assert.Equal("alpha:beta", response.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// The shorter route still works, which is why the defect goes unnoticed: whichever
+    /// route registered first behaves correctly.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheFirstRegisteredOverlappingRouteStillBinds(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/path/only-one");
+
+        response.Assert.Ok();
+        Assert.Equal("only-one", response.Deserialize<string>());
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ParameterBindingTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ParameterBindingTests.cs
@@ -1,0 +1,103 @@
+using Hardened.IntegrationTests.WebApp.SUT.Models;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// Every parameter binding source, driven through routing and the generated binding code.
+///
+/// Writing these surfaced three source generator defects that no existing test reached:
+/// named binding attributes emitted their name double-quoted, handlers with metadata but no
+/// parameters put the metadata array in the parameters slot, and [FromHeader] called Get on
+/// a plain dictionary. All three produced code that did not compile, so any project using
+/// those features failed to build.
+/// </summary>
+public class ParameterBindingTests {
+
+    [HardenedTest]
+    public async Task PathTokenBinds(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/path/abc123");
+
+        response.Assert.Ok();
+        Assert.Equal("abc123", response.Deserialize<string>());
+    }
+
+    [HardenedTest]
+    public async Task MultiplePathTokensBindInOrder(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/pair/first/second");
+
+        response.Assert.Ok();
+        Assert.Equal("first:second", response.Deserialize<string>());
+    }
+
+    /// <summary>Path tokens arrive as strings and are converted to the declared type.</summary>
+    [HardenedTest]
+    public async Task PathTokenConvertsToDeclaredType(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/path-typed/21");
+
+        response.Assert.Ok();
+        Assert.Equal(42, response.Deserialize<int>());
+    }
+
+    [HardenedTest]
+    public async Task QueryStringBindsByParameterName(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/query?name=hardened");
+
+        response.Assert.Ok();
+        Assert.Equal("hardened", response.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// The named form. This is what emitted a double-quoted literal before the generator fix.
+    /// </summary>
+    [HardenedTest]
+    public async Task QueryStringBindsByAttributeName(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/query-named?q=searchterm");
+
+        response.Assert.Ok();
+        Assert.Equal("searchterm", response.Deserialize<string>());
+    }
+
+    [HardenedTest]
+    public async Task QueryStringConvertsToDeclaredType(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/query-typed?page=7");
+
+        response.Assert.Ok();
+        Assert.Equal(8, response.Deserialize<int>());
+    }
+
+    /// <summary>
+    /// [FromHeader] binding. Documented since the framework's first release and, until the
+    /// generator fix, incapable of compiling.
+    /// </summary>
+    [HardenedTest]
+    public async Task HeaderBinds(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/header",
+            request => request.Headers["X-Tenant"] = "acme");
+
+        response.Assert.Ok();
+        Assert.Equal("acme", response.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// Path token, query string, header and an injected service in one handler - the case
+    /// most likely to break if binding order or parameter indexing regresses.
+    /// </summary>
+    [HardenedTest]
+    public async Task AllBindingSourcesCombineInASingleHandler(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/mixed/id-9?filter=active",
+            request => request.Headers["X-Tenant"] = "acme");
+
+        response.Assert.Ok();
+        Assert.Equal("id-9|active|acme|3", response.Deserialize<string>());
+    }
+
+    [HardenedTest]
+    public async Task BodyAndPathTokenCoexist(ITestWebApp testWebApp) {
+        var model = new MathAddModel { Values = new List<int> { 1, 2, 3 } };
+
+        var response = await testWebApp.Post(model, "/binding/body/totals");
+
+        response.Assert.Ok();
+        Assert.Equal("totals:1,2,3", response.Deserialize<string>());
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/BindingController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/BindingController.cs
@@ -1,0 +1,61 @@
+using Hardened.IntegrationTests.WebApp.SUT.Models;
+using Hardened.IntegrationTests.WebApp.SUT.Services;
+using Hardened.Web.Runtime.Attributes;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// Every parameter binding source, exercised through the routing and binding code the
+/// generator emits rather than by constructing parameters directly.
+/// </summary>
+[BasePath("/binding")]
+public class BindingController {
+
+    [Get("/path/{id}")]
+    public string FromPath(string id) => id;
+
+    [Get("/pair/{first}/{second}")]
+    public string FromMultiplePathTokens(string first, string second) => $"{first}:{second}";
+
+    /// <summary>
+    /// Deliberately overlaps /path/{id} above: same prefix, a path token in the same
+    /// position, but a different token name. The route tree stores the token name on the
+    /// node rather than the route, so both routes share whichever name was registered first
+    /// and this one cannot bind. See OverlappingRouteTokenNamesTests.
+    /// </summary>
+    [Get("/path/{first}/{second}")]
+    public string OverlappingPathTokens(string first, string second) => $"{first}:{second}";
+
+    [Get("/path-typed/{count}")]
+    public int TypedPathToken(int count) => count * 2;
+
+    [Get("/query")]
+    public string FromQuery([FromQueryString] string name) => name;
+
+    [Get("/query-named")]
+    public string FromNamedQuery([FromQueryString("q")] string search) => search;
+
+    [Get("/query-typed")]
+    public int TypedQuery([FromQueryString] int page) => page + 1;
+
+    [Get("/header")]
+    public string FromHeader([FromHeader("X-Tenant")] string tenant) => tenant;
+
+    /// <summary>
+    /// Path token, query string, header and an injected service in a single handler - the
+    /// case most likely to break if binding order or index tracking regresses.
+    /// </summary>
+    [Get("/mixed/{id}")]
+    public string Mixed(
+        string id,
+        [FromQueryString] string filter,
+        [FromHeader("X-Tenant")] string tenant,
+        IMathService<int> mathService) {
+        return $"{id}|{filter}|{tenant}|{mathService.Add(1, 2)}";
+    }
+
+    /// <summary>Body plus a path token, to confirm the two sources coexist.</summary>
+    [Post("/body/{label}")]
+    public string BodyWithPath(string label, MathAddModel model) =>
+        $"{label}:{string.Join(",", model.Values ?? new List<int>())}";
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ErrorController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ErrorController.cs
@@ -1,0 +1,54 @@
+using Hardened.Requests.Runtime.Errors;
+using Hardened.Web.Runtime.Attributes;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// Handlers that throw, so exception-to-status mapping can be exercised through the real
+/// pipeline rather than by calling the converter directly.
+/// </summary>
+[BasePath("/errors")]
+public class ErrorController {
+
+    /// <summary>An exception deriving from BadRequestException is a client error.</summary>
+    [Get("/bad-request")]
+    public string BadRequest() =>
+        throw new BadRequestException("the request was malformed");
+
+    /// <summary>A consumer-defined client error, identified by its base type.</summary>
+    [Get("/derived-client-error")]
+    public string DerivedClientError() =>
+        throw new TenantMismatchException();
+
+    [Get("/format")]
+    public string Format() =>
+        throw new FormatException("'abc' is not a number");
+
+    /// <summary>Anything else is a server error.</summary>
+    [Get("/server")]
+    public string Server() =>
+        throw new InvalidOperationException("the widget was not ready");
+
+    /// <summary>
+    /// Named so that the old substring classification would have called it a client error.
+    /// It derives from Exception, so it must be a 500.
+    /// </summary>
+    [Get("/badge-missing")]
+    public string BadgeMissing() =>
+        throw new BadgeNotFoundException();
+
+    /// <summary>
+    /// Unsupported Content-Encoding is raised by the deserializers and is a client error.
+    /// </summary>
+    [Get("/bad-encoding")]
+    public string BadEncoding() =>
+        throw new BadContentEncodingException("deflate");
+
+    public class TenantMismatchException : BadRequestException {
+        public TenantMismatchException() : base("tenant does not match") { }
+    }
+
+    public class BadgeNotFoundException : Exception {
+        public BadgeNotFoundException() : base("no badge with that id") { }
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Execution/HeaderDictionaryExtensions.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/HeaderDictionaryExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Runtime.Execution;
+
+/// <summary>
+/// Header access for generated request binding code.
+///
+/// IExecutionRequest exposes PathTokens and QueryString as collections that carry their own
+/// Get, but Headers is a plain IDictionary. Generated [FromHeader] binding calls Get on all
+/// three uniformly, so this supplies the missing one with the same semantics: a miss yields
+/// <see cref="StringValues.Empty"/> rather than throwing, exactly as
+/// IQueryStringCollection.Get does.
+///
+/// This namespace is already imported by generated handlers, which is why the extension
+/// lives here rather than alongside the header abstractions.
+/// </summary>
+public static class HeaderDictionaryExtensions {
+
+    public static StringValues Get(this IDictionary<string, StringValues> headers, string key) {
+        return headers.TryGetValue(key, out var value) ? value : StringValues.Empty;
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Function/FunctionModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Function/FunctionModelGenerator.cs
@@ -67,7 +67,7 @@ public class FunctionModelGenerator : BaseRequestModelGenerator {
                 switch (attributeName) {
                     case "FromContext":
                         var headerName =
-                            attribute.ArgumentList?.Arguments.FirstOrDefault()?.ToFullString() ?? "";
+                            attribute.GetFirstStringArgumentValue(generatorSyntaxContext);
 
                         return GetParameterInfoWithBinding(generatorSyntaxContext, parameter,
                             ParameterBindType.Header, headerName, parameterIndex);

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
@@ -70,6 +70,12 @@ public static class HandlerInfoCodeGenerator {
         if (handlerModel.RequestParameterInformationList.Count > 0) {
             parameterInfoField = ", _parameterInfo";
         }
+        else if (metadataArg.Length > 0) {
+            // Both are optional constructor arguments, and parameters comes first. A handler
+            // with metadata but no parameters must still fill the parameters slot, or the
+            // metadata array lands in it and the generated code does not compile.
+            parameterInfoField = ", null";
+        }
 
         handlerInfoField.InitializeValue =
             new CodeOutputComponent($"new ExecutionRequestHandlerInfo(\"{handlerModel.Name.Path}\", \"{handlerModel.Name.Method}\", typeof({handlerModel.ControllerType.Name}), \"{handlerModel.HandlerMethod}\"{parameterInfoField}{metadataArg})");

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/SyntaxNodeExtensions.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/SyntaxNodeExtensions.cs
@@ -6,6 +6,35 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Hardened.SourceGenerator.Shared;
 
 public static class SyntaxNodeExtensions {
+
+    /// <summary>
+    /// The value of an attribute's first argument as a string, or empty when there is none.
+    ///
+    /// This deliberately does not use ToFullString(). That returns the argument's source
+    /// text, so a name written as [FromHeader("X-Tenant")] comes back including its quotes
+    /// and gets quoted a second time when emitted, producing ""X-Tenant"" - which does not
+    /// compile. The constant value is what callers actually want.
+    /// </summary>
+    public static string GetFirstStringArgumentValue(
+        this AttributeSyntax attribute, GeneratorSyntaxContext generatorSyntaxContext) {
+        var expression = attribute.ArgumentList?.Arguments.FirstOrDefault()?.Expression;
+
+        if (expression == null) {
+            return "";
+        }
+
+        // Handles literals and references to string constants alike.
+        var constant = generatorSyntaxContext.SemanticModel.GetConstantValue(expression);
+
+        if (constant is { HasValue: true, Value: string value }) {
+            return value;
+        }
+
+        // Fall back to the source text with any surrounding quotes removed, so an argument
+        // the semantic model cannot fold still yields something usable rather than nothing.
+        return expression.ToFullString().Trim().Trim('"');
+    }
+
     public static string GetNamespace(this BaseTypeDeclarationSyntax syntax) {
         var parentSyntaxNode = syntax.Parent;
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
@@ -106,14 +106,14 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
                 switch (attributeName) {
                     case "FromHeader":
                         var headerName =
-                            attribute.ArgumentList?.Arguments.FirstOrDefault()?.ToFullString() ?? "";
+                            attribute.GetFirstStringArgumentValue(generatorSyntaxContext);
 
                         return GetParameterInfoWithBinding(generatorSyntaxContext, parameter,
                             ParameterBindType.Header, headerName,parameterIndex);
 
                     case "FromQueryString":
                         var queryName =
-                            attribute.ArgumentList?.Arguments.FirstOrDefault()?.ToFullString() ?? "";
+                            attribute.GetFirstStringArgumentValue(generatorSyntaxContext);
 
                         return GetParameterInfoWithBinding(generatorSyntaxContext, parameter,
                             ParameterBindType.QueryString, queryName,parameterIndex);


### PR DESCRIPTION
The web integration tests exercised four routes and asserted status codes. Adding handlers for the parameter binding sources and for exceptions turned up **three source generator defects that produce code which does not compile**, plus one routing defect that fails at runtime.

## 1. Named binding attributes emitted their name twice-quoted

The generator read attribute arguments with `ToFullString()` — which returns *source text*, quotes included — then quoted the result again:

```csharp
context.Request.QueryString.Get(""q"")   // does not compile
```

`[FromHeader("X-Request-Id")]` and `[FromQueryString("q")]` are **both documented** in `parameter-binding.md`, and neither has ever compiled. Both attributes sat at 0% coverage, so nothing exercised them.

Attribute arguments are now read as constant values, so literals and string constants both work. The same defect existed in the **function** generator and is fixed there too.

## 2. Handlers with metadata but no parameters put metadata in the wrong slot

```csharp
ExecutionRequestHandlerInfo(path, method, type, method,
    IReadOnlyList<IExecutionRequestParameter>? parameters = null,  // 5th
    IReadOnlyList<object>? metadata = null)                        // 6th
```

The emitter appended metadata positionally without accounting for an absent parameter list:

```csharp
new ExecutionRequestHandlerInfo("/errors/server", "GET", typeof(ErrorController), "Server", _metadata)
//                                                                                          ^ lands in `parameters`
```

**A `[BasePath]` controller with a no-argument action is completely ordinary, and it did not build.**

## 3. `[FromHeader]` called a method that does not exist

Generated binding calls `Get` uniformly on `PathTokens`, `QueryString` and `Headers` — but `IExecutionRequest` exposes `Headers` as a plain `IDictionary<string, StringValues>`, which has no `Get`. Header binding could not compile regardless of the quoting defect.

`HeaderDictionaryExtensions` supplies it with the same semantics as `IQueryStringCollection.Get`: a miss yields `StringValues.Empty`.

## 4. A routing defect — recorded, not fixed

Two routes sharing a prefix with **differently named path tokens in the same position** bind using whichever name registered first, because the route tree stores the token name on the *node* (the position) rather than the route:

```csharp
[Get("/path/{id}")]                 // registers the token as "id"
[Get("/path/{first}/{second}")]     // asks for "first" — missing
```

Routing succeeds — the log shows the correct handler — and binding then fails with `BadRequestException: "first was missing"`, returning 400. **This one fails at runtime, not at build time**, which makes it more dangerous than the three above: nothing surfaces until someone calls the route.

`OverlappingRouteTokenNamesTests` reproduces it as a skipped test carrying the analysis. Fixing it means moving token names from `RouteTreeNode` onto the leaf and updating the routing table emitter — a structural change that doesn't belong in this PR.

## Tests added

**Parameter binding** — path tokens, multiple tokens, type conversion, query string by parameter name *and* by attribute name, headers, all sources combined in a single handler, and body alongside a path token.

**Exception mapping through the pipeline** — `BadRequestException` and derived types, `FormatException` and `BadContentEncodingException` as 400s, unrecognised exceptions as 500s, the serialized `ErrorModel`, and a guard that an exception *merely named* like a client error is not treated as one.

**525 → 542 tests**, zero warnings under `ContinuousIntegrationBuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
