### PR TITLE
Test Hardened.Web.Kestrel.Runtime and give it a coverage baseline

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -55,6 +55,10 @@
     "line": 38.2,
     "branch": 76.4
   },
+  "Hardened.Web.Kestrel.Runtime": {
+    "line": 96.5,
+    "branch": 84.2
+  },
   "Hardened.Web.Runtime": {
     "line": 70.3,
     "branch": 71.8

--- a/src/Hardened.Framework.sln
+++ b/src/Hardened.Framework.sln
@@ -117,6 +117,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Web.Kestrel.Runtim
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.Kestrel.SUT", "IntegrationTests\Kestrel\Hardened.IntegrationTests.Kestrel.SUT\Hardened.IntegrationTests.Kestrel.SUT.csproj", "{F0691AA1-DB6E-4CA4-BDA7-90F87BE8EBAC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Web.Kestrel.Runtime.Tests", "Web\Hardened.Web.Kestrel.Runtime.Tests\Hardened.Web.Kestrel.Runtime.Tests.csproj", "{E34F4765-31FA-4BC6-BE5D-6BB13F803518}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -667,6 +669,18 @@ Global
 		{F0691AA1-DB6E-4CA4-BDA7-90F87BE8EBAC}.Release|x64.Build.0 = Release|Any CPU
 		{F0691AA1-DB6E-4CA4-BDA7-90F87BE8EBAC}.Release|x86.ActiveCfg = Release|Any CPU
 		{F0691AA1-DB6E-4CA4-BDA7-90F87BE8EBAC}.Release|x86.Build.0 = Release|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Debug|x64.Build.0 = Debug|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Debug|x86.Build.0 = Debug|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Release|x64.ActiveCfg = Release|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Release|x64.Build.0 = Release|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Release|x86.ActiveCfg = Release|Any CPU
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -721,6 +735,7 @@ Global
 		{DBE6AF8B-249C-4212-9048-49A00D3EA519} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 		{966D8056-1887-4BED-A891-F025FD499583} = {7DC696BF-0B4E-4B03-B309-ABDC7A502538}
 		{F0691AA1-DB6E-4CA4-BDA7-90F87BE8EBAC} = {592F787C-E5FC-4C0C-8F2F-2DC8559C326B}
+		{E34F4765-31FA-4BC6-BE5D-6BB13F803518} = {7DC696BF-0B4E-4B03-B309-ABDC7A502538}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF6CD1AB-6B41-427D-BA1B-C4803CF67E97}

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Conformance/FeatureExecutionRequestConformanceTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Conformance/FeatureExecutionRequestConformanceTests.cs
@@ -1,0 +1,55 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Testing.Conformance;
+using Hardened.Web.Kestrel.Runtime.Impl;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests.Conformance;
+
+/// <summary>
+/// Runs the shared transport conformance suite against the Kestrel adapter.
+///
+/// This is the suite's whole purpose: a request carried by Kestrel has to arrive at the pipeline
+/// as the same <see cref="IExecutionRequest"/> as one carried by ASP.NET Core or API Gateway.
+/// The Kestrel adapter reads the server's <see cref="IHttpRequestFeature"/> directly rather than
+/// going through an <c>HttpContext</c>, and parses the raw query string itself instead of
+/// converting ASP.NET's parsed collection, so it is exactly the kind of adapter where a
+/// divergence could go unnoticed without this.
+/// </summary>
+public class FeatureExecutionRequestConformanceTests : ExecutionRequestConformanceTests {
+
+    protected override IExecutionRequestConformanceAdapter Adapter { get; } = new KestrelAdapter();
+
+    private class KestrelAdapter : IExecutionRequestConformanceAdapter {
+        public string TransportName => "Kestrel";
+
+        public IExecutionRequest CreateRequest(ConformanceRequestSpec spec) {
+            var feature = new HttpRequestFeature {
+                Method = spec.Method,
+                Path = spec.Path
+            };
+
+            foreach (var header in spec.Headers) {
+                feature.Headers[header.Key] = header.Value;
+            }
+
+            // Built the way it arrives on the wire — percent-encoded — because that is what
+            // Kestrel hands over and what the adapter has to decode.
+            if (spec.QueryString.Count > 0) {
+                feature.QueryString = "?" + string.Join("&", spec.QueryString.Select(pair =>
+                    $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value)}"));
+            }
+
+            // Cookies arrive in a single Cookie header, which is the form the adapter splits.
+            if (spec.Cookies.Count > 0) {
+                feature.Headers.Cookie = string.Join("; ", spec.Cookies);
+            }
+
+            if (spec.Body is not null) {
+                feature.Body = new MemoryStream(spec.Body);
+                feature.Headers.ContentLength = spec.Body.Length;
+            }
+
+            return new FeatureExecutionRequest(feature);
+        }
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Hardened.Web.Kestrel.Runtime.Tests.csproj
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Hardened.Web.Kestrel.Runtime.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0"/>
+        <PackageReference Include="NSubstitute" Version="5.1.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
+        <ProjectReference Include="..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <ProjectReference Include="..\..\Requests\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
+        <ProjectReference Include="..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
+        <ProjectReference Include="..\Hardened.Web.Kestrel.Runtime\Hardened.Web.Kestrel.Runtime.csproj"/>
+        <ProjectReference Include="..\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/FeatureExecutionContextTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/FeatureExecutionContextTests.cs
@@ -1,0 +1,102 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Shared.Runtime.Metrics;
+using Hardened.Web.Kestrel.Runtime.Impl;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests.Impl;
+
+/// <summary>
+/// The context, and mostly <c>Clone</c>.
+///
+/// A filter forks the chain by cloning the context with something replaced — a rebound request,
+/// a redirected response — and running the rest of the chain against the copy. Everything not
+/// replaced has to carry over, or the fork silently loses whatever was dropped.
+/// </summary>
+public class FeatureExecutionContextTests {
+
+    private static FeatureExecutionContext Context(ServerFeatures features, out IServiceProvider provider) {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IKnownServices>());
+        provider = services.BuildServiceProvider();
+
+        return new FeatureExecutionContext(
+            provider, provider, features.Collection, Substitute.For<IMetricLogger>());
+    }
+
+    [Fact]
+    public void Constructor_ReadsTheRequestAndResponseFromTheFeatures() {
+        var features = new ServerFeatures("PUT", "/things/7");
+
+        var context = Context(features, out var provider);
+
+        Assert.Equal("PUT", context.Request.Method);
+        Assert.Equal("/things/7", context.Request.Path);
+        Assert.Same(provider, context.RootServiceProvider);
+        Assert.NotNull(context.KnownServices);
+    }
+
+    /// <summary>A null argument keeps the current value — that is what makes a partial fork work.</summary>
+    [Fact]
+    public void Clone_KeepsEverythingWhenNothingIsReplaced() {
+        var context = Context(new ServerFeatures(), out _);
+        context.HandlerInstance = "handler";
+        context.HandlerInfo = Substitute.For<IExecutionRequestHandlerInfo>();
+
+        var clone = context.Clone(null, null, null, null);
+
+        Assert.Same(context.Request, clone.Request);
+        Assert.Same(context.Response, clone.Response);
+        Assert.Same(context.RequestServices, clone.RequestServices);
+        Assert.Same(context.RequestMetrics, clone.RequestMetrics);
+        Assert.Same(context.KnownServices, clone.KnownServices);
+        Assert.Equal(context.StartTime, clone.StartTime);
+        Assert.Equal("handler", clone.HandlerInstance);
+        Assert.Same(context.HandlerInfo, clone.HandlerInfo);
+    }
+
+    [Fact]
+    public void Clone_ReplacesOnlyWhatItIsGiven() {
+        var context = Context(new ServerFeatures(), out _);
+        var request = Substitute.For<IExecutionRequest>();
+        var metrics = Substitute.For<IMetricLogger>();
+
+        var clone = context.Clone(request, null, null, metrics);
+
+        Assert.Same(request, clone.Request);
+        Assert.Same(metrics, clone.RequestMetrics);
+        Assert.Same(context.Response, clone.Response);
+    }
+
+    /// <summary>
+    /// Completion belongs to the body feature the server supplied, so a clone that replaced the
+    /// response still completes the real one. Otherwise a request finished through a fork leaves
+    /// the connection waiting.
+    /// </summary>
+    [Fact]
+    public async Task Clone_StillCompletesTheServerResponse() {
+        var features = new ServerFeatures();
+        var context = Context(features, out _);
+
+        var clone = (FeatureExecutionContext)context.Clone(
+            null, Substitute.For<IExecutionResponse>(), null, null);
+
+        await clone.CompleteAsync();
+
+        Assert.Equal(1, features.ResponseBody.CompleteCount);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsWhenTheServerOmitsARequiredFeature() {
+        var features = new ServerFeatures();
+        features.Collection.Set<Microsoft.AspNetCore.Http.Features.IHttpResponseFeature>(null!);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IKnownServices>());
+        var provider = services.BuildServiceProvider();
+
+        Assert.Throws<InvalidOperationException>(() => new FeatureExecutionContext(
+            provider, provider, features.Collection, Substitute.For<IMetricLogger>()));
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/FeatureExecutionResponseTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/FeatureExecutionResponseTests.cs
@@ -1,0 +1,137 @@
+using Hardened.Web.Kestrel.Runtime.Impl;
+using Xunit;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests.Impl;
+
+/// <summary>
+/// The response adapter, and in particular the status contract.
+///
+/// <c>ResourceNotFoundHandler</c> supplies a 404 only when it finds the status still unset, so
+/// the getter has to distinguish "nothing has decided yet" from "200". Reading the server's
+/// <c>StatusCode</c> back — which starts at 200 — collapses that distinction and makes every
+/// unmatched route return an empty 200. That is exactly what this adapter did before the
+/// integration SUT caught it.
+/// </summary>
+public class FeatureExecutionResponseTests {
+
+    private static FeatureExecutionResponse Response(ServerFeatures features) =>
+        new(features.Response, features.ResponseBody);
+
+    [Fact]
+    public void Status_IsNullBeforeAnythingSetsIt() {
+        Assert.Null(Response(new ServerFeatures()).Status);
+    }
+
+    [Fact]
+    public void Status_WritesThroughToTheServer() {
+        var features = new ServerFeatures();
+
+        Response(features).Status = 404;
+
+        Assert.Equal(404, features.Response.StatusCode);
+    }
+
+    [Fact]
+    public void Status_NullResetsTheServerToTwoHundred() {
+        var features = new ServerFeatures();
+        var response = Response(features);
+
+        response.Status = 500;
+        response.Status = null;
+
+        Assert.Null(response.Status);
+        Assert.Equal(200, features.Response.StatusCode);
+    }
+
+    /// <summary>
+    /// Once the response has started the status is settled, so it is reported rather than left
+    /// null. Without this, nothing sets a status on an ordinary success path and every successful
+    /// request logs a blank status at <c>RequestEnd</c>.
+    /// </summary>
+    [Fact]
+    public void Status_ReportsTheServerStatusOnceTheResponseHasStarted() {
+        var features = new ServerFeatures();
+        var response = Response(features);
+
+        Assert.Null(response.Status);
+
+        features.Response.StatusCode = 201;
+        features.Response.HasStarted = true;
+
+        Assert.Equal(201, response.Status);
+    }
+
+    [Fact]
+    public void ResponseStarted_TracksTheServerFeature() {
+        var features = new ServerFeatures();
+        var response = Response(features);
+
+        Assert.False(response.ResponseStarted);
+
+        features.Response.HasStarted = true;
+
+        Assert.True(response.ResponseStarted);
+    }
+
+    [Fact]
+    public void Body_DefaultsToTheStreamTheServerSupplied() {
+        var features = new ServerFeatures();
+
+        Assert.Same(features.Body, Response(features).Body);
+    }
+
+    /// <summary>
+    /// A filter that swaps the stream — the compression filter does — must be able to read back
+    /// what it set, rather than the write going one way and the read the other.
+    /// </summary>
+    [Fact]
+    public void Body_CanBeReplacedByAFilter() {
+        var replacement = new MemoryStream();
+        var response = Response(new ServerFeatures());
+
+        response.Body = replacement;
+
+        Assert.Same(replacement, response.Body);
+    }
+
+    [Fact]
+    public void ContentType_WritesThroughToTheResponseHeaders() {
+        var features = new ServerFeatures();
+
+        Response(features).ContentType = "application/json";
+
+        Assert.Equal("application/json", features.Response.Headers.ContentType);
+    }
+
+    [Fact]
+    public void Clone_CarriesTheStatusAndTheBodyOverride() {
+        var replacement = new MemoryStream();
+        var response = Response(new ServerFeatures());
+
+        response.Status = 418;
+        response.Body = replacement;
+
+        var clone = response.Clone();
+
+        Assert.Equal(418, clone.Status);
+        Assert.Same(replacement, clone.Body);
+    }
+
+    [Fact]
+    public void Clone_LeavesAnUnsetStatusUnset() {
+        Assert.Null(Response(new ServerFeatures()).Clone().Status);
+    }
+
+    /// <summary>
+    /// Kestrel needs this. A response that wrote no body never sends its headers otherwise, and
+    /// the connection is left waiting on a request the application considers finished.
+    /// </summary>
+    [Fact]
+    public async Task CompleteAsync_CompletesTheServerBody() {
+        var features = new ServerFeatures();
+
+        await Response(features).CompleteAsync();
+
+        Assert.Equal(1, features.ResponseBody.CompleteCount);
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/HardenedHttpApplicationTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/HardenedHttpApplicationTests.cs
@@ -1,0 +1,202 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Logging;
+using Hardened.Requests.Abstract.Metrics;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Shared.Runtime.Metrics;
+using Hardened.Web.Kestrel.Runtime.Impl;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests.Impl;
+
+/// <summary>
+/// The server-to-application contract: what happens across <c>CreateContext</c>,
+/// <c>ProcessRequestAsync</c> and <c>DisposeContext</c>.
+///
+/// These are the responsibilities <c>HostingApplication</c> carries for ASP.NET and this class
+/// carries here — the per-request scope, request logging, the duration metric, and turning an
+/// escaped exception into a response rather than a dropped connection.
+/// </summary>
+public class HardenedHttpApplicationTests {
+
+    [Fact]
+    public void CreateContext_BuildsAnExecutionContextFromTheServerFeatures() {
+        var harness = new Harness();
+        var features = new ServerFeatures("POST", "/orders", "?page=2");
+
+        var context = harness.Application.CreateContext(features.Collection);
+
+        Assert.Equal("POST", context.Execution.Request.Method);
+        Assert.Equal("/orders", context.Execution.Request.Path);
+        Assert.Equal("2", context.Execution.Request.QueryString.Get("page"));
+    }
+
+    [Fact]
+    public void CreateContext_LogsTheRequestBeginning() {
+        var harness = new Harness();
+
+        harness.Application.CreateContext(new ServerFeatures().Collection);
+
+        harness.RequestLogger.Received(1).RequestBegin(Arg.Any<IExecutionContext>());
+    }
+
+    /// <summary>
+    /// Without this a client disconnect never reaches the handler and the application keeps
+    /// working on a response nobody will read.
+    /// </summary>
+    [Fact]
+    public void CreateContext_TakesItsCancellationTokenFromTheRequestLifetime() {
+        var harness = new Harness();
+        var features = new ServerFeatures();
+
+        var context = harness.Application.CreateContext(features.Collection);
+
+        Assert.False(context.Execution.CancellationToken.IsCancellationRequested);
+
+        features.Aborted.Cancel();
+
+        Assert.True(context.Execution.CancellationToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task ProcessRequestAsync_RunsTheMiddlewareChain() {
+        var harness = new Harness();
+
+        await harness.Application.ProcessRequestAsync(
+            harness.Application.CreateContext(new ServerFeatures().Collection));
+
+        await harness.Chain.Received(1).Next();
+    }
+
+    [Fact]
+    public async Task ProcessRequestAsync_CompletesTheResponse() {
+        var harness = new Harness();
+        var features = new ServerFeatures();
+
+        await harness.Application.ProcessRequestAsync(
+            harness.Application.CreateContext(features.Collection));
+
+        Assert.Equal(1, features.ResponseBody.CompleteCount);
+    }
+
+    /// <summary>
+    /// Kestrel does handle an application that throws, but it treats the request as failed: it
+    /// logs against the server rather than the application's own logger, and aborts the
+    /// connection once the response has started. Catching here keeps the failure in Hardened's
+    /// logger and still sends a 500.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRequestAsync_SendsFiveHundredWhenTheChainThrows() {
+        var harness = new Harness();
+        var features = new ServerFeatures();
+        harness.Chain.Next().Throws(new InvalidOperationException("boom"));
+
+        await harness.Application.ProcessRequestAsync(
+            harness.Application.CreateContext(features.Collection));
+
+        Assert.Equal(500, features.Response.StatusCode);
+        harness.RequestLogger.Received(1).RequestFailed(
+            Arg.Any<IExecutionContext>(), Arg.Any<InvalidOperationException>());
+    }
+
+    [Fact]
+    public async Task ProcessRequestAsync_CompletesTheResponseEvenWhenTheChainThrows() {
+        var harness = new Harness();
+        var features = new ServerFeatures();
+        harness.Chain.Next().Throws(new InvalidOperationException("boom"));
+
+        await harness.Application.ProcessRequestAsync(
+            harness.Application.CreateContext(features.Collection));
+
+        Assert.Equal(1, features.ResponseBody.CompleteCount);
+    }
+
+    /// <summary>
+    /// Once the status line is on the wire there is nothing left to say, and writing a status
+    /// after the headers have gone out is an error rather than a correction.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRequestAsync_LeavesTheStatusAloneWhenTheResponseHasAlreadyStarted() {
+        var harness = new Harness();
+        var features = new ServerFeatures();
+        features.Response.StatusCode = 200;
+        harness.Chain.Next().Returns(_ => {
+            features.Response.HasStarted = true;
+            throw new InvalidOperationException("boom");
+        });
+
+        await harness.Application.ProcessRequestAsync(
+            harness.Application.CreateContext(features.Collection));
+
+        Assert.Equal(200, features.Response.StatusCode);
+    }
+
+    [Fact]
+    public void DisposeContext_LogsTheRequestEndingAndRecordsItsDuration() {
+        var harness = new Harness();
+        var context = harness.Application.CreateContext(new ServerFeatures().Collection);
+
+        harness.Application.DisposeContext(context, null);
+
+        harness.RequestLogger.Received(1).RequestEnd(Arg.Any<IExecutionContext>());
+        harness.MetricLogger.Received(1).Record(
+            RequestMetrics.TotalRequestDuration, Arg.Any<double>());
+    }
+
+    /// <summary>
+    /// The per-request scope is the application's, so nothing else will dispose it. A leak here
+    /// would show up as scoped services accumulating for the life of the process.
+    /// </summary>
+    [Fact]
+    public void DisposeContext_DisposesThePerRequestScope() {
+        var harness = new Harness();
+        var context = harness.Application.CreateContext(new ServerFeatures().Collection);
+
+        var scoped = context.Scope.ServiceProvider.GetRequiredService<TrackedScopedService>();
+        Assert.False(scoped.Disposed);
+
+        harness.Application.DisposeContext(context, null);
+
+        Assert.True(scoped.Disposed);
+    }
+
+    public sealed class TrackedScopedService : IDisposable {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+    }
+
+    private class Harness {
+        public Harness() {
+            RequestLogger = Substitute.For<IRequestLogger>();
+            MetricLogger = Substitute.For<IMetricLogger>();
+            Chain = Substitute.For<IExecutionChain>();
+            Chain.Next().Returns(Task.CompletedTask);
+
+            var metricLoggerProvider = Substitute.For<IMetricLoggerProvider>();
+            metricLoggerProvider.CreateLogger(Arg.Any<string>()).Returns(MetricLogger);
+
+            var middlewareService = Substitute.For<IMiddlewareService>();
+            middlewareService.GetExecutionChain(Arg.Any<IExecutionContext>()).Returns(Chain);
+
+            // A real provider rather than a substitute: the application opens a scope from it, and
+            // scope disposal is one of the things under test.
+            var services = new ServiceCollection();
+            services.AddSingleton(Substitute.For<IKnownServices>());
+            services.AddScoped<TrackedScopedService>();
+
+            Application = new HardenedHttpApplication(
+                services.BuildServiceProvider(), middlewareService, metricLoggerProvider, RequestLogger);
+        }
+
+        public IRequestLogger RequestLogger { get; }
+
+        public IMetricLogger MetricLogger { get; }
+
+        public IExecutionChain Chain { get; }
+
+        public HardenedHttpApplication Application { get; }
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/ServerFeatures.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/ServerFeatures.cs
@@ -1,0 +1,93 @@
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests.Impl;
+
+/// <summary>
+/// The feature collection a server hands to <c>IHttpApplication.CreateContext</c>.
+///
+/// Hand-rolled rather than taken from <c>DefaultHttpContext</c> because the response feature has
+/// to be able to report a started response. Kestrel sets that flag on the first body write and
+/// the adapter's status contract turns on it, but the stock <c>HttpResponseFeature</c> hardcodes
+/// it to <c>false</c> with no way to change it.
+/// </summary>
+internal sealed class ServerFeatures {
+    public ServerFeatures(string method = "GET", string path = "/test", string? queryString = null) {
+        Request = new HttpRequestFeature {
+            Method = method,
+            Path = path,
+            QueryString = queryString ?? ""
+        };
+
+        Body = new MemoryStream();
+        Response = new TestResponseFeature();
+        ResponseBody = new TestResponseBodyFeature(Body);
+
+        // The stock HttpRequestLifetimeFeature.Abort() is a no-op -- a server supplies the real
+        // implementation -- so aborting is driven through this source instead.
+        Aborted = new CancellationTokenSource();
+        Lifetime = new HttpRequestLifetimeFeature { RequestAborted = Aborted.Token };
+
+        Collection = new FeatureCollection();
+        Collection.Set<IHttpRequestFeature>(Request);
+        Collection.Set<IHttpResponseFeature>(Response);
+        Collection.Set<IHttpResponseBodyFeature>(ResponseBody);
+        Collection.Set<IHttpRequestLifetimeFeature>(Lifetime);
+    }
+
+    public FeatureCollection Collection { get; }
+
+    public HttpRequestFeature Request { get; }
+
+    public TestResponseFeature Response { get; }
+
+    public TestResponseBodyFeature ResponseBody { get; }
+
+    public HttpRequestLifetimeFeature Lifetime { get; }
+
+    /// <summary>Cancel this to simulate the client disconnecting mid-request.</summary>
+    public CancellationTokenSource Aborted { get; }
+
+    public MemoryStream Body { get; }
+
+    internal sealed class TestResponseFeature : IHttpResponseFeature {
+        public int StatusCode { get; set; } = 200;
+
+        public string? ReasonPhrase { get; set; }
+
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+
+        public Stream Body { get; set; } = new MemoryStream();
+
+        /// <summary>Settable, standing in for Kestrel flushing the response line and headers.</summary>
+        public bool HasStarted { get; set; }
+
+        public void OnStarting(Func<object, Task> callback, object state) { }
+
+        public void OnCompleted(Func<object, Task> callback, object state) { }
+    }
+
+    /// <summary>Records completion, which Kestrel requires and a response with no body relies on.</summary>
+    internal sealed class TestResponseBodyFeature : IHttpResponseBodyFeature {
+        public TestResponseBodyFeature(Stream stream) => Stream = stream;
+
+        public int CompleteCount { get; private set; }
+
+        public Stream Stream { get; }
+
+        public PipeWriter Writer => PipeWriter.Create(Stream);
+
+        public Task CompleteAsync() {
+            CompleteCount++;
+            return Task.CompletedTask;
+        }
+
+        public void DisableBuffering() { }
+
+        public Task SendFileAsync(string path, long offset, long? count, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/KestrelHostingTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/KestrelHostingTests.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Shared.Runtime.Application;
+using Hardened.Web.Kestrel.Runtime.Impl;
+using Hardened.Web.Runtime.Handlers;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests;
+
+/// <summary>
+/// Starting and stopping the server.
+///
+/// The ordering here is the part worth pinning down. Startup services populate the filter registry
+/// and the CORS configuration, and the routing filter is attached to a singleton middleware chain,
+/// so a server that begins listening before either has happened serves its first requests against
+/// a half-built application. None of that produces an error — it produces wrong behaviour on
+/// whichever requests arrive first.
+///
+/// Where a server is genuinely started it binds port 0, so the OS picks a free port and these
+/// cannot collide with each other or with anything already running.
+/// </summary>
+public class KestrelHostingTests {
+
+    [Fact]
+    public void Constructor_ResolvesTheApplicationThroughItsInterface() {
+        var harness = new Harness();
+
+        // Resolution is by IHttpApplication<> rather than by the concrete type, because
+        // [SingletonService] registers a class against the interfaces it implements. Getting this
+        // wrong fails at construction with "no service for type HardenedHttpApplication".
+        var runner = harness.CreateRunner();
+
+        Assert.False(runner.IsStarted);
+    }
+
+    [Fact]
+    public async Task StartAsync_RunsTheRegisteredStartupServices() {
+        var harness = new Harness();
+        await using var runner = harness.CreateRunner();
+
+        await runner.StartAsync(TestContext.Current.CancellationToken);
+
+        await harness.StartupService.Received(1).Startup(Arg.Any<IServiceProvider>());
+    }
+
+    /// <summary>
+    /// The equivalent of what <c>UseHardened</c> does for the ASP.NET pipeline. Without it the
+    /// chain has no routing filter and every request falls through to nothing.
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_AttachesTheRoutingFilterToTheMiddlewareChain() {
+        var harness = new Harness();
+        await using var runner = harness.CreateRunner();
+
+        await runner.StartAsync(TestContext.Current.CancellationToken);
+
+        harness.MiddlewareService.Received(1)
+            .Use(Arg.Any<Func<IExecutionContext, IExecutionFilter>>());
+    }
+
+    [Fact]
+    public async Task StartAsync_BindsAndReportsTheAddressItIsListeningOn() {
+        var harness = new Harness();
+        await using var runner = harness.CreateRunner();
+
+        Assert.Empty(runner.Addresses);
+
+        await runner.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(runner.IsStarted);
+        Assert.NotEmpty(runner.Addresses);
+    }
+
+    /// <summary>
+    /// <c>MiddlewareService</c> is a singleton holding a plain list, so starting twice would
+    /// append the routing filter a second time and run the whole chain twice per request — a
+    /// response that still looks correct while doing double the work.
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_RefusesToStartTwice() {
+        var harness = new Harness();
+        await using var runner = harness.CreateRunner();
+
+        await runner.StartAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => runner.StartAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task StopAsync_DoesNothingWhenTheServerNeverStarted() {
+        var harness = new Harness();
+        await using var runner = harness.CreateRunner();
+
+        await runner.StopAsync(TestContext.Current.CancellationToken);
+
+        await harness.StartupService.DidNotReceive().Startup(Arg.Any<IServiceProvider>());
+    }
+
+    [Fact]
+    public async Task StopAsync_StopsAStartedServer() {
+        var harness = new Harness();
+        await using var runner = harness.CreateRunner();
+
+        await runner.StartAsync(TestContext.Current.CancellationToken);
+        await runner.StopAsync(TestContext.Current.CancellationToken);
+
+        // Stopping twice is a no-op rather than an error, so a host that stops on shutdown and
+        // again on dispose does not throw on the way out.
+        await runner.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public void AddHardenedKestrel_RegistersTheServerAsAHostedService() {
+        var services = new ServiceCollection();
+
+        services.AddHardenedKestrel(kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+
+        Assert.Single(services, d => d.ServiceType == typeof(IHostedService));
+        Assert.Single(services, d => d.ServiceType == typeof(HardenedKestrelOptions));
+    }
+
+    [Fact]
+    public void AddHardenedKestrel_CarriesTheConfigurationThrough() {
+        var services = new ServiceCollection();
+
+        services.AddHardenedKestrel(
+            kestrel => kestrel.Listen(IPAddress.Loopback, 0),
+            transport => transport.Backlog = 128);
+
+        var options = services.BuildServiceProvider().GetRequiredService<HardenedKestrelOptions>();
+
+        Assert.NotNull(options.ConfigureKestrel);
+        Assert.NotNull(options.ConfigureTransport);
+    }
+
+    [Fact]
+    public async Task Application_StartsStopsAndReportsItsAddress() {
+        var harness = new Harness();
+        await using var app = HardenedKestrelApplication.Create(
+            harness.CreateServices(), kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+
+        Assert.False(app.IsStarted);
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(app.IsStarted);
+        Assert.NotEmpty(app.Addresses);
+        Assert.NotNull(app.Services.GetService<IMiddlewareService>());
+
+        await app.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// <c>RunAsync</c> starts only when it has not already been started, so a caller that needs
+    /// something in between — reading the bound address, most often — can start first and then
+    /// hand over.
+    /// </summary>
+    [Fact]
+    public async Task Application_RunAsyncReturnsWhenItsTokenIsCancelledAndDoesNotRestart() {
+        var harness = new Harness();
+        await using var app = HardenedKestrelApplication.Create(
+            harness.CreateServices(), kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        using var shutdown = new CancellationTokenSource();
+        await shutdown.CancelAsync();
+
+        // Would throw "already been started" if RunAsync started unconditionally.
+        await app.RunAsync(shutdown.Token);
+
+        await harness.StartupService.Received(1).Startup(Arg.Any<IServiceProvider>());
+    }
+
+    [Fact]
+    public async Task HostedService_StartsAndStopsTheServer() {
+        var harness = new Harness();
+        await using var hosted = new HardenedKestrelHostedService(
+            harness.Provider,
+            new HardenedKestrelOptions {
+                ConfigureKestrel = kestrel => kestrel.Listen(IPAddress.Loopback, 0)
+            });
+
+        await hosted.StartAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(hosted.Addresses);
+
+        await hosted.StopAsync(TestContext.Current.CancellationToken);
+    }
+
+    private class Harness {
+        public Harness() {
+            StartupService = Substitute.For<IStartupService>();
+            StartupService.Startup(Arg.Any<IServiceProvider>()).Returns(true);
+
+            MiddlewareService = Substitute.For<IMiddlewareService>();
+
+            Provider = CreateServices().BuildServiceProvider();
+        }
+
+        /// <summary>
+        /// The registrations a Hardened module would supply, standing in for one so these exercise
+        /// the hosting code rather than the generator.
+        /// </summary>
+        public IServiceCollection CreateServices() {
+            var services = new ServiceCollection();
+
+            services.AddSingleton(StartupService);
+            services.AddSingleton(MiddlewareService);
+            services.AddSingleton(Substitute.For<IWebExecutionHandlerService>());
+            services.AddSingleton(Substitute.For<IHttpApplication<HardenedHttpApplication.RequestContext>>());
+
+            return services;
+        }
+
+        public IStartupService StartupService { get; }
+
+        public IMiddlewareService MiddlewareService { get; }
+
+        public ServiceProvider Provider { get; }
+
+        /// <summary>
+        /// Port 0 so the OS assigns a free port and these cannot collide. Bound through
+        /// Listen rather than ListenLocalhost, which rejects dynamic ports outright:
+        /// "Dynamic port binding is not supported when binding to localhost."
+        /// </summary>
+        public KestrelServerRunner CreateRunner() =>
+            new(Provider, kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+    }
+}


### PR DESCRIPTION
The newest shipped assembly was the only one exempt from the floor guarding every other one. The gate reported it as *ungated* rather than failing, so it would have stayed that way indefinitely — and a baseline is only worth setting once there are tests behind it.

**Coverage: nothing → 96.5% line, 84.2% branch** — now the highest of any runtime assembly in the repo.

| Class | Line coverage |
|---|---|
| `FeatureExecutionContext` | 100% |
| `HardenedHttpApplication` | 100% |
| `HardenedKestrelApplication` | 100% |
| `HardenedKestrelHostedService` | 100% |
| `HardenedKestrelServiceCollectionExtensions` | 100% |
| `KestrelServerRunner` | 95.2% |
| `FeatureExecutionRequest` | 94% |
| `FeatureExecutionResponse` | 92.3% |

## The request adapter runs the shared conformance suite

That suite exists precisely for this: a request carried by Kestrel must arrive at the pipeline as the same `IExecutionRequest` as one carried by ASP.NET Core or API Gateway. This adapter reads `IHttpRequestFeature` directly rather than going through an `HttpContext`, and parses the raw query string itself instead of converting ASP.NET's parsed collection — exactly where a divergence could go unnoticed.

**All 20 cases passed unchanged**, first run.

## Three areas conformance doesn't reach

- **The status contract.** `ResourceNotFoundHandler` supplies a 404 only when it finds the status unset; the `HasStarted` fallback is what keeps `RequestEnd` from logging a blank status on every successful request.
- **The `IHttpApplication` contract** across `CreateContext` / `ProcessRequestAsync` / `DisposeContext` — per-request scope and its disposal, request logging, the duration metric, `RequestAborted` from the lifetime feature, and an escaped exception becoming a 500 with a completed response rather than a dropped connection.
- **Server start-up ordering**, previously 0% and the code where a mistake means the server doesn't start. Startup services populate the filter registry and CORS config, and the routing filter attaches to a *singleton* middleware chain — so a server that listens before either has happened serves its first requests against a half-built application, with no error, just wrong behaviour on whichever requests arrive first. Tests bind **port 0** so the OS picks a free port and they can't collide.

## Two gotchas for anyone extending these

1. Kestrel **rejects `ListenLocalhost(0)`** outright — *"Dynamic port binding is not supported when binding to localhost"* — dynamic ports need an explicit address.
2. The stock **`HttpRequestLifetimeFeature.Abort()` is a no-op** (servers supply the real one), so aborting is driven through a `CancellationTokenSource` the test owns.

## Baseline scope

Only the new assembly is added. Running `--update` would also raise the **13 floors that have drifted upward** since they were set — including `Hardened.Web.Runtime` at 70.3% → 100% — and those deserve review on their own rather than being swept in on the strength of one local run.

## Validation

CI-strict build (`ContinuousIntegrationBuild=true`) 0 warnings / 0 errors, **1,882 tests pass**, coverage gate passes with 18 assemblies and no ungated ones remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU1Gb2nNcBxikeiMsngCtv