### PR TITLE
Cover the function generator, and pin six defects it was hiding

### DIFF
--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionCombinedComparerTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionCombinedComparerTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Immutable;
+using CSharpAuthor;
+using Hardened.SourceGenerator.Function;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Shared;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// <see cref="FunctionIncrementalGenerator.CombinedComparer"/>, which decides whether the
+/// registration stage may serve its previous output.
+///
+/// <para>
+/// It is a second copy of the web generator's comparer of the same name, carrying the same
+/// asymmetry: the hash is structural over the handlers, while equality on both halves is by
+/// reference. Recorded for the web copy in <c>ModelComparisonTests</c> on 2026-08-11 and asserted
+/// here as the function copy behaves, not as it reads. The end-to-end consequence is in
+/// IncrementalFunctionGenerationTests — caching works because Roslyn hands back the same instances
+/// when nothing changed, not because the comparer would recognise an equal rebuild.
+/// </para>
+/// </summary>
+public class FunctionCombinedComparerTests {
+
+    private static ITypeDefinition Type(string name) => TypeDefinition.Get("System", name);
+
+    private static RequestHandlerModel Handler(string functionName = "Process") =>
+        new(
+            new RequestHandlerNameModel(functionName, "POST"),
+            TypeDefinition.Get("TestApp", "TestFunctions"),
+            "Process",
+            TypeDefinition.Get("TestApp.Generated", "TestFunctions_Process"),
+            [
+                new RequestParameterInformation(
+                    parameterType: TypeDefinition.Get("TestApp", "DataModel"),
+                    name: "model",
+                    required: true,
+                    defaultValue: null,
+                    bindingType: ParameterBindType.Body,
+                    bindingName: "model",
+                    parameterIndex: 0)
+            ],
+            new ResponseInformationModel { ReturnType = Type("String") },
+            []);
+
+    private static EntryPointSelector.Model EntryPoint(string name = "TestApplication") =>
+        new() {
+            EntryPointType = TypeDefinition.Get("TestApp", name),
+            RootEntryPoint = false,
+            AttributeModels = [],
+            MethodDefinitions = [],
+            PropertyDefinitions = null
+        };
+
+    /// <summary>
+    /// The instance-reuse path Roslyn actually takes, and the two changes that must be noticed:
+    /// a different entry point, and a different set of handlers.
+    /// </summary>
+    [Fact]
+    public void TheCombinedComparerComparesBothHalvesByReference() {
+        var comparer = new FunctionIncrementalGenerator.CombinedComparer();
+        var entryPoint = EntryPoint();
+        var handlers = ImmutableArray.Create(Handler());
+
+        Assert.True(comparer.Equals((entryPoint, handlers), (entryPoint, handlers)));
+
+        Assert.False(comparer.Equals((entryPoint, handlers), (EntryPoint("Other"), handlers)));
+
+        Assert.False(comparer.Equals(
+            (entryPoint, handlers),
+            (entryPoint, ImmutableArray.Create(Handler(), Handler("second")))));
+
+        // The missed cache hit: a rebuilt-but-identical entry point does not compare equal, because
+        // EntryPointSelector.Model has no Equals override and the comparer does not use
+        // EntryPointSelector.Comparer. This is the line that would flip to Assert.True if it did.
+        Assert.False(comparer.Equals((entryPoint, handlers), (EntryPoint(), handlers)));
+    }
+
+    /// <summary>
+    /// The handler half of the hash is structural: two arrays holding equal handlers agree, and a
+    /// changed function name disagrees. The entry point instance is held constant because the other
+    /// half of the hash is <see cref="object.GetHashCode"/>.
+    /// </summary>
+    [Fact]
+    public void TheCombinedComparerHashesTheHandlersStructurally() {
+        var comparer = new FunctionIncrementalGenerator.CombinedComparer();
+        var entryPoint = EntryPoint();
+
+        Assert.Equal(
+            comparer.GetHashCode((entryPoint, ImmutableArray.Create(Handler()))),
+            comparer.GetHashCode((entryPoint, ImmutableArray.Create(Handler()))));
+
+        Assert.NotEqual(
+            comparer.GetHashCode((entryPoint, ImmutableArray.Create(Handler()))),
+            comparer.GetHashCode((entryPoint, ImmutableArray.Create(Handler("renamed")))));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionEntryPointTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionEntryPointTests.cs
@@ -1,0 +1,135 @@
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// What the two output stages do when the application entry point is absent, added or moved.
+///
+/// <para>
+/// The stages are wired differently and this is where that shows. Invokers come from the handler
+/// provider alone; the registration comes from the entry point <em>combined</em> with the collected
+/// handlers, so with no entry point there is nothing to combine against and the whole second stage
+/// produces nothing.
+/// </para>
+/// </summary>
+public class FunctionEntryPointTests {
+
+    /// <summary>
+    /// A library of handlers with no application of its own. The invokers are still emitted — a
+    /// handler library is a legitimate thing to compile, and the application that consumes it
+    /// supplies the entry point in its own compilation.
+    /// </summary>
+    [Fact]
+    public void HandlersWithNoEntryPointStillGenerateTheirInvokers() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Handlers("""
+                [HardenedFunction]
+                public void Process() { }
+            """)).AssertNoErrors();
+
+        Assert.Contains("Process.FunctionHandler.cs", result.GeneratedSources.Keys);
+    }
+
+    /// <summary>
+    /// No entry point means no provider and no registration. Nothing is reported about it: a
+    /// handler library without an application is the normal case, not an error.
+    /// </summary>
+    [Fact]
+    public void HandlersWithNoEntryPointGenerateNoProvider() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Handlers("""
+                [HardenedFunction]
+                public void Process() { }
+            """)).AssertNoErrors();
+
+        Assert.DoesNotContain(result.GeneratedSources.Keys, key => key.Contains("FunctionHandlers"));
+        Assert.Empty(result.GeneratorDiagnostics);
+    }
+
+    /// <summary>
+    /// A compilation with neither an entry point nor a handler produces nothing at all, rather than
+    /// an empty provider.
+    /// </summary>
+    [Fact]
+    public void ACompilationWithNothingToGenerateProducesNoFiles() {
+        var result = FunctionGeneratorHarness.Generate("""
+            namespace TestApp;
+
+            public class NotAFunction {
+                public void Process() { }
+            }
+            """).AssertNoErrors();
+
+        Assert.Empty(result.GeneratedSources);
+    }
+
+    /// <summary>
+    /// A method without <c>[HardenedFunction]</c> is not a handler, even beside one that is.
+    /// </summary>
+    [Fact]
+    public void OnlyAttributedMethodsBecomeHandlers() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process() { }
+
+                public void NotAHandler() { }
+            """)).AssertNoErrors();
+
+        Assert.DoesNotContain(result.GeneratedSources.Keys, key => key.Contains("NotAHandler"));
+        Assert.Equal(2, result.GeneratedSources.Count);
+    }
+
+    /// <summary>
+    /// The entry point and the handlers may be in separate files — the ordinary project layout,
+    /// and the one SqsTest has.
+    /// </summary>
+    [Fact]
+    public void TheEntryPointAndItsHandlersMayLiveInSeparateFiles() {
+        var result = FunctionGeneratorHarness.Generate(new Dictionary<string, string> {
+            ["Application.cs"] = """
+                using Hardened.Shared.Runtime.Attributes;
+
+                namespace TestApp;
+
+                [HardenedModule]
+                public partial class TestApplication { }
+                """,
+            ["Functions.cs"] = """
+                using Hardened.Requests.Abstract.Attributes;
+
+                namespace TestApp;
+
+                public class TestFunctions {
+                    [HardenedFunction] public void Process() { }
+                }
+                """
+        }).AssertNoErrors();
+
+        Assert.Contains("Process.FunctionHandler.cs", result.GeneratedSources.Keys);
+        Assert.Contains("TestApplication.FunctionHandlers.cs", result.GeneratedSources.Keys);
+    }
+
+    /// <summary>
+    /// The attribute is matched fully qualified as well as by its short name. Until 2026-08-11
+    /// <c>IsAttributed</c> compared against the short name only, so an application written
+    /// <c>[Hardened.Shared.Runtime.Attributes.HardenedModule]</c> — which is what a project with a
+    /// name clash has to write — was not recognised as an entry point, and its registration was
+    /// silently never generated.
+    /// </summary>
+    [Fact]
+    public void AFullyQualifiedModuleAttributeIsStillAnEntryPoint() {
+        var result = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+
+            namespace TestApp;
+
+            [Hardened.Shared.Runtime.Attributes.HardenedModule]
+            public partial class TestApplication { }
+
+            public class TestFunctions {
+                [HardenedFunction] public void Process() { }
+            }
+            """).AssertNoErrors();
+
+        Assert.Contains("TestApplication.FunctionHandlers.cs", result.GeneratedSources.Keys);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionFilterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionFilterTests.cs
@@ -1,0 +1,128 @@
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// Which attributes on a function handler are read as filters, and which are read as something
+/// else.
+///
+/// <para>
+/// <c>FunctionModelGenerator.IsFilterAttribute</c> makes this call, and it is a denylist: everything
+/// is a filter except <c>[Template]</c>, <c>[RawResponse]</c> and <c>[HardenedFunction]</c> itself.
+/// Getting it wrong in either direction is quiet — a filter mistaken for response information never
+/// runs, and <c>[HardenedFunction]</c> mistaken for a filter is instantiated as one at startup.
+/// </para>
+/// </summary>
+public class FunctionFilterTests {
+
+    private static string Handler(string attributes, string signature) =>
+        FunctionGeneratorHarness.Generate($$"""
+            using System.Threading.Tasks;
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Requests.Runtime.Filters;
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class TestFunctions {
+                [HardenedFunction]
+                {{attributes}}
+                {{signature}}
+            }
+            """).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+    /// <summary>
+    /// A filter attribute reaches the handler's metadata array, and the array is passed to
+    /// <c>GetFilterInfo</c> — an attribute recorded but not passed would never run.
+    /// </summary>
+    [Fact]
+    public void AFilterAttributeIsRecordedInTheHandlerMetadata() {
+        var source = Handler("[Retry(Retries = 2)]", "public void Process() { }");
+
+        Assert.Contains("new global::Hardened.Requests.Runtime.Filters.RetryAttribute(){ Retries = 2 }", source);
+        Assert.Contains("ExecutionHelper.GetFilterInfo(_metadata)", source);
+    }
+
+    /// <summary>
+    /// <c>[HardenedFunction]</c> is what marks the handler, not a filter on it. Treated as one it
+    /// would be constructed and run on every invocation.
+    /// </summary>
+    [Fact]
+    public void TheHardenedFunctionAttributeIsNotItselfAFilter() {
+        var source = Handler("", "public void Process() { }");
+
+        Assert.DoesNotContain("_metadata", source);
+        Assert.DoesNotContain("HardenedFunctionAttribute()", source);
+    }
+
+    /// <summary>
+    /// <c>[RawResponse]</c> is response information: it becomes the handler's output function
+    /// rather than a filter, so it stays out of the metadata array.
+    /// </summary>
+    [Fact]
+    public void ARawResponseAttributeBecomesTheOutputFunctionRatherThanAFilter() {
+        var source = Handler("[RawResponse(\"text/csv\")]", "public string Process() => \"a,b\";");
+
+        Assert.Contains("RawOutputHelper.OutputFunc(\"text/csv\")", source);
+        Assert.DoesNotContain("_metadata", source);
+    }
+
+    /// <summary>
+    /// <c>[Template]</c> is read the same way — the template output function, not a filter.
+    /// </summary>
+    [Fact]
+    public void ATemplateAttributeBecomesTheOutputFunctionRatherThanAFilter() {
+        var source = Handler("[Template(\"Index\")]", "public string Process() => \"x\";");
+
+        Assert.Contains("DefaultOutputFuncHelper.GetTemplateOut(", source);
+        Assert.Contains("\"Index\"", source);
+        Assert.DoesNotContain("_metadata", source);
+    }
+
+    /// <summary>
+    /// A filter beside response information. The two are decided independently, so this is the
+    /// case where one being mistaken for the other shows up.
+    /// </summary>
+    [Fact]
+    public void AFilterAndAResponseAttributeCoexistOnOneHandler() {
+        var source = Handler(
+            """
+            [Retry(Retries = 3)]
+            [RawResponse("text/csv")]
+            """,
+            "public string Process() => \"a,b\";");
+
+        Assert.Contains("RetryAttribute(){ Retries = 3 }", source);
+        Assert.Contains("RawOutputHelper.OutputFunc(\"text/csv\")", source);
+    }
+
+    /// <summary>
+    /// A filter declared on the handler's class reaches every function it declares — filters are
+    /// collected from the class as well as the method.
+    /// </summary>
+    [Fact]
+    public void AFilterOnTheClassReachesItsFunctions() {
+        var source = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Requests.Runtime.Filters;
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            [Retry(Retries = 4)]
+            public class TestFunctions {
+                [HardenedFunction]
+                public void Process() { }
+            }
+            """).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("RetryAttribute(){ Retries = 4 }", source);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionGeneratorDefectTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionGeneratorDefectTests.cs
@@ -1,0 +1,262 @@
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// Three inputs the function generator handles badly, pinned as they behave on 2026-08-12.
+///
+/// <para>
+/// These are characterisation tests, not approvals. Each records what the generator does today so
+/// that a fix is visible as a failure here rather than as a silent change of behaviour; each is
+/// annotated with what the right answer would be. They are grouped in one file so the set is easy
+/// to delete when the defects are fixed.
+/// </para>
+///
+/// <para>
+/// The first two share a failure mode worth naming: the exception escapes the generator rather than
+/// being caught by <c>SourceGeneratorWrapper</c>, so Roslyn reports <c>CS8785</c> and the generator
+/// <em>contributes nothing to the whole compilation</em>. Not one handler is lost — all of them are,
+/// along with the dependency registration. This is the same failure the web generator's
+/// <c>UnresolvableTypeTests</c> exists to prevent, and the reason that fix reported a diagnostic and
+/// skipped the single bad handler instead of throwing.
+/// </para>
+/// </summary>
+public class FunctionGeneratorDefectTests {
+
+    /// <summary>
+    /// Two handlers that resolve to the same function name collide on the generated file name, and
+    /// the collision takes down the entire generator.
+    ///
+    /// <para>
+    /// The invoker <em>type</em> names are disambiguated — <c>A_Process</c> and <c>B_Process</c> —
+    /// but the file name is <c>model.Name.Path + ".FunctionHandler.cs"</c>, which is the function
+    /// name alone. Roslyn requires hint names to be unique within a generator and throws from
+    /// <c>AdditionalSourcesCollection.Add</c>, which runs when outputs are appended rather than
+    /// inside the wrapped delegate — so <c>SourceGeneratorWrapper</c> never sees it.
+    /// </para>
+    ///
+    /// <para>
+    /// Two classes each declaring a <c>Process</c> method is an ordinary thing to write. The fix
+    /// would be to include the declaring type in the file name, as the type name already does, and
+    /// to report a diagnostic when two handlers genuinely claim one function name.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TwoHandlersWithTheSameFunctionNameCostTheWholeCompilationItsGeneratedCode() {
+        var result = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class OrderFunctions {
+                [HardenedFunction] public void Process() { }
+            }
+
+            public class InvoiceFunctions {
+                [HardenedFunction] public void Process() { }
+            }
+            """);
+
+        // Observed 2026-08-12. The right answer is two invokers and a provider; what happens is
+        // nothing at all, including for the handler that had no name clash of its own.
+        Assert.Empty(result.GeneratedSources);
+
+        var exception = Assert.Single(result.GeneratorExceptions);
+
+        Assert.Contains("Process.FunctionHandler.cs", exception.Message);
+        Assert.Contains("must be unique within a generator", exception.Message);
+    }
+
+    /// <summary>
+    /// The same collision reached through explicit names, which is the form a reader is likelier to
+    /// notice — and the form a rename can introduce without touching either handler's body.
+    /// </summary>
+    [Fact]
+    public void TwoHandlersSharingAnExplicitFunctionNameCollideTheSameWay() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction("duplicate")] public void One() { }
+
+                [HardenedFunction("duplicate")] public void Two() { }
+            """));
+
+        // Observed 2026-08-12.
+        Assert.Empty(result.GeneratedSources);
+        Assert.Single(result.GeneratorExceptions);
+    }
+
+    /// <summary>
+    /// A handler class declared in the global namespace crashes the model transform.
+    ///
+    /// <para>
+    /// <c>BaseRequestModelGenerator.GetControllerType</c> takes <c>.First()</c> of the method's
+    /// namespace ancestors, and a type in the global namespace has none —
+    /// <c>InvalidOperationException: Sequence contains no elements</c>. It throws out of the syntax
+    /// transform, so again the whole generator contributes nothing.
+    /// <c>FunctionModelGenerator.GetInvokeHandlerType</c> makes the same assumption a few frames
+    /// later and would fail identically.
+    /// </para>
+    ///
+    /// <para>
+    /// Related to the <c>GetTypeDefinition</c> global-namespace fix on this branch, and not covered
+    /// by it: that one taught the type-definition helper to cope with an empty namespace, while
+    /// these two callers still assume a namespace declaration exists in the syntax tree. Top-level
+    /// files with no namespace are the default in new .NET templates, so this is reachable by
+    /// writing the most obvious possible handler.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AHandlerInTheGlobalNamespaceCrashesTheGenerator() {
+        var result = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+
+            public class GlobalFunctions {
+                [HardenedFunction] public void Process() { }
+            }
+            """);
+
+        // Observed 2026-08-12. The right answer is either a generated handler or a diagnostic
+        // naming the unsupported layout; what happens is an unhandled exception and no output.
+        Assert.Empty(result.GeneratedSources);
+
+        var exception = Assert.Single(result.GeneratorExceptions);
+
+        Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains("Sequence contains no elements", exception.Message);
+    }
+
+    /// <summary>
+    /// A <c>[FromContext]</c> parameter whose type the compiler cannot resolve crashes the model
+    /// transform with a <c>NullReferenceException</c>.
+    ///
+    /// <para>
+    /// <c>FunctionModelGenerator.GetParameterInfoWithBinding</c> writes
+    /// <c>parameter.Type?.GetTypeDefinition(context)!</c> — the <c>?.</c> honest about resolution
+    /// returning null, the <c>!</c> suppressing the warning that said so, and the dereference two
+    /// frames later in <c>CreateRequestParameterInformation</c>. This is the exact pattern the
+    /// unresolved-parameter fix removed from <c>BaseRequestModelGenerator.GetParameterInfo</c> on
+    /// 2026-08-12; the attributed path in the function generator was not changed with it, so
+    /// <c>[FromContext]</c> still reaches it.
+    /// </para>
+    ///
+    /// <para>
+    /// It throws out of the syntax transform, so the whole generator contributes nothing. That is
+    /// what the earlier fix was for: an editor runs generators over half-written code constantly,
+    /// and a parameter type is unresolved for as long as it takes to write the class.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AFromContextParameterWithAnUnresolvableTypeCrashesTheGenerator() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process([FromContext("id")] NotDeclaredAnywhere id) { }
+            """, FunctionGeneratorHarness.FromContextAttributeDeclaration));
+
+        // Observed 2026-08-12. The right answer is the ParameterBindType.Unresolved path: record
+        // the parameter, skip this handler, report HOAG010.
+        Assert.Empty(result.GeneratedSources);
+        Assert.IsType<NullReferenceException>(Assert.Single(result.GeneratorExceptions));
+    }
+
+    /// <summary>
+    /// An unresolvable parameter on a plain (unattributed) function parameter is handled one step
+    /// better and still ends badly: the handler is skipped, and the provider goes on referring to
+    /// the invoker that was never emitted.
+    ///
+    /// <para>
+    /// The <c>ParameterBindType.Unresolved</c> fix taught the web generator's routing table to skip
+    /// a handler that could not bind — <c>UnresolvableTypeTests.TheRoutingTableDoesNotRouteToThe
+    /// HandlerThatWasSkipped</c> is that guarantee. The function generator's provider has no
+    /// equivalent guard, so it emits <c>new global::TestApp.Generated.TestFunctions_Process(...)</c>
+    /// for a type that does not exist, and the consumer gets CS0234 on generated code they did not
+    /// write instead of only the CS0246 they caused.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AnUnresolvableParameterLeavesTheProviderReferencingAHandlerThatWasNeverGenerated() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(NotDeclaredAnywhere model) { }
+            """));
+
+        // The invoker is skipped — the binding generator has no case for Unresolved and throws,
+        // which SourceGeneratorWrapper turns into an Error-severity diagnostic.
+        Assert.DoesNotContain("Process.FunctionHandler.cs", result.GeneratedSources.Keys);
+
+        Assert.Contains(result.GeneratorDiagnostics,
+            diagnostic => diagnostic.Id == "HardenedException" &&
+                          diagnostic.GetMessage().Contains("Binding not supported yet: Unresolved"));
+
+        // Observed 2026-08-12: the provider is emitted anyway and still names the missing type.
+        var provider = result.SourceContaining("FunctionHandlers.cs");
+
+        Assert.Contains("global::TestApp.Generated.TestFunctions_Process", provider);
+
+        Assert.Contains(result.Errors,
+            error => error.Id == "CS0234" && error.GetMessage().Contains("Generated"));
+    }
+
+    /// <summary>
+    /// With more than one unnamed handler, only the first is ever returned — for any function name,
+    /// including the others' own method names.
+    ///
+    /// <para>
+    /// <c>CreateFunctionHandlerProviderClass</c> treats every handler whose name equals its method
+    /// name as a catch-all and emits <c>defaultHandlers[0]</c>. The second handler's invoker is
+    /// generated, compiles, is registered in DI, and is unreachable. Nothing is reported.
+    /// </para>
+    ///
+    /// <para>
+    /// Unlike the two collisions above this one is silent — the build is clean and the wrong
+    /// handler runs. Two <c>[HardenedFunction]</c> methods without explicit names is the shape any
+    /// application gets by adding a second function the same way it added the first.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void OnlyTheFirstUnnamedHandlerIsReachableFromTheProvider() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction] public void First() { }
+
+                [HardenedFunction] public void Second() { }
+            """)).AssertNoErrors();
+
+        // Both invokers are generated and both compile.
+        Assert.Contains("First.FunctionHandler.cs", result.GeneratedSources.Keys);
+        Assert.Contains("Second.FunctionHandler.cs", result.GeneratedSources.Keys);
+
+        var provider = result.SourceContaining("FunctionHandlers.cs");
+
+        // Observed 2026-08-12: the provider can only ever construct the first.
+        Assert.Contains("TestFunctions_First", provider);
+        Assert.DoesNotContain("TestFunctions_Second", provider);
+    }
+
+    /// <summary>
+    /// An explicit name identical to the method name is treated as no name at all, because the
+    /// named/unnamed split compares the function name against the method name rather than recording
+    /// whether the attribute carried an argument.
+    ///
+    /// <para>
+    /// Harmless on its own — a catch-all still answers to that name. It matters beside a second
+    /// unnamed handler, where it decides which of the two wins the single catch-all slot, and it
+    /// means <c>[HardenedFunction("Process")]</c> and <c>[HardenedFunction]</c> cannot be told
+    /// apart.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AnExplicitNameMatchingTheMethodNameIsTreatedAsUnnamed() {
+        var provider = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction("Process")]
+                public void Process() { }
+            """)).AssertNoErrors().SourceContaining("FunctionHandlers.cs");
+
+        // Observed 2026-08-12: a catch-all return, not a switch on "Process".
+        Assert.DoesNotContain("switch (functionName)", provider);
+        Assert.Contains("return new global::TestApp.Generated.TestFunctions_Process(serviceProvider);", provider);
+    }
+
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionHandlerProviderTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionHandlerProviderTests.cs
@@ -1,0 +1,396 @@
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// The second output stage: the <c>FunctionHandlerProvider</c> nested in the application class, and
+/// the dependency registration that makes it reachable.
+///
+/// <para>
+/// The invokers are useless without this. It is the only thing that turns an incoming function name
+/// into a handler, and the only place the handler classes themselves are registered — a handler that
+/// generates perfectly and is never registered fails at run time with a DI resolution error rather
+/// than at build time.
+/// </para>
+/// </summary>
+public class FunctionHandlerProviderTests {
+
+    private const string OneHandler = """
+        [HardenedFunction]
+        public void Process() { }
+        """;
+
+    private static string Provider(string body, string extraTypes = "") =>
+        FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application(body, extraTypes))
+            .AssertNoErrors()
+            .SourceContaining("FunctionHandlers.cs");
+
+    /// <summary>
+    /// The emitted source with every run of whitespace removed. CSharpAuthor breaks a returned
+    /// expression across lines and indents it oddly — <c>return</c>, a newline's worth of spaces,
+    /// <c>null</c>, then a bare <c>;</c> — so asserting on the shape of a statement means asserting
+    /// on something whitespace cannot move.
+    /// </summary>
+    private static string Compact(string source) =>
+        string.Concat(source.Where(character => !char.IsWhiteSpace(character)));
+
+    /// <summary>
+    /// The file is named after the entry point, and declares the same class as a partial — the
+    /// application class is where the registration has to land for DependencyRegistry to find it.
+    /// </summary>
+    [Fact]
+    public void TheProviderIsEmittedAsAPartialOfTheApplicationClass() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application(OneHandler))
+            .AssertNoErrors();
+
+        Assert.Contains("TestApplication.FunctionHandlers.cs", result.GeneratedSources.Keys);
+        Assert.Contains("public partial class TestApplication",
+            result.SourceContaining("FunctionHandlers.cs"));
+    }
+
+    [Fact]
+    public void TheProviderImplementsTheFunctionHandlerProviderInterface() {
+        Assert.Contains(
+            "class FunctionHandlerProvider : global::Hardened.Requests.Abstract.Execution.IFunctionHandlerProvider",
+            Provider(OneHandler));
+    }
+
+    /// <summary>
+    /// The provider is registered against the interface, as a singleton. Registered against its own
+    /// concrete type instead, nothing resolving <c>IFunctionHandlerProvider</c> would find it.
+    /// </summary>
+    [Fact]
+    public void TheProviderIsRegisteredAsASingletonAgainstItsInterface() {
+        var provider = Provider(OneHandler);
+
+        Assert.Contains("serviceCollection.AddSingleton<", provider);
+        Assert.Contains("global::Hardened.Requests.Abstract.Execution.IFunctionHandlerProvider", provider);
+        Assert.Contains("FunctionHandlerProvider", provider);
+    }
+
+    /// <summary>
+    /// The class declaring the handler is registered too — the invoker resolves it out of the
+    /// provider on every invocation, so without this the handler builds and then fails to resolve.
+    /// </summary>
+    [Fact]
+    public void TheHandlerTypeIsRegisteredAsTransient() {
+        Assert.Contains("serviceCollection.AddTransient<global::TestApp.TestFunctions>();",
+            Provider(OneHandler));
+    }
+
+    /// <summary>
+    /// Registration is hooked in through DependencyRegistry, keyed on the entry point, which is how
+    /// DependencyModules discovers it. The <c>[DynamicDependency]</c> keeps the method from being
+    /// trimmed — it is only ever called through the registry.
+    /// </summary>
+    [Fact]
+    public void RegistrationIsAddedToTheApplicationsDependencyRegistry() {
+        var provider = Provider(OneHandler);
+
+        Assert.Contains("DependencyRegistry<TestApplication>.Add(FunctionHandlersDI)", provider);
+        Assert.Contains("[DynamicDependency(nameof(FunctionHandlersDI))]", provider);
+    }
+
+    /// <summary>
+    /// A handler with no explicit name answers to any function name. A Lambda that hosts one
+    /// function never sends a name worth matching, which is the case SqsTest is.
+    /// </summary>
+    [Fact]
+    public void AnUnnamedHandlerAnswersToAnyFunctionName() {
+        var provider = Provider(OneHandler);
+
+        Assert.Contains("return new global::TestApp.Generated.TestFunctions_Process(serviceProvider);", provider);
+        Assert.DoesNotContain("switch (functionName)", provider);
+    }
+
+    /// <summary>
+    /// An explicitly named handler is matched by name instead, through a switch.
+    /// </summary>
+    [Fact]
+    public void ANamedHandlerIsMatchedByItsFunctionName() {
+        var provider = Provider("""
+            [HardenedFunction("order-received")]
+            public void Process() { }
+            """);
+
+        Assert.Contains("switch (functionName)", provider);
+        Assert.Contains("case \"order-received\":", provider);
+    }
+
+    /// <summary>
+    /// A name that does not match any handler returns null rather than falling through to an
+    /// arbitrary one. The caller distinguishes "no such function" from a handler that did nothing.
+    /// </summary>
+    [Fact]
+    public void AnUnmatchedFunctionNameReturnsNull() {
+        var provider = Compact(Provider("""
+            [HardenedFunction("order-received")]
+            public void Process() { }
+            """));
+
+        // The null return is the statement immediately after the switch closes, so a name matching
+        // no case falls out of the switch and returns null rather than reaching any handler.
+        Assert.Contains("}returnnull;", provider);
+    }
+
+    /// <summary>
+    /// A named handler and an unnamed one together: the switch matches the named one first, and the
+    /// unnamed one is the fallback for everything else.
+    /// </summary>
+    [Fact]
+    public void ANamedHandlerIsMatchedBeforeTheUnnamedFallback() {
+        var provider = Provider("""
+            [HardenedFunction("order-received")]
+            public void Named() { }
+
+            [HardenedFunction]
+            public void Fallback() { }
+            """);
+
+        var switchIndex = provider.IndexOf("case \"order-received\":", StringComparison.Ordinal);
+        var fallbackIndex = provider.IndexOf("return new global::TestApp.Generated.TestFunctions_Fallback",
+            StringComparison.Ordinal);
+
+        Assert.True(switchIndex >= 0, "the named handler should be a switch case");
+        Assert.True(fallbackIndex > switchIndex, "the unnamed handler should be the fallback after the switch");
+    }
+
+    /// <summary>
+    /// The name may be a constant expression rather than a literal — the generator reads it through
+    /// the semantic model, so a <c>const</c> resolves to its value rather than to its source text.
+    /// </summary>
+    [Fact]
+    public void AFunctionNameGivenAsAConstantResolvesToItsValue() {
+        var result = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            public static class FunctionNames {
+                public const string OrderReceived = "order-received";
+            }
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class TestFunctions {
+                [HardenedFunction(FunctionNames.OrderReceived)]
+                public void Process() { }
+            }
+            """).AssertNoErrors();
+
+        Assert.Contains("case \"order-received\":", result.SourceContaining("FunctionHandlers.cs"));
+        Assert.Contains("order-received.FunctionHandler.cs", result.GeneratedSources.Keys);
+    }
+
+    /// <summary>
+    /// A name expression the compiler cannot resolve falls back to the expression's source text
+    /// rather than throwing. An editor runs generators over half-written code constantly, and a
+    /// constant is unresolved for as long as it takes to declare it — the fallback keeps the rest of
+    /// the compilation's generated code alive while that is true. The input itself does not compile,
+    /// so this asserts on the generator's output rather than on a clean build.
+    /// </summary>
+    [Fact]
+    public void AnUnresolvableFunctionNameFallsBackToItsSourceText() {
+        var result = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class TestFunctions {
+                [HardenedFunction(NotDeclaredAnywhere.Name)]
+                public void Process() { }
+            }
+            """);
+
+        Assert.Empty(result.GeneratorExceptions);
+        Assert.Contains("NotDeclaredAnywhere.Name.FunctionHandler.cs", result.GeneratedSources.Keys);
+        Assert.Contains("case \"NotDeclaredAnywhere.Name\":", result.SourceContaining("FunctionHandlers.cs"));
+    }
+
+    /// <summary>
+    /// The function name is used verbatim as the generated file name, punctuation included. A name
+    /// shaped like a path — which reads naturally for a namespaced queue or topic — becomes a hint
+    /// name containing a separator. Roslyn accepts it, so this is recorded rather than raised:
+    /// checked 2026-08-12, and the reason to know it is that anything writing these files to disk,
+    /// as <c>EmitCompilerGeneratedFiles</c> does, is writing into a subdirectory.
+    /// </summary>
+    [Fact]
+    public void TheFunctionNameIsUsedVerbatimAsTheGeneratedFileName() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction("orders/received")]
+                public void Process() { }
+            """)).AssertNoErrors();
+
+        Assert.Contains("orders/received.FunctionHandler.cs", result.GeneratedSources.Keys);
+        Assert.Contains("case \"orders/received\":", result.SourceContaining("FunctionHandlers.cs"));
+    }
+
+    /// <summary>
+    /// Several handlers in one application. Each gets its own invoker file, each named function
+    /// gets its own case, and the declaring class is registered once.
+    /// </summary>
+    [Fact]
+    public void SeveralNamedHandlersEachGetTheirOwnCase() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction("first")] public void One() { }
+
+                [HardenedFunction("second")] public void Two() { }
+
+                [HardenedFunction("third")] public void Three() { }
+            """)).AssertNoErrors();
+
+        var provider = result.SourceContaining("FunctionHandlers.cs");
+
+        Assert.Contains("case \"first\":", provider);
+        Assert.Contains("case \"second\":", provider);
+        Assert.Contains("case \"third\":", provider);
+
+        Assert.Equal(4, result.GeneratedSources.Count);
+    }
+
+    /// <summary>
+    /// Handlers spread across two classes. Both classes have to be registered — registering only
+    /// the first would leave the second unresolvable at run time.
+    /// </summary>
+    [Fact]
+    public void HandlersOnSeparateClassesEachRegisterTheirDeclaringType() {
+        var provider = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class OrderFunctions {
+                [HardenedFunction("order")] public void Handle() { }
+            }
+
+            public class InvoiceFunctions {
+                [HardenedFunction("invoice")] public void Handle() { }
+            }
+            """).AssertNoErrors().SourceContaining("FunctionHandlers.cs");
+
+        Assert.Contains("serviceCollection.AddTransient<global::TestApp.OrderFunctions>();", provider);
+        Assert.Contains("serviceCollection.AddTransient<global::TestApp.InvoiceFunctions>();", provider);
+    }
+
+    /// <summary>
+    /// Two handlers on the same class register it once, not twice. A duplicate transient
+    /// registration is not an error, but it doubles the descriptor list for every handler declared.
+    /// </summary>
+    [Fact]
+    public void TwoHandlersOnOneClassRegisterItOnce() {
+        var provider = Provider("""
+            [HardenedFunction("first")] public void One() { }
+
+            [HardenedFunction("second")] public void Two() { }
+            """);
+
+        var registrations = provider.Split("serviceCollection.AddTransient<global::TestApp.TestFunctions>();").Length - 1;
+
+        Assert.Equal(1, registrations);
+    }
+
+    /// <summary>
+    /// An application with no function handlers at all still gets a provider — one that returns
+    /// null for every name. The registration is unconditional, so anything resolving
+    /// <c>IFunctionHandlerProvider</c> finds an implementation rather than failing to construct.
+    /// </summary>
+    [Fact]
+    public void AnApplicationWithNoHandlersStillRegistersAProviderThatReturnsNull() {
+        var result = FunctionGeneratorHarness.Generate("""
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+            """).AssertNoErrors();
+
+        var provider = result.SourceContaining("FunctionHandlers.cs");
+
+        Assert.Contains("global::Hardened.Requests.Abstract.Execution.IFunctionHandlerProvider", provider);
+        Assert.DoesNotContain("AddTransient", provider);
+
+        // Null for every name, with no switch and nothing to construct.
+        var compact = Compact(provider);
+
+        Assert.Contains("returnnull;", compact);
+        Assert.DoesNotContain("switch(functionName)", compact);
+        Assert.DoesNotContain("returnnew", compact);
+    }
+
+    /// <summary>
+    /// Two application entry points in one compilation each get their own provider, each keyed on
+    /// its own DependencyRegistry. The handlers are shared — they are selected per compilation, not
+    /// per application.
+    /// </summary>
+    [Fact]
+    public void EachEntryPointGetsItsOwnProvider() {
+        var result = FunctionGeneratorHarness.Generate("""
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Shared.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class AppOne { }
+
+            [HardenedModule]
+            public partial class AppTwo { }
+
+            public class TestFunctions {
+                [HardenedFunction] public void Process() { }
+            }
+            """).AssertNoErrors();
+
+        Assert.Contains("AppOne.FunctionHandlers.cs", result.GeneratedSources.Keys);
+        Assert.Contains("AppTwo.FunctionHandlers.cs", result.GeneratedSources.Keys);
+
+        Assert.Contains("DependencyRegistry<AppOne>", result.GeneratedSources["AppOne.FunctionHandlers.cs"]);
+        Assert.Contains("DependencyRegistry<AppTwo>", result.GeneratedSources["AppTwo.FunctionHandlers.cs"]);
+    }
+
+    /// <summary>
+    /// The provider is emitted into the entry point's namespace, wherever the handlers live. The
+    /// invoker types it constructs are referenced fully qualified, which is what lets the two sit in
+    /// different namespaces at all.
+    /// </summary>
+    [Fact]
+    public void TheProviderReferencesHandlersInOtherNamespacesFullyQualified() {
+        var result = FunctionGeneratorHarness.Generate(new Dictionary<string, string> {
+            ["Application.cs"] = """
+                using Hardened.Shared.Runtime.Attributes;
+
+                namespace TestApp;
+
+                [HardenedModule]
+                public partial class TestApplication { }
+                """,
+            ["Handlers.cs"] = """
+                using Hardened.Requests.Abstract.Attributes;
+
+                namespace TestApp.Handlers;
+
+                public class OrderFunctions {
+                    [HardenedFunction] public void Process() { }
+                }
+                """
+        }).AssertNoErrors();
+
+        var provider = result.SourceContaining("FunctionHandlers.cs");
+
+        Assert.Contains("namespace TestApp", provider);
+        Assert.Contains("global::TestApp.Handlers.Generated.OrderFunctions_Process", provider);
+        Assert.Contains("serviceCollection.AddTransient<global::TestApp.Handlers.OrderFunctions>();", provider);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionHandlerShapeTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionHandlerShapeTests.cs
@@ -1,0 +1,251 @@
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// Every return shape and arity a <c>[HardenedFunction]</c> handler can have.
+///
+/// <para>
+/// A function handler goes through the same InvokeClassGenerator as a web route, so the shape picks
+/// the same six constructor overloads — sync or async, with parameters or without. What differs is
+/// everything around it: the function generator supplies its own name model, its own invoker type
+/// name and its own file name, and none of that had ever been compiled before this suite.
+/// </para>
+/// </summary>
+public class FunctionHandlerShapeTests {
+
+    [Fact]
+    public void AVoidHandlerAssignsNoResponseValue() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process() { }
+            """)).AssertNoErrors();
+
+        var source = result.SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("controller.Process();", source);
+        Assert.DoesNotContain("ResponseValue", source);
+    }
+
+    [Fact]
+    public void AValueReturningHandlerAssignsTheResponseValue() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public string Process() => "x";
+            """)).AssertNoErrors();
+
+        Assert.Contains("context.Response.ResponseValue = controller.Process();",
+            result.SourceContaining("Process.FunctionHandler"));
+    }
+
+    /// <summary>
+    /// A bare <c>Task</c> return — the shape SqsTest's handler actually has. The generator rewrites
+    /// the return type to <c>void</c> while still marking the handler async, so it must await
+    /// without assigning a response value.
+    /// </summary>
+    [Fact]
+    public void ATaskReturningHandlerIsAwaitedAndAssignsNoResponseValue() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public Task Process() => Task.CompletedTask;
+            """)).AssertNoErrors();
+
+        var source = result.SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("await controller.Process();", source);
+        Assert.DoesNotContain("ResponseValue", source);
+    }
+
+    [Fact]
+    public void ATaskOfTReturningHandlerIsAwaitedIntoTheResponseValue() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public Task<string> Process() => Task.FromResult("x");
+            """)).AssertNoErrors();
+
+        Assert.Contains("context.Response.ResponseValue = await controller.Process();",
+            result.SourceContaining("Process.FunctionHandler"));
+    }
+
+    [Fact]
+    public void AValueTaskOfTReturningHandlerIsAwaitedIntoTheResponseValue() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public ValueTask<string> Process() => new ValueTask<string>("x");
+            """)).AssertNoErrors();
+
+        Assert.Contains("context.Response.ResponseValue = await controller.Process();",
+            result.SourceContaining("Process.FunctionHandler"));
+    }
+
+    /// <summary>
+    /// The exact signature SqsTest declares: <c>async Task</c> taking one payload model. If any
+    /// single test here stands for "the shipped consumer still builds", it is this one.
+    /// </summary>
+    [Fact]
+    public void AnAsyncTaskHandlerTakingAModelCompiles() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public async Task Process(DataModel model) {
+                    await Task.Yield();
+                }
+            """, FunctionGeneratorHarness.SupportTypes)).AssertNoErrors();
+
+        var source = result.SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("await controller.Process(parameters.model);", source);
+        Assert.Contains("AsyncStandardFilterWithParameters", source);
+    }
+
+    [Fact]
+    public void AZeroParameterHandlerUsesTheEmptyParameterConstructor() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public string Process() => "x";
+            """)).AssertNoErrors();
+
+        var source = result.SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("StandardFilterEmptyParameters", source);
+        Assert.DoesNotContain("BindRequestParameters", source);
+    }
+
+    /// <summary>
+    /// A zero-parameter handler emits no Parameters class and no <c>_parameterInfo</c> array.
+    /// Anything referring to either would not compile — that is how the metadata-slot defect
+    /// surfaced on the web side.
+    /// </summary>
+    [Fact]
+    public void AZeroParameterHandlerEmitsNoParametersClass() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process() { }
+            """)).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+        Assert.DoesNotContain("class Parameters", source);
+        Assert.DoesNotContain("_parameterInfo", source);
+    }
+
+    [Fact]
+    public void AnAsyncHandlerWithNoParametersUsesTheAsyncEmptyParameterConstructor() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public async Task<string> Process() {
+                    await Task.Yield();
+                    return "x";
+                }
+            """)).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("AsyncStandardFilterEmptyParameters", source);
+        Assert.DoesNotContain("BindRequestParameters", source);
+    }
+
+    /// <summary>
+    /// Several parameters at once. The invoke call has to list them in declaration order — a
+    /// reordering compiles whenever two parameters share a type and fails silently at run time.
+    /// </summary>
+    [Fact]
+    public void SeveralParametersAreInvokedInDeclarationOrder() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public Task<string> Process(DataModel model, IThing thing, IExecutionContext context) =>
+                    Task.FromResult("x");
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        var invoke = source.Substring(source.IndexOf("await controller.Process(", StringComparison.Ordinal));
+
+        Assert.True(
+            invoke.IndexOf("parameters.model", StringComparison.Ordinal) <
+            invoke.IndexOf("parameters.thing", StringComparison.Ordinal),
+            "the model is declared first and must be passed first");
+
+        Assert.True(
+            invoke.IndexOf("parameters.thing", StringComparison.Ordinal) <
+            invoke.IndexOf("parameters.context", StringComparison.Ordinal),
+            "the service is declared second and must be passed second");
+    }
+
+    /// <summary>
+    /// The indexer on the generated Parameters class, which the filter pipeline uses to read and
+    /// rewrite arguments by position. One case per parameter, or a filter silently reads the wrong
+    /// one.
+    /// </summary>
+    [Fact]
+    public void EachParameterGetsItsOwnIndexerCase() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(DataModel model, IThing thing) { }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("return model!;", source);
+        Assert.Contains("return thing!;", source);
+        Assert.Contains("case 0:", source);
+        Assert.Contains("case 1:", source);
+    }
+
+    /// <summary>A record payload, the shape most function models actually have.</summary>
+    [Fact]
+    public void ARecordPayloadCompiles() {
+        FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public Task<OrderModel> Process(OrderModel order) => Task.FromResult(order);
+            """, "public record OrderModel(string Sku, int Quantity);")).AssertNoErrors();
+    }
+
+    /// <summary>
+    /// Every shape on one handler class. Each gets its own invoker, so a name collision or a shared
+    /// static surfaces here and nowhere else.
+    /// </summary>
+    [Fact]
+    public void EveryHandlerShapeCoexistsOnOneClass() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction] public void Nothing() { }
+
+                [HardenedFunction] public Task Bare() => Task.CompletedTask;
+
+                [HardenedFunction] public string Value() => "x";
+
+                [HardenedFunction] public Task<string> TaskOfT() => Task.FromResult("x");
+
+                [HardenedFunction] public ValueTask<string> ValueTaskOfT() => new ValueTask<string>("x");
+
+                [HardenedFunction]
+                public async Task<string> WithParameter(DataModel model) {
+                    await Task.Yield();
+                    return model.Value;
+                }
+            """, FunctionGeneratorHarness.SupportTypes)).AssertNoErrors();
+
+        // Six invokers plus the one provider file.
+        Assert.Equal(7, result.GeneratedSources.Count);
+    }
+
+    /// <summary>
+    /// Two overloads of one method name, told apart by an explicit function name. The invoker type
+    /// name carries a hash of the parameter identifiers precisely so these do not collide.
+    /// </summary>
+    [Fact]
+    public void OverloadsWithDistinctFunctionNamesGetDistinctInvokerTypes() {
+        var result = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction("no-args")]
+                public void Process() { }
+
+                [HardenedFunction("with-args")]
+                public void Process(DataModel model) { }
+            """, FunctionGeneratorHarness.SupportTypes)).AssertNoErrors();
+
+        Assert.Contains("no-args.FunctionHandler.cs", result.GeneratedSources.Keys);
+        Assert.Contains("with-args.FunctionHandler.cs", result.GeneratedSources.Keys);
+
+        // The parameterless one keeps the bare name; the other is suffixed with the parameter hash.
+        var provider = result.SourceContaining("FunctionHandlers.cs");
+
+        Assert.Contains("TestFunctions_Process(serviceProvider)", provider);
+        Assert.Contains("TestFunctions_Process_", provider);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionParameterBindingTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionParameterBindingTests.cs
@@ -1,0 +1,247 @@
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// Where each parameter of a function handler comes from.
+///
+/// <para>
+/// A function has no route, so the binding rules a web handler leans on — path tokens, query string
+/// — do not apply. What is left is the rule that matters for a function: a plain class is the
+/// payload, an interface is a service, and the execution types are handed over directly. Getting
+/// this wrong does not fail to compile, it deserialises the request body into a service.
+/// </para>
+/// </summary>
+public class FunctionParameterBindingTests {
+
+    /// <summary>
+    /// The payload. Anything that is not an interface and not one of the execution types is
+    /// deserialised from the request body — this is the parameter SqsTest's <c>DataModel</c> is.
+    /// </summary>
+    [Fact]
+    public void AModelParameterIsDeserialisedFromTheRequestBody() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(DataModel model) { }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains(
+            "parameters.model = (await contentSerializationService.DeserializeRequestBody<global::TestApp.DataModel>(context))!;",
+            source);
+    }
+
+    /// <summary>
+    /// An interface parameter is resolved from the request's service provider, not from the body.
+    /// A payload model is a class and a service is an interface, and that is the whole distinction.
+    /// </summary>
+    [Fact]
+    public void AnInterfaceParameterIsResolvedFromTheServiceProvider() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(IThing thing) { }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains(
+            "parameters.thing = context.RequestServices.GetRequiredService<global::TestApp.IThing>();",
+            source);
+
+        Assert.DoesNotContain("DeserializeRequestBody<global::TestApp.IThing>", source);
+    }
+
+    /// <summary>
+    /// <c>IExecutionContext</c> is the context already in hand, assigned straight across. It is an
+    /// interface, so it has to be recognised before the general interface rule or it would be
+    /// resolved from DI — where nothing registers it.
+    /// </summary>
+    [Fact]
+    public void AnExecutionContextParameterIsHandedTheContextItself() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(IExecutionContext context) { }
+            """)).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("parameters.context = context;", source);
+        Assert.DoesNotContain("GetRequiredService<global::Hardened.Requests.Abstract.Execution.IExecutionContext>",
+            source);
+    }
+
+    [Fact]
+    public void AServiceProviderParameterIsHandedTheRequestServices() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(IServiceProvider provider) { }
+            """)).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("parameters.provider = context.RequestServices;", source);
+    }
+
+    [Fact]
+    public void AnExecutionRequestParameterIsHandedTheRequest() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(IExecutionRequest request) { }
+            """)).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("parameters.request = context.Request;", source);
+    }
+
+    [Fact]
+    public void AnExecutionResponseParameterIsHandedTheResponse() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(IExecutionResponse response) { }
+            """)).AssertNoErrors().SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("parameters.response = context.Response;", source);
+    }
+
+    /// <summary>
+    /// Every binding source a function handler has, in one signature. Each is decided
+    /// independently, so this is the case where one rule shadowing another shows up — and it is the
+    /// shape a real handler that needs both its payload and a service actually has.
+    /// </summary>
+    [Fact]
+    public void AllBindingSourcesCombineInASingleHandler() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public async Task<string> Process(
+                    DataModel model, IThing thing, IExecutionContext context, IServiceProvider provider) {
+                    await Task.Yield();
+                    return model.Value + thing.Describe();
+                }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("DeserializeRequestBody<global::TestApp.DataModel>", source);
+        Assert.Contains("GetRequiredService<global::TestApp.IThing>", source);
+        Assert.Contains("parameters.context = context;", source);
+        Assert.Contains("parameters.provider = context.RequestServices;", source);
+    }
+
+    /// <summary>
+    /// <c>[FromContext]</c> binds out of the request headers, which is how the Lambda runtime
+    /// carries the invocation context. The attribute itself ships in
+    /// <c>Hardened.Amz.Function.Lambda.Runtime</c> — Hardened.Framework cannot reference it without
+    /// inverting the dependency — but the generator matches it by syntactic name, so a local
+    /// declaration drives the same branch. The header lookup relies on
+    /// <c>HeaderDictionaryExtensions.Get</c>; calling <c>Get</c> on a plain dictionary without it is
+    /// a defect that shipped once already.
+    /// </summary>
+    [Fact]
+    public void AFromContextParameterBindsFromTheNamedHeader() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process([FromContext("awsRequestId")] string id) { }
+            """, FunctionGeneratorHarness.FromContextAttributeDeclaration))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("context.Request.Headers.Get(\"awsRequestId\")", source);
+    }
+
+    /// <summary>
+    /// <c>[FromContext]</c> with no name falls back to the parameter's own identifier, the same way
+    /// every other named binding attribute does.
+    /// </summary>
+    [Fact]
+    public void AFromContextParameterWithNoNameUsesTheParameterName() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process([FromContext] string awsRequestId) { }
+            """, FunctionGeneratorHarness.FromContextAttributeDeclaration))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("context.Request.Headers.Get(\"awsRequestId\")", source);
+    }
+
+    /// <summary>
+    /// A parameter with a default value is parsed with that default rather than required, so a
+    /// missing header leaves the handler with the declared value instead of throwing.
+    /// </summary>
+    [Fact]
+    public void AFromContextParameterWithADefaultIsParsedWithThatDefault() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process([FromContext("retry")] int retry = 3) { }
+            """, FunctionGeneratorHarness.FromContextAttributeDeclaration))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("ParseWithDefault", source);
+        Assert.DoesNotContain("ParseRequired", source);
+    }
+
+    /// <summary>
+    /// The parameter metadata array the filter pipeline reads: one entry per parameter, carrying
+    /// the declared name, position and type.
+    /// </summary>
+    [Fact]
+    public void ParameterMetadataRecordsEachParameterNamePositionAndType() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(DataModel model, IThing thing) { }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("new global::Hardened.Requests.Abstract.Execution.IExecutionRequestParameter[2]", source);
+        Assert.Contains("\"model\"", source);
+        Assert.Contains("typeof(global::TestApp.DataModel)", source);
+        Assert.Contains("\"thing\"", source);
+        Assert.Contains("typeof(global::TestApp.IThing)", source);
+    }
+
+    /// <summary>
+    /// A binding attribute other than <c>[FromContext]</c> falls through to the shared custom
+    /// attribute handling, which defers the binding to the attribute itself at run time rather than
+    /// deciding it here. <c>[FromServices]</c> is the one a function handler is most likely to
+    /// carry, on a service that is a class rather than an interface.
+    /// </summary>
+    [Fact]
+    public void AFromServicesParameterBindsThroughTheCustomAttributePath() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process([FromServices] IThing thing) { }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("ExecutionHelper.CustomAttributeData<global::TestApp.IThing>(", source);
+    }
+
+    /// <summary>
+    /// <c>[FromBody]</c> on a function parameter takes the same custom-attribute route. Worth
+    /// pinning because the payload already binds from the body without it — writing it explicitly
+    /// must not produce something different.
+    /// </summary>
+    [Fact]
+    public void AnExplicitFromBodyParameterBindsThroughTheCustomAttributePath() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process([FromBody] DataModel model) { }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.Contains("ExecutionHelper.CustomAttributeData<global::TestApp.DataModel>(", source);
+    }
+
+    /// <summary>
+    /// A nullable payload. The generated Parameters property has to be declared nullable too, or
+    /// the assignment from a nullable deserialise result warns — and CI treats warnings as errors.
+    /// </summary>
+    [Fact]
+    public void ANullablePayloadParameterCompiles() {
+        FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(DataModel? model) { }
+            """, FunctionGeneratorHarness.SupportTypes)).AssertNoErrors();
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/IncrementalFunctionGenerationTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/IncrementalFunctionGenerationTests.cs
@@ -1,0 +1,233 @@
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Function;
+
+/// <summary>
+/// Two consecutive runs over the same driver, asserting what the second did with the first's cached
+/// output.
+///
+/// <para>
+/// The function pipeline puts two comparers in the way: <c>RequestHandlerModelComparer</c> on the
+/// handler models, and <c>FunctionIncrementalGenerator.CombinedComparer</c> on the entry point
+/// paired with the collected handlers. The second is the interesting one — it is the only place the
+/// function generator supplies a comparer of its own, and a whole-application view is what an
+/// unrelated edit is most likely to churn.
+/// </para>
+/// </summary>
+public class IncrementalFunctionGenerationTests {
+
+    private static string Application(
+        string signature = "public void Process(DataModel model) { }",
+        string functionAttribute = "[HardenedFunction]",
+        string extraMembers = "",
+        string applicationMembers = "") => $$"""
+        using System;
+        using System.Threading.Tasks;
+        using Hardened.Requests.Abstract.Attributes;
+        using Hardened.Requests.Abstract.Execution;
+        using Hardened.Shared.Runtime.Attributes;
+
+        namespace TestApp;
+
+        public interface IThing { }
+
+        public class DataModel { public string Value { get; set; } = ""; }
+
+        [HardenedModule]
+        public partial class TestApplication {
+            {{applicationMembers}}
+        }
+
+        public class TestFunctions {
+            {{extraMembers}}
+
+            {{functionAttribute}}
+            {{signature}}
+        }
+        """;
+
+    private static IncrementalRunResult Rerun(string first, string second) =>
+        GeneratorTestHarness.RunIncremental(
+            new Dictionary<string, string> { ["Test.cs"] = first },
+            new Dictionary<string, string> { ["Test.cs"] = second },
+            [new FunctionGenerator()],
+            FunctionGeneratorHarness.Anchors);
+
+    private static void AssertRegenerated(IncrementalRunResult result) {
+        Assert.False(result.AllOutputsCached,
+            "the edit changes generated code, so serving the cached output would leave the " +
+            "generated file describing the previous source");
+
+        Assert.NotEqual(result.FirstRun.Values, result.SecondRun.Values);
+    }
+
+    /// <summary>The unchanged compilation. Anything less than fully cached here is a bug.</summary>
+    [Fact]
+    public void RerunningOverIdenticalSourceReusesEveryOutput() {
+        var result = Rerun(Application(), Application());
+
+        Assert.True(result.AllOutputsCached);
+        Assert.Equal(result.FirstRun, result.SecondRun);
+    }
+
+    /// <summary>
+    /// A comment. It changes the syntax tree, so both models are rebuilt and then have to compare
+    /// equal to the previous ones — which is the whole reason the comparers exist.
+    /// </summary>
+    [Fact]
+    public void AddingACommentReusesEveryOutput() {
+        var result = Rerun(Application(), Application(extraMembers: "// an explanatory comment"));
+
+        Assert.True(result.AllOutputsCached);
+        Assert.Equal(result.FirstRun, result.SecondRun);
+    }
+
+    /// <summary>
+    /// Editing the handler's own body. Only the signature reaches the model, and editing a body is
+    /// most of what happens between generator runs in an editor.
+    /// </summary>
+    [Fact]
+    public void ChangingAHandlerBodyReusesEveryOutput() {
+        var result = Rerun(
+            Application(signature: "public void Process(DataModel model) { }"),
+            Application(signature: "public void Process(DataModel model) { var x = model.Value; }"));
+
+        Assert.True(result.AllOutputsCached);
+    }
+
+    /// <summary>
+    /// A method on the handler class that is not itself a function. It cannot affect any generated
+    /// file.
+    /// </summary>
+    [Fact]
+    public void AddingANonHandlerMethodReusesEveryOutput() {
+        var result = Rerun(Application(), Application(extraMembers: "private string Helper() => \"x\";"));
+
+        Assert.True(result.AllOutputsCached);
+    }
+
+    /// <summary>
+    /// A member added to the application class itself. This goes through the entry-point model
+    /// rather than the handler model, and the combined comparer has to hold it steady — the
+    /// registration does not depend on the application's members.
+    /// </summary>
+    [Fact]
+    public void AddingAMemberToTheApplicationReusesTheRegistration() {
+        var result = Rerun(Application(), Application(applicationMembers: "// nothing that matters"));
+
+        Assert.True(result.AllOutputsCached);
+    }
+
+    [Fact]
+    public void ChangingTheFunctionNameRegeneratesTheHandler() {
+        AssertRegenerated(Rerun(
+            Application(),
+            Application(functionAttribute: "[HardenedFunction(\"renamed\")]")));
+    }
+
+    /// <summary>
+    /// Naming a function changes it from the provider's catch-all into a switch case, so the
+    /// registration has to be rebuilt as well as the handler.
+    /// </summary>
+    [Fact]
+    public void NamingAFunctionRebuildsTheRegistration() {
+        var result = Rerun(
+            Application(),
+            Application(functionAttribute: "[HardenedFunction(\"renamed\")]"));
+
+        Assert.NotEqual(
+            result.FirstRun["TestApplication.FunctionHandlers.cs"],
+            result.SecondRun["TestApplication.FunctionHandlers.cs"]);
+
+        Assert.Contains("switch (functionName)", result.SecondRun["TestApplication.FunctionHandlers.cs"]);
+    }
+
+    [Fact]
+    public void ChangingAParameterTypeRegeneratesTheHandler() {
+        AssertRegenerated(Rerun(
+            Application(),
+            Application(signature: "public void Process(IThing thing) { }")));
+    }
+
+    [Fact]
+    public void AddingAParameterRegeneratesTheHandler() {
+        AssertRegenerated(Rerun(
+            Application(),
+            Application(signature: "public void Process(DataModel model, IThing thing) { }")));
+    }
+
+    /// <summary>
+    /// Sync to async. The return type changes and so does every constructor the handler is built
+    /// with, so a cached result here would be a handler that never awaits.
+    /// </summary>
+    [Fact]
+    public void MakingAHandlerAsyncRegeneratesTheHandler() {
+        AssertRegenerated(Rerun(
+            Application(),
+            Application(signature: "public Task Process(DataModel model) => Task.CompletedTask;")));
+    }
+
+    /// <summary>
+    /// A value-returning handler that starts returning nothing. The invoke method stops assigning a
+    /// response value, so the emitted text changes as well as the model.
+    /// </summary>
+    [Fact]
+    public void ChangingAHandlerToReturnNothingRegeneratesTheHandler() {
+        AssertRegenerated(Rerun(
+            Application(signature: "public string Process(DataModel model) => model.Value;"),
+            Application(signature: "public void Process(DataModel model) { }")));
+    }
+
+    /// <summary>
+    /// Adding a handler produces a new file and leaves the existing one untouched, which is what
+    /// keeps a large project's rebuild proportional to the edit. The registration must still be
+    /// rebuilt — it is a whole-application view.
+    /// </summary>
+    [Fact]
+    public void AddingAHandlerLeavesTheExistingHandlersOutputUnchanged() {
+        var result = Rerun(
+            Application(),
+            Application(extraMembers: """
+                [HardenedFunction("other")]
+                public void Other() { }
+                """));
+
+        Assert.Equal(result.FirstRun["Process.FunctionHandler.cs"], result.SecondRun["Process.FunctionHandler.cs"]);
+        Assert.Contains("other.FunctionHandler.cs", result.SecondRun.Keys);
+
+        Assert.NotEqual(
+            result.FirstRun["TestApplication.FunctionHandlers.cs"],
+            result.SecondRun["TestApplication.FunctionHandlers.cs"]);
+    }
+
+    /// <summary>Removing a handler removes its file rather than leaving it behind.</summary>
+    [Fact]
+    public void RemovingAHandlerRemovesItsOutput() {
+        var result = Rerun(
+            Application(extraMembers: """
+                [HardenedFunction("other")]
+                public void Other() { }
+                """),
+            Application());
+
+        Assert.Contains("other.FunctionHandler.cs", result.FirstRun.Keys);
+        Assert.DoesNotContain("other.FunctionHandler.cs", result.SecondRun.Keys);
+    }
+
+    /// <summary>
+    /// Renaming the application class moves the registration to a new file, and the old one is not
+    /// left behind.
+    /// </summary>
+    [Fact]
+    public void RenamingTheApplicationMovesTheRegistrationFile() {
+        var result = Rerun(
+            Application(),
+            Application().Replace("class TestApplication", "class RenamedApplication"));
+
+        Assert.Contains("TestApplication.FunctionHandlers.cs", result.FirstRun.Keys);
+        Assert.Contains("RenamedApplication.FunctionHandlers.cs", result.SecondRun.Keys);
+        Assert.DoesNotContain("TestApplication.FunctionHandlers.cs", result.SecondRun.Keys);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Infrastructure/FunctionGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Infrastructure/FunctionGenerator.cs
@@ -1,0 +1,149 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.Shared;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Tests.Infrastructure;
+
+/// <summary>
+/// Drives the function-handler pipeline that lives in Hardened.SourceGenerator.Function.
+///
+/// <para>
+/// Same arrangement as <see cref="RequestGenerator"/>, and for the same reason: the library ships no
+/// <c>[Generator]</c> type of its own, so referencing the shipped wrapper
+/// (Hardened.Function.SourceGenerator) would put a second copy of every model type in scope and make
+/// each use ambiguous (CS0433). This driver calls the same
+/// <c>FunctionIncrementalGenerator.Setup</c> entry point the wrapper does, against the assembly under
+/// test, and builds its entry-point provider identically.
+/// </para>
+/// </summary>
+public class FunctionGenerator : IIncrementalGenerator {
+
+    public void Initialize(IncrementalGeneratorInitializationContext context) {
+        var applicationModel = context.SyntaxProvider.CreateSyntaxProvider(
+            EntryPointSelector.UsingAttribute(),
+            EntryPointSelector.TransformModel(false)
+        ).WithComparer(new EntryPointSelector.Comparer());
+
+        global::Hardened.SourceGenerator.Function.FunctionIncrementalGenerator.Setup(context, applicationModel);
+    }
+}
+
+/// <summary>
+/// The reference set generated function handlers bind against, and the source shapes every test in
+/// this suite goes through.
+/// </summary>
+public static class FunctionGeneratorHarness {
+
+    /// <summary>
+    /// One type per assembly the generated code touches. <c>typeof</c> rather than an assembly name
+    /// because it forces the assembly to load, which is what makes it resolvable.
+    ///
+    /// <para>
+    /// No web anchor: a function handler binds against the request pipeline and the DI helpers, and
+    /// nothing in Hardened.Web.Runtime. Microsoft.Extensions.DependencyInjection and
+    /// DependencyModules.Runtime — which the emitted registration needs — arrive transitively
+    /// through Hardened.Shared.Runtime.
+    /// </para>
+    /// </summary>
+    public static readonly Type[] Anchors = [
+        typeof(HardenedFunctionAttribute),   // Hardened.Requests.Abstract
+
+        // Fully qualified: this assembly's own namespace is Hardened.SourceGenerator.*, so an
+        // unqualified Requests. or Shared. binds there instead of to the runtime packages.
+        typeof(global::Hardened.Requests.Runtime.Execution.BaseExecutionHandler<>),
+        typeof(global::Hardened.Shared.Runtime.Attributes.HardenedModuleAttribute)
+    ];
+
+    /// <summary>
+    /// Runs the generator over one source file. Every caller is expected to finish with
+    /// <see cref="GeneratorResult.AssertNoErrors"/> — see docs/testing-conventions.md §1.
+    /// </summary>
+    public static GeneratorResult Generate(string source) =>
+        GeneratorTestHarness.Run(source, new FunctionGenerator(), Anchors);
+
+    /// <summary>Runs the generator over several source files.</summary>
+    public static GeneratorResult Generate(IReadOnlyDictionary<string, string> sources) =>
+        GeneratorTestHarness.Run(sources, [new FunctionGenerator()], Anchors);
+
+    /// <summary>
+    /// An application entry point beside a handler class holding <paramref name="body"/>.
+    ///
+    /// <para>
+    /// The entry point is what the provider stage combines against, so this is the shape that
+    /// produces both outputs: one invoker per handler, plus <c>TestApplication.FunctionHandlers.cs</c>.
+    /// It mirrors SqsTest, the real consumer, which is a <c>[HardenedModule] public partial class</c>
+    /// beside a plain handler class.
+    /// </para>
+    /// </summary>
+    public static string Application(string body, string extraTypes = "") => $$"""
+        {{Preamble}}
+
+        {{extraTypes}}
+
+        [HardenedModule]
+        public partial class TestApplication { }
+
+        public class TestFunctions {
+        {{body}}
+        }
+        """;
+
+    /// <summary>
+    /// A handler class with no application entry point, for the cases that are about the invoker
+    /// alone.
+    /// </summary>
+    public static string Handlers(string body, string extraTypes = "") => $$"""
+        {{Preamble}}
+
+        {{extraTypes}}
+
+        public class TestFunctions {
+        {{body}}
+        }
+        """;
+
+    /// <summary>A payload model and a service interface, for the binding cases.</summary>
+    public const string SupportTypes = """
+        public interface IThing {
+            string Describe();
+        }
+
+        public class DataModel {
+            public string Value { get; set; } = "";
+
+            public int Count { get; set; }
+        }
+        """;
+
+    /// <summary>
+    /// Stands in for <c>Hardened.Amz.Function.Lambda.Runtime</c>'s <c>[FromContext]</c>.
+    ///
+    /// <para>
+    /// The generator matches the attribute by its syntactic name, so a local declaration drives the
+    /// same branch. The shipped attribute lives in Hardened.Amz, which Hardened.Framework cannot
+    /// reference without inverting the dependency — see FunctionParameterBindingTests.
+    /// </para>
+    /// </summary>
+    public const string FromContextAttributeDeclaration = """
+        [AttributeUsage(AttributeTargets.Parameter)]
+        public class FromContextAttribute : Attribute {
+            public FromContextAttribute(string? name = null) {
+                Name = name;
+            }
+
+            public string? Name { get; }
+        }
+        """;
+
+    private const string Preamble = """
+        using System;
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Hardened.Requests.Abstract.Attributes;
+        using Hardened.Requests.Abstract.Execution;
+        using Hardened.Shared.Runtime.Attributes;
+
+        namespace TestApp;
+        """;
+}


### PR DESCRIPTION
`Hardened.SourceGenerator/Function/` was at **0% across 272 lines** and owned by no workstream. It is the Lambda-style `[HardenedFunction]` handler generator, and it had never been executed by a test.

| | Line | Branch |
|---|---|---|
| Before | 0/272 — **0%** | 0/76 — **0%** |
| After | 272/272 — **100%** | 74/76 — **97.4%** |

81 tests across 8 files. 2075 passing overall, no warnings, coverage gate green. Every generation test ends in `AssertNoErrors()`.

Tests live in `Hardened.SourceGenerator.Tests` with a `FunctionGenerator` driver calling `FunctionIncrementalGenerator.Setup` directly — the same pattern `RequestGenerator` already uses, because `Hardened.SourceGenerator` ships no `[Generator]` of its own.

## Six defects found, reported not fixed

Pinned as dated characterization tests, so a fix shows up as a failing test rather than silently changing behaviour.

**Two handlers with the same function name destroy all generated output for the compilation.** The invoker *type* name is disambiguated; the hint name is not. Two classes each with a `Process` method collide. The `ArgumentException` is thrown from Roslyn's `SourceOutputNode.AppendOutputs` — **outside** the wrapped delegate — so `SourceGeneratorWrapper` cannot catch it. CS8785, and nothing is generated for the entire assembly.

**A handler class in the global namespace crashes the generator.** `BaseRequestModelGenerator.GetControllerType` takes `.First()` of namespace ancestors. This is the same defect class #95 fixed in `GetTypeDefinition`, but that fix does not cover this caller — nor `FunctionModelGenerator.GetInvokeHandlerType`, which repeats the assumption.

**`[FromContext]` with an unresolvable parameter type NREs.** `GetParameterInfoWithBinding` still carries `parameter.Type?.GetTypeDefinition(ctx)!` — precisely the pattern removed from `GetParameterInfo` on 2026-08-12. The attributed path was missed.

**An unresolvable parameter leaves the provider referencing a handler that was never generated** — CS0234 in generated code. The web routing table has a guard for exactly this; the function provider has none.

**A second unnamed handler is silently unreachable.** Only `defaultHandlers[0]` is ever returned, so the wrong handler runs — clean build, no diagnostic, no crash. The quietest of the six and the most likely to reach production.

**`[HardenedFunction("Process")]` on a method named `Process` is indistinguishable from `[HardenedFunction]`**, because named-vs-unnamed is decided by comparing the name to the method name rather than by whether an argument was supplied.

## Notes

`[FromContext]` is declared locally in the test source: the real attribute ships in `Hardened.Amz.Function.Lambda.Runtime`, which this repository cannot reference without inverting the dependency. The generator matches it syntactically, so a local declaration drives the same branch.

The two uncovered branches are defensive null paths reachable only through inputs that crash first — defects 2 and 3 above.

`coverage-baseline.json` is not ratcheted here; a merged run should raise the Function floor separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoucMfctBPuZjTMiesoFGS