### PR TITLE
Put back the template contract that the engine removal took with it

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -31,6 +31,11 @@ namespace Hardened.Requests.Abstract.Attributes
     {
         public RawResponseAttribute(string contentType = "text/plain") { }
     }
+    public class TemplateAttribute : System.Attribute
+    {
+        public TemplateAttribute(string templateName) { }
+        public string TemplateName { get; }
+    }
 }
 namespace Hardened.Requests.Abstract.Authorization
 {
@@ -163,6 +168,7 @@ namespace Hardened.Requests.Abstract.Execution
         bool ShouldCompress { get; set; }
         bool ShouldSerialize { get; set; }
         int? Status { get; set; }
+        string? TemplateName { get; set; }
         Hardened.Requests.Abstract.Execution.IExecutionResponse Clone(Hardened.Requests.Abstract.Headers.IHeaderCollection? headerCollection = null);
     }
     public interface IFunctionHandlerProvider

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
@@ -88,6 +88,7 @@ namespace Hardened.Requests.Testing
         public bool ShouldCompress { get; set; }
         public bool ShouldSerialize { get; set; }
         public int? Status { get; set; }
+        public string? TemplateName { get; set; }
         public Hardened.Requests.Abstract.Execution.IExecutionResponse Clone(Hardened.Requests.Abstract.Headers.IHeaderCollection? headerCollection) { }
     }
 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.AspNetCore.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.AspNetCore.Runtime.approved.txt
@@ -74,6 +74,7 @@ namespace Hardened.Web.AspNetCore.Runtime.Impl
         public bool ShouldCompress { get; set; }
         public bool ShouldSerialize { get; set; }
         public int? Status { get; set; }
+        public string? TemplateName { get; set; }
         public Hardened.Requests.Abstract.Execution.IExecutionResponse Clone(Hardened.Requests.Abstract.Headers.IHeaderCollection? headerCollection) { }
     }
     public interface IAspNetCoreRequestHandler

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Kestrel.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Kestrel.Runtime.approved.txt
@@ -93,6 +93,7 @@ namespace Hardened.Web.Kestrel.Runtime.Impl
         public bool ShouldCompress { get; set; }
         public bool ShouldSerialize { get; set; }
         public int? Status { get; set; }
+        public string? TemplateName { get; set; }
         public Hardened.Requests.Abstract.Execution.IExecutionResponse Clone(Hardened.Requests.Abstract.Headers.IHeaderCollection? headerCollection = null) { }
         public System.Threading.Tasks.ValueTask CompleteAsync() { }
     }

--- a/src/Requests/Hardened.Requests.Abstract/Attributes/TemplateAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Attributes/TemplateAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace Hardened.Requests.Abstract.Attributes;
+
+/// <summary>
+/// Attribute request handlers with this to return template instead of raw data
+/// </summary>
+public class TemplateAttribute : Attribute {
+    public TemplateAttribute(string templateName) {
+        TemplateName = templateName;
+    }
+
+    public string TemplateName { get; }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionResponse.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionResponse.cs
@@ -10,6 +10,8 @@ public interface IExecutionResponse {
 
     object? ResponseValue { get; set; }
 
+    string? TemplateName { get; set; }
+
     int? Status { get; set; }
 
     bool ShouldCompress { get; set; }

--- a/src/Requests/Hardened.Requests.Testing/TestExecutionResponse.cs
+++ b/src/Requests/Hardened.Requests.Testing/TestExecutionResponse.cs
@@ -15,6 +15,7 @@ public class TestExecutionResponse : IExecutionResponse {
     public IExecutionResponse Clone(IHeaderCollection? headerCollection) {
         return new TestExecutionResponse(Body) {
             ResponseValue = ResponseValue,
+            TemplateName = TemplateName,
             Status = Status,
             ShouldCompress = ShouldCompress,
             Headers = headerCollection as IDictionary<string, StringValues> ?? Headers,
@@ -29,6 +30,8 @@ public class TestExecutionResponse : IExecutionResponse {
     }
 
     public object? ResponseValue { get; set; }
+
+    public string? TemplateName { get; set; }
 
     public int? Status { get; set; }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
@@ -178,17 +178,18 @@ public class ModelComparisonTests {
         Assert.NotEqual(baseline, baseline with { IsAsync = true });
         Assert.NotEqual(baseline, baseline with { IsAsyncEnumerable = true });
         Assert.NotEqual(baseline, baseline with { AsyncEnumerableItemType = Type("String") });
+        Assert.NotEqual(baseline, baseline with { TemplateName = "Index" });
         Assert.NotEqual(baseline, baseline with { RawResponseContentType = "text/csv" });
         Assert.NotEqual(baseline, baseline with { DefaultStatusCode = 201 });
     }
 
     [Fact]
-    public void AResponseModelDescribesItsAsyncnessRawContentTypeAndReturnType() {
+    public void AResponseModelDescribesItsAsyncnessTemplateAndReturnType() {
         var model = new ResponseInformationModel {
-            IsAsync = true, RawResponseContentType = "text/csv", ReturnType = Type("String")
+            IsAsync = true, TemplateName = "Index", ReturnType = Type("String")
         };
 
-        Assert.Equal("True:text/csv:System.String", model.ToString());
+        Assert.Equal("True:Index:System.String", model.ToString());
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionFilterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionFilterTests.cs
@@ -9,7 +9,7 @@ namespace Hardened.SourceGenerator.Tests.Function;
 ///
 /// <para>
 /// <c>FunctionModelGenerator.IsFilterAttribute</c> makes this call, and it is a denylist: everything
-/// is a filter except <c>[RawResponse]</c> and <c>[HardenedFunction]</c> itself.
+/// is a filter except <c>[Template]</c>, <c>[RawResponse]</c> and <c>[HardenedFunction]</c> itself.
 /// Getting it wrong in either direction is quiet — a filter mistaken for response information never
 /// runs, and <c>[HardenedFunction]</c> mistaken for a filter is instantiated as one at startup.
 /// </para>
@@ -71,6 +71,22 @@ public class FunctionFilterTests {
         Assert.DoesNotContain("_metadata", source);
     }
 
+
+    /// <summary>
+    /// <c>[Template]</c> is read the same way: response information, not a filter, so it stays
+    /// out of the metadata array.
+    ///
+    /// It no longer emits an output function. The template engine it called into was removed, and
+    /// the attribute is kept as the annotation a future renderer will bind to — so what is
+    /// asserted here is the classification, which is unchanged, and not an emission that no
+    /// longer happens.
+    /// </summary>
+    [Fact]
+    public void ATemplateAttributeIsResponseInformationRatherThanAFilter() {
+        var source = Handler("[Template(\"Index\")]", "public string Process() => \"x\";");
+
+        Assert.DoesNotContain("_metadata", source);
+    }
 
     /// <summary>
     /// A filter beside response information. The two are decided independently, so this is the

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/HandlerShapeCompilesTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/HandlerShapeCompilesTests.cs
@@ -267,14 +267,15 @@ public class HandlerShapeCompilesTests {
 
 
     /// <summary>
-    /// <c>[RawResponse]</c> is read as response information rather than as a filter, so it never
-    /// reaches the metadata array. A handler carrying only it has no metadata at all — which is
-    /// also the shape that broke the parameters slot.
+    /// <c>[Template]</c> and <c>[RawResponse]</c> are read as response information, not as filters,
+    /// so neither reaches the metadata array. A handler carrying only one of them has no metadata
+    /// at all — which is also the shape that broke the parameters slot.
     /// </summary>
     [Fact]
-    public void RawResponseIsNotTreatedAsAFilter() {
+    public void TemplateAndRawResponseAreNotTreatedAsFilters() {
         var result = RequestGeneratorHarness.Generate(RequestGeneratorHarness.Controller("""
                 [Get("/page")]
+                [Template("Index")]
                 [RawResponse("text/html")]
                 public string Page() => "x";
             """)).AssertNoErrors();

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
@@ -11,11 +11,13 @@ public record ResponseInformationModel {
 
     public ITypeDefinition? ReturnType { get; set; }
 
+    public string? TemplateName { get; set; }
+
     public int? DefaultStatusCode { get; set; }
 
     public string? RawResponseContentType { get; set; }
 
     public override string ToString() {
-        return $"{IsAsync}:{RawResponseContentType}:{ReturnType}";
+        return $"{IsAsync}:{TemplateName}:{ReturnType}";
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -220,6 +220,13 @@ public abstract class BaseRequestModelGenerator {
     protected virtual ResponseInformationModel GetResponseInformation(
         GeneratorSyntaxContext context,
         MethodDeclarationSyntax methodDeclaration) {
+        var templateAttribute = context.Node.GetAttribute("Template");
+        var template = "";
+
+        if (templateAttribute is { ArgumentList.Arguments.Count: > 0 }) {
+            template = templateAttribute.ArgumentList.Arguments[0].ToString().Trim('"');
+        }
+
         var returnType = methodDeclaration.ReturnType.GetTypeDefinition(context);
 
         var isAsync = false;
@@ -251,6 +258,7 @@ public abstract class BaseRequestModelGenerator {
             IsAsync = isAsync,
             IsAsyncEnumerable = isAsyncEnumerable,
             AsyncEnumerableItemType = asyncEnumerableItemType,
+            TemplateName = template,
             ReturnType = returnType,
             RawResponseContentType = rawResponse
         };

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteCompilationTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteCompilationTests.cs
@@ -482,6 +482,7 @@ public class RouteCompilationTests {
     [InlineData("[CacheControl(Type = global::Hardened.Web.Runtime.CacheControl.CacheControlEnum.NoStore)]")]
     [InlineData("[RawResponse]")]
     [InlineData("[RawResponse(\"text/csv\")]")]
+    [InlineData("[Template(\"home\")]")]
     public void EveryHandlerOptionAttributeCompiles(string attribute) {
         CompileApplication($$"""
             public class OptionController {
@@ -513,8 +514,8 @@ public class RouteCompilationTests {
     }
 
     /// <summary>
-    /// An attribute the generator has never heard of. Anything that is not a verb or
-    /// <c>[RawResponse]</c> is treated as a filter attribute and copied into
+    /// An attribute the generator has never heard of. Anything that is not a verb,
+    /// <c>[Template]</c> or <c>[RawResponse]</c> is treated as a filter attribute and copied into
     /// the handler's metadata verbatim — which means an ordinary framework attribute on a handler
     /// has to survive the trip into a file carrying none of the consumer's usings.
     /// </summary>

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
@@ -177,6 +177,7 @@ public class AspNetExecutionResponse : IExecutionResponse {
         return new AspNetExecutionResponse(_httpResponse) {
             _status = _status,
             ResponseValue = ResponseValue,
+            TemplateName = TemplateName,
             ShouldCompress = ShouldCompress,
             IsBinary = IsBinary,
             ShouldSerialize = ShouldSerialize,
@@ -189,6 +190,8 @@ public class AspNetExecutionResponse : IExecutionResponse {
     }
 
     public object? ResponseValue { get; set; }
+
+    public string? TemplateName { get; set; }
 
     /// <summary>
     /// Null while the status is still undecided; otherwise what will be, or has been, sent.

--- a/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionResponse.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionResponse.cs
@@ -45,6 +45,7 @@ public sealed class FeatureExecutionResponse : IExecutionResponse {
         return new FeatureExecutionResponse(
             _feature, _bodyFeature, _bodyOverride, _status, Cookies) {
             ResponseValue = ResponseValue,
+            TemplateName = TemplateName,
             ShouldCompress = ShouldCompress,
             IsBinary = IsBinary,
             ShouldSerialize = ShouldSerialize
@@ -57,6 +58,8 @@ public sealed class FeatureExecutionResponse : IExecutionResponse {
     }
 
     public object? ResponseValue { get; set; }
+
+    public string? TemplateName { get; set; }
 
     /// <summary>
     /// Null while the status is still undecided; otherwise what will be, or has been, sent.

--- a/src/Web/Hardened.Web.Testing.Tests/FakeExecutionResponse.cs
+++ b/src/Web/Hardened.Web.Testing.Tests/FakeExecutionResponse.cs
@@ -25,6 +25,8 @@ internal class FakeExecutionResponse : IExecutionResponse {
 
     public object? ResponseValue { get; set; }
 
+    public string? TemplateName { get; set; }
+
     public bool ShouldCompress { get; set; }
 
     public Exception? ExceptionValue { get; set; }


### PR DESCRIPTION
Removing the template engine (#101) should have removed the template *project* and nothing else. It also took three things that had no dependency on the engine and compiled fine without it:

- **`[Template]`** on a handler, in `Requests.Abstract`
- **`IExecutionResponse.TemplateName`** and its four implementations
- **`ResponseInformationModel.TemplateName`**, with `BaseRequestModelGenerator` reading the attribute into it

That over-reach is what broke `Hardened.Amz` — removing a member from a published interface breaks every downstream implementation of it, and Amz implements `IExecutionResponse` three times on a floating `1.0.0-preview*`.

This puts all three back. **16 files, +74/−11.**

## Still gone, correctly

The Mustache runtime, abstractions, parser and emitters, and the `InvokeClassGenerator` branch that called `DefaultOutputFuncHelper.GetTemplateOut` — that helper was part of the engine, so the branch couldn't compile without it.

`[Template]` is accepted and inert until a renderer binds to it.

## Downstream

`Hardened.Amz` needs **no source change** as a result. `ipjohnson/Hardened.Amz#61` reduces to removing a vestigial `Hardened.Templates.SourceGenerator` reference in `LambdaWebTest` — that reference pulls a generator which emits code against an assembly that no longer ships, so it fails the build on its own account.

## Validation

Built and tested in an isolated worktree off clean `main`, so nothing else is mixed in. CI-strict build 0 warnings / 0 errors, **1,884 tests pass**.

Replaces #104, which got tangled with concurrent work in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU1Gb2nNcBxikeiMsngCtv