### PR TITLE
Stop the release workflow restoring from a feed it cannot authenticate to

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,12 +31,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      # No source-url, and no NUGET_AUTH_TOKEN. Restore reads src/nuget.config, which is nuget.org
+      # and nothing else since ValidationModules was published there at 0.1.0-alpha.1.
+      #
+      # Pointing setup-dotnet at GitHub Packages writes a nuget.config whose credential is the
+      # literal string %NUGET_AUTH_TOKEN%, expanded by NuGet when it restores rather than when the
+      # config is written - so the variable has to still be set several steps later, and here it was
+      # scoped to this step. An authenticated source that answers 401 is fatal to the whole restore
+      # rather than to the packages it serves, so the restore below would have failed on the first
+      # tag anyone pushed. build-package.yaml and benchmarks.yaml carried the same arrangement and
+      # were fixed the same way.
+      #
+      # Both push steps are unaffected: each names its feed and key on the command line.
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-          source-url: https://nuget.pkg.github.com/ipjohnson/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Resolve version
         id: version


### PR DESCRIPTION
`release.yaml` pointed `setup-dotnet` at GitHub Packages and set `NUGET_AUTH_TOKEN` scoped to that step:

```yaml
source-url: https://nuget.pkg.github.com/ipjohnson/index.json
env:
  NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
```

The credential `setup-dotnet` writes is the literal string `%NUGET_AUTH_TOKEN%`, which NuGet expands **when it restores** rather than when the config is written. Scoped to the setup step, the variable is gone by the time `dotnet restore` runs two steps later. An authenticated source that answers 401 is fatal to the whole restore rather than to the packages it serves — so the first `v*` tag anyone pushed would have failed before packing anything.

That feed existed for one reason: ValidationModules was published only there. It is on nuget.org from `0.1.0-alpha.1`, and `src/nuget.config` no longer lists it. `build-package.yaml` and `benchmarks.yaml` had the same arrangement removed in #106; this workflow landed in #103 carrying the copy that had not been fixed yet, and its green check was `build-package.yaml`, which never exercises `release.yaml`.

## Publishing is untouched

Both push steps name their feed and key on the command line and read neither from `setup-dotnet` nor from `nuget.config` — including the one that still pushes to GitHub Packages:

```yaml
dotnet nuget push "./artifacts/*.nupkg" \
  --api-key ${{ secrets.GITHUB_TOKEN }} \
  --source "https://nuget.pkg.github.com/ipjohnson/index.json" \
  --skip-duplicate --no-symbols
```

## Verification

The restore path this leaves — nuget.org alone, no token — was run against a cleaned tree while landing #106: restore, a warnings-as-errors build and the full suite, with `GITHUB_TOKEN` unset and `UseLocalValidationModules=false`. This workflow cannot be exercised without pushing a tag, so that is the evidence available short of cutting a release.
