### PR TITLE
Make the source generators opt-in rather than inherited

### DIFF
--- a/src/Commands/Hardened.Commands/Hardened.Commands.csproj
+++ b/src/Commands/Hardened.Commands/Hardened.Commands.csproj
@@ -8,6 +8,16 @@
         <IsPackable>True</IsPackable>
     </PropertyGroup>
 
+        <!--
+      Declared rather than inherited. It used to arrive transitively from
+      Hardened.Shared.Runtime, which meant a project in this repository got the module
+      generator for free while a consumer of the package never did - the flowed dependency
+      excludes analyzers. Every project that writes a [HardenedModule] asks for it.
+    -->
+    <ItemGroup>
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    </ItemGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
         <ProjectReference Include="..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>

--- a/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
+++ b/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
+++ b/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />

--- a/src/SourceGenerators/Hardened.Console.SourceGenerator/Hardened.Console.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Console.SourceGenerator/Hardened.Console.SourceGenerator.csproj
@@ -33,6 +33,13 @@
 
     <PropertyGroup>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
@@ -29,6 +29,13 @@
         <IsPackable>True</IsPackable>
         <PackageId>Hardened.DependencyModules.SourceGenerator</PackageId>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj
@@ -46,6 +46,13 @@
 
     <PropertyGroup>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
@@ -42,6 +42,13 @@
 
     <PropertyGroup>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
@@ -11,6 +11,13 @@
         <IsPackable>True</IsPackable>
         <PackageId>Hardened.OpenApi.SourceGenerator</PackageId>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Hardened.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Hardened.SourceGenerator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <_CSharpAuthorRoot>$(MSBuildThisFileDirectory)../../../CSharpAuthor</_CSharpAuthorRoot>
@@ -14,6 +14,13 @@
         <Nullable>enable</Nullable>
         <IsPackable>True</IsPackable>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     

--- a/src/SourceGenerators/Hardened.Templates.SourceGenerator/Hardened.Templates.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Templates.SourceGenerator/Hardened.Templates.SourceGenerator.csproj
@@ -45,6 +45,13 @@
 
     <PropertyGroup>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator/Hardened.Web.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator/Hardened.Web.SourceGenerator.csproj
@@ -45,6 +45,13 @@
 
     <PropertyGroup>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+
+        <!--
+          Build-only. This does not stop the package flowing to consumers on its own - only
+          PrivateAssets on the reference does that - but it is what makes `dotnet add package`
+          write PrivateAssets for you, so the next reference starts out right.
+        -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Templates/Hardened.Templates.Runtime/Hardened.Templates.Runtime.csproj
+++ b/src/Templates/Hardened.Templates.Runtime/Hardened.Templates.Runtime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Hardened.Web.AspNetCore.Runtime.csproj
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Hardened.Web.AspNetCore.Runtime.csproj
@@ -8,6 +8,16 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 
+        <!--
+      Declared rather than inherited. It used to arrive transitively from
+      Hardened.Shared.Runtime, which meant a project in this repository got the module
+      generator for free while a consumer of the package never did - the flowed dependency
+      excludes analyzers. Every project that writes a [HardenedModule] asks for it.
+    -->
+    <ItemGroup>
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    </ItemGroup>
+
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>

--- a/src/Web/Hardened.Web.Runtime/Hardened.Web.Runtime.csproj
+++ b/src/Web/Hardened.Web.Runtime/Hardened.Web.Runtime.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9200" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9200" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />


### PR DESCRIPTION
Every runtime package this repository publishes carried `DependencyModules.SourceGenerator` as a dependency, and every project inside the repository picked the generator up transitively through `Hardened.Shared.Runtime` without ever asking for it.

## The asymmetry

A consumer of the package never got that. The flowed dependency carries `exclude="Build,Analyzers"`, so an external project downloaded the generator and received nothing runnable from it. That is why **every `Hardened.Amz` runtime project already declares its own** — it had to.

So projects in this repository were relying on something nobody outside could rely on. Inheriting it was never the contract; it was an accident of being in the same solution.

## What changed

`PrivateAssets="all"` on the generator references, and the two projects that were inheriting it now declare it:

- `Hardened.Commands`
- `Hardened.Web.AspNetCore.Runtime`

Those two lines are the whole reason the build fails without them, and **the break is the point** — what used to be invisible is now stated. Any future project writing a `[HardenedModule]` gets a clear compile error naming the missing attribute rather than silently depending on its neighbours.

## `DevelopmentDependency` does not do this

Worth recording, because it is the obvious thing to reach for and it does not work. It is set on the generator packages here, but on its own it changes nothing:

```
dependencymodules.sourcegenerator 1.0.0-rc9200   developmentDependency=true
```

That is the exact version this repository pins. It has the flag, and it was still being carried into every nuspec. `developmentDependency` is only read by tooling at install time — it makes `dotnet add package` write `PrivateAssets` for you, so the next reference starts out right. It has no effect on a reference already written into a csproj. `PrivateAssets` on the reference is what actually stops the flow.

Verified by A/B against a local feed: same package, with and without the flag, both still appeared in the consumer's dependencies. Adding `PrivateAssets="all"` removed it, and the generator still ran in the project that declared it.

## Result

**No package produced by this repository lists a source generator as a dependency any more.** 544 tests, unchanged, nothing skipped.

Downstream was checked rather than assumed: Hardened.Amz was built and tested against these packages (packed to a local feed) *before* this was opened. It needed one project to opt in — `Hardened.Amz.Shared.Lambda.Runtime`, which uses `[SingletonService]` and was inheriting the generator — and that is in the matching Hardened.Amz PR. Amz also still builds against the currently published `preview10147`, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117kbrZB7JqhRHg4xJfoAAd
