### PR TITLE
Fail the build if any test skips in CI

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -53,6 +53,26 @@ jobs:
           fi
           echo "No silently skipped tests."
 
+      # The check above catches tests that vanish by accident. This one catches
+      # tests that vanish on purpose: a Skip is a test the suite is not running,
+      # and once it is green nothing distinguishes it from one that passed.
+      #
+      # Skipping is still the right answer locally, for a machine missing
+      # something the suite needs. It is not an answer on a runner, where
+      # everything is present and a skip means a requirement went missing.
+      #
+      # A repro pinned to a defect belongs in the same change as the fix, so it
+      # runs. If a test genuinely cannot run here, delete it and open an issue -
+      # a permanent Skip is a comment that costs a test run.
+      - name: Fail if any test skipped
+        run: |
+          if grep -Eq "Skipped:[[:space:]]*[1-9]" test-output.log; then
+            echo "::error::Tests skipped in CI. A skipped test is one the suite is not running - land the repro with its fix, or remove it."
+            grep -E "Skipped:[[:space:]]*[1-9]" test-output.log
+            exit 1
+          fi
+          echo "Every test ran."
+
       - name: Coverage summary
         run: |
           dotnet tool install --global dotnet-reportgenerator-globaltool


### PR DESCRIPTION
The workflow already fails when xUnit drops test cases that share a unique ID — tests vanishing *by accident*. This adds the other half: tests vanishing *on purpose*.

A `Skip` is a test the suite is not running. Once the build is green, nothing distinguishes it from one that passed — the count is smaller and no one is looking at the count.

## Why now

Hardened.Amz gained its first tests with an external requirement: the DynamoDB Local ones need a Docker daemon and skip with a stated reason without one, so that `git clone && dotnet test` on a machine with no Docker reads as "you need Docker" rather than as broken code. That is right locally and wrong on a runner, where everything the suite needs is present and a skip means a requirement went missing.

This repository has no skipping tests today — twelve assemblies, all at `Skipped: 0` — so nothing that passes now stops passing. It closes the gap before something opens it.

```
Skipped:     0   → passes
Skipped:     4   → fails
Skipped:    10   → fails
```

## What it asks of a repro

A test pinned to a known defect belongs in the same change as the fix, so it runs. That is not a new rule so much as the one this makes enforceable — a permanently skipped repro is a comment that costs a test run, and it tends to stay skipped after the defect is gone.

**Sequencing:** #88 ships such a repro, skipped, which #89 then un-skips. With this merged, #88 landing alone turns main red — correctly, since it does ship a test that does not run. The two need to land together, in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
