### PR TITLE
Emit Set-Cookie on the web hosts, and put the generated OpenAPI sources in front of the IDE

### DIFF
--- a/src/Benchmarks/Hardened.Benchmarks/Pipeline/FilterAwaitableBenchmarks.cs
+++ b/src/Benchmarks/Hardened.Benchmarks/Pipeline/FilterAwaitableBenchmarks.cs
@@ -1,0 +1,131 @@
+using BenchmarkDotNet.Attributes;
+using Hardened.Benchmarks.Infrastructure;
+
+namespace Hardened.Benchmarks.Pipeline;
+
+/// <summary>
+/// What returning <c>Task</c> from the filter interfaces costs, against <c>ValueTask</c>.
+///
+/// <para>
+/// <c>IExecutionFilter.Execute</c> and <c>IExecutionChain.Next</c> both return <c>Task</c>. A filter
+/// that completes synchronously — which most do, most of the time — still has to hand back a
+/// <c>Task</c>, and if it is written <c>async</c> it also boxes a state machine. <c>ValueTask</c>
+/// lets that path return without allocating.
+/// </para>
+///
+/// <para>
+/// Changing the real interfaces means touching 72 implementations across three repositories, so
+/// this measures the shape in isolation first: two chains that differ only in what they return,
+/// walked the same way, so the difference is the awaitable and nothing else. Multiply the per-filter
+/// figure by the chain length to size the real change.
+/// </para>
+///
+/// <para>
+/// Both variants mirror <c>ExecutionChain</c>: an index walked forwards, a filter list, and
+/// <c>CompletedTask</c> at the end. The synchronous variants model a filter that does its work and
+/// returns; the async ones model a filter written with <c>async</c>/<c>await</c> that happens to
+/// complete without yielding, which is the common case and the expensive one.
+/// </para>
+/// </summary>
+[MemoryDiagnoser]
+[BenchmarkCategory(BenchmarkCategories.Pipeline)]
+public class FilterAwaitableBenchmarks {
+
+    [Params(3, 6, 12)]
+    public int FilterCount { get; set; }
+
+    private interface ITaskFilter {
+        Task Execute(TaskChain chain);
+    }
+
+    private interface IValueTaskFilter {
+        ValueTask Execute(ValueTaskChain chain);
+    }
+
+    private sealed class TaskChain {
+        private readonly ITaskFilter[] _filters;
+        private int _index;
+
+        public TaskChain(ITaskFilter[] filters) => _filters = filters;
+
+        public void Reset() => _index = 0;
+
+        public Task Next() =>
+            _index >= _filters.Length ? Task.CompletedTask : _filters[_index++].Execute(this);
+    }
+
+    private sealed class ValueTaskChain {
+        private readonly IValueTaskFilter[] _filters;
+        private int _index;
+
+        public ValueTaskChain(IValueTaskFilter[] filters) => _filters = filters;
+
+        public void Reset() => _index = 0;
+
+        public ValueTask Next() =>
+            _index >= _filters.Length ? ValueTask.CompletedTask : _filters[_index++].Execute(this);
+    }
+
+    /// <summary>Written <c>async</c>, completes without yielding — the common filter.</summary>
+    private sealed class AsyncTaskFilter : ITaskFilter {
+        public async Task Execute(TaskChain chain) {
+            await chain.Next();
+        }
+    }
+
+    private sealed class AsyncValueTaskFilter : IValueTaskFilter {
+        public async ValueTask Execute(ValueTaskChain chain) {
+            await chain.Next();
+        }
+    }
+
+    /// <summary>Hand-written to avoid the state machine, for reference.</summary>
+    private sealed class SyncTaskFilter : ITaskFilter {
+        public Task Execute(TaskChain chain) => chain.Next();
+    }
+
+    private sealed class SyncValueTaskFilter : IValueTaskFilter {
+        public ValueTask Execute(ValueTaskChain chain) => chain.Next();
+    }
+
+    private TaskChain _asyncTask = null!;
+    private ValueTaskChain _asyncValueTask = null!;
+    private TaskChain _syncTask = null!;
+    private ValueTaskChain _syncValueTask = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        _asyncTask = new TaskChain(Enumerable.Range(0, FilterCount)
+            .Select(_ => (ITaskFilter)new AsyncTaskFilter()).ToArray());
+        _asyncValueTask = new ValueTaskChain(Enumerable.Range(0, FilterCount)
+            .Select(_ => (IValueTaskFilter)new AsyncValueTaskFilter()).ToArray());
+        _syncTask = new TaskChain(Enumerable.Range(0, FilterCount)
+            .Select(_ => (ITaskFilter)new SyncTaskFilter()).ToArray());
+        _syncValueTask = new ValueTaskChain(Enumerable.Range(0, FilterCount)
+            .Select(_ => (IValueTaskFilter)new SyncValueTaskFilter()).ToArray());
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task AsyncFiltersReturningTask() {
+        _asyncTask.Reset();
+        await _asyncTask.Next();
+    }
+
+    [Benchmark]
+    public async Task AsyncFiltersReturningValueTask() {
+        _asyncValueTask.Reset();
+        await _asyncValueTask.Next();
+    }
+
+    [Benchmark]
+    public async Task SyncFiltersReturningTask() {
+        _syncTask.Reset();
+        await _syncTask.Next();
+    }
+
+    [Benchmark]
+    public async Task SyncFiltersReturningValueTask() {
+        _syncValueTask.Reset();
+        await _syncValueTask.Next();
+    }
+}

--- a/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT/Hardened.IntegrationTests.Benchmark.SUT.csproj
+++ b/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT/Hardened.IntegrationTests.Benchmark.SUT.csproj
@@ -44,10 +44,16 @@
         <HardenedOpenApiTaskAssembly>$(MSBuildThisFileDirectory)..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\bin\$(Configuration)\net8.0\Hardened.OpenApi.BuildTask.dll</HardenedOpenApiTaskAssembly>
     </PropertyGroup>
 
-    <Import Project="..\..\..\SourceGenerators\Hardened.OpenApi.SourceGenerator\Package\Hardened.OpenApi.SourceGenerator.targets"/>
-
     <ItemGroup>
         <HardenedOpenApiSpec Include="Specs\benchmark.yaml"/>
     </ItemGroup>
+
+    <!--
+        Imported after the specs, which is where a package's build/*.targets lands anyway. The
+        targets file puts the generated sources into @(Compile) from a top-level ItemGroup so the
+        IDE sees them without a build, and top-level item groups are evaluated in document order -
+        so an import above @(HardenedOpenApiSpec) reads it as empty and contributes nothing.
+    -->
+    <Import Project="..\..\..\SourceGenerators\Hardened.OpenApi.SourceGenerator\Package\Hardened.OpenApi.SourceGenerator.targets"/>
 
 </Project>

--- a/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT/Hardened.IntegrationTests.Benchmark.SUT.csproj
+++ b/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT/Hardened.IntegrationTests.Benchmark.SUT.csproj
@@ -32,17 +32,21 @@
 
     <!--
         In-repo wiring for the build task, matching the OpenApi SUT. The ProjectReference exists
-        only to order the build; HardenedOpenApiTaskAssembly points UsingTask at its output.
+        only to order the build; HardenedOpenApiTaskAssembly points UsingTask at its output, and
+        selects the flavour on $(MSBuildRuntimeType) because setting the property suppresses the
+        package's own selection - Visual Studio's MSBuild is .NET Framework and cannot load net8.0.
     -->
+    <PropertyGroup>
+        <_HardenedOpenApiTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">net8.0</_HardenedOpenApiTaskTfm>
+        <_HardenedOpenApiTaskTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_HardenedOpenApiTaskTfm>
+        <HardenedOpenApiTaskAssembly>$(MSBuildThisFileDirectory)..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\bin\$(Configuration)\$(_HardenedOpenApiTaskTfm)\Hardened.OpenApi.BuildTask.dll</HardenedOpenApiTaskAssembly>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\Hardened.OpenApi.BuildTask.csproj"
                           ReferenceOutputAssembly="false"
-                          SetTargetFramework="TargetFramework=net8.0"/>
+                          SetTargetFramework="TargetFramework=$(_HardenedOpenApiTaskTfm)"/>
     </ItemGroup>
-
-    <PropertyGroup>
-        <HardenedOpenApiTaskAssembly>$(MSBuildThisFileDirectory)..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\bin\$(Configuration)\net8.0\Hardened.OpenApi.BuildTask.dll</HardenedOpenApiTaskAssembly>
-    </PropertyGroup>
 
     <ItemGroup>
         <HardenedOpenApiSpec Include="Specs\benchmark.yaml"/>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
@@ -26,16 +26,25 @@
         In-repo wiring for the build task, which the package does through build/*.targets. The
         ProjectReference exists only to order the build - nothing here binds against the task
         assembly - and HardenedOpenApiTaskAssembly points UsingTask at where that build puts it.
+
+        The flavour is selected on $(MSBuildRuntimeType), exactly as the package's targets select
+        between tasks/net472 and tasks/net8.0, because MSBuild has two hosts: Visual Studio runs on
+        .NET Framework, the dotnet CLI and Rider on .NET. Setting this property is what suppresses
+        the package's own selection, so pinning it to net8.0 hands .NET Framework MSBuild a .NET 8
+        assembly and fails at task execution rather than at build. The ProjectReference tracks the
+        same flavour, so the one the host is about to load is the one built first.
     -->
+    <PropertyGroup>
+        <_HardenedOpenApiTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">net8.0</_HardenedOpenApiTaskTfm>
+        <_HardenedOpenApiTaskTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</_HardenedOpenApiTaskTfm>
+        <HardenedOpenApiTaskAssembly>$(MSBuildThisFileDirectory)..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\bin\$(Configuration)\$(_HardenedOpenApiTaskTfm)\Hardened.OpenApi.BuildTask.dll</HardenedOpenApiTaskAssembly>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\Hardened.OpenApi.BuildTask.csproj"
                           ReferenceOutputAssembly="false"
-                          SetTargetFramework="TargetFramework=net8.0"/>
+                          SetTargetFramework="TargetFramework=$(_HardenedOpenApiTaskTfm)"/>
     </ItemGroup>
-
-    <PropertyGroup>
-        <HardenedOpenApiTaskAssembly>$(MSBuildThisFileDirectory)..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\bin\$(Configuration)\net8.0\Hardened.OpenApi.BuildTask.dll</HardenedOpenApiTaskAssembly>
-    </PropertyGroup>
 
     <ItemGroup>
         <HardenedOpenApiSpec Include="Specs\petstore.yaml" />

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
@@ -37,10 +37,16 @@
         <HardenedOpenApiTaskAssembly>$(MSBuildThisFileDirectory)..\..\..\SourceGenerators\Hardened.OpenApi.BuildTask\bin\$(Configuration)\net8.0\Hardened.OpenApi.BuildTask.dll</HardenedOpenApiTaskAssembly>
     </PropertyGroup>
 
-    <Import Project="..\..\..\SourceGenerators\Hardened.OpenApi.SourceGenerator\Package\Hardened.OpenApi.SourceGenerator.targets"/>
-
     <ItemGroup>
         <HardenedOpenApiSpec Include="Specs\petstore.yaml" />
     </ItemGroup>
+
+    <!--
+        Imported after the specs, which is where a package's build/*.targets lands anyway. The
+        targets file puts the generated sources into @(Compile) from a top-level ItemGroup so the
+        IDE sees them without a build, and top-level item groups are evaluated in document order -
+        so an import above @(HardenedOpenApiSpec) reads it as empty and contributes nothing.
+    -->
+    <Import Project="..\..\..\SourceGenerators\Hardened.OpenApi.SourceGenerator\Package\Hardened.OpenApi.SourceGenerator.targets"/>
 
 </Project>

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -290,6 +290,12 @@ namespace Hardened.Requests.Runtime.Headers
         public bool TryGet(string key, out Microsoft.Extensions.Primitives.StringValues value) { }
         public bool TryGetValue(string key, out Microsoft.Extensions.Primitives.StringValues value) { }
     }
+    public class HeaderCookieSetCollection : Hardened.Requests.Abstract.Headers.ICookieSetCollection
+    {
+        public HeaderCookieSetCollection(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, System.Tuple<string, Hardened.Requests.Abstract.Headers.CookieSetOptions>> Cookies { get; }
+        public void Append(string cookieName, string cookieValue, Hardened.Requests.Abstract.Headers.CookieSetOptions? options = null) { }
+    }
 }
 namespace Hardened.Requests.Runtime.Logging
 {

--- a/src/Requests/Hardened.Requests.Runtime/Headers/HeaderCookieSetCollection.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Headers/HeaderCookieSetCollection.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using Hardened.Requests.Abstract.Headers;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Runtime.Headers;
+
+/// <summary>
+/// A cookie collection that writes <c>Set-Cookie</c> onto the response headers, for hosts where
+/// that is how a cookie reaches the client.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="CookieSetCollectionImpl"/> only records: it stores into a dictionary and something
+/// else is expected to serialise it. That works on API Gateway, whose response carries a
+/// <c>cookies</c> array separate from its headers and whose processor reads the dictionary. On an
+/// HTTP host nothing read it, so <c>Response.Cookies.Append(...)</c> compiled, ran, and never
+/// reached the client.
+/// </para>
+/// <para>
+/// Headers are written on append rather than flushed at the end, because a response's headers go
+/// out when the body first writes — anything deferred past that is already too late.
+/// </para>
+/// </remarks>
+public class HeaderCookieSetCollection : ICookieSetCollection {
+    private static readonly IReadOnlyDictionary<string, Tuple<string, CookieSetOptions>> None =
+        new Dictionary<string, Tuple<string, CookieSetOptions>>();
+
+    private readonly IDictionary<string, StringValues> _headers;
+
+    /// <summary>
+    /// Created on the first cookie. Most responses set none, so the common path allocates nothing
+    /// beyond this collection itself — and hosts create that lazily too.
+    /// </summary>
+    private Dictionary<string, Tuple<string, CookieSetOptions>>? _cookies;
+
+    public HeaderCookieSetCollection(IDictionary<string, StringValues> headers) {
+        _headers = headers;
+    }
+
+    public void Append(string cookieName, string cookieValue, CookieSetOptions? options = null) {
+        _cookies ??= new Dictionary<string, Tuple<string, CookieSetOptions>>();
+        _cookies[cookieName] =
+            new Tuple<string, CookieSetOptions>(cookieValue, options ?? CookieSetOptions.Empty);
+
+        WriteHeader();
+    }
+
+    /// <summary>
+    /// Rewrites the whole header from the dictionary rather than appending one value.
+    /// </summary>
+    /// <remarks>
+    /// Last write for a name wins — the semantic <see cref="CookieSetCollectionImpl"/> and the API
+    /// Gateway collection both document. Appending would emit the replaced value as well, leaving
+    /// the client to pick, and which one it picks is not something to leave to a client.
+    /// </remarks>
+    private void WriteHeader() {
+        var values = new string[_cookies!.Count];
+        var index = 0;
+
+        foreach (var cookie in _cookies) {
+            var builder = new StringBuilder();
+
+            builder.Append(cookie.Key);
+            builder.Append('=');
+            builder.Append(cookie.Value.Item1);
+            cookie.Value.Item2.AppendSettings(builder);
+
+            values[index++] = builder.ToString();
+        }
+
+        _headers["Set-Cookie"] = new StringValues(values);
+    }
+
+    public IReadOnlyDictionary<string, Tuple<string, CookieSetOptions>> Cookies => _cookies ?? None;
+}

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
@@ -25,13 +25,58 @@
                AssemblyFile="$(HardenedOpenApiTaskAssembly)"/>
 
     <!--
-        The model directory is resolved inside a target, not in a PropertyGroup up here.
-        $(IntermediateOutputPath) is set by Microsoft.Common.CurrentVersion.targets, so at import
-        time it is defined for a package - build/*.targets is imported last - and empty for anyone
-        importing this file from the body of a csproj. Empty meant the models were written to
-        ./openapi/ beside the project instead of into obj/, and because that directory then survived
-        every clean, the Inputs/Outputs check reported the target up to date while the compiler saw
-        no models at all.
+        The files the task will write are declared here, at the top level, and NOT inside the target
+        that writes them.
+
+        An IDE builds its project model out of MSBuild *evaluation*, not out of a build. Rider has no
+        CompileDesignTime target at all, so a file that only becomes a @(Compile) item while some
+        target is running is a file the editor never hears about: the spec-derived models and service
+        interfaces resolve on the compiler command line and nowhere else, and every reference to them
+        reddens in a project that builds clean. Same for @(AdditionalFiles) - the generator reading
+        the model produces nothing in-editor if the model is not in view at evaluation. The source
+        generator this replaced never had the problem, because Roslyn runs generators inside the
+        IDE's own compilation.
+
+        Top level is also what makes the paths resolvable. MSBuild evaluates every top-level ItemGroup
+        in a pass that runs after every property and every import, so $(IntermediateOutputPath) is
+        final here even though it is still empty at the point a csproj body imports this file - which
+        is why these paths can be spelled here but not in a PropertyGroup beside them, and why
+        HardenedOpenApiResolveModelDir below still has to be a target.
+
+        Transforms of @(HardenedOpenApiSpec), not a glob of the output directory: on a clean tree the
+        files do not exist yet, and a glob would come back empty on exactly the build that has to
+        declare them. Deriving from the specs also means deleting a spec drops its generated code from
+        the compilation, rather than leaving whatever an earlier build wrote to be picked up.
+    -->
+    <ItemGroup Condition="'@(HardenedOpenApiSpec)' != ''">
+        <_HardenedOpenApiModel Condition="'$(HardenedOpenApiModelDir)' == ''"
+                               Include="@(HardenedOpenApiSpec->'$(IntermediateOutputPath)openapi/%(Filename).openapi-model.txt')"/>
+        <_HardenedOpenApiModel Condition="'$(HardenedOpenApiModelDir)' != ''"
+                               Include="@(HardenedOpenApiSpec->'$(HardenedOpenApiModelDir)%(Filename).openapi-model.txt')"/>
+
+        <_HardenedOpenApiSource Condition="'$(HardenedOpenApiGeneratedDir)' == '' And '$(HardenedOpenApiModelDir)' == ''"
+                                Include="@(HardenedOpenApiSpec->'$(IntermediateOutputPath)openapi/generated/%(Filename).g.cs')"/>
+        <_HardenedOpenApiSource Condition="'$(HardenedOpenApiGeneratedDir)' == '' And '$(HardenedOpenApiModelDir)' != ''"
+                                Include="@(HardenedOpenApiSpec->'$(HardenedOpenApiModelDir)generated/%(Filename).g.cs')"/>
+        <_HardenedOpenApiSource Condition="'$(HardenedOpenApiGeneratedDir)' != ''"
+                                Include="@(HardenedOpenApiSpec->'$(HardenedOpenApiGeneratedDir)%(Filename).g.cs')"/>
+
+        <AdditionalFiles Include="@(_HardenedOpenApiModel)"/>
+        <Compile Include="@(_HardenedOpenApiSource)" Visible="false"/>
+    </ItemGroup>
+
+    <!--
+        The directories the task writes to repeat the defaults above because they have to be resolved
+        inside a target. $(IntermediateOutputPath) is set by Microsoft.Common.CurrentVersion.targets,
+        so at import time it is defined for a package - build/*.targets is imported last - and empty
+        for anyone importing this file from the body of a csproj. Empty meant the models were written
+        to ./openapi/ beside the project instead of into obj/, and because that directory then
+        survived every clean, the Inputs/Outputs check reported the target up to date while the
+        compiler saw no models at all.
+
+        The repetition is guarded rather than eliminated: if the two ever disagree, the task writes
+        somewhere the compilation is not looking, and HOAT004 below fails the build naming the file
+        that is missing.
     -->
     <Target Name="HardenedOpenApiResolveModelDir">
         <PropertyGroup>
@@ -46,16 +91,18 @@
         The task both emits C# and writes the normalised model, because it has the parsed spec in
         hand either way and parsing it twice is the one thing this design exists to avoid.
 
-        Inputs/Outputs so an untouched spec does not re-run. Each spec produces exactly two files
-        whose names follow from its own, so both can be declared here - MSBuild has to be able to
-        list a target's outputs without running it, which is the whole reason the task emits one file
-        per spec rather than one per type.
+        Inputs/Outputs so an untouched spec does not re-run. The outputs are the same items the
+        compilation was handed at evaluation, so the up-to-date check is made against exactly the
+        files the compiler will open - MSBuild has to be able to list a target's outputs without
+        running it, which is the whole reason the task emits one file per spec rather than one per
+        type.
     -->
     <Target Name="HardenedOpenApiExtractSpecs"
             DependsOnTargets="HardenedOpenApiResolveModelDir"
+            BeforeTargets="CoreCompile"
             Condition="'@(HardenedOpenApiSpec)' != ''"
             Inputs="@(HardenedOpenApiSpec)"
-            Outputs="@(HardenedOpenApiSpec->'$(HardenedOpenApiModelDir)%(Filename).openapi-model.txt');@(HardenedOpenApiSpec->'$(HardenedOpenApiGeneratedDir)%(Filename).g.cs')">
+            Outputs="@(_HardenedOpenApiModel);@(_HardenedOpenApiSource)">
 
         <ExtractOpenApiSpec Specs="@(HardenedOpenApiSpec)"
                             OutputDirectory="$(HardenedOpenApiModelDir)"
@@ -69,30 +116,36 @@
     </Target>
 
     <!--
-        Always runs, even when the target above is skipped as up to date: a skipped target
-        contributes nothing to @(Compile) or @(AdditionalFiles), and the compiler would then see
-        neither the emitted types nor the models. Both come from the same transform as the target's
-        Outputs rather than from a directory glob, so removing a spec removes its generated code from
-        the compilation instead of leaving whatever an earlier build wrote to be picked up.
+        Runs even when the target above is skipped as up to date, because that is the case worth
+        catching: a spec whose model or generated source is not on disk means the up-to-date check
+        was made against files that are not there, or that the task wrote them somewhere other than
+        where evaluation said they would be. Either way the compiler is about to open a file that
+        does not exist. Silence would surface as an empty generator run and a project full of
+        missing types.
     -->
-    <Target Name="HardenedOpenApiAddModels"
+    <Target Name="HardenedOpenApiVerifyModels"
             DependsOnTargets="HardenedOpenApiExtractSpecs"
             BeforeTargets="CoreCompile"
             Condition="'@(HardenedOpenApiSpec)' != ''">
 
-        <ItemGroup>
-            <AdditionalFiles Include="@(HardenedOpenApiSpec->'$(HardenedOpenApiModelDir)%(Filename).openapi-model.txt')"/>
-            <Compile Include="@(HardenedOpenApiSpec->'$(HardenedOpenApiGeneratedDir)%(Filename).g.cs')" Visible="false"/>
-        </ItemGroup>
-
         <!--
-            A model that is missing here means the target above was skipped as up to date against
-            files that are not there. Silence would surface as an empty generator run and a project
-            full of missing types.
+            Specs at build time but nothing declared at evaluation means this file was imported above
+            the @(HardenedOpenApiSpec) declaration: top-level item groups are evaluated in document
+            order, so the ItemGroup up top saw an empty list and put nothing into @(Compile). The
+            build would still succeed - HardenedOpenApiExtractSpecs writes the files either way - and
+            every spec-derived type would be missing from the compilation. Fail here instead.
         -->
-        <Error Condition="!Exists('%(AdditionalFiles.FullPath)') And '%(AdditionalFiles.Extension)' == '.txt' And $([System.String]::Copy('%(AdditionalFiles.Filename)').EndsWith('.openapi-model'))"
+        <Error Condition="'@(_HardenedOpenApiSource)' == ''"
+               Code="HOAT005"
+               Text="Hardened.OpenApi.SourceGenerator.targets was imported before these specs were declared: @(HardenedOpenApiSpec). No generated source reached the compilation. Move the &lt;Import&gt; below the &lt;HardenedOpenApiSpec&gt; item group."/>
+
+        <Error Condition="!Exists('%(_HardenedOpenApiModel.FullPath)')"
                Code="HOAT004"
-               Text="The OpenAPI model '%(AdditionalFiles.Identity)' was not written. Delete $(HardenedOpenApiModelDir) and rebuild."/>
+               Text="The OpenAPI model '%(_HardenedOpenApiModel.Identity)' was not written. Delete $(HardenedOpenApiModelDir) and rebuild."/>
+
+        <Error Condition="!Exists('%(_HardenedOpenApiSource.FullPath)')"
+               Code="HOAT004"
+               Text="The generated OpenAPI source '%(_HardenedOpenApiSource.Identity)' was not written. Delete $(HardenedOpenApiModelDir) and rebuild."/>
     </Target>
 
     <!--

--- a/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Impl/AspNetExecutionResponseTests.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Impl/AspNetExecutionResponseTests.cs
@@ -1,3 +1,4 @@
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Web.AspNetCore.Runtime.Impl;
 using Microsoft.AspNetCore.Http;
 using NSubstitute;
@@ -80,5 +81,77 @@ public class AspNetExecutionResponseTests {
         var clone = response.Clone(null);
 
         Assert.Null(clone.Status);
+    }
+
+    /// <summary>
+    /// A cookie set by a handler has to reach the client, which over HTTP means a Set-Cookie
+    /// header on the response.
+    /// </summary>
+    /// <remarks>
+    /// The collection had no reader on this host either: Append stored into a dictionary nothing
+    /// serialised, so the call compiled, ran, and the client never saw it. Same defect as the
+    /// Kestrel host, and the same one Hardened.Amz fixed on 2026-08-11.
+    /// </remarks>
+    [Fact]
+    public void AppendingACookieWritesASetCookieHeader() {
+        var httpContext = new DefaultHttpContext();
+        var response = new AspNetExecutionResponse(httpContext.Response);
+
+        response.Cookies.Append("session", "abc123");
+
+        Assert.Equal("session=abc123; HttpOnly; Secure", httpContext.Response.Headers["Set-Cookie"]);
+    }
+
+    [Fact]
+    public void AppendingSeveralCookiesWritesAHeaderForEach() {
+        var httpContext = new DefaultHttpContext();
+        var response = new AspNetExecutionResponse(httpContext.Response);
+
+        response.Cookies.Append("first", "1");
+        response.Cookies.Append("second", "2");
+
+        var written = httpContext.Response.Headers["Set-Cookie"];
+
+        Assert.Equal(2, written.Count);
+        Assert.Contains(written.ToArray(), v => v!.StartsWith("first=1"));
+        Assert.Contains(written.ToArray(), v => v!.StartsWith("second=2"));
+    }
+
+    /// <summary>Last write for a name wins, matching the other collections.</summary>
+    [Fact]
+    public void AppendingTheSameCookieTwiceKeepsOnlyTheLastValue() {
+        var httpContext = new DefaultHttpContext();
+        var response = new AspNetExecutionResponse(httpContext.Response);
+
+        response.Cookies.Append("session", "first");
+        response.Cookies.Append("session", "second");
+
+        var written = httpContext.Response.Headers["Set-Cookie"];
+
+        Assert.Equal(1, written.Count);
+        Assert.StartsWith("session=second", written.ToString());
+    }
+
+    [Fact]
+    public void CookieOptionsAreSerialisedOntoTheHeader() {
+        var httpContext = new DefaultHttpContext();
+        var response = new AspNetExecutionResponse(httpContext.Response);
+
+        response.Cookies.Append("session", "abc",
+            new CookieSetOptions(Path: "/api", SameSite: SameSite.Strict));
+
+        var written = httpContext.Response.Headers["Set-Cookie"].ToString();
+
+        Assert.Contains("Path=/api", written);
+        Assert.Contains("SameSite=Strict", written);
+    }
+
+    /// <summary>A response that sets no cookie allocates no collection.</summary>
+    [Fact]
+    public void AResponseThatSetsNoCookieWritesNoHeader() {
+        var httpContext = new DefaultHttpContext();
+        _ = new AspNetExecutionResponse(httpContext.Response);
+
+        Assert.False(httpContext.Response.Headers.ContainsKey("Set-Cookie"));
     }
 }

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
@@ -233,7 +233,16 @@ public class AspNetExecutionResponse : IExecutionResponse {
 
     public bool IsBinary { get; set; }
 
-    public ICookieSetCollection Cookies { get; } = new CookieSetCollectionImpl();
+    /// <summary>
+    /// Header backed, and lazily. Over HTTP a cookie reaches the client as <c>Set-Cookie</c>, and
+    /// nothing on this host serialised the recording collection that used to sit here — so
+    /// <c>Response.Cookies.Append(...)</c> compiled, ran, and the client never saw it. The same
+    /// defect the Kestrel host had, and the one Hardened.Amz fixed on 2026-08-11.
+    /// </summary>
+    public ICookieSetCollection Cookies =>
+        _cookies ??= new HeaderCookieSetCollection(_httpResponse.Headers);
+
+    private ICookieSetCollection? _cookies;
 
     public bool ShouldSerialize { get; set; } = true;
 }

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/FeatureExecutionResponseTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/FeatureExecutionResponseTests.cs
@@ -1,3 +1,4 @@
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Web.Kestrel.Runtime.Impl;
 using Xunit;
 
@@ -133,5 +134,69 @@ public class FeatureExecutionResponseTests {
         await Response(features).CompleteAsync();
 
         Assert.Equal(1, features.ResponseBody.CompleteCount);
+    }
+
+    /// <summary>
+    /// A cookie set by a handler has to reach the client, which over HTTP means a Set-Cookie
+    /// header on the response the server writes.
+    /// </summary>
+    /// <remarks>
+    /// The collection had no reader on this host: Append stored into a dictionary nothing
+    /// serialised, so the call compiled, ran, and the client never saw it. Hardened.Amz carried the
+    /// same defect until 2026-08-11, where it at least threw NotImplementedException rather than
+    /// silently accepting the cookie.
+    /// </remarks>
+    [Fact]
+    public void AppendingACookieWritesASetCookieHeader() {
+        var features = new ServerFeatures();
+        var response = new FeatureExecutionResponse(features.Response, features.ResponseBody);
+
+        response.Cookies.Append("session", "abc123");
+
+        Assert.Equal("session=abc123; HttpOnly; Secure", features.Response.Headers["Set-Cookie"]);
+    }
+
+    [Fact]
+    public void AppendingSeveralCookiesWritesAHeaderForEach() {
+        var features = new ServerFeatures();
+        var response = new FeatureExecutionResponse(features.Response, features.ResponseBody);
+
+        response.Cookies.Append("first", "1");
+        response.Cookies.Append("second", "2");
+
+        var written = features.Response.Headers["Set-Cookie"];
+
+        Assert.Equal(2, written.Count);
+        Assert.Contains(written.ToArray(), v => v!.StartsWith("first=1"));
+        Assert.Contains(written.ToArray(), v => v!.StartsWith("second=2"));
+    }
+
+    /// <summary>Last write for a name wins, which is the semantic Hardened.Amz documents.</summary>
+    [Fact]
+    public void AppendingTheSameCookieTwiceKeepsOnlyTheLastValue() {
+        var features = new ServerFeatures();
+        var response = new FeatureExecutionResponse(features.Response, features.ResponseBody);
+
+        response.Cookies.Append("session", "first");
+        response.Cookies.Append("session", "second");
+
+        var written = features.Response.Headers["Set-Cookie"];
+
+        Assert.Equal(1, written.Count);
+        Assert.StartsWith("session=second", written.ToString());
+    }
+
+    [Fact]
+    public void CookieOptionsAreSerialisedOntoTheHeader() {
+        var features = new ServerFeatures();
+        var response = new FeatureExecutionResponse(features.Response, features.ResponseBody);
+
+        response.Cookies.Append("session", "abc",
+            new CookieSetOptions(Path: "/api", SameSite: SameSite.Strict));
+
+        var written = features.Response.Headers["Set-Cookie"].ToString();
+
+        Assert.Contains("Path=/api", written);
+        Assert.Contains("SameSite=Strict", written);
     }
 }

--- a/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionResponse.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionResponse.cs
@@ -20,12 +20,17 @@ public sealed class FeatureExecutionResponse : IExecutionResponse {
     private Stream? _bodyOverride;
     private int? _status;
 
+    /// <summary>
+    /// Created on first use. Most responses set no cookie, so this stays null and the per-request
+    /// cost is a null check rather than a dictionary.
+    /// </summary>
+    private ICookieSetCollection? _cookies;
+
     public FeatureExecutionResponse(
         IHttpResponseFeature feature,
         IHttpResponseBodyFeature bodyFeature) {
         _feature = feature;
         _bodyFeature = bodyFeature;
-        Cookies = new CookieSetCollectionImpl();
     }
 
     private FeatureExecutionResponse(
@@ -38,7 +43,7 @@ public sealed class FeatureExecutionResponse : IExecutionResponse {
         _bodyFeature = bodyFeature;
         _bodyOverride = bodyOverride;
         _status = status;
-        Cookies = cookies;
+        _cookies = cookies;
     }
 
     public IExecutionResponse Clone(IHeaderCollection? headerCollection = null) {
@@ -108,7 +113,13 @@ public sealed class FeatureExecutionResponse : IExecutionResponse {
 
     public bool IsBinary { get; set; }
 
-    public ICookieSetCollection Cookies { get; }
+    /// <summary>
+    /// Header backed: over HTTP a cookie reaches the client as <c>Set-Cookie</c>, and nothing on
+    /// this host serialised the recording collection that used to sit here — so
+    /// <c>Response.Cookies.Append(...)</c> compiled, ran, and the client never saw it.
+    /// </summary>
+    public ICookieSetCollection Cookies =>
+        _cookies ??= new HeaderCookieSetCollection(_feature.Headers);
 
     public bool ShouldSerialize { get; set; } = true;
 


### PR DESCRIPTION
Two unrelated fixes that landed on the same branch, kept together rather than
splitting the branch.

## Set-Cookie on the web hosts

Nothing emitted `Set-Cookie`. `HeaderCookieSetCollection` carries the set
cookies, `AspNetExecutionContext` and `FeatureExecutionResponse` write them out,
and the public API baseline moves with it. Covered by
`FeatureExecutionResponseTests`.

## Generated OpenAPI sources were invisible to the IDE

Moving OpenAPI generation from a source generator to a build task lost
IntelliSense for every spec-derived type: models and service interfaces resolved
on the compiler command line and nowhere else, so the projects built clean with
every reference to them red.

A Roslyn generator runs inside the IDE's own compilation, so its output was
always in view. The build task's output only reached `@(Compile)` from inside a
target — and an IDE builds its project model out of MSBuild **evaluation**, not
out of a build. Rider has no `CompileDesignTime` target at all, so a file that
only becomes an item while a target is running is a file it never hears about.
`@(AdditionalFiles)` had it worse: the generator that reads the normalised model
saw no model in-editor and produced nothing.

Confirmed before the fix — neither reached evaluation:

```
$ dotnet msbuild ...SUT.csproj -getItem:Compile          → petstore.g.cs absent
$ dotnet msbuild ...SUT.csproj -getItem:AdditionalFiles  → model .txt absent
```

Both are now declared from a top-level `ItemGroup`. Item groups are evaluated in
a pass that runs after every property and import, so `$(IntermediateOutputPath)`
is final there even though it is still empty where a csproj body imports the
targets file — which is why the target that resolves the task's output
directories has to stay a target.

Top-level item groups are evaluated in document order, though, so both in-repo
consumers now import *below* their `<HardenedOpenApiSpec>`, matching where a
package's `build/*.targets` lands anyway. Package consumers are unaffected and
need no change. `HOAT005` fails the build if that ordering is ever reversed,
because the symptom otherwise is a green build that silently drops every
generated type. `HOAT004` also got simpler and now checks generated sources, not
just models.

## Visual Studio could not have loaded the task at all

Found while checking the above. Both integration SUTs pinned
`HardenedOpenApiTaskAssembly` to the net8.0 build — and setting that property is
exactly what suppresses the package targets' own selection between
`tasks/net472` and `tasks/net8.0`. Visual Studio's MSBuild is .NET Framework, so
those two projects handed a .NET 8 assembly to a host that cannot load one,
failing at task execution rather than at build. CI is `ubuntu-latest` on all
three workflows and the CLI's MSBuild is .NET, so nothing exercised it.

Now selected on `$(MSBuildRuntimeType)` the same way the package targets do, with
the `ProjectReference` tracking the same flavour so the one the host is about to
load is the one built first.

## Verification

- Generated source and model now present at evaluation for both SUTs
- Clean build from a deleted `obj/`: succeeds, 0 warnings — no `CS2002`
- Incremental no-op and spec-touch rebuild both correct
- `HOAT005` verified by deliberately reversing the import order
- Full `Hardened.Framework.sln` Release build: 0 warnings, 0 errors
- **2267 tests pass, 0 failed assemblies**

Not tested on Windows — the Visual Studio reasoning is from MSBuild mechanics,
not a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGFuqFPCcVynfZmBpL9chd
