### PR TITLE
Move onto DependencyModules rc9230

### DIFF
--- a/src/Commands/Hardened.Commands/Hardened.Commands.csproj
+++ b/src/Commands/Hardened.Commands/Hardened.Commands.csproj
@@ -15,7 +15,7 @@
       excludes analyzers. Every project that writes a [HardenedModule] asks for it.
     -->
     <ItemGroup>
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9220" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9230" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
+++ b/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9220" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9220" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9230" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9230" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
+++ b/src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9220" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9220" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9230" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9230" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />

--- a/src/Shared/Hardened.Shared.Testing/Hardened.Shared.Testing.csproj
+++ b/src/Shared/Hardened.Shared.Testing/Hardened.Shared.Testing.csproj
@@ -28,7 +28,7 @@
         <ProjectReference Include="..\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\..\DependencyModules\src\DependencyModules.xUnit\DependencyModules.xUnit.csproj"
                           Condition="Exists('..\..\..\..\DependencyModules\src\DependencyModules.xUnit\DependencyModules.xUnit.csproj')"/>
-        <PackageReference Include="DependencyModules.xUnit" Version="1.0.0-rc9220"
+        <PackageReference Include="DependencyModules.xUnit" Version="1.0.0-rc9230"
                           Condition="!Exists('..\..\..\..\DependencyModules\src\DependencyModules.xUnit\DependencyModules.xUnit.csproj')"/>
     </ItemGroup>
 

--- a/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
@@ -63,7 +63,7 @@
 
     <!-- DependencyModules source: NuGet package or local linked files -->
     <ItemGroup Condition="'$(UseLocalDependencyModules)' != 'true'">
-        <PackageReference Include="DependencyModules.SourceGenerator.Impl" Version="1.0.0-rc9220">
+        <PackageReference Include="DependencyModules.SourceGenerator.Impl" Version="1.0.0-rc9230">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>build</IncludeAssets>
         </PackageReference>

--- a/src/Templates/Hardened.Templates.Runtime/Hardened.Templates.Runtime.csproj
+++ b/src/Templates/Hardened.Templates.Runtime/Hardened.Templates.Runtime.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9220" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9220" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9230" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9230" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Hardened.Web.AspNetCore.Runtime.csproj
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Hardened.Web.AspNetCore.Runtime.csproj
@@ -15,7 +15,7 @@
       excludes analyzers. Every project that writes a [HardenedModule] asks for it.
     -->
     <ItemGroup>
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9220" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9230" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Web/Hardened.Web.Runtime/Hardened.Web.Runtime.csproj
+++ b/src/Web/Hardened.Web.Runtime/Hardened.Web.Runtime.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9220" />
-        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9220" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+        <PackageReference Include="DependencyModules.Runtime" Version="1.0.0-rc9230" />
+        <PackageReference Include="DependencyModules.SourceGenerator" Version="1.0.0-rc9230" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />


### PR DESCRIPTION
Twelve references across eight projects, `rc9220` → `rc9230`. **1994 passing, no warnings, no source changes needed** — the surface this repository uses is unchanged.

## What the release gives us

From its changelog, all in the module load path:

- `ProcessModuleEnvironment` no longer builds a `ConcurrentDictionary` on every `AddModules` call for a cache most applications never read
- Discovery stopped routing through `EqualityComparer<IDependencyModule>.Default` to search a list that usually holds one item — constructing that comparer for an interface was the single most expensive step
- Interface defaults return `Array.Empty<T>()` instead of building an enumerator
- The `System.Linq` tokens in `GetModules` moved behind a non-inlined method, so that assembly is not loaded by applications that never call `AddModule`

**Empty module 2.92ms → 1.81ms. 200 services 4.44ms → 3.17ms. 42 → 34 methods JIT-ed.**

## On "smaller binaries" — worth being precise

The changelog's **33KB** is off a *Native AOT published binary*, and it comes from those paths no longer being reachable for the trimmer.

It is **not** a smaller library. Measured from the local package cache:

| | `DependencyModules.Runtime.dll` |
|---|---:|
| rc9220 | 35,840 bytes |
| rc9230 | **36,352 bytes** (+512) |

The library is marginally *larger* — that is the cost of the lazy initialisation and the isolated LINQ call that buy the trimming. Consumers publishing Native AOT get the size win; everyone gets the startup one. I verified the DLL sizes directly; the 33KB AOT figure is the changelog's, not something I measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoucMfctBPuZjTMiesoFGS