### PR TITLE
Opt an OpenAPI response into a byte[] signature

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Emitters/ServiceInterfaceEmitter.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Emitters/ServiceInterfaceEmitter.cs
@@ -40,6 +40,13 @@ internal static class ServiceInterfaceEmitter {
     }
 
     internal static ITypeDefinition GetReturnType(OperationModel operation, string modelsNamespace) {
+        // Ahead of the schema, because it is a deliberate override of it. x-hardened-raw-bytes says
+        // the application holds this payload already encoded, which the schema has no way to say -
+        // type: string describes the wire, not what the handler is holding.
+        if (operation.RawBytesResponse) {
+            return Task(TypeDefinition.Get(typeof(byte[])));
+        }
+
         if (operation.ResponseRef != null) {
             return Task(Model(operation.ResponseRef, modelsNamespace));
         }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/OpenApiSpecParser.cs
@@ -719,6 +719,15 @@ internal static class OpenApiSpecParser {
                 opModel.TemplateName = templateName.Value;
             }
 
+            // x-hardened-raw-bytes opts the signature into byte[] for a response the spec types as
+            // a string. Also not something the content map can say: text/plain describes the wire,
+            // not whether the application holds the payload already encoded.
+            if (operation.Extensions != null &&
+                operation.Extensions.TryGetValue("x-hardened-raw-bytes", out var rawBytesExt) &&
+                rawBytesExt is OpenApiBoolean { Value: true }) {
+                opModel.RawBytesResponse = true;
+            }
+
             if (!operationsByTag.TryGetValue(tag, out var list)) {
                 list = new List<OperationModel>();
                 operationsByTag[tag] = list;

--- a/src/SourceGenerators/Hardened.OpenApi.Shared/Models/OperationModel.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.Shared/Models/OperationModel.cs
@@ -48,6 +48,19 @@ internal class OperationModel : IEquatable<OperationModel> {
     /// </summary>
     public string? TemplateName { get; set; }
 
+    /// <summary>
+    /// Opt in to a <c>byte[]</c> signature for a response the spec types as a string.
+    /// </summary>
+    /// <remarks>
+    /// The default stays <c>string</c>, which is what <c>type: string</c> means and what a caller
+    /// reading the document expects. <c>byte[]</c> is a performance choice about a payload the
+    /// application already holds encoded: RawOutputHelper writes a byte[] straight to the body,
+    /// where a string is UTF-8 encoded into a fresh array on every request. It only pays when the
+    /// value is cached - encoding per request just moves the allocation - so it is the author's
+    /// call rather than something inferred from the schema.
+    /// </remarks>
+    public bool RawBytesResponse { get; set; }
+
     // x-filters: typed filter attribute instances applied to this operation
     public List<FilterInstanceModel> FilterInstances { get; set; } = new();
 

--- a/src/SourceGenerators/Hardened.OpenApi.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.Shared/SpecModelSerializer.cs
@@ -370,6 +370,7 @@ internal static class SpecModelSerializer {
         record.Add("RequestBodyRef", operation.RequestBodyRef);
         record.Add("RequestBodyType", operation.RequestBodyType);
         record.Add("ResponseContentType", operation.ResponseContentType);
+        record.Add("RawBytesResponse", operation.RawBytesResponse);
         record.Add("ResponseRef", operation.ResponseRef);
         record.Add("ResponseType", operation.ResponseType);
         record.Add("ResponseFormat", operation.ResponseFormat);
@@ -428,6 +429,7 @@ internal static class SpecModelSerializer {
         RequestBodyRef = record.String("RequestBodyRef"),
         RequestBodyType = record.String("RequestBodyType"),
         ResponseContentType = record.String("ResponseContentType"),
+        RawBytesResponse = record.Bool("RawBytesResponse"),
         ResponseRef = record.String("ResponseRef"),
         ResponseType = record.String("ResponseType"),
         ResponseFormat = record.String("ResponseFormat"),

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/RawResponseTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/RawResponseTests.cs
@@ -1,0 +1,91 @@
+using Hardened.SourceGeneration.Testing;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// Responses a spec declares as something other than JSON, and the opt-in to a byte[] signature.
+///
+/// <para>
+/// The parser has carried the media type the signature was built from for a while; nothing read it.
+/// An operation declaring <c>text/plain</c> generated a handler whose result went through the JSON
+/// serializer, so a plain-text endpoint described in a specification answered with a quoted JSON
+/// string under <c>application/json</c> — the one thing the document said it would not do.
+/// </para>
+/// </summary>
+public class RawResponseTests {
+
+    private const string PlainText =
+        """
+        openapi: "3.0.0"
+        info: { title: Text, version: "1.0" }
+        paths:
+          /greeting:
+            get:
+              tags: [Greeting]
+              operationId: getGreeting
+              responses:
+                '200':
+                  description: A greeting
+                  content:
+                    text/plain:
+                      schema: { type: string }
+        """;
+
+    private const string PlainTextRawBytes =
+        """
+        openapi: "3.0.0"
+        info: { title: Text, version: "1.0" }
+        paths:
+          /greeting:
+            get:
+              tags: [Greeting]
+              operationId: getGreeting
+              x-hardened-raw-bytes: true
+              responses:
+                '200':
+                  description: A greeting
+                  content:
+                    text/plain:
+                      schema: { type: string }
+        """;
+    /// <summary>
+    /// The default stays string, because that is what <c>type: string</c> means and what someone
+    /// reading the document expects the handler to return.
+    /// </summary>
+    [Fact]
+    public void ATextResponseIsAStringUnlessAskedOtherwise() {
+        var generated = OpenApiGenerator.Run(PlainText).AssertNoErrors()
+            .SourceContaining("petstore.g.cs");
+
+        Assert.Contains("Task<string> GetGreeting()", generated);
+        Assert.DoesNotContain("Task<byte[]>", generated);
+    }
+
+    /// <summary>
+    /// x-hardened-raw-bytes opts into byte[], which RawOutputHelper writes straight to the body
+    /// where a string is UTF-8 encoded into a fresh array per request.
+    /// </summary>
+    [Fact]
+    public void RawBytesOptsTheSignatureIntoByteArray() {
+        var generated = OpenApiGenerator.Run(PlainTextRawBytes).AssertNoErrors()
+            .SourceContaining("petstore.g.cs");
+
+        Assert.Contains("Task<byte[]> GetGreeting()", generated);
+    }
+    [Fact]
+    public void AByteArrayResponseCompilesForItsConsumer() {
+        OpenApiGenerator.Run(
+                PlainTextRawBytes,
+                OpenApiGenerator.EntryPointWithHandler(
+                    """
+                    [Handler]
+                    public class GreetingServiceImpl : IGreetingService {
+                        private static readonly byte[] Payload = "Hello"u8.ToArray();
+
+                        public Task<byte[]> GetGreeting() => Task.FromResult(Payload);
+                    }
+                    """))
+            .AssertNoErrors();
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/RequestModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/RequestModelBuilder.cs
@@ -330,6 +330,12 @@ internal static class RequestModelBuilder {
             }
         }
 
+        // byte[] in place of the string the schema asked for, when the operation opted in. Written
+        // before the Task<> wrap so the signature comes out Task<byte[]>.
+        if (operation.RawBytesResponse) {
+            returnType = TypeDefinition.Get(typeof(byte[]));
+        }
+
         if (returnType != null) {
             returnType = new GenericTypeDefinition(typeof(Task<>), new[] { returnType });
         }
@@ -340,5 +346,6 @@ internal static class RequestModelBuilder {
             TemplateName = operation.TemplateName
         };
     }
+
 
 }


### PR DESCRIPTION
`x-hardened-raw-bytes: true` on an operation makes the generated method return `Task<byte[]>` where the schema's `type: string` would give `Task<string>`.

```yaml
/greeting:
  get:
    operationId: getGreeting
    x-hardened-raw-bytes: true
    responses:
      '200':
        content:
          text/plain:
            schema: { type: string }
```

## Why opt in rather than infer it

The payload reaches the body either way; what differs is the encoding. The raw writer writes a `byte[]` straight out, where a `string` is UTF-8 encoded into a fresh array on **every request**. For a constant payload — the plaintext benchmark is exactly this — encoding once at startup removes an allocation from the hottest path there is.

But it only pays when the application already holds the value encoded. Encoding per request to satisfy a `byte[]` signature just moves the allocation somewhere less obvious. And `type: string` is what the document says and what someone reading it expects the handler to return, so the default has to stay `string`.

It is also not something the content map can express: `text/plain` describes the wire, not what the handler is holding.

## Carried through the serializer

The build task and the generator are separate processes, so anything not in `SpecModelSerializer` is silently lost between them.

## Tests

Three: the signature stays `string` by default, the extension changes it to `byte[]`, and a handler implementing the `byte[]` form compiles.

## What this deliberately does not do

I started by wiring the spec's media type into `RawResponseContentType`, so a `text/plain` operation would take the raw path. Three existing tests named `DoesNotForceTheContentType` failed, along with eight Fortunes tests, and their rationale is right:

> a content map describes the representation *available*, and the client says which it wants… `/plaintext` still answers text/plain because the client asks for it, and a handler that genuinely must force one says so with `[RawResponse]`.

Forcing the content type from the spec is the producer overruling `Accept`. Reverted; only the opt-in remains. Worth noting the guard did its job — that decision was already encoded in tests and they caught the attempt.

## Verification

Full suite: **2,266 passed, 0 failed**, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)