### PR TITLE
Give path token names to the route rather than the tree position

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/OverlappingRouteTokenNamesTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/OverlappingRouteTokenNamesTests.cs
@@ -1,37 +1,26 @@
 namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
 
 /// <summary>
-/// A known routing defect, captured as a runnable reproduction rather than left in a
-/// tracker.
-///
-/// When two routes share a prefix and both have a path token in the same position, the
-/// route tree stores the token name on the tree *node* - that is, on the position - rather
-/// than on the individual route. Both routes therefore share whichever name was registered
-/// first, and the other one fails to bind.
-///
-/// BindingController declares:
+/// Two routes sharing a prefix, with a path token in the same position under different
+/// names. BindingController declares:
 ///
 ///     [Get("/path/{id}")]                  FromPath
 ///     [Get("/path/{first}/{second}")]      OverlappingPathTokens
 ///
-/// A request to /binding/path/a/b routes correctly to OverlappingPathTokens - the log shows
-/// the right handler - and then fails binding with BadRequestException "first was missing",
-/// returning 400. The generated binding code is correct; it asks PathTokens for "first",
-/// and the collection was populated under the name from the shorter route.
+/// The route tree shares one node for that token position, so the node cannot know which
+/// name applies. It used to take the name from whichever route registered first, which meant
+/// /binding/path/a/b routed correctly to OverlappingPathTokens and then failed binding with
+/// "first was missing" - a 400 that only appeared when the route was called.
 ///
-/// This fails at runtime rather than at build time, which makes it more dangerous than the
-/// generator defects fixed alongside it: nothing surfaces until someone calls the route.
+/// Token names now belong to the route rather than the tree node: the matched leaf supplies
+/// them and values are filled in positionally as the match unwinds.
 ///
-/// Fixing it means moving the token name from RouteTreeNode onto the leaf so each route
-/// carries its own, and updating the routing table emitter to match. That is a structural
-/// change to the route tree, so it is recorded here rather than bundled into this work.
-///
-/// Remove the Skip when the token name moves to the route.
+/// This shape is ordinary REST - /users/{id} alongside /users/{userId}/posts/{postId} - and
+/// the old behaviour was triggered by the rename that makes the second route clearer.
 /// </summary>
 public class OverlappingRouteTokenNamesTests {
 
-    [HardenedTest(Skip = "Known defect: route tree stores path token names per position, " +
-                         "so overlapping routes with differently named tokens cannot both bind.")]
+    [HardenedTest]
     public async Task OverlappingRoutesBindTheirOwnTokenNames(ITestWebApp testWebApp) {
         var response = await testWebApp.Get("/binding/path/alpha/beta");
 
@@ -40,8 +29,8 @@ public class OverlappingRouteTokenNamesTests {
     }
 
     /// <summary>
-    /// The shorter route still works, which is why the defect goes unnoticed: whichever
-    /// route registered first behaves correctly.
+    /// The shorter route keeps working. It always did, which is why the defect went
+    /// unnoticed: whichever route registered first behaved correctly.
     /// </summary>
     [HardenedTest]
     public async Task TheFirstRegisteredOverlappingRouteStillBinds(ITestWebApp testWebApp) {
@@ -49,5 +38,17 @@ public class OverlappingRouteTokenNamesTests {
 
         response.Assert.Ok();
         Assert.Equal("only-one", response.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// The deeper route's second token is unambiguous - only one route reaches that position
+    /// - so it was never affected. Asserted so a future change cannot regress it silently.
+    /// </summary>
+    [HardenedTest]
+    public async Task DeeperUnsharedTokenStillBinds(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/binding/pair/one/two");
+
+        response.Assert.Ok();
+        Assert.Equal("one:two", response.Deserialize<string>());
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/PathTokens/PathTokenCollection.cs
+++ b/src/Requests/Hardened.Requests.Runtime/PathTokens/PathTokenCollection.cs
@@ -1,42 +1,108 @@
-﻿using Hardened.Requests.Abstract.PathTokens;
+using Hardened.Requests.Abstract.PathTokens;
 using Microsoft.Extensions.Primitives;
 
 namespace Hardened.Requests.Runtime.PathTokens;
 
+/// <summary>
+/// Path token values for a matched route.
+///
+/// Names and values are stored separately. The names belong to the route that matched and
+/// are known at compile time, so generated code passes a static array that is shared across
+/// every request. Only the values are per-request.
+///
+/// That separation is what makes overlapping routes work. The route tree shares a node when
+/// two routes have a token in the same position, so the node cannot know which name applies
+/// - /users/{id} and /users/{userId}/posts/{postId} share their first token position. The
+/// matched route's leaf supplies the names, and the values are filled in positionally as the
+/// match unwinds.
+/// </summary>
 public class PathTokenCollection : IPathTokenCollection {
-    private readonly PathToken[] _pathTokens;
+    private readonly string[] _names;
+    private readonly string?[] _values;
 
-    public static readonly PathTokenCollection Empty = new PathTokenCollection(0);
+    /// <summary>
+    /// True when _names was allocated here rather than supplied by the caller, and may
+    /// therefore be written to. A route-supplied array is shared and must never be mutated.
+    /// </summary>
+    private readonly bool _ownsNames;
 
-    public PathTokenCollection(int count, PathToken? lastToken = null) {
-        _pathTokens = new PathToken[count];
+    public static readonly PathTokenCollection Empty = new(0);
 
-        if (lastToken != null) {
-            _pathTokens[count - 1] = lastToken;
+    /// <summary>
+    /// Names come from the matched route and are expected to be a static, shared array.
+    /// </summary>
+    public PathTokenCollection(int count, string[] names, string? lastValue = null) {
+        _values = new string?[count];
+        _names = names;
+        _ownsNames = false;
+
+        if (lastValue != null && count > 0) {
+            _values[count - 1] = lastValue;
         }
     }
 
-    public int Count => _pathTokens.Length;
+    /// <summary>
+    /// Retained for generated code produced before names moved to the route. Such code
+    /// supplies a name with every value, so this allocates a names array to write into.
+    /// </summary>
+    public PathTokenCollection(int count, PathToken? lastToken = null) {
+        _values = new string?[count];
+        _names = count == 0 ? Array.Empty<string>() : new string[count];
+        _ownsNames = true;
+
+        if (lastToken != null && count > 0) {
+            _names[count - 1] = lastToken.TokenName;
+            _values[count - 1] = lastToken.TokenValue;
+        }
+    }
+
+    public int Count => _values.Length;
+
+    /// <summary>Sets a value positionally; the name comes from the matched route.</summary>
+    public void SetValue(int index, string value) {
+        GuardIndex(index);
+
+        _values[index] = value;
+    }
+
+    /// <summary>
+    /// Retained for generated code that supplies names alongside values. The name is only
+    /// recorded when this collection owns its names array - a route-supplied array is shared
+    /// across requests and its names already describe the matched route.
+    /// </summary>
+    public void Set(int index, PathToken pathToken) {
+        GuardIndex(index);
+
+        if (_ownsNames) {
+            _names[index] = pathToken.TokenName;
+        }
+
+        _values[index] = pathToken.TokenValue;
+    }
 
     public PathToken Get(int index) {
-        return _pathTokens[index];
+        GuardIndex(index);
+
+        return new PathToken(NameAt(index), _values[index] ?? "");
     }
 
     public StringValues Get(string id) {
-        for (var i = 0; i < _pathTokens.Length; i++) {
-            if (_pathTokens[i]?.TokenName == id) {
-                return _pathTokens[i].TokenValue;
+        for (var i = 0; i < _values.Length; i++) {
+            if (NameAt(i) == id) {
+                return _values[i] ?? StringValues.Empty;
             }
         }
 
         return StringValues.Empty;
     }
 
-    public void Set(int index, PathToken pathToken) {
-        if (index >= _pathTokens.Length) {
-            throw new Exception($"Index {index} is greater than expected path token length {_pathTokens.Length}");
-        }
+    private string NameAt(int index) =>
+        index < _names.Length ? _names[index] ?? "" : "";
 
-        _pathTokens[index] = pathToken;
+    private void GuardIndex(int index) {
+        if (index < 0 || index >= _values.Length) {
+            throw new IndexOutOfRangeException(
+                $"Index {index} is outside the expected path token length {_values.Length}");
+        }
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeGenerator.cs
@@ -125,7 +125,7 @@ public class RouteTreeGenerator<T> {
         foreach (var entry in entries) {
             _cancellationToken.ThrowIfCancellationRequested();
 
-            leafNodes.Add(new RouteTreeLeafNode<T>(entry.Method, entry.Value));
+            leafNodes.Add(new RouteTreeLeafNode<T>(entry.Method, entry.Value, entry.WildCardTokens));
         }
 
         return leafNodes;

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeLeafNode.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeLeafNode.cs
@@ -1,12 +1,23 @@
-﻿namespace Hardened.SourceGenerator.Web.Routing;
+namespace Hardened.SourceGenerator.Web.Routing;
 
 public class RouteTreeLeafNode<T> {
-    public RouteTreeLeafNode(string method, T value) {
+    public RouteTreeLeafNode(string method, T value, IReadOnlyList<string> wildCardTokens) {
         Method = method;
         Value = value;
+        WildCardTokens = wildCardTokens;
     }
 
     public string Method { get; }
 
     public T Value { get; }
+
+    /// <summary>
+    /// The token names declared by this route, in order.
+    ///
+    /// They live here rather than on RouteTreeNode because a node is shared by every route
+    /// with a token in that position, and those routes may name it differently -
+    /// /users/{id} and /users/{userId}/posts/{postId} share their first token position. Only
+    /// the matched route knows what its own tokens are called.
+    /// </summary>
+    public IReadOnlyList<string> WildCardTokens { get; }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
@@ -372,19 +372,16 @@ public static class RoutingTableGenerator {
         var matchIfHandlerBlock =
             ifStatement.If(NotEquals(handlerInfo, Null()));
 
-        var newPathToken = New(KnownTypes.Requests.PathToken,
-            QuoteString(wildCardNode.WildCardToken!),
-            span.Invoke(
-                "Slice",
-                index,
-                Subtract(currentIndex, index)).Invoke("ToString")
-        );
-
+        // The value is positional. Its name belongs to whichever route matched, which is
+        // only known further down, so the collection was created with that route's names.
         matchIfHandlerBlock.AddIndentedStatement(
             handlerInfo.Property("PathTokens").Invoke(
-                "Set",
+                "SetValue",
                 wildCardNode.WildCardDepth - 1,
-                newPathToken
+                span.Invoke(
+                    "Slice",
+                    index,
+                    Subtract(currentIndex, index)).Invoke("ToString")
             ));
 
         matchIfHandlerBlock.Return(handlerInfo);
@@ -411,15 +408,11 @@ public static class RoutingTableGenerator {
 
                 coalesceHandler.PrintParentheses = false;
 
-                var pathToken = New(KnownTypes.Requests.PathToken,
-                    QuoteString(wildCardNode.WildCardToken!),
-                    span.Invoke("Slice", index).Invoke("ToString")
-                );
-
                 IOutputComponent pathTokensCollection =
                     New(KnownTypes.Requests.PathTokenCollection,
                         wildCardNode.WildCardDepth,
-                        pathToken
+                        PathTokenNamesField(routingClass, leafNode),
+                        span.Invoke("Slice", index).Invoke("ToString")
                     );
 
                 caseStatement.Return(
@@ -462,7 +455,9 @@ public static class RoutingTableGenerator {
             IOutputComponent pathTokensCollection = EmptyTokens;
 
             if (routeNode.WildCardDepth > 0) {
-                pathTokensCollection = New(KnownTypes.Requests.PathTokenCollection, routeNode.WildCardDepth);
+                pathTokensCollection = New(KnownTypes.Requests.PathTokenCollection,
+                    routeNode.WildCardDepth,
+                    PathTokenNamesField(routingClass, leafNode));
             }
 
             caseStatement.Return(
@@ -551,4 +546,31 @@ public static class RoutingTableGenerator {
 
         return "";
     }
+
+    /// <summary>
+    /// Emits a static readonly array of the route's path token names and returns a reference
+    /// to it. The names are compile-time constants belonging to the route, so one shared
+    /// array serves every request rather than allocating a PathToken per token per request.
+    /// </summary>
+    private static IOutputComponent PathTokenNamesField(
+        ClassDefinition routingClass, RouteTreeLeafNode<RequestHandlerModel> leafNode) {
+        var fieldName = "_pathTokenNames" + leafNode.Value.InvokeHandlerType.Name;
+
+        var existing = routingClass.Fields.FirstOrDefault(f => f.Name == fieldName);
+
+        if (existing != null) {
+            return existing.Instance;
+        }
+
+        var field = routingClass.AddField(typeof(string).MakeArrayType(), fieldName);
+
+        field.Modifiers |= ComponentModifier.Private | ComponentModifier.Static | ComponentModifier.Readonly;
+
+        var names = string.Join(", ", leafNode.WildCardTokens.Select(t => "\"" + t + "\""));
+
+        field.InitializeValue = new CodeOutputComponent("new string[] { " + names + " }");
+
+        return field.Instance;
+    }
+
 }


### PR DESCRIPTION
Two routes sharing a prefix with a path token in the same position could not both bind.

## The cause

The route tree shares one node for a token position, and the node carried the name — taken from whichever route registered first:

```csharp
var token = keyValuePair.First().WildCardTokens[wildCardDepth - 1];
returnList.ForEach(n => n.WildCardToken = token);
```

So this routed correctly and then failed binding with `"userId was missing"`, returning 400:

```csharp
[Get("/users/{id}")]
[Get("/users/{userId}/posts/{postId}")]
```

Two things made it worse than a normal bug:

- **It surfaced only at runtime**, when the route was actually called. Nothing failed at build time.
- **The constraint was not local.** The tree is built from every endpoint in the application, so the two colliding routes can live in different controllers and different files. Adding a route in one file could break binding in another, with nothing in either mentioning the other.

And the shape is ordinary REST. The old behaviour was triggered by the rename that *improves* clarity — `{id}` becomes `{userId}` precisely when a second identifier appears.

## The fix

Names now belong to the route rather than the position. `RouteTreeLeafNode` carries the token names the route declared, the matched leaf supplies them when constructing the collection, and values are filled positionally as the match unwinds.

**Positions already worked.** The leaf sized the collection by depth and each unwind level set `depth - 1`. Only the names were wrong.

## It removes allocations rather than adding them

Names are compile-time constants, so the generator emits one static array per route:

```csharp
private readonly static string[] _pathTokenNamesSomeController_Concat_443 = new string[] { "a", "b" };
...
new PathTokenCollection(2, _pathTokenNamesSomeController_Concat_443, span.Slice(index).ToString())
...
handlerInfo.PathTokens.SetValue(0, ...);
```

| Per request, N tokens | Before | After |
|---|---|---|
| Allocations | collection + `PathToken[N]` + **N `PathToken` records** | collection + `string[N]` values |

`PathToken` is a record, so each token was a separate heap allocation carrying a name already known at compile time. The generated routing table now contains **no `PathToken` construction at all**.

## Compatibility

`PathTokenCollection` keeps its previous constructor and `Set(int, PathToken)`, so generated code produced before this change still compiles and runs — relevant because Hardened.Amz builds against the published runtime with whatever generator version it has. That legacy path allocates its own names array and writes to it; a route-supplied array is shared across requests and is never mutated.

## Tests

`OverlappingRouteTokenNamesTests` was a skipped reproduction; it now runs. Added a case covering the deeper unshared token, which was never affected but should not regress silently.

**542 → 544 tests**, zero warnings under `ContinuousIntegrationBuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
