### PR TITLE
Stop publishing Hardened.DependencyModules.SourceGenerator standalone

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,6 +116,15 @@ jobs:
       # is not marked IsPackable=false, which is how Hardened.IntegrationTests.Console.SUT and
       # .OpenApi.SUT ended up on the GitHub feed as packages. On nuget.org a mistake like that
       # claims a public ID permanently.
+      #
+      # Hardened.DependencyModules.SourceGenerator is deliberately absent. Its generator ships
+      # embedded in Hardened.Library.SourceGenerator's analyzers/dotnet/cs, because both projects
+      # compile CSharpAuthor in from source and an assembly reference between them collides on
+      # CSharpAuthor.TypeExtensions - so a nuspec dependency is not available and embedding is the
+      # only mechanism that works. Publishing it standalone as well, as v0.1.0-rc1 did, put the
+      # same generator in two packages: a consumer referencing both loaded it twice and both
+      # copies emitted the module onto the same partial class, failing with CS0111/CS8646. One
+      # publishable supplier is what keeps that impossible.
       - name: Pack
         run: |
           for project in \
@@ -129,7 +138,6 @@ jobs:
             src/SourceGenerators/Hardened.SourceGenerator/Hardened.SourceGenerator.csproj \
             src/SourceGenerators/Hardened.SourceGeneration.Testing/Hardened.SourceGeneration.Testing.csproj \
             src/SourceGenerators/Hardened.Console.SourceGenerator/Hardened.Console.SourceGenerator.csproj \
-            src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj \
             src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj \
             src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj \
             src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj \
@@ -157,7 +165,9 @@ jobs:
           # 19 when the list was written. #108 added Hardened.Templates.RazorBlade and
           # Hardened.Validation.SourceGenerator to the pack list and did not update this, which is
           # what this step is for - it failed the v0.1.0-rc1 release before anything was pushed.
-          EXPECTED=21
+          # 20 after Hardened.DependencyModules.SourceGenerator was removed from the list; see the
+          # note above the pack step for why it is not published on its own.
+          EXPECTED=20
           ACTUAL=$(ls -1 ./artifacts/*.nupkg 2>/dev/null | wc -l | tr -d ' ')
 
           if [ "$ACTUAL" != "$EXPECTED" ]; then


### PR DESCRIPTION
## The bug

`v0.1.0-rc1` published the same source generator in two packages:

```
hardened.library.sourcegenerator          → Hardened.Library.SourceGenerator.dll
                                            Hardened.DependencyModules.SourceGenerator.dll   ← embedded copy
hardened.dependencymodules.sourcegenerator → Hardened.DependencyModules.SourceGenerator.dll
```

A consumer referencing both loads `HardenedSourceGenerator` twice. Both copies match `[HardenedModule]` and both emit the module onto the same partial class, failing with 14 `CS0111`/`CS8646` errors that point at the consumer's own `Application.cs` rather than at the reference that caused them.

## Why nothing here caught it

Nine projects in this repository reference both generators. As `ProjectReference`s the analyzer resolves exactly once no matter how many projects ask for it — the duplication only exists in the packed form, and no test consumes these as packages.

## Why one supplier rather than a nuspec dependency

The embed is not incidental. Both projects compile CSharpAuthor in from source, so an assembly reference between them is ambiguous on `CSharpAuthor.TypeExtensions` — I tried it, and every call site in `GenericTypeDefinition` and `TypeDefinition` fails `CS0121`. `ReferenceOutputAssembly="false"` avoids that, and it is also what makes pack drop the `ProjectReference` from the nuspec, which is what the original embed (`f87cb05`) worked around.

So there is no nuspec dependency available. Embedding is the only mechanism the source-import architecture allows, which leaves one publishable supplier as the only way to keep the duplication impossible.

The csproj is unchanged; this removes the project from the release pack list and updates `EXPECTED` 21 → 20.

## Verification

- Packed `Hardened.Library.SourceGenerator` from this branch to a local feed — still self-contained, both generators in `analyzers/dotnet/cs`
- Compiled a `[HardenedModule]` consumer against the **packed** output with no other generator referenced — builds, runs, `PopulateServiceCollection` present
- Pack list is 20 entries, `EXPECTED=20`, the project is absent

## Follow-ups

- `Hardened.DependencyModules.SourceGenerator` `0.1.0-rc1` is live on nuget.org and should be **unlisted** — a published version can be unlisted but never removed, so an explicit reference alongside Library still collides.
- The durable fix is a smoke test that restores the packed packages from a local feed and compiles a module. That is the gap that let this ship; I ran it by hand for this PR but did not add it to CI.

## CI note (corrected after merge)

An earlier version of this section claimed CI would fail here because `origin/main` was red. That was wrong — the failure was local only.

`Hardened.Requests.Runtime.csproj` sets `UseLocalValidationModules` automatically when `../../../../../ValidationModules` exists, which from a clone at `~/Hardened/Hardened.Framework` resolves to `~/ValidationModules`. That swaps the pinned `ValidationModules.Runtime` package for a local working tree whose validators lack the `Instance` member the generator emits — hence 20 x `CS0117` across the SUTs and generated parameter validators.

`dotnet build src/Hardened.Framework.sln -p:UseLocalValidationModules=false` builds clean: 0 errors, 0 warnings. On a CI runner the probe path lands outside the workspace, so the auto-detect never fires and no flag is needed — confirmed by this PR and the post-merge main build both passing.

Whether "is main green?" should depend on where a clone lives is worth a separate look; a directory probe is easy to trip over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)