### PR TITLE
Flush the per-request metric logger from every web host

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
@@ -92,7 +92,7 @@ namespace Hardened.Requests.Testing
 {
     public class TestExecutionContext : Hardened.Requests.Abstract.Execution.IExecutionContext
     {
-        public TestExecutionContext(System.IServiceProvider rootServiceProvider, System.IServiceProvider requestServices, Hardened.Requests.Abstract.Execution.IKnownServices knownServices, Hardened.Requests.Abstract.Execution.IExecutionRequest request, Hardened.Requests.Abstract.Execution.IExecutionResponse response, System.Threading.CancellationToken cancellationToken) { }
+        public TestExecutionContext(System.IServiceProvider rootServiceProvider, System.IServiceProvider requestServices, Hardened.Requests.Abstract.Execution.IKnownServices knownServices, Hardened.Requests.Abstract.Execution.IExecutionRequest request, Hardened.Requests.Abstract.Execution.IExecutionResponse response, System.Threading.CancellationToken cancellationToken, Hardened.Shared.Runtime.Metrics.IMetricLogger? metricLogger = null) { }
         public System.Threading.CancellationToken CancellationToken { get; }
         public Hardened.Requests.Abstract.Execution.DefaultOutputFunc? DefaultOutput { get; set; }
         public Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo? HandlerInfo { get; set; }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/TestExecutionContextMetricsTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/TestExecutionContextMetricsTests.cs
@@ -1,0 +1,81 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Testing;
+using Hardened.Shared.Runtime.Metrics;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Execution;
+
+/// <summary>
+/// The harness context's metric sink.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This built its own <c>NullMetricsLogger</c> and ignored everything else, which had two effects.
+/// An application had no way to write a test asserting what a request emitted — the harness
+/// discarded every measurement the pipeline recorded. And <see cref="IExecutionContext.Clone"/>
+/// dropped the logger it was handed, so a test written against per-fork metric attribution would
+/// have passed no matter what the code under test did.
+/// </para>
+/// <para>
+/// That second one is the reason this file exists rather than a comment: the conformance suites and
+/// the Lambda batch filter both depend on a forked context carrying its own sink, and this type is
+/// what those tests would be written against.
+/// </para>
+/// </remarks>
+public class TestExecutionContextMetricsTests {
+
+    // Typed as the interface because the implementations do not repeat Clone's optional parameters
+    // - the defaults live on IExecutionContext - so a caller holding the concrete type has to pass
+    // all four.
+    private static IExecutionContext Create(IMetricLogger? metricLogger = null) {
+        var provider = Substitute.For<IServiceProvider>();
+
+        return new TestExecutionContext(
+            provider,
+            provider,
+            Substitute.For<IKnownServices>(),
+            Substitute.For<IExecutionRequest>(),
+            Substitute.For<IExecutionResponse>(),
+            CancellationToken.None,
+            metricLogger);
+    }
+
+    [Fact]
+    public void TheContextRecordsIntoTheLoggerItWasGiven() {
+        var metricLogger = Substitute.For<IMetricLogger>();
+
+        Assert.Same(metricLogger, Create(metricLogger).RequestMetrics);
+    }
+
+    /// <summary>
+    /// Omitting one is still valid — most tests do not care — and gets the null sink this type
+    /// used to hardcode.
+    /// </summary>
+    [Fact]
+    public void OmittingALoggerFallsBackToTheNullSink() {
+        Assert.IsType<NullMetricsLogger>(Create().RequestMetrics);
+    }
+
+    [Fact]
+    public void CloneKeepsTheParentsLoggerWhenGivenNone() {
+        var metricLogger = Substitute.For<IMetricLogger>();
+        var clone = Create(metricLogger).Clone();
+
+        Assert.Same(metricLogger, clone.RequestMetrics);
+    }
+
+    /// <summary>
+    /// The one that was broken. A fork exists to be measured separately.
+    /// </summary>
+    [Fact]
+    public void CloneTakesTheLoggerItIsGiven() {
+        var parent = Substitute.For<IMetricLogger>();
+        var fork = Substitute.For<IMetricLogger>();
+
+        var clone = Create(parent).Clone(metricLogger: fork);
+
+        Assert.Same(fork, clone.RequestMetrics);
+        Assert.NotSame(parent, clone.RequestMetrics);
+    }
+}

--- a/src/Requests/Hardened.Requests.Testing/TestExecutionContext.cs
+++ b/src/Requests/Hardened.Requests.Testing/TestExecutionContext.cs
@@ -5,19 +5,29 @@ using Hardened.Shared.Runtime.Metrics;
 namespace Hardened.Requests.Testing;
 
 public class TestExecutionContext : IExecutionContext {
+    /// <param name="metricLogger">
+    /// The sink measurements recorded during the request land in. Optional, and a
+    /// <see cref="NullMetricsLogger"/> when omitted, which is what this always used to build.
+    ///
+    /// Hardcoding it meant the harness had no metric seam at all: an application could not write a
+    /// test asserting what a request emitted, and <see cref="Clone"/> silently discarded the logger
+    /// it was handed - so a test about per-fork attribution would have passed against any behaviour
+    /// whatsoever.
+    /// </param>
     public TestExecutionContext(
         IServiceProvider rootServiceProvider,
         IServiceProvider requestServices,
         IKnownServices knownServices,
         IExecutionRequest request,
         IExecutionResponse response,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken,
+        IMetricLogger? metricLogger = null) {
         RootServiceProvider = rootServiceProvider;
         RequestServices = requestServices;
         Request = request;
         Response = response;
         KnownServices = knownServices;
-        RequestMetrics = new NullMetricsLogger();
+        RequestMetrics = metricLogger ?? new NullMetricsLogger();
         StartTime = MachineTimestamp.Now;
         CancellationToken = cancellationToken;
     }
@@ -33,7 +43,8 @@ public class TestExecutionContext : IExecutionContext {
             KnownServices,
             request ?? Request,
             response ?? Response,
-            CancellationToken) {
+            CancellationToken,
+            metricLogger ?? RequestMetrics) {
             HandlerInstance = HandlerInstance,
             HandlerInfo = HandlerInfo,
         };

--- a/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Impl/AspNetCoreRequestHandlerTests.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Impl/AspNetCoreRequestHandlerTests.cs
@@ -40,6 +40,37 @@ public class AspNetCoreRequestHandlerTests {
         harness.MetricLogger.Received(1).Record(RequestMetrics.TotalRequestDuration, Arg.Any<double>());
     }
 
+    /// <summary>
+    /// The logger is created per request and nothing else owns it. Disposal is how a provider
+    /// learns the request finished — <c>EmbeddedMetricLogger</c> writes its EMF line there — so a
+    /// host that never disposes gets nothing out of any provider that emits on completion.
+    /// </summary>
+    [Fact]
+    public async Task HandleRequest_FlushesTheMetricLogger() {
+        var harness = new Harness();
+
+        await harness.Handler.HandleRequest(harness.HttpContext, _ => Task.CompletedTask);
+
+        harness.MetricLogger.Received(1).Dispose();
+    }
+
+    /// <summary>
+    /// The close-out ran as straight-line statements after the chain, so an exception on its way to
+    /// ASP.NET's own handler took the duration, the end and the flush with it — leaving no record
+    /// of the request most worth having one.
+    /// </summary>
+    [Fact]
+    public async Task HandleRequest_ClosesTheRequestOutWhenTheChainThrows() {
+        var harness = new Harness(chainEffect: _ => throw new InvalidOperationException("boom"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => harness.Handler.HandleRequest(harness.HttpContext, _ => Task.CompletedTask));
+
+        harness.MetricLogger.Received(1).Record(RequestMetrics.TotalRequestDuration, Arg.Any<double>());
+        harness.RequestLogger.Received(1).RequestEnd(Arg.Any<IExecutionContext>());
+        harness.MetricLogger.Received(1).Dispose();
+    }
+
     [Fact]
     public async Task HandleRequest_RunsTheExecutionChain() {
         var harness = new Harness();

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetCoreRequestHandler.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetCoreRequestHandler.cs
@@ -44,18 +44,29 @@ public class AspNetCoreRequestHandler : IAspNetCoreRequestHandler {
 
         _requestLogger.RequestBegin(executionContext);
 
-        var executionChain = _middlewareService.GetExecutionChain(executionContext);
+        try {
+            var executionChain = _middlewareService.GetExecutionChain(executionContext);
 
-        await executionChain.Next();
+            await executionChain.Next();
 
-        if (!Answered(executionContext)) {
-            await requestDelegate(context);
+            if (!Answered(executionContext)) {
+                await requestDelegate(context);
+            }
         }
+        finally {
+            // In a finally because these ran as straight-line statements after the chain, so an
+            // exception escaping to ASP.NET's own handler took the whole close-out with it: no
+            // duration, no end, and no flush. A request that threw is one worth having a record of.
+            executionContext.RequestMetrics.Record(
+                RequestMetrics.TotalRequestDuration, requestStartTimestamp.GetElapsedMilliseconds());
 
-        executionContext.RequestMetrics.Record(
-            RequestMetrics.TotalRequestDuration, requestStartTimestamp.GetElapsedMilliseconds());
+            _requestLogger.RequestEnd(executionContext);
 
-        _requestLogger.RequestEnd(executionContext);
+            // The logger is per request and nothing else owns it. Disposal is how a provider learns
+            // the request finished - EmbeddedMetricLogger writes its EMF line here - so without it
+            // any provider that emits on completion emitted nothing at all.
+            executionContext.RequestMetrics.Dispose();
+        }
     }
 
     /// <summary>

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/HardenedHttpApplicationTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Impl/HardenedHttpApplicationTests.cs
@@ -146,6 +146,22 @@ public class HardenedHttpApplicationTests {
     }
 
     /// <summary>
+    /// The metric logger is created per request in <c>CreateContext</c> and nothing else owns it.
+    /// Disposal is how a provider learns the request finished — <c>EmbeddedMetricLogger</c> writes
+    /// its EMF line there — so a host that recorded but never disposed produced nothing at all from
+    /// any provider that emits on completion.
+    /// </summary>
+    [Fact]
+    public void DisposeContext_FlushesTheMetricLogger() {
+        var harness = new Harness();
+        var context = harness.Application.CreateContext(new ServerFeatures().Collection);
+
+        harness.Application.DisposeContext(context, null);
+
+        harness.MetricLogger.Received(1).Dispose();
+    }
+
+    /// <summary>
     /// The per-request scope is the application's, so nothing else will dispose it. A leak here
     /// would show up as scoped services accumulating for the life of the process.
     /// </summary>

--- a/src/Web/Hardened.Web.Kestrel.Runtime/Impl/HardenedHttpApplication.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/Impl/HardenedHttpApplication.cs
@@ -114,6 +114,14 @@ public class HardenedHttpApplication : IHttpApplication<HardenedHttpApplication.
 
         _requestLogger.RequestEnd(execution);
 
+        // The logger is created per request in CreateContext and nothing else owns it. Disposal is
+        // how a provider learns the request finished - EmbeddedMetricLogger writes its EMF line
+        // here - so without it any provider that emits on completion emitted nothing at all.
+        //
+        // Kestrel calls DisposeContext for every request it created a context for, including one
+        // that threw, so this needs no guard of its own.
+        execution.RequestMetrics.Dispose();
+
         context.Scope.Dispose();
     }
 }

--- a/src/Web/Hardened.Web.Testing/TestWebApp.cs
+++ b/src/Web/Hardened.Web.Testing/TestWebApp.cs
@@ -11,6 +11,7 @@ using Hardened.Requests.Testing;
 using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Runtime.Diagnostics;
 using Hardened.Shared.Runtime.Json;
+using Hardened.Shared.Runtime.Metrics;
 using Hardened.Shared.Testing.Impl;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -63,12 +64,14 @@ public class TestWebApp : TestContext, ITestWebApp {
 
         var middlewareService = _applicationRoot.Provider.GetRequiredService<IMiddlewareService>();
         var requestLogger = _applicationRoot.Provider.GetRequiredService<IRequestLogger>();
+        var metricLoggerProvider = _applicationRoot.Provider.GetRequiredService<IMetricLoggerProvider>();
 
         var responseBody = new MemoryStream();
         var scope = _applicationRoot.Provider.CreateScope();
 
         var context = CreateContext(
-            httpMethod, path, webRequest, responseBody, scope);
+            httpMethod, path, webRequest, responseBody, scope,
+            metricLoggerProvider.CreateLogger("test-session"));
 
         context.Request.Headers[KnownHeaders.AcceptEncoding]= KnownEncoding.GZip;
 
@@ -89,13 +92,23 @@ public class TestWebApp : TestContext, ITestWebApp {
             Console.WriteLine(e);
             throw;
         }
+        finally {
+            // In a finally because these ran as straight-line statements after the chain, so a
+            // request that threw closed out nothing: no duration, no end, and the scope leaked.
+            context.RequestMetrics.Record(
+                RequestMetrics.TotalRequestDuration, startTimestamp.GetElapsedMilliseconds());
 
-        scope.Dispose();
+            requestLogger.RequestEnd(context);
+
+            // The logger is per request and nothing else owns it. Disposal is how a provider learns
+            // the request finished, so a harness assertion about what a request emitted has nothing
+            // to read without it.
+            context.RequestMetrics.Dispose();
+
+            scope.Dispose();
+        }
 
         responseBody.Position = 0;
-
-        context.RequestMetrics.Record(RequestMetrics.TotalRequestDuration, startTimestamp.GetElapsedMilliseconds());
-        requestLogger.RequestEnd(context);
 
         return new TestWebResponse(context.Response);
     }
@@ -123,7 +136,8 @@ public class TestWebApp : TestContext, ITestWebApp {
         string path,
         Action<TestWebRequest>? webRequest,
         MemoryStream responseBody,
-        IServiceScope serviceScope) {
+        IServiceScope serviceScope,
+        IMetricLogger metricLogger) {
         var header = new Dictionary<string, StringValues>();
 
         var testWebRequest = new TestWebRequest { Headers = header };
@@ -177,7 +191,8 @@ public class TestWebApp : TestContext, ITestWebApp {
             serviceScope.ServiceProvider.GetRequiredService<IKnownServices>(),
             request,
             response,
-            testWebRequest.Token.Value);
+            testWebRequest.Token.Value,
+            metricLogger);
     }
 
     private IQueryStringCollection ParseQueryStringFromPath(string path) {


### PR DESCRIPTION
Groundwork for P5.3 (a `Meter`-backed `IMetricLoggerProvider`), but the defect stands on its own.

## Three hosts created a logger and never disposed it

`HardenedHttpApplication`, `AspNetCoreRequestHandler` and `TestWebApp` each call `IMetricLoggerProvider.CreateLogger(...)` per request, record `TotalRequestDuration` into it, and never dispose. Disposal is how a provider learns the request finished — `EmbeddedMetricLogger.Dispose` is what writes the EMF line — so **any provider that emits on completion emitted nothing at all** from these three. `ApiGatewayEventProcessor` was the only host already doing it.

Invisible until now because the framework default is `NullMetricLoggerProvider`, whose logger discards everything. It stops being invisible the moment a `Meter`-backed provider exists, which is why this goes in ahead of that work rather than being discovered by it.

## Two of them also closed out only on the success path

The record, the end and the flush were straight-line statements after the chain. An exception on its way to ASP.NET's own handler took all three with it — and in `TestWebApp`, leaked the request scope too. Both now use a `finally`.

Kestrel needed no guard: it calls `DisposeContext` for every request it created a context for, including one that threw.

## The harness had no metric seam to flush

`TestWebApp`'s half of the above was fixing a symptom of nothing. `TestExecutionContext` hardcoded `new NullMetricsLogger()` and ignored everything else, which had two effects worth separating:

- **An application could not write a test asserting what a request emitted.** Every measurement the pipeline recorded went into a sink nothing could read.
- **`Clone` silently discarded the `metricLogger` argument it was handed**, so a test written against per-fork attribution would have passed against any behaviour whatsoever. That is exactly the shape of the batch bug just fixed in [Hardened.Amz#66](https://github.com/ipjohnson/Hardened.Amz/pull/66) — and this type is what a test for it would have been written against.

So the constructor takes an optional `IMetricLogger`, `Clone` passes it on, and `TestWebApp` resolves the provider like every other host.

## Public API

`TestExecutionContext`'s constructor gains an optional parameter. Additive with a default, so every existing caller still compiles — verified by building `Hardened.Amz` clean against this checkout — but it is a signature change, so the approved API file moves with it.

## Verification

Clean build, 0 warnings, 18/18 assemblies green. All five new tests were checked against the previous behaviour:

| Reverted | Fails |
|---|---|
| AspNet `finally` + dispose | `HandleRequest_FlushesTheMetricLogger`, `HandleRequest_ClosesTheRequestOutWhenTheChainThrows` |
| Kestrel dispose | `DisposeContext_FlushesTheMetricLogger` |
| `Clone` logger pass-through | `CloneTakesTheLoggerItIsGiven`, `CloneKeepsTheParentsLoggerWhenGivenNone` |

## Not included

`TestWebApp`'s wiring is covered by compilation and by the `TestExecutionContext` tests, not by an end-to-end assertion — that would mean standing up a full application with a recording provider swapped in, which is disproportionate for a harness. The two production hosts are covered directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnFd3pmQzm4m41u8vk1mbw