### PR TITLE
Pack the two packages the release list did not know about

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,11 +133,13 @@ jobs:
             src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj \
             src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj \
             src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj \
+            src/SourceGenerators/Hardened.Validation.SourceGenerator/Hardened.Validation.SourceGenerator.csproj \
             src/SourceGenerators/Hardened.Web.SourceGenerator/Hardened.Web.SourceGenerator.csproj \
             src/Web/Hardened.Web.Runtime/Hardened.Web.Runtime.csproj \
             src/Web/Hardened.Web.AspNetCore.Runtime/Hardened.Web.AspNetCore.Runtime.csproj \
             src/Web/Hardened.Web.Kestrel.Runtime/Hardened.Web.Kestrel.Runtime.csproj \
-            src/Web/Hardened.Web.Testing/Hardened.Web.Testing.csproj; do
+            src/Web/Hardened.Web.Testing/Hardened.Web.Testing.csproj \
+            src/Templates/Hardened.Templates.RazorBlade/Hardened.Templates.RazorBlade.csproj; do
             dotnet pack "$project" --configuration Release --no-build --output ./artifacts \
               "/p:PackageVersion=${{ steps.version.outputs.version }}"
           done


### PR DESCRIPTION
`release.yaml` names the projects it packs explicitly rather than packing the solution. That is deliberate — packing the solution is how `Hardened.IntegrationTests.Console.SUT` and `.OpenApi.SUT` ended up on the GitHub feed as packages, and the workflow says so in a comment.

The cost of an explicit list is that it cannot notice a new package. Two have appeared since it was written:

| Package | Added by | What it is |
|---|---|---|
| `Hardened.Templates.RazorBlade` | #106 | The RazorBlade rendering engine |
| `Hardened.Validation.SourceGenerator` | earlier on the same branch | Emits the validators spec-first and attribute-driven validation depend on |

Both are marked `IsPackable`, both are referenced by applications, and neither would have been published. A release would have put a framework on nuget.org that cannot render a template or validate a request — permanently, since a published version can be unlisted but never removed.

Found by diffing the projects marked `IsPackable` against the pack list:

```
grep -rl "<IsPackable>True</IsPackable>" --include="*.csproj" src/ | sort > packable
sed -n '/name: Pack/,/done/p' .github/workflows/release.yaml \
  | grep -oE "src/[A-Za-z0-9./]+\.csproj" | sort > packlist
comm -23 packable packlist
```

That is the check the list cannot perform on itself, and it is worth running whenever a package is added. It now returns nothing.

Caught while preparing a `v0.1.0-rc1` trial release, before tagging.
