### PR TITLE
Give a oneOf a type that says which branch it is

### DIFF
--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -111,9 +111,24 @@ internal static class JsonTypeInfoEmitter {
         var sb = new StringBuilder();
 
         foreach (var schema in schemas) {
-            if (schema.Kind != SchemaKind.Object && schema.Kind != SchemaKind.Enum) continue;
             var name = NamingHelper.ToPascalCase(schema.Name);
             var typeName = TypeMapper.QualifiedName(modelsNamespace, name, false);
+
+            if (schema.Kind == SchemaKind.OneOf) {
+                var converter = TypeMapper.QualifiedName(
+                    modelsNamespace, OneOfEmitter.ConverterName(schema.Name), false);
+
+                // A value type like the generated enums, so both forms are answered: the nullable
+                // one is what an optional payload lands on, and GetNullableConverter finds the
+                // converter through the entry above.
+                sb.AppendLine(
+                    $"        if (type == typeof({typeName})) return JsonMetadataServices.CreateValueInfo<{typeName}>(options, {converter}.Instance);");
+                sb.AppendLine(
+                    $"        if (type == typeof({typeName}?)) return JsonMetadataServices.CreateValueInfo<{typeName}?>(options, JsonMetadataServices.GetNullableConverter<{typeName}>(options));");
+                continue;
+            }
+
+            if (schema.Kind != SchemaKind.Object && schema.Kind != SchemaKind.Enum) continue;
 
             sb.AppendLine($"        if (type == typeof({typeName})) return Create{name}TypeInfo(options);");
         }
@@ -455,7 +470,10 @@ internal static class JsonTypeInfoEmitter {
                 string.Equals(s.Name, refName, StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(NamingHelper.ToPascalCase(s.Name), NamingHelper.ToPascalCase(refName),
                     StringComparison.OrdinalIgnoreCase));
-            if (refSchema != null && refSchema.Kind == SchemaKind.Enum) {
+            // A choice type is a struct for the same reason a generated enum is - see
+            // TypeMapper.IsGeneratedChoice - so an optional one is T? here too.
+            if (refSchema != null &&
+                (refSchema.Kind == SchemaKind.Enum || refSchema.Kind == SchemaKind.OneOf)) {
                 return true;
             }
         }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfConverterEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfConverterEmitter.cs
@@ -1,0 +1,388 @@
+using System.Collections.Generic;
+using CSharpAuthor;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+
+namespace Hardened.Idl.Emitters;
+
+/// <summary>
+/// The converter that decides which branch a payload is, and reads it into that type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the part that makes the wrapper worth having. The document says a payload is one of
+/// several schemas; something has to decide which, and doing it here means it is decided once, while
+/// reading, rather than by every caller afterwards.
+/// </para>
+/// <para>
+/// A discriminator is the document saying which branch a payload is, so it is what this reads when
+/// there is one - <c>mapping</c> where declared, otherwise the schema's own name, which is what the
+/// specification says a bare discriminator implies. Without one the only thing left is the payload's
+/// shape, and that is a guess: two branches whose properties are all optional both match, and
+/// binding the first would be silently wrong. Hence off unless the file asks for it.
+/// </para>
+/// <para>
+/// Every read and write goes through a <c>JsonTypeInfo</c> taken from the options rather than the
+/// reflection overloads, so the whole path stays valid under trimming and AOT - which is the point
+/// of generating a resolver at all.
+/// </para>
+/// </remarks>
+internal static class OneOfConverterEmitter {
+
+    private static readonly ITypeDefinition Reader =
+        TypeDefinition.Get("System.Text.Json", "Utf8JsonReader");
+
+    private static readonly ITypeDefinition Writer =
+        TypeDefinition.Get("System.Text.Json", "Utf8JsonWriter");
+
+    /// <summary>The helpers' type parameter, which is a name rather than a type.</summary>
+    private static readonly ITypeDefinition Generic = TypeDefinition.Get("", "T");
+
+    private static readonly ITypeDefinition Options =
+        TypeDefinition.Get("System.Text.Json", "JsonSerializerOptions");
+
+    public static ClassDefinition Emit(
+        IConstructContainer container, SchemaModel schema, string modelsNamespace,
+        IReadOnlyList<SchemaModel> allSchemas) {
+        var name = NamingHelper.ToPascalCase(schema.Name);
+        var converterName = OneOfEmitter.ConverterName(schema.Name);
+        var wrapper = TypeDefinition.Get(modelsNamespace, name);
+        var branches = OneOfEmitter.Branches(schema, modelsNamespace);
+
+        var converter = container.AddClass(converterName);
+
+        converter.Modifiers |= ComponentModifier.Public | ComponentModifier.Sealed;
+        converter.AddBaseType(
+            new GenericTypeDefinition(
+                TypeDefinitionEnum.ClassDefinition,
+                "System.Text.Json.Serialization",
+                "JsonConverter",
+                new[] { wrapper }));
+
+        converter.Comment = $"Reads and writes {name}, resolving which type a payload is.";
+
+        var instance = converter.AddField(
+            TypeDefinition.Get(modelsNamespace, converterName), "Instance");
+
+        instance.Modifiers |=
+            ComponentModifier.Public | ComponentModifier.Static | ComponentModifier.Readonly;
+        instance.InitializeValue = new CodeOutputComponent("new()") { Indented = false };
+
+        EmitRead(converter, schema, wrapper, branches, modelsNamespace, allSchemas);
+        EmitWrite(converter, schema, wrapper, branches, modelsNamespace);
+        EmitHelpers(converter);
+
+        return converter;
+    }
+
+    private static void EmitRead(
+        ClassDefinition converter, SchemaModel schema, ITypeDefinition wrapper,
+        List<string> branches, string modelsNamespace, IReadOnlyList<SchemaModel> allSchemas) {
+        var method = converter.AddMethod("Read");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        method.SetReturnType(wrapper);
+        method.AddParameter(Reader, "reader").Modifier = ParameterModifier.Ref;
+        method.AddParameter(TypeDefinition.Get(typeof(System.Type)), "typeToConvert");
+        method.AddParameter(Options, "options");
+
+        var lines = new List<string> {
+            // Buffered, because deciding the branch means looking at the payload before reading it,
+            // and a reader cannot be rewound.
+            "using var document = global::System.Text.Json.JsonDocument.ParseValue(ref reader);",
+            "var element = document.RootElement;",
+            ""
+        };
+
+        if (schema.DiscriminatorPropertyName != null && schema.DiscriminatorMapping.Count > 0) {
+            Discriminated(lines, schema, modelsNamespace);
+        } else {
+            ShapeMatched(lines, schema, modelsNamespace, allSchemas);
+        }
+
+        Write(method, lines);
+    }
+
+    private static void Discriminated(
+        List<string> lines, SchemaModel schema, string modelsNamespace) {
+        var property = Escape(schema.DiscriminatorPropertyName!);
+
+        lines.Add($"if (!element.TryGetProperty(\"{property}\", out var discriminator))");
+        lines.Add("{");
+        lines.Add("    throw new global::System.Text.Json.JsonException(");
+        lines.Add($"        \"Expected a '{property}' property to say which type this is.\");");
+        lines.Add("}");
+        lines.Add("");
+        lines.Add("var kind = discriminator.GetString();");
+        lines.Add("");
+        lines.Add("return kind switch");
+        lines.Add("{");
+
+        foreach (var mapping in schema.DiscriminatorMapping) {
+            var branch = TypeMapper.QualifiedName(
+                modelsNamespace, NamingHelper.ToPascalCase(TypeMapper.GetRefName(mapping.Ref)), false);
+
+            lines.Add($"    \"{Escape(mapping.Value)}\" => new(Read<{branch}>(element, options)),");
+        }
+
+        lines.Add("    _ => throw new global::System.Text.Json.JsonException(");
+        lines.Add($"        \"'\" + kind + \"' is not a type '{property}' may name.\")");
+        lines.Add("};");
+    }
+
+    /// <summary>
+    /// The test <see cref="ChoiceResolution"/> worked out for each branch, strongest evidence first.
+    /// </summary>
+    /// <remarks>
+    /// Not a try-each-in-turn: two branches whose properties are all optional both read, so the
+    /// first would win and the payload would silently become the wrong type. Every test emitted
+    /// here was proved to hold for exactly one branch before any of this was written - which is
+    /// also why there is no case for "matched several".
+    /// </remarks>
+    /// <summary>
+    /// The test <see cref="ChoiceResolution"/> proved for each branch, and match counting for any
+    /// branch it could not prove.
+    /// </summary>
+    /// <remarks>
+    /// Never a first-one-that-reads: that is what <c>serde(untagged)</c> and Pydantic's default do,
+    /// and it binds the wrong type without saying so. Where the schemas prove a branch apart the
+    /// test is exact and costs one comparison. Where they do not, every candidate is tried and
+    /// exactly one has to match - the same answer openapi-generator gives, and reached only for the
+    /// branches that needed it.
+    /// </remarks>
+    private static void ShapeMatched(
+        List<string> lines, SchemaModel schema, string modelsNamespace,
+        IReadOnlyList<SchemaModel> allSchemas) {
+        var plan = ChoiceResolution.Resolve(schema.OneOf, allSchemas);
+
+        var tag = 0;
+
+        foreach (var branch in plan.Branches) {
+            if (!branch.Proved) {
+                continue;
+            }
+
+            var type = TypeMapper.QualifiedName(
+                modelsNamespace, ChoiceResolution.CSharpType(branch.Model), false);
+
+            if (branch.ValueKind != null) {
+                // Boolean is two kinds in System.Text.Json and one type here.
+                var test = branch.ValueKind == "Boolean"
+                    ? "element.ValueKind is global::System.Text.Json.JsonValueKind.True or " +
+                      "global::System.Text.Json.JsonValueKind.False"
+                    : $"element.ValueKind == global::System.Text.Json.JsonValueKind.{branch.ValueKind}";
+
+                lines.Add($"if ({test})");
+            } else if (branch.ConstProperty != null) {
+                // Numbered, because several branches in one method each declare one and C# scopes
+                // an out variable to the whole method body rather than to its if.
+                var name = "tag" + tag++.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+                lines.Add(
+                    $"if (element.TryGetProperty(\"{Escape(branch.ConstProperty)}\", out var {name}) && " +
+                    $"{name}.ValueEquals(\"{Escape(branch.ConstValue!)}\"))");
+            } else {
+                lines.Add(
+                    $"if (element.TryGetProperty(\"{Escape(branch.DistinctProperty!)}\", out _))");
+            }
+
+            lines.Add("{");
+            lines.Add($"    return new(Read<{type}>(element, options));");
+            lines.Add("}");
+            lines.Add("");
+        }
+
+        if (plan.Overlapping.Count == 0) {
+            lines.Add("throw new global::System.Text.Json.JsonException(");
+            lines.Add(
+                $"    \"The payload matched none of the {plan.Branches.Count} permitted types.\");");
+
+            return;
+        }
+
+        // The branches nothing separates on paper. A payload usually settles it - two schemas whose
+        // properties are all optional overlap until one arrives carrying a property only one of them
+        // declares - so each is tried and the count decides.
+        lines.Add("object? matched = null;");
+        lines.Add("var matches = 0;");
+        lines.Add("");
+
+        foreach (var branch in plan.Overlapping) {
+            var type = TypeMapper.QualifiedName(
+                modelsNamespace, ChoiceResolution.CSharpType(branch.Model), false);
+
+            lines.Add("try");
+            lines.Add("{");
+            lines.Add($"    matched = Read<{type}>(element, options);");
+            lines.Add("    matches++;");
+            lines.Add("}");
+            lines.Add("catch (global::System.Text.Json.JsonException)");
+            lines.Add("{");
+            lines.Add("}");
+            lines.Add("");
+        }
+
+        lines.Add("if (matches == 1)");
+        lines.Add("{");
+        lines.Add("    return new(matched!);");
+        lines.Add("}");
+        lines.Add("");
+
+        // Both failures are worth telling apart: nothing matched is a payload the schema does not
+        // describe, and several matched is a payload the schema describes two ways.
+        lines.Add("throw new global::System.Text.Json.JsonException(");
+        lines.Add("    matches == 0");
+        lines.Add(
+            $"        ? \"The payload matched none of the {plan.Branches.Count} permitted types.\"");
+        lines.Add(
+            "        : \"The payload matched \" + matches + \" permitted types at once, so which " +
+            "one it is cannot be decided.\");");
+    }
+
+    private static void EmitWrite(
+        ClassDefinition converter, SchemaModel schema, ITypeDefinition wrapper,
+        List<string> branches, string modelsNamespace) {
+        var method = converter.AddMethod("Write");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        method.AddParameter(Writer, "writer");
+        method.AddParameter(wrapper, "value");
+        method.AddParameter(Options, "options");
+
+        var discriminator = Discriminators(schema, modelsNamespace);
+        var lines = new List<string> { "switch (value.Value)", "{" };
+
+        foreach (var branch in branches) {
+            lines.Add($"    case {branch} branch:");
+
+            if (schema.DiscriminatorPropertyName != null &&
+                discriminator.TryGetValue(branch, out var value)) {
+                lines.Add(
+                    "        Write(writer, branch, options, " +
+                    $"\"{Escape(schema.DiscriminatorPropertyName)}\", \"{Escape(value)}\");");
+            } else {
+                lines.Add("        Write(writer, branch, options, null, null);");
+            }
+
+            lines.Add("        break;");
+        }
+
+        // Reachable only through default(T), which nothing here produces - but writing null for it
+        // would put a payload on the wire that the schema does not permit.
+        lines.Add("    default:");
+        lines.Add("        throw new global::System.Text.Json.JsonException(");
+        lines.Add("            \"The value is not one of the permitted types.\");");
+        lines.Add("}");
+
+        Write(method, lines);
+    }
+
+    /// <summary>The discriminator value for each branch, by the branch's qualified name.</summary>
+    private static Dictionary<string, string> Discriminators(
+        SchemaModel schema, string modelsNamespace) {
+        var values = new Dictionary<string, string>(System.StringComparer.Ordinal);
+
+        foreach (var mapping in schema.DiscriminatorMapping) {
+            var branch = TypeMapper.QualifiedName(
+                modelsNamespace, NamingHelper.ToPascalCase(TypeMapper.GetRefName(mapping.Ref)), false);
+
+            // First wins: a document may map two values onto one schema, and the payload can only
+            // carry one of them.
+            if (!values.ContainsKey(branch)) {
+                values[branch] = mapping.Value;
+            }
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// Reading and writing one branch, through the resolver rather than the reflection overloads.
+    /// </summary>
+    private static void EmitHelpers(ClassDefinition converter) {
+        var read = converter.AddMethod("Read");
+
+        read.Modifiers |= ComponentModifier.Private | ComponentModifier.Static;
+        read.AddGenericParameter(Generic);
+        read.SetReturnType(Generic);
+        read.AddParameter(TypeDefinition.Get("System.Text.Json", "JsonElement"), "element");
+        read.AddParameter(Options, "options");
+
+        Write(read, new List<string> {
+            "var typeInfo = (global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>)",
+            "    options.GetTypeInfo(typeof(T));",
+            "",
+            "var value = global::System.Text.Json.JsonSerializer.Deserialize(element, typeInfo);",
+            "",
+            "if (value is null)",
+            "{",
+            "    throw new global::System.Text.Json.JsonException(",
+            "        \"Expected \" + typeof(T).Name + \", found null.\");",
+            "}",
+            "",
+            "return value;"
+        });
+
+        var write = converter.AddMethod("Write");
+
+        write.Modifiers |= ComponentModifier.Private | ComponentModifier.Static;
+        write.AddGenericParameter(Generic);
+        write.AddParameter(Writer, "writer");
+        write.AddParameter(Generic, "value");
+        write.AddParameter(Options, "options");
+        write.AddParameter(TypeDefinition.Get(typeof(string)).MakeNullable(), "discriminator");
+        write.AddParameter(TypeDefinition.Get(typeof(string)).MakeNullable(), "kind");
+
+        Write(write, new List<string> {
+            "var typeInfo = (global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>)",
+            "    options.GetTypeInfo(typeof(T));",
+            "",
+            "if (discriminator is null || kind is null)",
+            "{",
+            "    global::System.Text.Json.JsonSerializer.Serialize(writer, value, typeInfo);",
+            "    return;",
+            "}",
+            "",
+            "var element = global::System.Text.Json.JsonSerializer.SerializeToElement(value, typeInfo);",
+            "",
+            "// A branch that is not an object has nowhere to carry a discriminator; the document",
+            "// declaring one on it is a contradiction this cannot resolve, so the value goes out",
+            "// as it is rather than being wrapped in something the schema does not describe.",
+            "if (element.ValueKind != global::System.Text.Json.JsonValueKind.Object)",
+            "{",
+            "    element.WriteTo(writer);",
+            "    return;",
+            "}",
+            "",
+            "writer.WriteStartObject();",
+            "writer.WriteString(discriminator, kind);",
+            "",
+            "foreach (var property in element.EnumerateObject())",
+            "{",
+            "    // Skipped rather than written twice - the value above is the authority.",
+            "    if (property.NameEquals(discriminator))",
+            "    {",
+            "        continue;",
+            "    }",
+            "",
+            "    property.WriteTo(writer);",
+            "}",
+            "",
+            "writer.WriteEndObject();"
+        });
+    }
+
+    /// <summary>
+    /// Bodies are added as lines rather than statements: <c>AddIndentedStatement</c> appends a
+    /// <c>;</c> per component, which turns a brace into <c>{;</c> and an <c>if</c> into a statement
+    /// that guards nothing - code that compiles and does the opposite of what it says.
+    /// </summary>
+    private static void Write(MethodDefinition method, List<string> lines) {
+        foreach (var line in lines) {
+            method.Add(new CodeOutputComponent(line) { Indented = true });
+        }
+    }
+
+    private static string Escape(string value) =>
+        value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfEmitter.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using CSharpAuthor;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+
+namespace Hardened.Idl.Emitters;
+
+/// <summary>
+/// A type holding exactly one of the schemas a <c>oneOf</c> names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The alternative was to type the property <c>JsonElement</c> and let the caller take it apart,
+/// which is what happened before this: the payload arrived as unparsed JSON, the branch types were
+/// reachable from nothing so they were not generated at all, and the caller who wanted a <c>Cat</c>
+/// had neither the type nor a way to know it was one. Here the converter resolves the branch while
+/// reading, so <c>Value</c> is already a <c>Cat</c> and <c>switch (payload.Value)</c> binds it.
+/// </para>
+/// <para>
+/// A struct, so an optional payload is <c>T?</c> and a required one cannot be null - the same shape
+/// a generated enum already has, which is why the type mapper needs one predicate for both. The
+/// constructor is the only way in and it refuses anything that is not a branch, so the only instance
+/// that can hold nothing is <c>default</c>, which nothing here produces. It would be a
+/// <c>readonly struct</c> if CSharpAuthor rendered that modifier on a type; the single get-only
+/// property makes it immutable either way.
+/// </para>
+/// <para>
+/// Named for where it is declared rather than for what it holds - <c>OneOfHolderPayload</c> rather
+/// than <c>CatOrDog</c> - so adding a branch does not rename the type, and a document with fifteen
+/// of them does not produce a name with fifteen words in it.
+/// </para>
+/// <para>
+/// <b>C# 15 declares this natively</b> - <c>public union OneOfHolderPayload(Cat, Dog);</c> - and it
+/// is the same design: cases composed from existing types, implicit conversions from each, and the
+/// contents in a public <c>Value</c> of type <c>object?</c>. What the language adds is what a
+/// generator cannot: <c>switch (payload)</c> unwraps without naming <c>Value</c>, and a switch
+/// covering every case is checked for exhaustiveness.
+/// </para>
+/// <para>
+/// Not emitted here because generated code compiles in the consumer's project, and unions need
+/// <c>net11.0</c>. When that is the floor this becomes a second emit gated on the target framework,
+/// and it is not a breaking change for anyone: <c>Value</c> is spelled the same either way, so
+/// <c>switch (payload.Value) { case Cat c: ... }</c> written against this keeps compiling against
+/// the native one. The converter is needed in both cases - the union feature says nothing about
+/// System.Text.Json - so the discriminator and shape work is what carries over.
+/// </para>
+/// </remarks>
+internal static class OneOfEmitter {
+
+    /// <summary>The converter's type name, which the allocator reserves alongside the type.</summary>
+    public static string ConverterName(string schemaName) =>
+        NamingHelper.ToPascalCase(schemaName) + "Converter";
+
+    public static ClassDefinition Emit(
+        IConstructContainer container, SchemaModel schema, string modelsNamespace) {
+        var name = NamingHelper.ToPascalCase(schema.Name);
+        var branches = Branches(schema, modelsNamespace);
+        var readable = Readable(branches);
+
+        var type = container.AddClass(name);
+
+        type.TypeKeyword = ClassKeyword.Struct;
+        type.Modifiers |= ComponentModifier.Public;
+        type.Comment = DocComment.Format(schema.Description) ?? $"One of {readable}.";
+
+        EmitValue(type);
+        EmitConstructor(type, name, branches, readable);
+        EmitConversions(type, name, branches);
+        EmitToString(type);
+
+        return type;
+    }
+
+    /// <summary>
+    /// Nullable, because <c>default</c> bypasses the constructor. Nothing here produces one, and a
+    /// caller who writes it gets a value that matches no branch in a <c>switch</c> rather than a
+    /// null reference at some later point.
+    /// </summary>
+    private static void EmitValue(ClassDefinition type) {
+        var value = type.AddProperty(TypeDefinition.Get(typeof(object)).MakeNullable(), "Value");
+
+        value.Modifiers |= ComponentModifier.Public;
+        value.Comment = "The value, which is one of the types this may hold.";
+        value.Set = null;
+    }
+
+    private static void EmitConstructor(
+        ClassDefinition type, string name, List<string> branches, string readable) {
+        var constructor = type.AddConstructor();
+
+        constructor.Modifiers |= ComponentModifier.Public;
+        constructor.AddParameter(TypeDefinition.Get(typeof(object)), "value");
+        constructor.Comment = $"Wraps a value the schema permits.";
+
+        // The check the type exists for. Written as a pattern rather than a chain of `is`, so
+        // adding a branch adds a word instead of a clause.
+        //
+        // Add rather than AddIndentedStatement: that appends a ";" per component, which turns the
+        // guard into `if (...);` followed by an unconditional throw - code that compiles, and that
+        // refuses every value the type was built to accept.
+        var lines = new[] {
+            $"if (value is not ({string.Join(" or ", branches)}))",
+            "{",
+            "    throw new global::System.ArgumentException(",
+            $"        \"Expected {readable}, got \" + (value?.GetType().Name ?? \"null\") + \".\",",
+            "        nameof(value));",
+            "}",
+            "",
+            "Value = value;"
+        };
+
+        foreach (var line in lines) {
+            constructor.Add(new CodeOutputComponent(line) { Indented = true });
+        }
+    }
+
+    /// <summary>
+    /// One conversion per branch, so assigning a <c>Cat</c> where the payload goes is checked by the
+    /// compiler rather than by the constructor at run time.
+    /// </summary>
+    private static void EmitConversions(ClassDefinition type, string name, List<string> branches) {
+        foreach (var branch in branches) {
+            type.AddComponent(
+                new CodeOutputComponent(
+                    $"public static implicit operator {name}({branch} value) => new(value);") {
+                    Indented = true
+                });
+        }
+    }
+
+    private static void EmitToString(ClassDefinition type) {
+        var method = type.AddMethod("ToString");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        method.SetReturnType(TypeDefinition.Get(typeof(string)));
+        method.AddIndentedStatement("return Value?.ToString() ?? \"\"");
+    }
+
+    /// <summary>The branch types, qualified, in the order the document declares them.</summary>
+    public static List<string> Branches(SchemaModel schema, string modelsNamespace) {
+        var branches = new List<string>();
+
+        foreach (var described in schema.OneOf) {
+            var branch = TypeMapper.QualifiedName(
+                modelsNamespace, ChoiceResolution.CSharpType(described), false);
+
+            // A branch this parser could not type reads as JsonElement, which every other branch
+            // would also accept - so it is not one of the types the wrapper distinguishes.
+            if (branch.EndsWith("JsonElement", System.StringComparison.Ordinal)) {
+                continue;
+            }
+
+            if (!branches.Contains(branch)) {
+                branches.Add(branch);
+            }
+        }
+
+        return branches;
+    }
+
+    /// <summary>The branch list as prose, for a message a person reads.</summary>
+    private static string Readable(List<string> branches) {
+        var names = new List<string>();
+
+        foreach (var branch in branches) {
+            var lastDot = branch.LastIndexOf('.');
+
+            names.Add(lastDot >= 0 ? branch.Substring(lastDot + 1) : branch);
+        }
+
+        return names.Count switch {
+            0 => "nothing",
+            1 => names[0],
+            _ => string.Join(", ", names.GetRange(0, names.Count - 1)) + " or " + names[names.Count - 1]
+        };
+    }
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
@@ -28,8 +28,24 @@ internal static class SchemaEmitter {
         schema.Kind switch {
             SchemaKind.Object => EmitRecord(container, schema, modelsNamespace, patterns, allSchemas),
             SchemaKind.Enum => EmitEnum(container, schema),
+            SchemaKind.OneOf => EmitOneOf(container, schema, modelsNamespace, allSchemas),
             _ => null,
         };
+
+    /// <summary>
+    /// The choice type and the converter that resolves it, which are one thing in two declarations.
+    /// </summary>
+    private static IOutputComponent EmitOneOf(
+        IConstructContainer container, SchemaModel schema, string modelsNamespace,
+        IReadOnlyList<SchemaModel>? allSchemas) {
+        var type = OneOfEmitter.Emit(container, schema, modelsNamespace);
+
+        OneOfConverterEmitter.Emit(
+            container, schema, modelsNamespace,
+            allSchemas ?? System.Array.Empty<SchemaModel>());
+
+        return type;
+    }
 
     /// <summary>
     /// A positional record, or a declaration-only one when the schema carries no properties.

--- a/src/SourceGenerators/Hardened.Idl.Emit/Filtering/SpecSlicer.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Filtering/SpecSlicer.cs
@@ -201,8 +201,8 @@ internal static class SpecSlicer {
                 // The property is typed JsonElement, so nothing emitted names these - but they are
                 // what the payload is allowed to be, and a caller deserializing into one needs the
                 // type to exist.
-                foreach (var branch in property.OneOfRefs) {
-                    Reach(branch);
+                foreach (var branch in property.OneOf) {
+                    Reach(branch.Ref);
                 }
             }
         }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/ChoiceResolution.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/ChoiceResolution.cs
@@ -1,0 +1,284 @@
+using System.Collections.Generic;
+using Hardened.Idl.Models;
+
+namespace Hardened.Idl;
+
+/// <summary>
+/// How a payload is told apart from the other branches of a <c>oneOf</c>, decided here rather than
+/// at run time wherever it can be.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Two questions, not one.</b> Whether the branches overlap is a property of the schemas and is
+/// answered here. Whether a <em>particular payload</em> is ambiguous is a property of that payload
+/// and can only be answered when it arrives. Conflating them is why the first version of this
+/// refused to generate a type for 16% of the corpus's choices: two schemas whose properties are all
+/// optional overlap on paper, but a payload carrying <c>meow</c> matches only one of them.
+/// </para>
+/// <para>
+/// So a branch gets a static test where the schemas prove one - 84% of the corpus - and where they
+/// do not, the branch is still generated and decided by counting matches when a payload arrives.
+/// What is never done is taking the first branch that reads, which is what
+/// <c>serde(untagged)</c> and Pydantic's default do and is the one behaviour that binds the wrong
+/// type without saying so.
+/// </para>
+/// <para>
+/// <b>What the corpus declares.</b> Of 338 undiscriminated <c>oneOf</c> properties across 38
+/// published descriptions, 189 have branches of different JSON kinds - <c>oneOf: [string,
+/// boolean]</c> and the like - 57 give one branch a property no other has, 18 differ by required
+/// set, and 19 carry a <c>const</c> that is a discriminator in all but name.
+/// </para>
+/// <para>
+/// <b>The tests are ordered by how much they prove.</b> A value kind is a fact about the payload; a
+/// property unique to one branch is a fact about the schemas; a required set is a promise the
+/// document makes. Applying them in that order means a branch is chosen on the strongest evidence
+/// available rather than on whichever test happened to be written first.
+/// </para>
+/// </remarks>
+internal static class ChoiceResolution {
+
+    /// <summary>How one branch is recognised.</summary>
+    internal sealed class Branch {
+        public Branch(ChoiceBranchModel model) {
+            Model = model;
+        }
+
+        public ChoiceBranchModel Model { get; }
+
+        /// <summary>
+        /// The JSON kind a payload must have, as a <c>JsonValueKind</c> member, or null where the
+        /// kind does not distinguish this branch from the others.
+        /// </summary>
+        public string? ValueKind { get; set; }
+
+        /// <summary>A property only this branch declares, if there is one.</summary>
+        public string? DistinctProperty { get; set; }
+
+        /// <summary>A property whose value only this branch permits, and that value.</summary>
+        public string? ConstProperty { get; set; }
+
+        public string? ConstValue { get; set; }
+
+        /// <summary>
+        /// Whether the schemas prove this branch apart from every other. False means the branch is
+        /// still generated and decided by counting matches on the payload.
+        /// </summary>
+        public bool Proved =>
+            ValueKind != null || DistinctProperty != null || ConstProperty != null;
+    }
+
+    internal sealed class Plan {
+        public List<Branch> Branches { get; } = new();
+
+        /// <summary>Branches no static test separates, which are decided when a payload arrives.</summary>
+        public List<Branch> Overlapping { get; } = new();
+
+        /// <summary>
+        /// Whether a type is worth generating at all. False only where nothing can read the branches
+        /// back - a choice whose every branch is a schema this parser could not resolve.
+        /// </summary>
+        public bool Usable { get; set; } = true;
+
+        /// <summary>Whether every branch has a static test, so no payload is ever counted.</summary>
+        public bool FullyProved => Overlapping.Count == 0;
+    }
+
+    public static Plan Resolve(
+        IReadOnlyList<ChoiceBranchModel> branches, IReadOnlyList<SchemaModel> schemas) {
+        var plan = new Plan();
+        var byName = new Dictionary<string, SchemaModel>(System.StringComparer.Ordinal);
+
+        foreach (var schema in schemas) {
+            byName[schema.Name] = schema;
+        }
+
+        var resolved = new List<SchemaModel?>();
+
+        foreach (var branch in branches) {
+            SchemaModel? schema = null;
+
+            if (branch.Ref != null) {
+                byName.TryGetValue(TypeMapper.GetRefName(branch.Ref), out schema);
+            }
+
+            resolved.Add(schema);
+            plan.Branches.Add(new Branch(branch));
+        }
+
+        AssignValueKinds(plan, resolved);
+        AssignDistinctProperties(plan, resolved);
+        AssignConstProperties(plan, resolved);
+
+        foreach (var branch in plan.Branches) {
+            if (!branch.Proved) {
+                plan.Overlapping.Add(branch);
+            }
+        }
+
+        // A branch that names a schema nothing declares cannot be read into anything, so a choice
+        // made entirely of those has no type to offer.
+        var readable = 0;
+
+        for (var index = 0; index < plan.Branches.Count; index++) {
+            if (plan.Branches[index].Model.Ref == null || resolved[index] != null) {
+                readable++;
+            }
+        }
+
+        plan.Usable = readable > 1;
+
+        return plan;
+    }
+
+    /// <summary>
+    /// A kind is a test only where it belongs to one branch alone, so two object branches leave both
+    /// to be separated by something else.
+    /// </summary>
+    private static void AssignValueKinds(Plan plan, List<SchemaModel?> resolved) {
+        var counts = new Dictionary<string, int>(System.StringComparer.Ordinal);
+
+        for (var index = 0; index < resolved.Count; index++) {
+            var kind = ValueKindOf(plan.Branches[index].Model, resolved[index]);
+
+            if (kind == null) {
+                continue;
+            }
+
+            counts.TryGetValue(kind, out var count);
+            counts[kind] = count + 1;
+        }
+
+        for (var index = 0; index < resolved.Count; index++) {
+            var kind = ValueKindOf(plan.Branches[index].Model, resolved[index]);
+
+            if (kind != null && counts[kind] == 1) {
+                plan.Branches[index].ValueKind = kind;
+            }
+        }
+    }
+
+    /// <summary>A property no other branch declares.</summary>
+    private static void AssignDistinctProperties(Plan plan, List<SchemaModel?> resolved) {
+        for (var index = 0; index < resolved.Count; index++) {
+            if (plan.Branches[index].Proved || resolved[index] == null) {
+                continue;
+            }
+
+            foreach (var property in resolved[index]!.Properties) {
+                if (!DeclaredElsewhere(property.Name, resolved, index)) {
+                    plan.Branches[index].DistinctProperty = property.Name;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A property pinned to one value is a discriminator the document did not label as one - which
+    /// is how a great many descriptions spell it.
+    /// </summary>
+    private static void AssignConstProperties(Plan plan, List<SchemaModel?> resolved) {
+        for (var index = 0; index < resolved.Count; index++) {
+            var branch = plan.Branches[index];
+
+            if (branch.Proved || resolved[index] == null) {
+                continue;
+            }
+
+            foreach (var property in resolved[index]!.Properties) {
+                if (property.EnumValues is not { Count: 1 }) {
+                    continue;
+                }
+
+                var value = property.EnumValues[0];
+
+                if (!ValueUsedElsewhere(property.Name, value, resolved, index)) {
+                    branch.ConstProperty = property.Name;
+                    branch.ConstValue = value;
+                    break;
+                }
+            }
+        }
+    }
+
+    private static bool DeclaredElsewhere(string property, List<SchemaModel?> resolved, int skip) {
+        for (var index = 0; index < resolved.Count; index++) {
+            if (index == skip || resolved[index] == null) {
+                continue;
+            }
+
+            foreach (var other in resolved[index]!.Properties) {
+                if (string.Equals(other.Name, property, System.StringComparison.Ordinal)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ValueUsedElsewhere(
+        string property, string value, List<SchemaModel?> resolved, int skip) {
+        for (var index = 0; index < resolved.Count; index++) {
+            if (index == skip || resolved[index] == null) {
+                continue;
+            }
+
+            foreach (var other in resolved[index]!.Properties) {
+                if (!string.Equals(other.Name, property, System.StringComparison.Ordinal)) {
+                    continue;
+                }
+
+                // A property of the same name with no fixed value could carry anything, this value
+                // included.
+                if (other.EnumValues == null || other.EnumValues.Contains(value)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The <c>JsonValueKind</c> a payload of this branch arrives as.
+    /// </summary>
+    /// <remarks>
+    /// Integer and number are one kind, and so are all the string formats - the reader does not see
+    /// those distinctions, so neither can a test written against it. <c>true</c> and <c>false</c>
+    /// are two kinds in System.Text.Json and one type here, which is why a boolean branch is matched
+    /// with a check rather than a switch label.
+    /// </remarks>
+    private static string? ValueKindOf(ChoiceBranchModel branch, SchemaModel? schema) {
+        if (schema != null) {
+            if (schema.Kind == SchemaKind.Enum) {
+                return "String";
+            }
+
+            if (schema.Kind == SchemaKind.Array) {
+                return "Array";
+            }
+
+            if (schema.Kind == SchemaKind.Object && schema.Properties.Count > 0) {
+                return "Object";
+            }
+        }
+
+        var type = schema?.Type ?? branch.Type;
+
+        return type?.ToLowerInvariant() switch {
+            "string" => "String",
+            "integer" or "number" => "Number",
+            "boolean" => "Boolean",
+            "array" => "Array",
+            "object" => "Object",
+            _ => null
+        };
+    }
+
+    /// <summary>The C# type a branch is read into.</summary>
+    public static string CSharpType(ChoiceBranchModel branch) =>
+        branch.Ref != null
+            ? NamingHelper.ToPascalCase(TypeMapper.GetRefName(branch.Ref))
+            : TypeMapper.MapToCSharpType(branch.Type, branch.Format);
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
@@ -59,12 +59,10 @@ internal static class ModelRefs {
                 yield return new Handle(
                     property.DictionaryValueRef, value => propertyCaptured.DictionaryValueRef = value);
 
-                for (var index = 0; index < property.OneOfRefs.Count; index++) {
-                    var position = index;
+                foreach (var branch in property.OneOf) {
+                    var branchCaptured = branch;
 
-                    yield return new Handle(
-                        property.OneOfRefs[position],
-                        value => propertyCaptured.OneOfRefs[position] = value ?? "");
+                    yield return new Handle(branch.Ref, value => branchCaptured.Ref = value);
                 }
             }
         }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
@@ -176,6 +176,12 @@ internal static class NameAllocator {
 
             scope.Reserve(allocated + "Validator");
 
+            // Same argument for a choice type: the converter is named after it and has nowhere
+            // else to go. See OneOfConverterEmitter.
+            if (schema.Kind == SchemaKind.OneOf) {
+                scope.Reserve(allocated + "Converter");
+            }
+
             if (allocated != schema.Name) {
                 renamed[schema.Name] = allocated;
                 schema.Name = allocated;

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
@@ -37,10 +37,48 @@ internal static class SpecDiagnostics {
         public bool Fatal { get; }
     }
 
+    /// <summary>
+    /// A <c>oneOf</c> that could not become a type, and why.
+    /// </summary>
+    /// <remarks>
+    /// The property lands on <c>JsonElement</c>, which works and is the weakest thing that does -
+    /// the caller gets unparsed JSON and no help deciding what is in it. Worth saying out loud
+    /// rather than leaving to be discovered: the fix is a discriminator in the document, or
+    /// ShapeMatchOneOf if the branches really can be told apart by shape.
+    /// </remarks>
+    private static void FindUnresolvableChoices(ServiceSpecModel model, List<Problem> problems) {
+        foreach (var schema in model.Schemas) {
+            if (schema.Kind != SchemaKind.OneOf || schema.DiscriminatorPropertyName != null) {
+                continue;
+            }
+
+            var plan = ChoiceResolution.Resolve(schema.OneOf, model.Schemas);
+
+            if (plan.FullyProved) {
+                continue;
+            }
+
+            var names = new List<string>();
+
+            foreach (var branch in plan.Overlapping) {
+                names.Add(ChoiceResolution.CSharpType(branch.Model));
+            }
+
+            problems.Add(new Problem(
+                "HOAT010",
+                $"'{schema.Name}' declares no discriminator and nothing in the schemas separates " +
+                $"{string.Join(" from ", names)}, so those are told apart by reading the payload " +
+                "into each and requiring exactly one to fit. A payload matching several is an " +
+                "error at that point. Declaring a discriminator would decide it here instead.",
+                fatal: false));
+        }
+    }
+
     public static IReadOnlyList<Problem> Find(ServiceSpecModel model) {
         var problems = new List<Problem>();
 
         FindDuplicateSchemaNames(model, problems);
+        FindUnresolvableChoices(model, problems);
 
         foreach (var schema in model.Schemas) {
             var typeName = NamingHelper.ToPascalCase(schema.Name);

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/ChoiceBranchModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/ChoiceBranchModel.cs
@@ -1,0 +1,72 @@
+namespace Hardened.Idl.Models;
+
+/// <summary>
+/// One of the things a <c>oneOf</c> permits.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A branch is a named schema or an inline type, and it has to be both because published
+/// descriptions are mostly the second kind: of 338 undiscriminated choices across the corpus, 200
+/// name nothing at all - <c>oneOf: [string, boolean]</c> and its variations - and another 45 mix a
+/// reference with an inline type. Modelling a branch as a reference covers 28% of them and silently
+/// drops the rest, which reads as a <c>oneOf</c> with one branch and produces no type.
+/// </para>
+/// <para>
+/// The two are exclusive: <see cref="Ref"/> names a schema the document declares, and
+/// <see cref="Type"/> is a type written in place. Nothing carries both.
+/// </para>
+/// </remarks>
+internal class ChoiceBranchModel : IEquatable<ChoiceBranchModel> {
+
+    /// <summary>The schema this branch names, or null for an inline one.</summary>
+    public string? Ref { get; set; }
+
+    /// <summary>The spec type written in place, or null for a reference.</summary>
+    public string? Type { get; set; }
+
+    /// <summary>The inline type's format, which decides what it maps to.</summary>
+    public string? Format { get; set; }
+
+    /// <summary>
+    /// The branch as one string, for the model file.
+    /// </summary>
+    /// <remarks>
+    /// A reference is written as itself; an inline type is prefixed with <c>=</c>, which a
+    /// reference cannot start with because one always begins <c>#/</c>. That keeps the whole list
+    /// on the existing string-list encoding rather than adding a record type and the ordering
+    /// machinery that goes with it.
+    /// </remarks>
+    public string Encoded =>
+        Ref ?? "=" + Type + (Format == null ? "" : ":" + Format);
+
+    public static ChoiceBranchModel Decode(string encoded) {
+        if (!encoded.StartsWith("=", StringComparison.Ordinal)) {
+            return new ChoiceBranchModel { Ref = encoded };
+        }
+
+        var body = encoded.Substring(1);
+        var colon = body.IndexOf(':');
+
+        return colon < 0
+            ? new ChoiceBranchModel { Type = Empty(body) }
+            : new ChoiceBranchModel {
+                Type = Empty(body.Substring(0, colon)),
+                Format = Empty(body.Substring(colon + 1))
+            };
+    }
+
+    private static string? Empty(string value) => value.Length == 0 ? null : value;
+
+    public bool Equals(ChoiceBranchModel? other) =>
+        other is not null && Ref == other.Ref && Type == other.Type && Format == other.Format;
+
+    public override bool Equals(object? obj) => Equals(obj as ChoiceBranchModel);
+
+    public override int GetHashCode() {
+        unchecked {
+            var hash = Ref?.GetHashCode() ?? 0;
+            hash = (hash * 397) ^ (Type?.GetHashCode() ?? 0);
+            return (hash * 397) ^ (Format?.GetHashCode() ?? 0);
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/PropertyModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/PropertyModel.cs
@@ -107,7 +107,7 @@ internal class PropertyModel : IEquatable<PropertyModel>, IConstraintFacets {
     /// deserialize into or switch over. Without this the reachability pass sees a property nothing
     /// points from, and the branch types are not emitted at all.
     /// </remarks>
-    public List<string> OneOfRefs { get; set; } = new();
+    public List<ChoiceBranchModel> OneOf { get; set; } = new();
 
     // Validation constraints
     public int? MinLength { get; set; }

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/SchemaModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/SchemaModel.cs
@@ -10,6 +10,17 @@ internal class SchemaModel : IEquatable<SchemaModel> {
     /// <summary>The schema's <c>description</c>, as the generated type's doc comment.</summary>
     public string? Description { get; set; }
     public List<PropertyModel> Properties { get; set; } = new();
+
+    /// <summary>
+    /// The schemas a <see cref="SchemaKind.OneOf"/> may hold, in declaration order.
+    /// </summary>
+    /// <remarks>
+    /// The document says a payload is exactly one of these, so the generated type says the same: it
+    /// carries the value as <c>object</c> and refuses anything that is not one of them. Order is the
+    /// document's, because it decides the order branches are tried when there is no discriminator to
+    /// key on.
+    /// </remarks>
+    public List<ChoiceBranchModel> OneOf { get; set; } = new();
     public List<string> EnumValues { get; set; } = new();
 
     /// <summary>
@@ -99,5 +110,11 @@ internal enum SchemaKind {
     Enum,
     Array,
     Primitive,
-    Dictionary
+    Dictionary,
+
+    /// <summary>
+    /// A choice between named schemas - a <c>oneOf</c>, which becomes a type holding exactly one of
+    /// them. See <see cref="SchemaModel.OneOf"/>.
+    /// </summary>
+    OneOf
 }

--- a/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
@@ -323,7 +323,7 @@ internal static class SpecModelSerializer {
         record.Add("DictionaryValueType", property.DictionaryValueType);
         record.Add("DictionaryValueRef", property.DictionaryValueRef);
         record.Add("EnumValues", property.EnumValues);
-        record.Add("OneOfRefs", property.OneOfRefs);
+        record.Add("OneOf", Encode(property.OneOf));
         record.Add("MinLength", property.MinLength);
         record.Add("MaxLength", property.MaxLength);
         record.Add("Minimum", property.Minimum);
@@ -334,6 +334,30 @@ internal static class SpecModelSerializer {
         record.Add("MinItems", property.MinItems);
         record.Add("MaxItems", property.MaxItems);
         record.WriteTo(builder);
+    }
+
+    private static List<string> Encode(List<ChoiceBranchModel> branches) {
+        var encoded = new List<string>(branches.Count);
+
+        foreach (var branch in branches) {
+            encoded.Add(branch.Encoded);
+        }
+
+        return encoded;
+    }
+
+    private static List<ChoiceBranchModel> Decode(List<string>? encoded) {
+        var branches = new List<ChoiceBranchModel>();
+
+        if (encoded == null) {
+            return branches;
+        }
+
+        foreach (var value in encoded) {
+            branches.Add(ChoiceBranchModel.Decode(value));
+        }
+
+        return branches;
     }
 
     private static PropertyModel ReadProperty(Record record) => new() {
@@ -355,7 +379,7 @@ internal static class SpecModelSerializer {
         DictionaryValueType = record.String("DictionaryValueType"),
         DictionaryValueRef = record.String("DictionaryValueRef"),
         EnumValues = record.Strings("EnumValues"),
-        OneOfRefs = record.Strings("OneOfRefs") ?? new List<string>(),
+        OneOf = Decode(record.Strings("OneOf")),
         MinLength = record.Int("MinLength"),
         MaxLength = record.Int("MaxLength"),
         Minimum = record.Decimal("Minimum"),

--- a/src/SourceGenerators/Hardened.Idl.Shared/TypeMapper.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/TypeMapper.cs
@@ -189,7 +189,32 @@ internal static class TypeMapper {
     /// </remarks>
     public static bool IsNonNullableValueType(
         string csType, IEnumerable<SchemaModel>? schemas) =>
-        IsNonNullableValueType(csType) || IsGeneratedEnum(csType, schemas);
+        IsNonNullableValueType(csType) ||
+        IsGeneratedEnum(csType, schemas) ||
+        IsGeneratedChoice(csType, schemas);
+
+    /// <summary>
+    /// Whether the type names a <c>oneOf</c> wrapper this specification generates.
+    /// </summary>
+    /// <remarks>
+    /// A struct, for the same reason a generated enum is one: an optional payload is then <c>T?</c>
+    /// and a required one cannot be null, which is what the schema says either way. Every caller
+    /// that had to know an enum was a value type has to know this too, and there is exactly one
+    /// place that answers the question.
+    /// </remarks>
+    public static bool IsGeneratedChoice(string csType, IEnumerable<SchemaModel>? schemas) {
+        if (schemas == null) {
+            return false;
+        }
+
+        foreach (var schema in schemas) {
+            if (schema.Kind == SchemaKind.OneOf && NamingHelper.ToPascalCase(schema.Name) == csType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Whether the type names an enum this specification generates.

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OneOfTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OneOfTests.cs
@@ -1,0 +1,460 @@
+using System.Collections.Generic;
+using System.Threading;
+using Hardened.Idl.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// A <c>oneOf</c> becoming a type that holds exactly one of its branches.
+/// </summary>
+/// <remarks>
+/// The property used to land on <c>JsonElement</c>: the payload arrived as unparsed JSON, the
+/// branch types were reachable from nothing so they were not generated, and a caller who wanted a
+/// <c>Cat</c> had neither the type nor a way to know it was one. What is asserted here is that the
+/// document decides - a discriminator resolves the branch, and without one nothing is guessed.
+/// </remarks>
+public class OneOfTests {
+
+    private static ServiceSpecModel Parse(string yaml) {
+        var model = OpenApiSpecParser.Parse(yaml, "spec", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static SchemaModel? Choice(ServiceSpecModel model) {
+        foreach (var schema in model.Schemas) {
+            if (schema.Kind == SchemaKind.OneOf) {
+                return schema;
+            }
+        }
+
+        return null;
+    }
+
+    [Fact]
+    public void ADiscriminatedChoiceBecomesATypeNamedForWhereItIsDeclared() {
+        var model = Parse(Discriminated);
+
+        var choice = Choice(model);
+
+        Assert.NotNull(choice);
+
+        // Named for its owner and property, not for its branches, so adding a branch does not
+        // rename it and fifteen branches do not produce a fifteen-word name.
+        Assert.Equal("HolderPayload", choice!.Name);
+        Assert.Equal("kind", choice.DiscriminatorPropertyName);
+        Assert.Equal(2, choice.OneOf.Count);
+    }
+
+    /// <summary>The property is typed as the choice, which is the whole point.</summary>
+    [Fact]
+    public void ThePropertyIsTypedAsTheChoiceRatherThanLeftLoose() {
+        var model = Parse(Discriminated);
+
+        var holder = Assert.Single(model.Schemas, schema => schema.Name == "Holder");
+        var payload = Assert.Single(holder.Properties, property => property.Name == "payload");
+
+        Assert.NotNull(payload.Ref);
+        Assert.Equal("HolderPayload", Hardened.Idl.TypeMapper.GetRefName(payload.Ref!));
+    }
+
+    /// <summary>
+    /// A bare discriminator maps each value to the schema it names, which is what the
+    /// specification says it means and what most descriptions rely on.
+    /// </summary>
+    [Fact]
+    public void ABareDiscriminatorMapsEachValueToTheSchemaItNames() {
+        var model = Parse(Discriminated);
+
+        var choice = Choice(model)!;
+        var values = new List<string>();
+
+        foreach (var mapping in choice.DiscriminatorMapping) {
+            values.Add(mapping.Value);
+        }
+
+        Assert.Contains("Cat", values);
+        Assert.Contains("Dog", values);
+    }
+
+    [Fact]
+    public void AnExplicitMappingIsUsedWhereTheDocumentDeclaresOne() {
+        var model = Parse(ExplicitMapping);
+
+        var choice = Choice(model)!;
+        var values = new List<string>();
+
+        foreach (var mapping in choice.DiscriminatorMapping) {
+            values.Add(mapping.Value);
+        }
+
+        Assert.Contains("feline", values);
+        Assert.Contains("canine", values);
+    }
+
+    /// <summary>
+    /// No discriminator, but the shapes decide it - which is most of the published corpus.
+    /// </summary>
+    /// <remarks>
+    /// <c>Cat</c> declares <c>meow</c> and <c>Dog</c> declares <c>bark</c>, so the presence of
+    /// either says which branch a payload is. That is proved here rather than attempted at run
+    /// time: the generated converter tests for the property instead of trying each branch and
+    /// keeping whichever happens to read.
+    /// </remarks>
+    [Fact]
+    public void AChoiceWithNoDiscriminatorIsResolvedWhenTheShapesDecideIt() {
+        var model = Parse(Undiscriminated);
+
+        var choice = Choice(model);
+
+        Assert.NotNull(choice);
+        Assert.Null(choice!.DiscriminatorPropertyName);
+        Assert.Equal(2, choice.OneOf.Count);
+    }
+
+    /// <summary>
+    /// Branches the schemas do not separate still get a type, decided when a payload arrives.
+    /// </summary>
+    /// <remarks>
+    /// Overlapping on paper is not the same as ambiguous in fact: two schemas whose properties are
+    /// all optional overlap until a payload turns up carrying one that only one of them declares.
+    /// Refusing to generate anything would throw away every such payload to guard against the ones
+    /// that genuinely collide, so the branch is generated and the count decides - which is what
+    /// openapi-generator does, and unlike serde's first-one-that-reads it cannot bind silently.
+    /// </remarks>
+    [Fact]
+    public void BranchesTheSchemasDoNotSeparateAreDecidedByCountingMatches() {
+        var model = Parse(Ambiguous);
+
+        var choice = Choice(model);
+
+        Assert.NotNull(choice);
+
+        var plan = Hardened.Idl.ChoiceResolution.Resolve(choice!.OneOf, model.Schemas);
+
+        Assert.False(plan.FullyProved);
+        Assert.Equal(2, plan.Overlapping.Count);
+
+        // And the generated converter counts rather than taking the first that reads.
+        var emitted = EmitterHarness.Schema(choice);
+
+        Assert.Contains("var matches = 0;", emitted);
+        Assert.Contains("if (matches == 1)", emitted);
+        Assert.Contains("permitted types at once", emitted);
+    }
+
+    /// <summary>An inline branch, which most published choices are made of.</summary>
+    [Fact]
+    public void InlineBranchesAreModelledAsWellAsNamedOnes() {
+        var model = Parse(InlinePrimitives);
+
+        var choice = Choice(model);
+
+        Assert.NotNull(choice);
+        Assert.Equal(2, choice!.OneOf.Count);
+
+        // Neither branch names a schema; both are types written in place.
+        foreach (var branch in choice.OneOf) {
+            Assert.Null(branch.Ref);
+            Assert.NotNull(branch.Type);
+        }
+
+        var plan = Hardened.Idl.ChoiceResolution.Resolve(choice.OneOf, model.Schemas);
+
+        Assert.True(plan.FullyProved);
+    }
+
+    /// <summary>Branches of different JSON kinds, which is 56% of the corpus's choices.</summary>
+    [Fact]
+    public void BranchesOfDifferentValueKindsAreDecidedByKind() {
+        var model = Parse(DifferentKinds);
+
+        var choice = Choice(model);
+
+        Assert.NotNull(choice);
+
+        var plan = Hardened.Idl.ChoiceResolution.Resolve(choice!.OneOf, model.Schemas);
+
+        Assert.True(plan.FullyProved);
+
+        foreach (var branch in plan.Branches) {
+            Assert.NotNull(branch.ValueKind);
+        }
+    }
+
+    /// <summary>The one that is easy to leave silent.</summary>
+    [Fact]
+    public void AnUnresolvableChoiceIsReported() {
+        var model = Parse(Ambiguous);
+
+        var problems = Hardened.Idl.SpecDiagnostics.Find(model);
+        var codes = new List<string>();
+
+        foreach (var problem in problems) {
+            codes.Add(problem.Code);
+        }
+
+        Assert.Contains("HOAT010", codes);
+
+        // Reported, not fatal: JsonElement is a working answer, just the weakest one.
+        foreach (var problem in problems) {
+            if (problem.Code == "HOAT010") {
+                Assert.False(problem.Fatal);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The converter writes the discriminator itself, from the runtime type.
+    /// </summary>
+    /// <remarks>
+    /// It used to be left to the branch's own properties, which went wrong two ways: a branch whose
+    /// discriminator property was never assigned wrote null and could not be read back, and one
+    /// assigned the other branch's value round-tripped into that branch - a Cat written and a Dog
+    /// read, silently. What the payload is is the document's statement, not the caller's.
+    /// </remarks>
+    [Fact]
+    public void TheDiscriminatorIsWrittenFromTheTypeRatherThanTheModel() {
+        var model = Parse(Discriminated);
+
+        var choice = Choice(model)!;
+        var emitted = EmitterHarness.Schema(choice);
+
+        // Each branch is written with the value the mapping gives it, passed to the writer rather
+        // than read back off the value.
+        Assert.Contains("Write(writer, branch, options, \"kind\", \"Cat\");", emitted);
+        Assert.Contains("Write(writer, branch, options, \"kind\", \"Dog\");", emitted);
+
+        // And the property the model carries is skipped, so it cannot be written twice or disagree.
+        Assert.Contains("writer.WriteString(discriminator, kind);", emitted);
+        Assert.Contains("if (property.NameEquals(discriminator))", emitted);
+    }
+
+    /// <summary>A single branch is not a choice, and does not need a type to say so.</summary>
+    [Fact]
+    public void AOneOfWithOneBranchIsNotGivenAType() {
+        var model = Parse(SingleBranch);
+
+        Assert.Null(Choice(model));
+    }
+
+    private const string SingleBranch = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /holders:
+            get:
+              tags: [Holder]
+              operationId: getHolder
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Holder' }
+        components:
+          schemas:
+            Holder:
+              type: object
+              properties:
+                payload:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator: { propertyName: kind }
+            Cat:
+              type: object
+              properties: { kind: { type: string }, meow: { type: boolean } }
+        """;
+
+    private const string Discriminated = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /holders:
+            get:
+              tags: [Holder]
+              operationId: getHolder
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Holder' }
+        components:
+          schemas:
+            Holder:
+              type: object
+              properties:
+                payload:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator: { propertyName: kind }
+            Cat:
+              type: object
+              properties: { kind: { type: string }, meow: { type: boolean } }
+            Dog:
+              type: object
+              properties: { kind: { type: string }, bark: { type: boolean } }
+        """;
+
+    private const string ExplicitMapping = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /holders:
+            get:
+              tags: [Holder]
+              operationId: getHolder
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Holder' }
+        components:
+          schemas:
+            Holder:
+              type: object
+              properties:
+                payload:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      feline: '#/components/schemas/Cat'
+                      canine: '#/components/schemas/Dog'
+            Cat:
+              type: object
+              properties: { kind: { type: string }, meow: { type: boolean } }
+            Dog:
+              type: object
+              properties: { kind: { type: string }, bark: { type: boolean } }
+        """;
+
+    /// <summary>A string beside a boolean, named by nothing - 59% of the corpus's choices.</summary>
+    private const string InlinePrimitives = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /holders:
+            get:
+              tags: [Holder]
+              operationId: getHolder
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Holder' }
+        components:
+          schemas:
+            Holder:
+              type: object
+              properties:
+                payload:
+                  oneOf:
+                    - type: string
+                    - type: boolean
+        """;
+
+    /// <summary>Two branches of the same shape, which nothing separates on paper.</summary>
+    private const string Ambiguous = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /holders:
+            get:
+              tags: [Holder]
+              operationId: getHolder
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Holder' }
+        components:
+          schemas:
+            Holder:
+              type: object
+              properties:
+                payload:
+                  oneOf:
+                    - $ref: '#/components/schemas/Left'
+                    - $ref: '#/components/schemas/Right'
+            Left:
+              type: object
+              properties: { name: { type: string } }
+            Right:
+              type: object
+              properties: { name: { type: string } }
+        """;
+
+    /// <summary>A string branch beside an object one - decided by the payload's kind alone.</summary>
+    private const string DifferentKinds = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /holders:
+            get:
+              tags: [Holder]
+              operationId: getHolder
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Holder' }
+        components:
+          schemas:
+            Holder:
+              type: object
+              properties:
+                payload:
+                  oneOf:
+                    - $ref: '#/components/schemas/Slug'
+                    - $ref: '#/components/schemas/Cat'
+            Slug:
+              type: string
+            Cat:
+              type: object
+              properties: { kind: { type: string }, meow: { type: boolean } }
+        """;
+
+    private const string Undiscriminated = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /holders:
+            get:
+              tags: [Holder]
+              operationId: getHolder
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Holder' }
+        components:
+          schemas:
+            Holder:
+              type: object
+              properties:
+                payload:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+            Cat:
+              type: object
+              properties: { kind: { type: string }, meow: { type: boolean } }
+            Dog:
+              type: object
+              properties: { kind: { type: string }, bark: { type: boolean } }
+        """;
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/ExtractOpenApiSpec.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/ExtractOpenApiSpec.cs
@@ -156,6 +156,15 @@ public sealed class ExtractOpenApiSpec : Microsoft.Build.Utilities.Task {
             GroupUntaggedByPath,
             LoadExternalRefs ? Path.GetDirectoryName(Path.GetFullPath(specPath)) : null);
 
+    /// <summary>A task-level default a spec item may override either way.</summary>
+    private static bool Overridden(ITaskItem spec, string name, bool fallback) {
+        var declared = spec.GetMetadata(name);
+
+        return string.IsNullOrWhiteSpace(declared)
+            ? fallback
+            : string.Equals(declared, "true", System.StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// Narrows a document to what one service implements. Returns true if that failed.
     /// </summary>
@@ -229,13 +238,7 @@ public sealed class ExtractOpenApiSpec : Microsoft.Build.Utilities.Task {
     /// emitted and said out loud.
     /// </remarks>
     private string ServedDocument(ITaskItem spec, string path, string document, bool sliced) {
-        var declared = spec.GetMetadata("EmbedDocument");
-
-        var embed = string.IsNullOrWhiteSpace(declared)
-            ? EmbedDocument
-            : string.Equals(declared, "true", System.StringComparison.OrdinalIgnoreCase);
-
-        if (!embed) {
+        if (!Overridden(spec, "EmbedDocument", EmbedDocument)) {
             return "";
         }
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -171,7 +171,9 @@ internal static class OpenApiSpecParser {
 
         // Order matters, and only here. References are cleared before names are allocated so the
         // allocator never names a type nothing will emit; base types are dropped before that
-        // because a dropped base changes which members a type declares.
+        // because a dropped base changes which members a type declares. Choices go first of all,
+        // because dropping one is another way a reference stops naming something.
+        DropUndecidableChoices(model);
         InlineNonObjectRefs(model);
         DropIncompatibleBaseTypes(model);
         NameAllocator.Apply(model, fileName);
@@ -268,16 +270,63 @@ internal static class OpenApiSpecParser {
     /// because a reference can be read before the schema it names has been.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Removes a <c>oneOf</c> whose branches cannot be told apart, leaving the property loose.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A pass rather than a check at the point of synthesis, because deciding this needs every
+    /// branch schema and a branch may be declared after the property referring to it.
+    /// </para>
+    /// <para>
+    /// The alternative to dropping it is to generate a type that guesses - try each branch and keep
+    /// the first that reads - and a guess is exactly what a generated type should not contain. Of
+    /// the published corpus's 338 undiscriminated choices, 84% are decided by a test on the value's
+    /// kind or its properties; the rest are pairs nothing separates, and for those a
+    /// <c>JsonElement</c> the caller inspects is more honest than a type that picks one.
+    /// </para>
+    /// </remarks>
+    private static void DropUndecidableChoices(ServiceSpecModel model) {
+        var dropped = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var schema in model.Schemas) {
+            if (schema.Kind != SchemaKind.OneOf || schema.DiscriminatorPropertyName != null) {
+                continue;
+            }
+
+            if (!ChoiceResolution.Resolve(schema.OneOf, model.Schemas).Usable) {
+                dropped.Add(schema.Name);
+            }
+        }
+
+        if (dropped.Count == 0) {
+            return;
+        }
+
+        model.Schemas.RemoveAll(schema => dropped.Contains(schema.Name));
+
+        // The property keeps its OneOfRefs, so the branches stay reachable and the diagnostic can
+        // still say which schemas it was choosing between.
+        foreach (var reference in ModelRefs.All(model)) {
+            if (reference.Value != null &&
+                dropped.Contains(TypeMapper.GetRefName(reference.Value))) {
+                reference.Set(null);
+            }
+        }
+    }
+
     private static void InlineNonObjectRefs(ServiceSpecModel model) {
-        // Only objects and enums become types. A reference to anything else - a top-level array
-        // alias, an anyOf with no shape of its own, a schema this parser could not read - was still
-        // typed by the reference's name, naming something nothing declares. Slack's `blocks`,
-        // GitHub's `code-frequency-stat` and Stripe's `external_account` were all CS0246.
+        // Only objects, enums and choice types become types. A reference to anything else - a
+        // top-level array alias, an anyOf with no shape of its own, a schema this parser could not
+        // read - was still typed by the reference's name, naming something nothing declares.
+        // Slack's `blocks`, GitHub's `code-frequency-stat` and Stripe's `external_account` were all
+        // CS0246.
         var emittable = new HashSet<string>();
         var arrays = new Dictionary<string, SchemaModel>();
 
         foreach (var schema in model.Schemas) {
-            if (schema.Kind == SchemaKind.Object || schema.Kind == SchemaKind.Enum) {
+            if (schema.Kind == SchemaKind.Object || schema.Kind == SchemaKind.Enum ||
+                schema.Kind == SchemaKind.OneOf) {
                 emittable.Add(schema.Name);
             }
 
@@ -700,13 +749,69 @@ internal static class OpenApiSpecParser {
     }
 
     /// <summary>
-    /// The named schemas among a <c>oneOf</c> or <c>anyOf</c>'s branches.
+    /// Every branch of a <c>oneOf</c> or <c>anyOf</c>, named or written in place.
     /// </summary>
     /// <remarks>
-    /// Only the ones written as a <c>$ref</c>: an inline branch has no component to keep alive, and
-    /// a branch that is a bare primitive never had a type of its own.
+    /// Inline branches are the majority and were the reason this could not work as a list of
+    /// references: of the corpus's 338 undiscriminated choices, 200 name nothing at all -
+    /// <c>oneOf: [string, boolean]</c> - and 45 more mix a reference with an inline type. Keeping
+    /// only the references read those as a choice with one branch, or none, and produced no type.
     /// </remarks>
-    private static void CollectBranchRefs(IList<IOpenApiSchema>? branches, PropertyModel model) {
+    /// <summary>
+    /// A choice the reader has already folded into a union of types.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Microsoft.OpenApi 3.x normalises <c>oneOf: [{type: string}, {type: boolean}]</c> into one
+    /// schema whose <c>Type</c> carries both flags, with <c>OneOf</c> left empty. That is the
+    /// majority spelling in the wild - 200 of the corpus's 338 undiscriminated choices name no
+    /// schema at all - so a parser that only reads <c>OneOf</c> sees nothing there and types the
+    /// property as <c>JsonElement</c>. This is the same choice arriving under a different name.
+    /// </para>
+    /// <para>
+    /// <c>Null</c> is stripped first: <c>type: [string, "null"]</c> is 3.1 for a nullable string,
+    /// which is one type and a flag, not a choice between two.
+    /// </para>
+    /// </remarks>
+    private static void CollectTypeUnion(IOpenApiSchema prop, PropertyModel model) {
+        if (prop.Type is not { } declared) {
+            return;
+        }
+
+        var types = declared & ~JsonSchemaType.Null;
+
+        foreach (var candidate in new[] {
+                     JsonSchemaType.String, JsonSchemaType.Integer, JsonSchemaType.Number,
+                     JsonSchemaType.Boolean, JsonSchemaType.Array, JsonSchemaType.Object
+                 }) {
+            if ((types & candidate) != candidate) {
+                continue;
+            }
+
+            // One bit is an ordinary type, not a choice - left alone so nothing changes for the
+            // documents that were always read correctly.
+            if (types == candidate) {
+                return;
+            }
+
+            var branch = new ChoiceBranchModel {
+                Type = candidate switch {
+                    JsonSchemaType.String => "string",
+                    JsonSchemaType.Integer => "integer",
+                    JsonSchemaType.Number => "number",
+                    JsonSchemaType.Boolean => "boolean",
+                    JsonSchemaType.Array => "array",
+                    _ => "object"
+                }
+            };
+
+            if (!model.OneOf.Contains(branch)) {
+                model.OneOf.Add(branch);
+            }
+        }
+    }
+
+    private static void CollectBranches(IList<IOpenApiSchema>? branches, PropertyModel model) {
         if (branches == null) {
             return;
         }
@@ -714,10 +819,88 @@ internal static class OpenApiSpecParser {
         foreach (var branch in branches) {
             var reference = GetNonPrimitiveRef(branch);
 
-            if (reference != null && !model.OneOfRefs.Contains(reference)) {
-                model.OneOfRefs.Add(reference);
+            if (reference == null && SchemaType(branch) == null) {
+                // A branch that types to nothing. Two spellings reach here and neither is a choice
+                // between anything: `{type: "null"}`, which is 3.1 for "and it may be null" and is
+                // how OpenAI writes every optional string, and `{}`, which permits any value at all
+                // and so cannot be told from the branch beside it. Dropping both leaves the real
+                // branches, and a property left with one of those is an ordinary property again.
+                continue;
+            }
+
+            var described = reference != null
+                ? new ChoiceBranchModel { Ref = reference }
+                : new ChoiceBranchModel { Type = SchemaType(branch), Format = branch.Format };
+
+            if (!model.OneOf.Contains(described)) {
+                model.OneOf.Add(described);
             }
         }
+    }
+
+    /// <summary>
+    /// A type holding exactly one of a <c>oneOf</c>'s branches, or null to leave the property loose.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Synthesized only when the payload can be resolved to a branch on the way in, because the
+    /// whole value of the type is that <c>Value</c> is already a <c>Cat</c> when the caller switches
+    /// on it. A discriminator says which branch a payload is and the document is the one asserting
+    /// it; without one, the only way to decide is to look at the shape, which is a guess this does
+    /// not make unless asked.
+    /// </para>
+    /// <para>
+    /// Named for where it is declared rather than for what it holds - <c>OneOfHolderPayload</c>,
+    /// not <c>CatOrDog</c> - so the name stays put when a branch is added, and stays short when a
+    /// document declares fifteen of them.
+    /// </para>
+    /// </remarks>
+    private static string? SynthesizeOneOf(
+        string parentName, string propertyName, IOpenApiSchema prop, PropertyModel property,
+        SchemaCollector collector) {
+        var discriminator = prop.Discriminator;
+
+        var name = NamingHelper.ToPascalCase(parentName) + NamingHelper.ToPascalCase(propertyName);
+
+        if (collector.IsTaken(name)) {
+            name += "_" + StableSuffix(parentName + "/" + propertyName);
+        }
+
+        collector.Reserve(name);
+
+        var model = new SchemaModel {
+            Name = name,
+            Kind = SchemaKind.OneOf,
+            OneOf = new List<ChoiceBranchModel>(property.OneOf),
+            Description = FirstNonEmpty(prop.Description),
+            DiscriminatorPropertyName = discriminator?.PropertyName
+        };
+
+        // Explicit mapping if the document gives one; otherwise the specification says a value maps
+        // to the schema it names, which is what most descriptions rely on.
+        if (discriminator?.Mapping is { Count: > 0 }) {
+            foreach (var mapping in discriminator.Mapping) {
+                model.DiscriminatorMapping.Add(new DiscriminatorMappingModel {
+                    Value = mapping.Key,
+                    Ref = mapping.Value?.Reference?.ReferenceV3 ?? ""
+                });
+            }
+        } else if (model.DiscriminatorPropertyName != null) {
+            foreach (var branch in model.OneOf) {
+                if (branch.Ref == null) {
+                    continue;
+                }
+
+                model.DiscriminatorMapping.Add(new DiscriminatorMappingModel {
+                    Value = TypeMapper.GetRefName(branch.Ref),
+                    Ref = branch.Ref
+                });
+            }
+        }
+
+        collector.Add(model);
+
+        return TypeMapper.MakeRef(name);
     }
 
     private static PropertyModel ParseProperty(
@@ -733,11 +916,24 @@ internal static class OpenApiSpecParser {
         // Extract validation constraints
         ExtractValidationConstraints(prop, model);
 
-        // What the payload is allowed to be. Recorded before the type is decided, because the
-        // property lands on JsonElement either way and the branches would otherwise leave no trace
-        // in the model at all - and a type nothing in the model points at is not generated.
-        CollectBranchRefs(prop.OneOf, model);
-        CollectBranchRefs(prop.AnyOf, model);
+        // What the payload is allowed to be. Recorded whether or not it becomes a type of its own,
+        // because the branches would otherwise leave no trace in the model - and a schema nothing
+        // in the model points at is not generated.
+        CollectBranches(prop.OneOf, model);
+        CollectBranches(prop.AnyOf, model);
+        CollectTypeUnion(prop, model);
+
+        // A choice between named schemas becomes a type that holds exactly one of them, rather than
+        // a JsonElement the caller has to take apart. Only where the document says which branch a
+        // payload is - see SynthesizeOneOf.
+        if (model.OneOf.Count > 1 && SchemaRef(prop) == null) {
+            var choice = SynthesizeOneOf(parentName, name, prop, model, collector);
+
+            if (choice != null) {
+                model.Ref = choice;
+                return model;
+            }
+        }
 
         // Only keep $ref when it points to an object or enum that gets a generated C# type.
         // Primitive refs (e.g. CustomId → string) are inlined to their underlying type.


### PR DESCRIPTION
A property written as `oneOf` landed on `JsonElement` — unparsed JSON, and a caller holding it had no way to know what was in it. It now gets a type.

```csharp
switch (holder.Payload.Value)
{
    case Cat cat: …
    case Dog dog: …
}
```

`Value` is already a `Cat` — the converter resolves the branch while reading, rather than handing back JSON for the caller to take apart.

## Which branch, decided before anything runs

A discriminator is the document saying which branch a payload is, and where there is one the converter reads it. Almost no published description has one: across 38 specs, **zero** of 338 undiscriminated choices declared a discriminator on the property.

So branches are told apart by shape — as a **build-time proof**, not a runtime attempt. Every branch schema is in hand, so "can these be told apart" has an answer before anything runs:

| how the branches differ | sites |
|---|---|
| JSON value kind (`oneOf: [string, boolean]`) | 189 (56%) |
| a property unique to one branch | 57 (17%) |
| required-property set | 18 (5%) |
| a `const` — a discriminator in all but name | 19 (6%) |

**84% decided by one comparison**, emitted as an explicit test. The rest overlap on paper and are read into each candidate with exactly one required to fit — what openapi-generator does. Never the first branch that reads, which is `serde(untagged)` and Pydantic's default, and the one behaviour that binds the wrong type silently.

Overlapping on paper is not ambiguous in fact: two schemas whose properties are all optional overlap until a payload arrives carrying one only one of them declares. Refusing to generate would throw all of those away to guard against the few that genuinely collide.

## The discriminator is written, not trusted

It used to be left to whatever the branch's own properties carried. That went wrong two ways — a branch whose discriminator property was never assigned wrote `null` and could not be read back, and one assigned the *other* branch's value round-tripped into that branch. A `Cat` written and a `Dog` read, silently. It is now written from the runtime type.

## Two findings from the corpus

Each had made the feature produce nothing at all:

- **Microsoft.OpenApi 3.x folds `oneOf: [{type: string}, {type: boolean}]`** into one schema whose `Type` carries both flags, leaving `OneOf` empty. That is the majority spelling — 200 of 338 name no schema at all — so reading only `OneOf` saw nothing there.
- **`anyOf: [{type: string}, {type: "null"}]` is 3.1 for a nullable string**, not a choice. Treating it as one turned every optional string in OpenAI's description into a two-branch union: 596 generated types where 92 are real, and 500 warnings about telling `JsonElement` apart from `JsonElement`.

## Verification

- **2,440 tests pass**; solution builds clean under `ContinuousIntegrationBuild`.
- **76 of 76 corpus builds green** — 38 published descriptions, each with and without the validation generator.
- Round-tripped through the generated metadata: a `Cat` serializes with the right discriminator, reads back, and binds as a `Cat` in a `switch`.

## Known gap

`oneOf: [string, SomeEnum]` overlaps, because an enum *is* a string — so match-counting sees two and throws. The fix is "most-constrained branch wins": an enum is strictly narrower than an open string, so if the enum matches it *is* the enum. Not done here; `HOAT010` names each occurrence (3 in OpenAI's description).

C# 15 declares all of this natively — `union Pet(Cat, Dog)`, with `Value` as `object?` and implicit conversions from each case. The shape here matches it deliberately, so consumer code keeps compiling when that becomes a second emit gated on `net11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kk8qzFFvJKGrEoHG9aeywL