### PR TITLE
Teach the package count about the two packages #108 added

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,7 +150,14 @@ jobs:
       # consumer failed to restore it.
       - name: Verify every expected package was produced
         run: |
-          EXPECTED=19
+          # Deliberately a literal rather than derived from the list above. Counting the list
+          # would make this agree with itself and check nothing; a number someone has to change
+          # is what makes adding a package a two-line edit instead of a silent one.
+          #
+          # 19 when the list was written. #108 added Hardened.Templates.RazorBlade and
+          # Hardened.Validation.SourceGenerator to the pack list and did not update this, which is
+          # what this step is for - it failed the v0.1.0-rc1 release before anything was pushed.
+          EXPECTED=21
           ACTUAL=$(ls -1 ./artifacts/*.nupkg 2>/dev/null | wc -l | tr -d ' ')
 
           if [ "$ACTUAL" != "$EXPECTED" ]; then


### PR DESCRIPTION
The verify step failed the `v0.1.0-rc1` release:

```
::error::Packed 21 packages, expected 19. Update the list in this workflow if a package was added or removed.
```

Which is exactly what it is for. #108 added `Hardened.Templates.RazorBlade` and `Hardened.Validation.SourceGenerator` to the pack list and left `EXPECTED=19` behind. **Nothing was published** — the step runs before both push steps, so the release stopped with the artifacts built and none of them sent.

Kept as a literal rather than derived from the list above it. Counting that list would make the check agree with itself and verify nothing; a number someone has to change by hand is what makes adding a package a visible edit rather than a silent one. The comment now records what it was and why it moved.

The pack list and the count are both 21.