### PR TITLE
Decide a choice by which schema accepts fewer values

### DIFF
--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfConverterEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfConverterEmitter.cs
@@ -156,9 +156,17 @@ internal static class OneOfConverterEmitter {
         var plan = ChoiceResolution.Resolve(schema.OneOf, allSchemas);
 
         var tag = 0;
+        var fallback = (ChoiceResolution.Branch?)null;
 
         foreach (var branch in plan.Branches) {
             if (!branch.Proved) {
+                continue;
+            }
+
+            // Accepts everything a narrower branch of its kind does, so a test for it would claim
+            // that branch's payloads too. Emitted last, after those have had their turn.
+            if (branch.IsWiderFallback) {
+                fallback = branch;
                 continue;
             }
 
@@ -173,6 +181,16 @@ internal static class OneOfConverterEmitter {
                     : $"element.ValueKind == global::System.Text.Json.JsonValueKind.{branch.ValueKind}";
 
                 lines.Add($"if ({test})");
+            } else if (branch.ValueSet != null) {
+                // A membership test rather than a trial read: the values are known here, so this
+                // decides the branch outright instead of leaning on a failed parse.
+                var values = new List<string>();
+
+                foreach (var value in branch.ValueSet) {
+                    values.Add($"\"{Escape(value)}\"");
+                }
+
+                lines.Add($"if (element.GetString() is {string.Join(" or ", values)})");
             } else if (branch.ConstProperty != null) {
                 // Numbered, because several branches in one method each declare one and C# scopes
                 // an out variable to the whole method body rather than to its if.
@@ -190,6 +208,15 @@ internal static class OneOfConverterEmitter {
             lines.Add($"    return new(Read<{type}>(element, options));");
             lines.Add("}");
             lines.Add("");
+        }
+
+        if (fallback != null) {
+            var type = TypeMapper.QualifiedName(
+                modelsNamespace, ChoiceResolution.CSharpType(fallback.Model), false);
+
+            lines.Add($"return new(Read<{type}>(element, options));");
+
+            return;
         }
 
         if (plan.Overlapping.Count == 0) {

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/ChoiceResolution.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/ChoiceResolution.cs
@@ -60,11 +60,30 @@ internal static class ChoiceResolution {
         public string? ConstValue { get; set; }
 
         /// <summary>
+        /// The values this branch accepts, where they are a strict subset of what another branch of
+        /// the same kind accepts.
+        /// </summary>
+        /// <remarks>
+        /// <c>oneOf: [string, SomeEnum]</c> is common and both branches are strings, so nothing
+        /// above separates them and every payload matches both. But an enum accepts strictly fewer
+        /// values than an open string, so testing its members decides it - not a guess about which
+        /// branch was meant, a fact about which schemas the value satisfies.
+        /// </remarks>
+        public List<string>? ValueSet { get; set; }
+
+        /// <summary>
+        /// Whether this branch accepts everything a narrower one of the same kind does, so it
+        /// answers only after those have been tested.
+        /// </summary>
+        public bool IsWiderFallback { get; set; }
+
+        /// <summary>
         /// Whether the schemas prove this branch apart from every other. False means the branch is
         /// still generated and decided by counting matches on the payload.
         /// </summary>
         public bool Proved =>
-            ValueKind != null || DistinctProperty != null || ConstProperty != null;
+            ValueKind != null || DistinctProperty != null || ConstProperty != null ||
+            ValueSet != null || IsWiderFallback;
     }
 
     internal sealed class Plan {
@@ -108,6 +127,7 @@ internal static class ChoiceResolution {
         AssignValueKinds(plan, resolved);
         AssignDistinctProperties(plan, resolved);
         AssignConstProperties(plan, resolved);
+        AssignValueSets(plan, resolved);
 
         foreach (var branch in plan.Branches) {
             if (!branch.Proved) {
@@ -199,6 +219,71 @@ internal static class ChoiceResolution {
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Separates an enum from the open type it shares a kind with, most constrained first.
+    /// </summary>
+    /// <remarks>
+    /// The alternative was to call them ambiguous and count matches, which throws on every value
+    /// the enum permits - <c>oneOf: [string, AssistantSupportedModels]</c> appears three times in
+    /// OpenAI's description and would have refused every model name it names. One branch accepting
+    /// strictly fewer values than another is an ordering, not an ambiguity.
+    /// </remarks>
+    private static void AssignValueSets(Plan plan, List<SchemaModel?> resolved) {
+        for (var index = 0; index < resolved.Count; index++) {
+            var branch = plan.Branches[index];
+
+            if (branch.Proved || resolved[index]?.Kind != SchemaKind.Enum) {
+                continue;
+            }
+
+            var values = resolved[index]!.EnumValues;
+
+            if (values is not { Count: > 0 }) {
+                continue;
+            }
+
+            // Only where something else of the same kind would also accept these - otherwise the
+            // kind already separated it and this adds nothing.
+            var wider = WiderOfSameKind(plan, resolved, index);
+
+            if (wider == null) {
+                continue;
+            }
+
+            branch.ValueSet = new List<string>(values);
+            wider.IsWiderFallback = true;
+        }
+    }
+
+    /// <summary>
+    /// A branch of the same JSON kind that constrains nothing, and so accepts everything the branch
+    /// at <paramref name="index"/> does.
+    /// </summary>
+    private static Branch? WiderOfSameKind(Plan plan, List<SchemaModel?> resolved, int index) {
+        var kind = ValueKindOf(plan.Branches[index].Model, resolved[index]);
+
+        for (var other = 0; other < resolved.Count; other++) {
+            if (other == index) {
+                continue;
+            }
+
+            if (ValueKindOf(plan.Branches[other].Model, resolved[other]) != kind) {
+                continue;
+            }
+
+            var schema = resolved[other];
+
+            // Unconstrained: an inline type, or a named schema that is neither an enum nor an
+            // object with a shape of its own.
+            if (schema == null ||
+                (schema.Kind != SchemaKind.Enum && schema.Properties.Count == 0)) {
+                return plan.Branches[other];
+            }
+        }
+
+        return null;
     }
 
     private static bool DeclaredElsewhere(string property, List<SchemaModel?> resolved, int skip) {

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ScenarioSpecs.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ScenarioSpecs.cs
@@ -1,0 +1,247 @@
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// One document per thing a published description did that this generator got wrong.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every scenario here was found by building against real descriptions - four rounds of ten - and
+/// each one cost a download, a build, and a read of several megabytes of generated C# to find. That
+/// is a poor way to learn the same lesson twice, so what each round taught is written down here as
+/// the smallest document that produces it.
+/// </para>
+/// <para>
+/// The point is not coverage for its own sake. A scenario earns a place here by having broken
+/// something, and the comment on it names what: the description it came from and what it did. A
+/// document nothing ever got wrong belongs in <c>Specs</c> with the ordinary fixtures.
+/// </para>
+/// </remarks>
+internal static class ScenarioSpecs {
+
+    private const string Head = """
+        openapi: "3.1.0"
+        info: { title: Scenario, version: "1.0" }
+        paths:
+          /things:
+            get:
+              tags: [Thing]
+              operationId: getThing
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Thing' }
+        components:
+          schemas:
+        """;
+
+    /// <summary>
+    /// OpenAPI 3.1 states nullability as a type array, which the 3.0 line spelled with a flag.
+    /// </summary>
+    /// <remarks>
+    /// OpenAI writes every optional string this way. Read as a choice between two things it turns
+    /// each one into a two-branch union - 596 generated types where 92 were real - so what is
+    /// asserted is that it stays one nullable property.
+    /// </remarks>
+    public const string NullableByTypeArray = Head + """
+
+            Thing:
+              type: object
+              required: [name]
+              properties:
+                name: { type: [string, "null"] }
+                count: { type: [integer, "null"] }
+        """;
+
+    /// <summary>
+    /// 3.1's <c>const</c>, which is a single-valued enum and is how a great many descriptions spell
+    /// a discriminator without declaring one.
+    /// </summary>
+    public const string ConstProperty = Head + """
+
+            Thing:
+              type: object
+              properties:
+                kind: { type: string, const: thing }
+                name: { type: string }
+        """;
+
+    /// <summary>
+    /// A bound the type its format implies cannot hold.
+    /// </summary>
+    /// <remarks>
+    /// DigitalOcean declares <c>eq_range_index_dive_limit</c> as an integer with a maximum of
+    /// 4294967295. Left as <c>int</c> the generated model overflows on a payload the description
+    /// calls valid, so the bound is part of the type.
+    /// </remarks>
+    public const string BoundsWiderThanInt = Head + """
+
+            Thing:
+              type: object
+              properties:
+                small: { type: integer, maximum: 100 }
+                wide: { type: integer, maximum: 4294967295 }
+        """;
+
+    /// <summary>
+    /// A constraint that cannot apply to the type it is written on.
+    /// </summary>
+    /// <remarks>
+    /// <c>minLength</c> on an integer and <c>minimum</c> on a string are both meaningless, and
+    /// emitting them produced validator code comparing an int against a string length. The
+    /// description is wrong and there is nothing to be done about it, so the constraint is dropped.
+    /// </remarks>
+    public const string ConstraintsOnMismatchedTypes = Head + """
+
+            Thing:
+              type: object
+              properties:
+                counted: { type: integer, minLength: 3 }
+                measured: { type: string, minimum: 5 }
+                listed: { type: array, items: { type: string }, minItems: 1 }
+        """;
+
+    /// <summary>
+    /// A pattern that is not a regular expression any .NET engine will accept.
+    /// </summary>
+    /// <remarks>
+    /// Emitted verbatim it fails at run time inside generated code, where the message names neither
+    /// the property nor the description it came from.
+    /// </remarks>
+    public const string InvalidPattern = Head + """
+
+            Thing:
+              type: object
+              properties:
+                good: { type: string, pattern: "^[a-z]+$" }
+                bad: { type: string, pattern: "^(unclosed" }
+        """;
+
+    /// <summary>
+    /// A value set that reaches C# as nothing at all.
+    /// </summary>
+    /// <remarks>
+    /// Docker and Cloudflare both declare an enum whose members include the empty string; GitHub's
+    /// reaction enum is <c>+1</c> and <c>-1</c>; Elasticsearch declares <c>buckets.count</c> beside
+    /// <c>buckets_count</c>. Each produced an enum member with no name, or two with the same one.
+    /// </remarks>
+    public const string AwkwardEnumValues = Head + """
+
+            Thing:
+              type: object
+              properties:
+                reaction: { $ref: '#/components/schemas/Reaction' }
+            Reaction:
+              type: string
+              enum: ["+1", "-1", "", "buckets.count", "buckets_count", "StartTime>"]
+        """;
+
+    /// <summary>Binary content, which is a string in the description and bytes in C#.</summary>
+    public const string BinaryFormats = Head + """
+
+            Thing:
+              type: object
+              properties:
+                avatar: { type: string, format: byte }
+                blob: { type: string, format: binary }
+                when: { type: string, format: date-time }
+                day: { type: string, format: date }
+        """;
+
+    /// <summary>
+    /// A schema that refers to itself, and one that nests arrays.
+    /// </summary>
+    /// <remarks>
+    /// A recursive reference is a cycle in every pass that walks references, and each of those had
+    /// to be written not to follow it forever.
+    /// </remarks>
+    public const string RecursiveAndNested = Head + """
+
+            Thing:
+              type: object
+              properties:
+                self: { $ref: '#/components/schemas/Thing' }
+                children:
+                  type: array
+                  items: { $ref: '#/components/schemas/Thing' }
+                matrix:
+                  type: array
+                  items:
+                    type: array
+                    items: { type: number }
+                inline:
+                  type: object
+                  properties:
+                    nested: { type: string }
+        """;
+
+    /// <summary>
+    /// A request body that is not JSON.
+    /// </summary>
+    /// <remarks>
+    /// An upload is <c>multipart/form-data</c>, and a description that offers only that had its body
+    /// read as though the content map were empty.
+    /// </remarks>
+    public const string MultipartBody = """
+        openapi: "3.1.0"
+        info: { title: Scenario, version: "1.0" }
+        paths:
+          /uploads:
+            post:
+              tags: [Upload]
+              operationId: upload
+              requestBody:
+                content:
+                  multipart/form-data:
+                    schema:
+                      type: object
+                      properties:
+                        file: { type: string, format: binary }
+                        name: { type: string }
+              responses:
+                '201': { description: created }
+        components:
+          schemas: {}
+        """;
+
+    /// <summary>
+    /// 3.1's <c>webhooks</c>, which this generator does not implement.
+    /// </summary>
+    /// <remarks>
+    /// Here so that it is known what happens rather than assumed: a document carrying them parses,
+    /// and the operations it does declare are unaffected. If webhooks are ever generated, this is
+    /// the document that says what changed.
+    /// </remarks>
+    public const string Webhooks = """
+        openapi: "3.1.0"
+        info: { title: Scenario, version: "1.0" }
+        webhooks:
+          thingCreated:
+            post:
+              operationId: onThingCreated
+              requestBody:
+                content:
+                  application/json:
+                    schema: { $ref: '#/components/schemas/Thing' }
+              responses:
+                '200': { description: ok }
+        paths:
+          /things:
+            get:
+              tags: [Thing]
+              operationId: getThing
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Thing' }
+        components:
+          schemas:
+            Thing:
+              type: object
+              properties:
+                name: { type: string }
+        """;
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ScenarioTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ScenarioTests.cs
@@ -1,0 +1,204 @@
+using System.Collections.Generic;
+using System.Threading;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// What each document in <see cref="ScenarioSpecs"/> produces.
+/// </summary>
+/// <remarks>
+/// Assertions written from what the generator actually emits, checked against a dump rather than
+/// guessed - twice in this file's history an expectation was written from what the code looked like
+/// it should do and passed against output that was wrong in a different way.
+/// </remarks>
+public class ScenarioTests {
+
+    private static ServiceSpecModel Parse(string yaml) {
+        var model = OpenApiSpecParser.Parse(yaml, "spec", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static PropertyModel Property(ServiceSpecModel model, string schema, string property) {
+        var found = Assert.Single(model.Schemas, candidate => candidate.Name == schema);
+
+        return Assert.Single(found.Properties, candidate => candidate.Name == property);
+    }
+
+    private static string TypeOf(ServiceSpecModel model, string schema, string property) =>
+        TypeMapper.MapPropertyToCSharpType(Property(model, schema, property));
+
+    /// <summary>
+    /// 3.1 spells nullability as a type array, and it is one property either way.
+    /// </summary>
+    /// <remarks>
+    /// Read as a choice between two things it became a two-branch union - which turned every
+    /// optional string in OpenAI's description into a generated type, 596 of them against 92 real
+    /// ones.
+    /// </remarks>
+    [Fact]
+    public void ATypeArrayEndingInNullIsANullablePropertyRatherThanAChoice() {
+        var model = Parse(ScenarioSpecs.NullableByTypeArray);
+
+        Assert.Equal("string", TypeOf(model, "Thing", "name"));
+        Assert.Equal("int", TypeOf(model, "Thing", "count"));
+
+        Assert.True(Property(model, "Thing", "name").IsNullable);
+        Assert.DoesNotContain(model.Schemas, schema => schema.Kind == SchemaKind.OneOf);
+    }
+
+    /// <summary>
+    /// <c>const</c> is an enum of one, and is how 3.1 pins a value.
+    /// </summary>
+    /// <remarks>
+    /// Never read at all until this test was written: a pinned property looked unconstrained, and
+    /// the choice resolution that uses one to tell branches apart could not fire because nothing
+    /// put a pinned value in the model.
+    /// </remarks>
+    [Fact]
+    public void AConstIsReadAsTheSingleValueItPermits() {
+        var model = Parse(ScenarioSpecs.ConstProperty);
+
+        var kind = Property(model, "Thing", "kind");
+
+        Assert.NotNull(kind.EnumValues);
+        Assert.Equal(new[] { "thing" }, kind.EnumValues!);
+    }
+
+    /// <summary>
+    /// A declared bound wider than the type its format implies widens the type.
+    /// </summary>
+    /// <remarks>
+    /// DigitalOcean declares an integer with a maximum of 4294967295. Left as <c>int</c> the model
+    /// overflows on a payload the description calls valid.
+    /// </remarks>
+    [Fact]
+    public void ABoundTooWideForIntWidensTheTypeThatCarriesIt() {
+        var model = Parse(ScenarioSpecs.BoundsWiderThanInt);
+
+        Assert.Equal("int", TypeOf(model, "Thing", "small"));
+        Assert.Equal("long", TypeOf(model, "Thing", "wide"));
+    }
+
+    /// <summary>
+    /// Awkward values reach C# as names, and as different ones.
+    /// </summary>
+    /// <remarks>
+    /// GitHub's reaction enum is <c>+1</c> and <c>-1</c>, Docker and Cloudflare declare an empty
+    /// member, and Elasticsearch declares <c>buckets.count</c> beside <c>buckets_count</c> - which
+    /// sanitize to one name. Each produced a member with no identifier, or two with the same one.
+    /// </remarks>
+    [Fact]
+    public void EveryEnumValueBecomesADistinctName() {
+        var model = Parse(ScenarioSpecs.AwkwardEnumValues);
+
+        var reaction = Assert.Single(model.Schemas, schema => schema.Name == "Reaction");
+
+        Assert.Equal(
+            new[] {
+                "Plus1", "Minus1", "Empty", "BucketsCount", "ReactionBucketsCount",
+                "StartTimeGreaterThan"
+            },
+            reaction.EnumMembers);
+
+        // The wire values are untouched - only the C# member moved.
+        Assert.Contains("+1", reaction.EnumValues);
+        Assert.Contains("", reaction.EnumValues);
+    }
+
+    [Fact]
+    public void BinaryAndDateFormatsMapToTheTypesThatHoldThem() {
+        var model = Parse(ScenarioSpecs.BinaryFormats);
+
+        Assert.Equal("byte[]", TypeOf(model, "Thing", "avatar"));
+        Assert.Equal("byte[]", TypeOf(model, "Thing", "blob"));
+        Assert.Equal("DateTime", TypeOf(model, "Thing", "when"));
+        Assert.Equal("DateOnly", TypeOf(model, "Thing", "day"));
+    }
+
+    /// <summary>
+    /// A schema that refers to itself parses, and an inline object is lifted into a type.
+    /// </summary>
+    /// <remarks>
+    /// A recursive reference is a cycle in every pass that walks references. The array of arrays is
+    /// here to record what happens rather than to approve of it - see the assertion.
+    /// </remarks>
+    [Fact]
+    public void ARecursiveSchemaParsesAndAnInlineObjectIsLifted() {
+        var model = Parse(ScenarioSpecs.RecursiveAndNested);
+
+        Assert.Equal("Thing", TypeOf(model, "Thing", "self"));
+        Assert.Equal("List<Thing>", TypeOf(model, "Thing", "children"));
+
+        // Lifted, so the nested shape survives instead of degrading to JsonElement.
+        Assert.Contains(model.Schemas, schema => schema.Name == "ThingInline");
+
+        // Known: an array of arrays loses its inner element type. Pinned so that fixing it is a
+        // deliberate change to this line rather than a surprise.
+        Assert.Equal("List<JsonElement>", TypeOf(model, "Thing", "matrix"));
+    }
+
+    /// <summary>A body that is not JSON is still a body.</summary>
+    [Fact]
+    public void AMultipartBodyIsReadRatherThanSkipped() {
+        var model = Parse(ScenarioSpecs.MultipartBody);
+
+        var operation = Assert.Single(model.Services[0].Operations);
+
+        Assert.Equal("multipart/form-data", operation.RequestBodyContentType);
+        Assert.Equal("object", operation.RequestBodyType);
+    }
+
+    /// <summary>
+    /// A document declaring webhooks parses, and the operations it declares are unaffected.
+    /// </summary>
+    /// <remarks>
+    /// Webhooks are not generated. This says what happens today, so that generating them is a
+    /// change someone makes on purpose and this test is what tells them what moved.
+    /// </remarks>
+    [Fact]
+    public void WebhooksAreIgnoredWithoutDisturbingTheRestOfTheDocument() {
+        var model = Parse(ScenarioSpecs.Webhooks);
+
+        var operation = Assert.Single(model.Services[0].Operations);
+
+        Assert.Equal("GetThing", operation.MethodName);
+        Assert.Contains(model.Schemas, schema => schema.Name == "Thing");
+    }
+
+    /// <summary>
+    /// Every scenario document parses at all.
+    /// </summary>
+    /// <remarks>
+    /// The cheapest thing this file does and the one most likely to catch the next regression: a
+    /// pass that throws on a shape it has not met before fails here, on a document small enough to
+    /// read, rather than in a megabyte of generated C# from a vendor's description.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(EveryScenario))]
+    public void EveryScenarioParses(string name, string yaml) {
+        var diagnostics = new List<string>();
+
+        var model = OpenApiSpecParser.Parse(
+            yaml, "spec", CancellationToken.None, diagnostics: diagnostics);
+
+        Assert.True(model != null, $"{name} did not parse: {string.Join("; ", diagnostics)}");
+        Assert.Empty(diagnostics);
+    }
+
+    public static IEnumerable<object[]> EveryScenario() {
+        foreach (var field in typeof(ScenarioSpecs).GetFields(
+                     System.Reflection.BindingFlags.Public |
+                     System.Reflection.BindingFlags.Static)) {
+            if (field.GetRawConstantValue() is string yaml) {
+                yield return new object[] { field.Name, yaml };
+            }
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -243,18 +243,6 @@ internal static class OpenApiSpecParser {
     /// churns the file and recompiles every consumer. Derived from provenance rather than from the
     /// order things were parsed in, so reordering a document cannot rename a type.
     /// </remarks>
-    private static string StableSuffix(string provenance) {
-        unchecked {
-            var hash = 2166136261;
-
-            foreach (var character in provenance) {
-                hash = (hash ^ character) * 16777619;
-            }
-
-            return hash.ToString("x8", System.Globalization.CultureInfo.InvariantCulture);
-        }
-    }
-
 
     /// <summary>
     /// Rewrites references to top-level array schemas into the array they stand for.
@@ -717,6 +705,28 @@ internal static class OpenApiSpecParser {
     /// cannot find in their specification.
     /// </para>
     /// </remarks>
+    /// <summary>A name nothing has taken, numbered where the plain one is gone.</summary>
+    /// <remarks>
+    /// Numbered rather than qualified, and that is the whole of what can be said: two provenances
+    /// that collide here differ only in where the boundary between parent and property falls, so
+    /// they spell the same words in the same order and nothing readable separates them. Same rule
+    /// as NameAllocator - a number appears only where the scope distinguishes nothing.
+    /// </remarks>
+    private static string Unique(string name, SchemaCollector collector) {
+        if (!collector.IsTaken(name)) {
+            return name;
+        }
+
+        for (var suffix = 2; ; suffix++) {
+            var candidate =
+                name + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            if (!collector.IsTaken(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
     private static string SynthesizeSchema(
         string parentName, string propertyName, IOpenApiSchema schema, SchemaCollector collector) {
         // `title` is OpenAPI's own way to name a schema and would give far better names than this
@@ -730,10 +740,15 @@ internal static class OpenApiSpecParser {
         // on one name: Stripe's POST .../financial_account with `features.card_issuing` collides
         // with POST .../financial_account/features with `card_issuing`, 28 times over. Nothing in
         // the document is wrong and neither name is declared, so there is nothing an author could
-        // rename. Qualify by where it came from instead - the provenance is what actually differs.
-        if (collector.IsTaken(name)) {
-            name += "_" + StableSuffix(parentName + "/" + propertyName);
-        }
+        // rename.
+        //
+        // Numbered rather than qualified, and that is the whole of what can be said: the two
+        // provenances differ only in where the boundary between parent and property falls, so they
+        // spell the same words in the same order and nothing human-readable separates them. This
+        // used to carry a hash of the provenance, which was stable and unreadable - and stable was
+        // never the hard part. Same rule as NameAllocator: a number appears only where the scope
+        // distinguishes nothing.
+        name = Unique(name, collector);
 
         // Claimed before the children are read, since they are lifted during that read.
         collector.Reserve(name);
@@ -860,11 +875,9 @@ internal static class OpenApiSpecParser {
         SchemaCollector collector) {
         var discriminator = prop.Discriminator;
 
-        var name = NamingHelper.ToPascalCase(parentName) + NamingHelper.ToPascalCase(propertyName);
-
-        if (collector.IsTaken(name)) {
-            name += "_" + StableSuffix(parentName + "/" + propertyName);
-        }
+        var name = Unique(
+            NamingHelper.ToPascalCase(parentName) + NamingHelper.ToPascalCase(propertyName),
+            collector);
 
         collector.Reserve(name);
 
@@ -941,6 +954,21 @@ internal static class OpenApiSpecParser {
         if (nonPrimitiveRef != null) {
             model.Ref = nonPrimitiveRef;
             return model;
+        }
+
+        // JSON Schema's const is an enum of one, and 3.1 descriptions use it where 3.0 wrote a
+        // single-member enum. Read as neither, a property pinned to one value looked unconstrained -
+        // and the choice resolution that uses a pinned value to tell branches apart could never
+        // fire, because nothing ever put one in the model.
+        if (prop.Const is { } constant && prop.Enum is not { Count: > 0 }) {
+            var value = EnumMember(constant);
+
+            if (value != null) {
+                model.Type = SchemaType(prop) ?? "string";
+                model.EnumValues = new List<string> { value };
+
+                return model;
+            }
         }
 
         if (prop.Enum is { Count: > 0 }) {


### PR DESCRIPTION
Three things, and the second found the first to be half dead.

## Most constrained wins

`oneOf: [string, SomeEnum]` has two branches of the same JSON kind, so nothing separated them and every payload matched both — which match counting then called ambiguous and refused. OpenAI declares that three times, and it would have rejected every model name the enum names.

An enum accepts strictly fewer values than an open string, so this is an **ordering, not an ambiguity**. Test the enum's members; what falls through is the string:

```csharp
if (element.GetString() is "gpt-5" or "gpt-5-mini" or … )
    return new(Read<AssistantSupportedModels>(element, options));

return new(Read<string>(element, options));
```

A membership test rather than a trial read, because the values are known at build time. OpenAI now resolves every choice it declares statically, with no diagnostics left.

## The scenarios, written down

Each round of ten published descriptions taught something, and each lesson cost a download, a build, and a read through megabytes of generated C# to find. `ScenarioSpecs` is one minimal document per lesson, each commented with the description it came from and what it did: 3.1 type arrays, `const`, bounds wider than `int`, GitHub's `+1`/`-1` beside Docker's empty enum member, binary formats, recursion, a multipart body, webhooks.

Assertions are written from **dumping what the generator emits**, not from reading what it looks like it should emit. That isn't a style preference — twice in this branch's history an expectation written the other way passed against output that was wrong in a different way.

It found one immediately: **`const` was never parsed.** The reader exposes it and the parser ignored it, so a property pinned to one value looked unconstrained — and the choice resolution that uses a pinned value to tell branches apart could not fire, because nothing put one in the model. The 84% claimed for static resolution was overstated by the 6% `const` accounts for.

Two limitations are pinned rather than left to be rediscovered: an array of arrays loses its inner element type, and webhooks are ignored. Both assert what happens today, so changing either is a deliberate edit to a line that says so.

## The last hash

`SchemaCollector` still qualified a colliding synthesized name with a hash of its provenance — the thing the allocator stopped doing. Both synthesis sites now share one helper that numbers.

Numbered rather than prefixed, and the difference is the point: the allocator prefixes because a document or a declaring type is a real thing to name. Here the two provenances differ only in *where the boundary between parent and property falls*, so they spell the same words in the same order and nothing readable separates them. Same rule either way — a number appears only where the scope distinguishes nothing.

## Verification

- **2,458 tests pass**; solution builds clean under `ContinuousIntegrationBuild`.
- **76 of 76 corpus builds green** — 38 published descriptions, each with and without the validation generator.
- **552 choice types generated** across the corpus, against zero before this branch. 132 sites remain on match counting — Stripe 108, GitHub 12, Cloudflare 8 — each named by `HOAT010` rather than silently guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kk8qzFFvJKGrEoHG9aeywL