### PR TITLE
Make a crashed generator fail the build, and fix the crashes it hid

### DIFF
--- a/src/SourceGenerators/Hardened.SourceGeneration.Testing/GeneratorResult.cs
+++ b/src/SourceGenerators/Hardened.SourceGeneration.Testing/GeneratorResult.cs
@@ -64,6 +64,21 @@ public class GeneratorResult(
             "The generator threw:" + Environment.NewLine +
             string.Join(Environment.NewLine, GeneratorExceptions.Select(exception => $"  {exception}")));
 
+        // A crash the generator caught itself. Hardened's generators wrap their emit in
+        // SourceGeneratorWrapper, which turns an exception into a diagnostic - so the exception
+        // never reaches GeneratorExceptions above, and the run looks orderly while having produced
+        // nothing. Called out separately from the generic error check below because "the generator
+        // crashed and emitted no code" and "the code it emitted does not compile" want very
+        // different messages.
+        var crashes = GeneratorDiagnostics
+            .Where(diagnostic => diagnostic.Id == "HardenedException")
+            .ToArray();
+
+        Assert.True(crashes.Length == 0,
+            "The generator caught an exception while emitting, so it produced " + Describe() + ":" +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, crashes.Select(diagnostic => $"  {diagnostic.GetMessage()}")));
+
         Assert.True(DuplicateHintNames.Count == 0,
             "More than one generator emitted the same hint name, so one output overwrote another: " +
             string.Join(", ", DuplicateHintNames));

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/SourceGeneratorWrapper.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/SourceGeneratorWrapper.cs
@@ -2,19 +2,41 @@
 
 namespace Hardened.SourceGenerator.Shared;
 
+/// <summary>
+/// Catches anything thrown while a generator writes source, so one failing item does not take the
+/// compiler down with it.
+/// </summary>
 internal class SourceGeneratorWrapper {
+
+    /// <summary>
+    /// Reported when a generator throws while emitting. Named here so tests and the generator test
+    /// harness can recognise it rather than matching on a message.
+    /// </summary>
+    public const string DiagnosticId = "HardenedException";
+
     public static Action<SourceProductionContext, T> Wrap<T>(Action<SourceProductionContext, T> writeSourceFile) {
         return (context, value) => {
             try {
                 writeSourceFile(context, value);
             }
             catch (Exception exp) {
+                // Error, not warning. Reaching here means the generator emitted nothing for this
+                // item, so whatever depended on it is missing and the build cannot succeed in any
+                // useful sense - a consumer without TreatWarningsAsErrors would otherwise carry on
+                // and be told only about the downstream damage, with the cause filed as a warning
+                // they may never see.
+                //
+                // It also closes a hole in the test suites. GeneratorResult.AssertNoErrors checks
+                // for Error-severity diagnostics, so while this was a warning a generator could
+                // crash, produce no code at all, and every OutputCompiles test over it still
+                // passed. Three suites had grown their own local check for this diagnostic to work
+                // around it.
                 var descriptor = new DiagnosticDescriptor(
-                    id: "HardenedException",
-                    title: "Unexpected Error",
-                    messageFormat: "Error for object: {0}",
-                    category: "Design",
-                    defaultSeverity: DiagnosticSeverity.Warning,
+                    id: DiagnosticId,
+                    title: "Generator failed",
+                    messageFormat: "The generator threw and produced no source: {0}",
+                    category: "Hardened.Generation",
+                    defaultSeverity: DiagnosticSeverity.Error,
                     isEnabledByDefault: true);
 
                 context.ReportDiagnostic(Diagnostic.Create(descriptor, Location.None, GetExceptionMessage(exp)));
@@ -23,6 +45,15 @@ internal class SourceGeneratorWrapper {
     }
 
     private static string GetExceptionMessage(Exception exp) {
-        return $"Report the exception:  {exp.Message} {exp.TargetSite.DeclaringType?.FullName} {exp.TargetSite}";
+        // TargetSite is null for an exception that never unwound a managed frame, and this used to
+        // dereference it - so the handler for a generator crash could itself throw, replacing a
+        // reported diagnostic with an unhandled one.
+        var site = exp.TargetSite;
+
+        var where = site == null
+            ? "(no target site)"
+            : $"{site.DeclaringType?.FullName}.{site}";
+
+        return $"{exp.GetType().Name}: {exp.Message} at {where}";
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/SyntaxNodeExtensions.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/SyntaxNodeExtensions.cs
@@ -67,10 +67,27 @@ public static class SyntaxNodeExtensions {
         return stringBuilder.ToString();
     }
 
+    /// <summary>
+    /// The type this class declares.
+    ///
+    /// <para>
+    /// A class in the global namespace has no <c>BaseNamespaceDeclarationSyntax</c> ancestor, and
+    /// this used to take <c>.First()</c> of that empty sequence. Because it runs inside an
+    /// incremental generator's transform it escaped <c>SourceGeneratorWrapper</c> entirely, so
+    /// Roslyn reported <c>CS8785</c> at warning severity and the generator contributed nothing to
+    /// the whole assembly. Recorded against the web generator in TESTING-PLAN.md section 12 as
+    /// "a controller in the global namespace crashes the generator"; the same call is reached from
+    /// the template and console generators. Fixed 2026-08-12 — the global namespace is the empty
+    /// string, which is what <see cref="TypeDefinition"/> already means by it.
+    /// </para>
+    /// </summary>
     public static ITypeDefinition GetTypeDefinition(this ClassDeclarationSyntax classDeclarationSyntax) {
-        var namespaceSyntax = classDeclarationSyntax.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().First();
+        var namespaceSyntax = classDeclarationSyntax.Ancestors()
+            .OfType<BaseNamespaceDeclarationSyntax>()
+            .FirstOrDefault();
 
-        return TypeDefinition.Get(namespaceSyntax.Name.ToFullString().TrimEnd(),
+        return TypeDefinition.Get(
+            namespaceSyntax?.Name.ToFullString().TrimEnd() ?? "",
             classDeclarationSyntax.Identifier.Text);
     }
 
@@ -97,14 +114,45 @@ public static class SyntaxNodeExtensions {
                 });
     }
 
+    /// <summary>
+    /// Whether <paramref name="node"/> carries the named attribute, however the author qualified it.
+    ///
+    /// <para>
+    /// This is a syntactic pre-filter for an incremental generator's predicate, so it sees the text
+    /// as written and no symbols. It used to compare only against the bare name, the bare name plus
+    /// <c>Attribute</c>, and those two prefixed with <paramref name="ns"/> — which meant a fully
+    /// qualified <c>[global::Hardened.Shared.Runtime.Attributes.HardenedModule]</c> matched
+    /// nothing, and the class carrying it was simply not seen. Legal C#, and the form to reach for
+    /// when avoiding a using or emitting from another generator. Found 2026-08-12.
+    /// </para>
+    ///
+    /// <para>
+    /// Comparing the last dotted segment covers every qualification of the name. It can in
+    /// principle match an unrelated attribute that ends the same way, which the bare-name check
+    /// above could already do; over-matching here costs a transform that resolves the symbol
+    /// properly and discards it, while under-matching loses the type silently.
+    /// </para>
+    /// </summary>
     public static bool IsAttributed(this SyntaxNode node, string attributeName, string ns = "") {
         return node.DescendantNodes()
             .OfType<AttributeSyntax>().Any(
                 a => {
                     var name = a.Name.ToString();
 
-                    return name.Equals(attributeName) || name.Equals(attributeName + "Attribute") ||
-                           name.Equals(ns + "." + attributeName) || name.Equals(ns + "." + attributeName + "Attribute");
+                    if (name.Equals(attributeName) || name.Equals(attributeName + "Attribute") ||
+                        name.Equals(ns + "." + attributeName) || name.Equals(ns + "." + attributeName + "Attribute")) {
+                        return true;
+                    }
+
+                    var lastDot = name.LastIndexOf('.');
+
+                    if (lastDot < 0) {
+                        return false;
+                    }
+
+                    var simpleName = name.Substring(lastDot + 1);
+
+                    return simpleName.Equals(attributeName) || simpleName.Equals(attributeName + "Attribute");
                 });
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateIncrementalGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Templates/Generator/TemplateIncrementalGenerator.cs
@@ -100,9 +100,27 @@ public static class TemplateIncrementalGenerator {
     private static void GenerateTemplateSource(SourceProductionContext sourceProductionContext,
         (TemplateModel templateModel, ImmutableArray<EntryPointSelector.Model> applicationModels) templateData) {
         var templateModel = templateData.templateModel;
-        var applicationModel = templateData.applicationModels.First();
+
+        // A template is named after the application it belongs to, so without an entry point there
+        // is nothing to emit against. This used to be .First() and threw on an empty collection,
+        // which the wrapper turned into a diagnostic and the whole template generator produced
+        // nothing - for every template in the project, not just this one.
+        if (templateData.applicationModels.Length == 0) {
+            return;
+        }
+
+        var applicationModel = templateData.applicationModels[0];
+
+        // An application in the global namespace has none to prefix, and concatenating anyway
+        // emitted "namespace .Generated" - CS1001, in a file the consumer never wrote.
+        var applicationNamespace = applicationModel.EntryPointType.Namespace;
+
+        var generatedNamespace = string.IsNullOrEmpty(applicationNamespace)
+            ? "Generated"
+            : applicationNamespace + ".Generated";
+
         templateModel.TemplateDefinitionType = TypeDefinition.Get(
-            applicationModel.EntryPointType.Namespace + ".Generated", "Template_" + templateModel.TemplateName);
+            generatedNamespace, "Template_" + templateModel.TemplateName);
 
         var templateSource = _generator.GenerateCSharpFile(templateModel.TemplateActionNodes,
             templateModel.TemplateName, templateModel.TemplateExtension,


### PR DESCRIPTION
`SourceGeneratorWrapper` reported an emit-time exception as `HardenedException` at **warning** severity. `GeneratorResult.AssertNoErrors` checks for Error-severity diagnostics, so a generator could crash, emit nothing at all, and every `OutputCompiles` test over it still passed. Three suites had grown their own local check for that diagnostic to work around it.

It is now an Error, and the harness names it explicitly — "the generator crashed and emitted no code" and "the code it emitted does not compile" want different messages.

## What that immediately exposed

Nine tests in `GeneratedTemplateCompilesTests` — a suite whose entire job is to compile generated templates, and which had been compiling **nothing**. Four defects behind them, each hiding the next:

**`IsAttributed` did not match a qualified attribute name.** It compared only the bare name, the bare name plus `Attribute`, and those prefixed with a namespace argument. A fully qualified `[global::Hardened.Shared.Runtime.Attributes.HardenedModule]` matched nothing, so the class carrying it was never seen. Legal C#, and the form to reach for when avoiding a using or emitting from another generator.

**`GetTypeDefinition` crashed on the global namespace** — `.First()` over the namespace ancestors of a class that has none. This is the defect recorded against the web generator in `TESTING-PLAN.md` §12 as *"a controller in the global namespace crashes the generator"*; the same call is reached from templates and console. It runs in a syntax transform, so it escapes the wrapper entirely: Roslyn reports `CS8785` at warning severity and the generator contributes nothing to the whole assembly.

**`GenerateTemplateSource` took `.First()` of the application models**, so a template with no entry point in the compilation crashed the generator for every template in the project.

**An application in the global namespace emitted `namespace .Generated`** — `CS1001`, in a file the consumer never wrote.

**And the wrapper's own error handler dereferenced `Exception.TargetSite`**, which is null for an exception that never unwound a managed frame — so the handler for a generator crash could itself throw and replace a reported diagnostic with an unhandled one.

## Verification

1994 passing, no warnings, coverage gate green. The nine template tests now compile real generated output for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoucMfctBPuZjTMiesoFGS