### PR TITLE
Stop DeserializeAsync closing a stream it was handed

### DIFF
--- a/src/Shared/Hardened.Shared.Runtime.Tests/Json/JsonSerializerImplTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Json/JsonSerializerImplTests.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using Hardened.Shared.Runtime.Collections;
+using Hardened.Shared.Runtime.Json;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Json;
+
+/// <summary>
+/// The serializer every request body goes through.
+///
+/// <para>
+/// The behaviour worth guarding is ownership: it reads and writes streams it is handed and closes
+/// none of them. <c>DeserializeAsync</c> used to open a <c>StreamReader</c> over the stream in a
+/// <c>using</c> and never read from it — deserialization goes to the stream directly — so the
+/// reader's only effect was its disposal, and the default constructor is <c>leaveOpen: false</c>.
+/// Every call closed a stream it did not own. Fixed 2026-08-12.
+/// </para>
+/// </summary>
+public class JsonSerializerImplTests {
+
+    private record Payload(string Name, int Count);
+
+    private static IJsonSerializer Serializer() {
+        var configuration = Substitute.For<IJsonSerializerConfiguration>();
+
+        configuration.Options.Returns(new System.Text.Json.JsonSerializerOptions {
+            PropertyNameCaseInsensitive = true
+        });
+
+        return new JsonSerializerImpl(Options.Create(configuration));
+    }
+
+    private static MemoryStream Json(string json) => new(Encoding.UTF8.GetBytes(json));
+
+    [Fact]
+    public async Task DeserializeReadsTheStream() {
+        var payload = await Serializer()
+            .DeserializeAsync<Payload>(
+                Json("""{"name":"first","count":2}"""), TestContext.Current.CancellationToken);
+
+        Assert.Equal("first", payload.Name);
+        Assert.Equal(2, payload.Count);
+    }
+
+    /// <summary>
+    /// The caller closes what the caller opened. Anything that pools or reuses a stream depends on
+    /// this — see <see cref="ReturningADeserializedStreamToThePoolDoesNotThrow"/>.
+    /// </summary>
+    [Fact]
+    public async Task DeserializeLeavesTheStreamOpen() {
+        var stream = Json("""{"name":"first","count":2}""");
+
+        await Serializer().DeserializeAsync<Payload>(stream, TestContext.Current.CancellationToken);
+
+        Assert.True(stream.CanRead, "DeserializeAsync closed a stream it was handed");
+
+        stream.Position = 0;
+    }
+
+    /// <summary>
+    /// The shape the SQS integration harness hit: a pooled stream is handed to the pipeline, the
+    /// pipeline deserializes it, and the caller then returns the reservation. The pool resets
+    /// <c>Position</c> on return, which throws on a closed stream.
+    /// </summary>
+    [Fact]
+    public async Task ReturningADeserializedStreamToThePoolDoesNotThrow() {
+        var pool = new MemoryStreamPool();
+        var serializer = Serializer();
+
+        using (var reservation = pool.Get()) {
+            await serializer.SerializeAsync(reservation.Item, new Payload("pooled", 1), cancellationToken: TestContext.Current.CancellationToken);
+
+            reservation.Item.Position = 0;
+
+            var payload = await serializer.DeserializeAsync<Payload>(reservation.Item, TestContext.Current.CancellationToken);
+
+            Assert.Equal("pooled", payload.Name);
+        }
+    }
+
+    [Fact]
+    public async Task SerializeLeavesTheStreamOpen() {
+        var stream = new MemoryStream();
+
+        await Serializer().SerializeAsync(stream, new Payload("written", 3), cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(stream.CanWrite, "SerializeAsync closed a stream it was handed");
+        Assert.True(stream.Length > 0);
+    }
+
+    /// <summary>Two payloads written to one stream, which only works if the first left it open.</summary>
+    [Fact]
+    public async Task AStreamCanBeReusedAcrossCalls() {
+        var serializer = Serializer();
+        var stream = new MemoryStream();
+
+        await serializer.SerializeAsync(stream, new Payload("first", 1), cancellationToken: TestContext.Current.CancellationToken);
+
+        stream.Position = 0;
+
+        var first = await serializer.DeserializeAsync<Payload>(stream, TestContext.Current.CancellationToken);
+
+        stream.SetLength(0);
+
+        await serializer.SerializeAsync(stream, new Payload("second", 2), cancellationToken: TestContext.Current.CancellationToken);
+
+        stream.Position = 0;
+
+        var second = await serializer.DeserializeAsync<Payload>(stream, TestContext.Current.CancellationToken);
+
+        Assert.Equal("first", first.Name);
+        Assert.Equal("second", second.Name);
+    }
+}

--- a/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerImpl.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerImpl.cs
@@ -30,9 +30,22 @@ public class JsonSerializerImpl : IJsonSerializer {
         _prettyOptions = new JsonSerializerOptions(_serializerOptions) { WriteIndented = true };
     }
 
+    /// <summary>
+    /// Reads <paramref name="jsonStream"/> without taking ownership of it — the caller closes what
+    /// the caller opened.
+    ///
+    /// <para>
+    /// This used to open a <see cref="StreamReader"/> over the stream in a <c>using</c> and then
+    /// never read from it: deserialization goes to <paramref name="jsonStream"/> directly. The
+    /// reader's only effect was its disposal, and the default <see cref="StreamReader"/> constructor
+    /// is <c>leaveOpen: false</c>, so every call closed a stream it did not own. A caller that
+    /// pooled or reused the stream got an <see cref="ObjectDisposedException"/> afterwards —
+    /// <c>MemoryStreamPool</c> resets <c>Position</c> when a reservation is returned, which throws
+    /// on a closed stream. Found 2026-08-12 through the SQS integration harness, where the batch
+    /// filter deserializes the request body and the caller then returns that body to the pool.
+    /// </para>
+    /// </summary>
     public async Task<T> DeserializeAsync<T>(Stream jsonStream, CancellationToken cancellationToken = default) {
-        using var streamReader = new StreamReader(jsonStream);
-
         return await JsonSerializer.DeserializeAsync<T>(jsonStream, _serializerOptions, cancellationToken) ??
                throw new Exception("Deserialized to null instance");
     }


### PR DESCRIPTION
`JsonSerializerImpl.DeserializeAsync` opened a `StreamReader` over the stream in a `using` and **never read from it** — deserialization goes to the stream directly:

```csharp
using var streamReader = new StreamReader(jsonStream);   // never used

return await JsonSerializer.DeserializeAsync<T>(jsonStream, _serializerOptions, cancellationToken);
```

The reader's only effect was its disposal, and the default `StreamReader` constructor is `leaveOpen: false`. So **every call closed a stream it did not own**, and allocated a reader in order to do it.

## Why it matters

Any caller that pools or reuses the stream is broken by this. `MemoryStreamPool` resets `Position` when a reservation is returned, which throws `ObjectDisposedException` on a closed stream — *after* the read has already succeeded, so the failure surfaces somewhere unrelated to its cause.

## How it was found

Through the SQS integration harness. The batch filter deserializes the request body; `TestSqsApp` owns that body and returns it to the pool afterwards:

```
System.ObjectDisposedException : Cannot access a closed Stream
  at MemoryStreamPool.<>c.<.ctor>b__0_1(MemoryStream ms)
  at ItemPool`1.PoolItemReservation.Dispose()
```

Nothing else had caught it because the pipeline's own paths hand over streams they never take back, so the closure is invisible to them.

## Tests

Five, covering ownership in both directions and the pooled round trip specifically. **Three of them fail against the previous implementation** — checked by restoring it rather than assumed, since a regression test that passes on the old code is worthless.

2080 passing, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoucMfctBPuZjTMiesoFGS
