### PR TITLE
Report the request lifecycle as a span, not only as a log line

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/RequestTelemetryTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/RequestTelemetryTests.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// The span a real request produces, through the real routing table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The unit tests around <c>RequestLogger</c> drive its methods directly, which proves what it does
+/// with a route but not that a route ever reaches it. This goes through the host: an actual request,
+/// matched by the generated routing table, dispatched by <c>WebExecutionHandlerService</c> — which is
+/// what calls <c>RequestMapped</c>, and therefore the only thing that makes <c>http.route</c> real.
+/// </para>
+/// <para>
+/// Attribute names and the source name are literals, not constants shared with the code under test.
+/// They are the contract a trace backend reads, and sharing a constant would let a rename pass here
+/// while breaking every consumer.
+/// </para>
+/// </remarks>
+public class RequestTelemetryTests {
+
+    /// <summary>
+    /// Runs one request and returns the span it produced.
+    /// </summary>
+    /// <remarks>
+    /// An <c>ActivitySource</c> is process-global and every other test in this assembly runs in
+    /// parallel through the same one, so the wanted span is picked out inside the callback by a path
+    /// nothing else requests. Filtering here rather than collecting everything and filtering
+    /// afterwards is what keeps a shared collection from being written while it is read — which is
+    /// exactly how the first version of this file failed.
+    /// </remarks>
+    private static async Task<Activity> SpanFor(ITestWebApp testWebApp, string path) {
+        Activity? captured = null;
+
+        using var listener = new ActivityListener {
+            ShouldListenTo = source => source.Name == "Hardened.Requests",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = span => {
+                if ((string?)span.GetTagItem("url.path") == path) {
+                    captured = span;
+                }
+            }
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        await testWebApp.Get(path);
+
+        Assert.NotNull(captured);
+
+        return captured;
+    }
+
+    [HardenedTest]
+    public async Task ARequestProducesOneServerSpanCarryingItsRouteTemplate(ITestWebApp testWebApp) {
+        var span = await SpanFor(testWebApp, "/binding/path/telemetry-probe");
+
+        Assert.Equal(ActivityKind.Server, span.Kind);
+
+        // The template the routing table matched, not the path that arrived. This is the assertion
+        // the whole design turns on: it is low cardinality, and Hardened knows it before the handler
+        // runs rather than having to rename the span at the end of the request.
+        Assert.Equal("/binding/path/{id}", span.GetTagItem("http.route"));
+        Assert.Equal("GET /binding/path/{id}", span.DisplayName);
+
+        Assert.Equal("GET", span.GetTagItem("http.request.method"));
+        Assert.Equal("/binding/path/telemetry-probe", span.GetTagItem("url.path"));
+
+        // Nothing assigns a status on an ordinary success path — null means "handled, no opinion" —
+        // so this is the one attribute that only a request through a real host could have caught.
+        Assert.Equal(200, span.GetTagItem("http.response.status_code"));
+        Assert.Equal(ActivityStatusCode.Unset, span.Status);
+    }
+
+    /// <summary>
+    /// A path the routing table does not match never reaches <c>RequestMapped</c>, so the span has
+    /// no route to carry and keeps the method as its name — one span per unmatched URL is exactly
+    /// the cardinality explosion the conventions exist to prevent.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnUnmatchedRequestGetsASpanWithNoRoute(ITestWebApp testWebApp) {
+        var span = await SpanFor(testWebApp, "/telemetry-probe-no-such-route");
+
+        Assert.Null(span.GetTagItem("http.route"));
+        Assert.Equal("GET", span.DisplayName);
+
+        // A 404 is the caller asking for something that is not there, not this service failing.
+        Assert.Equal(404, span.GetTagItem("http.response.status_code"));
+        Assert.Equal(ActivityStatusCode.Unset, span.Status);
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -63,6 +63,15 @@ namespace Hardened.Requests.Runtime.DependencyInjection
         public DependencyModules.Runtime.Interfaces.IDependencyModule GetModule() { }
     }
 }
+namespace Hardened.Requests.Runtime.Diagnostics
+{
+    public static class HardenedDiagnostics
+    {
+        public const string SourceName = "Hardened.Requests";
+        public static readonly System.Diagnostics.ActivitySource ActivitySource;
+        public static readonly System.Diagnostics.Metrics.Meter Meter;
+    }
+}
 namespace Hardened.Requests.Runtime.Errors
 {
     public class BadContentEncodingException : Hardened.Requests.Runtime.Errors.BadRequestException

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/DiagnosticsListenerCollection.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/DiagnosticsListenerCollection.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Diagnostics;
+
+/// <summary>
+/// Serialises every test that registers an <c>ActivityListener</c> or a <c>MeterListener</c>.
+/// </summary>
+/// <remarks>
+/// Both are process-global. A listener registered by a test running in parallel is visible to every
+/// other test in the process, so an assertion that <em>nothing</em> is listening — which is the
+/// property that lets the pipeline instrument unconditionally — cannot be made robust any other
+/// way. Anything added for the rest of the telemetry work belongs in this collection too.
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DiagnosticsListenerCollection {
+    public const string Name = "diagnostics-listeners";
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/HardenedDiagnosticsTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/HardenedDiagnosticsTests.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using Hardened.Requests.Runtime.Diagnostics;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Diagnostics;
+
+/// <summary>
+/// The two objects the request pipeline reports through, and the one string that reaches them.
+/// </summary>
+[Collection(DiagnosticsListenerCollection.Name)]
+public class HardenedDiagnosticsTests {
+
+    /// <summary>
+    /// A published contract, not an implementation detail. This is the literal an application passes
+    /// to <c>AddSource</c> and <c>AddMeter</c>, so changing it does not break a build anywhere — it
+    /// silently stops collection for everyone who already configured it. Asserting the value is the
+    /// only thing that turns that into a failure someone sees.
+    /// </summary>
+    [Fact]
+    public void TheSourceNameIsTheStringApplicationsSubscribeTo() {
+        Assert.Equal("Hardened.Requests", HardenedDiagnostics.SourceName);
+    }
+
+    /// <summary>
+    /// One name for both signals, so an application configures traces and metrics with the same
+    /// literal rather than discovering that one of the two was spelled differently.
+    /// </summary>
+    [Fact]
+    public void TheMeterAndTheActivitySourceShareThatName() {
+        Assert.Equal(HardenedDiagnostics.SourceName, HardenedDiagnostics.ActivitySource.Name);
+        Assert.Equal(HardenedDiagnostics.SourceName, HardenedDiagnostics.Meter.Name);
+    }
+
+    /// <summary>
+    /// The property the whole design rests on: with nothing listening, starting an activity
+    /// allocates nothing and returns null. That is what makes it reasonable for the pipeline to
+    /// instrument unconditionally, in the runtime, rather than behind a flag or an opt-in package —
+    /// so it is worth an assertion rather than a comment.
+    /// </summary>
+    [Fact]
+    public void NothingIsProducedWhenNothingIsListening() {
+        Assert.Null(HardenedDiagnostics.ActivitySource.StartActivity("GET /orders"));
+    }
+
+    /// <summary>
+    /// And the other half: a listener that subscribes by name gets the activity. No OpenTelemetry
+    /// involved — <c>ActivityListener</c> is in the base class library, which is the same reason the
+    /// instrumented side needs no package either.
+    /// </summary>
+    [Fact]
+    public void AListenerSubscribedByNameSeesActivities() {
+        var started = new List<Activity>();
+
+        using var listener = new ActivityListener {
+            ShouldListenTo = source => source.Name == HardenedDiagnostics.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = started.Add
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        using var activity = HardenedDiagnostics.ActivitySource.StartActivity("GET /orders");
+
+        Assert.NotNull(activity);
+        Assert.Equal("GET /orders", Assert.Single(started).OperationName);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/RequestLoggerSpanTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/RequestLoggerSpanTests.cs
@@ -1,0 +1,291 @@
+using System.Diagnostics;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Logging;
+using Hardened.Shared.Runtime.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Diagnostics;
+
+/// <summary>
+/// The span <see cref="RequestLogger"/> produces alongside its log lines.
+/// </summary>
+/// <remarks>
+/// Attribute names are written as literals here rather than shared with the code under test. They
+/// are a contract with every trace backend that reads them, and a constant shared between the two
+/// would let a rename pass this file while breaking every consumer.
+/// </remarks>
+[Collection(DiagnosticsListenerCollection.Name)]
+public class RequestLoggerSpanTests {
+
+    private static RequestLogger Logger() => new(NullLogger<RequestLogger>.Instance);
+
+    private static IExecutionContext Context(
+        string method = "GET",
+        string path = "/orders/42",
+        int? status = null,
+        string? route = null) {
+
+        var request = Substitute.For<IExecutionRequest>();
+        request.Method.Returns(method);
+        request.Path.Returns(path);
+
+        var response = Substitute.For<IExecutionResponse>();
+        response.Status.Returns(status);
+
+        var context = Substitute.For<IExecutionContext>();
+        context.Request.Returns(request);
+        context.Response.Returns(response);
+        context.StartTime.Returns(MachineTimestamp.Now);
+
+        if (route != null) {
+            var handlerInfo = Substitute.For<IExecutionRequestHandlerInfo>();
+            handlerInfo.Path.Returns(route);
+            handlerInfo.HandlerType.Returns(typeof(RequestLoggerSpanTests));
+            handlerInfo.InvokeMethod.Returns("Handle");
+
+            context.HandlerInfo.Returns(handlerInfo);
+        }
+
+        return context;
+    }
+
+    /// <summary>
+    /// Collects the spans produced while it is alive.
+    /// </summary>
+    private sealed class Listening : IDisposable {
+        private readonly ActivityListener _listener;
+
+        public Listening() {
+            _listener = new ActivityListener {
+                ShouldListenTo = source => source.Name == "Hardened.Requests",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = Started.Add,
+                ActivityStopped = Stopped.Add
+            };
+
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public List<Activity> Started { get; } = [];
+
+        public List<Activity> Stopped { get; } = [];
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    /// <summary>
+    /// The instrumentation is unconditional, so the uninstrumented path has to cost nothing. A
+    /// begin with no listener produces no span and stores nothing.
+    /// </summary>
+    [Fact]
+    public void NoSpanIsStartedWhenNothingIsListening() {
+        Logger().RequestBegin(Context());
+
+        Assert.Null(Activity.Current);
+    }
+
+    [Fact]
+    public void ABeginStartsAServerSpan() {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context());
+
+        var span = Assert.Single(listening.Started);
+
+        Assert.Equal(ActivityKind.Server, span.Kind);
+    }
+
+    /// <summary>
+    /// Named for the method alone at this point: routing has not run, and the conventions are
+    /// explicit that a raw path must never become a span name — one span per order id is a trace
+    /// backend's worst case.
+    /// </summary>
+    [Fact]
+    public void TheSpanIsNamedForTheMethodBeforeRoutingHasRun() {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context(method: "GET", path: "/orders/42"));
+
+        Assert.Equal("GET", Assert.Single(listening.Started).DisplayName);
+    }
+
+    [Fact]
+    public void TheSpanCarriesTheMethodAndPath() {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context(method: "POST", path: "/orders/42"));
+
+        var span = Assert.Single(listening.Started);
+
+        Assert.Equal("POST", span.GetTagItem("http.request.method"));
+        Assert.Equal("/orders/42", span.GetTagItem("url.path"));
+    }
+
+    /// <summary>
+    /// The route template, not the path that arrived — <c>http.route</c> is the low-cardinality
+    /// dimension every latency chart groups by, and <c>/orders/42</c> would make it useless.
+    /// </summary>
+    [Fact]
+    public void MappingAttachesTheRouteTemplateRatherThanThePath() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context(path: "/orders/42", route: "/orders/{id}");
+
+        logger.RequestBegin(context);
+        logger.RequestMapped(context);
+
+        Assert.Equal("/orders/{id}", Assert.Single(listening.Started).GetTagItem("http.route"));
+    }
+
+    /// <summary>
+    /// And the span is renamed the moment routing decides, which is before the handler runs. ASP.NET
+    /// has to go back and rename its span at the end of the request instead.
+    /// </summary>
+    [Fact]
+    public void MappingRenamesTheSpanToMethodAndRoute() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context(method: "GET", path: "/orders/42", route: "/orders/{id}");
+
+        logger.RequestBegin(context);
+        logger.RequestMapped(context);
+
+        Assert.Equal("GET /orders/{id}", Assert.Single(listening.Started).DisplayName);
+    }
+
+    [Fact]
+    public void EndStopsTheSpanAndRecordsTheStatusCode() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context(status: 200);
+
+        logger.RequestBegin(context);
+        logger.RequestEnd(context);
+
+        var span = Assert.Single(listening.Stopped);
+
+        Assert.Equal(200, span.GetTagItem("http.response.status_code"));
+    }
+
+    /// <summary>
+    /// Nothing assigns a status on an ordinary success path in this pipeline — null means "handled,
+    /// no opinion", and each transport renders it as 200 when it writes the response. Leaving the
+    /// tag off for that case would strip a required attribute from every successful span, which is
+    /// what an integration test through a real host caught and the unit tests here did not.
+    /// </summary>
+    [Fact]
+    public void ARequestThatSetNoStatusIsRecordedAsTwoHundred() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context(status: null);
+
+        logger.RequestBegin(context);
+        logger.RequestEnd(context);
+
+        Assert.Equal(200, Assert.Single(listening.Stopped).GetTagItem("http.response.status_code"));
+    }
+
+    /// <summary>
+    /// 5xx is the server failing, and shows up in a backend's error rate.
+    /// </summary>
+    [Fact]
+    public void AServerErrorMarksTheSpanErrored() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context(status: 503);
+
+        logger.RequestBegin(context);
+        logger.RequestEnd(context);
+
+        Assert.Equal(ActivityStatusCode.Error, Assert.Single(listening.Stopped).Status);
+    }
+
+    /// <summary>
+    /// 4xx is the caller's mistake and is deliberately left Unset, so that an error rate means "this
+    /// service is failing" rather than "someone requested something that is not there".
+    /// </summary>
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    [InlineData(422)]
+    public void AClientErrorLeavesTheSpanUnset(int status) {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context(status: status);
+
+        logger.RequestBegin(context);
+        logger.RequestEnd(context);
+
+        Assert.Equal(ActivityStatusCode.Unset, Assert.Single(listening.Stopped).Status);
+    }
+
+    [Fact]
+    public void AFailureRecordsTheExceptionTypeAndMarksTheSpanErrored() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context();
+
+        logger.RequestBegin(context);
+        logger.RequestFailed(context, new InvalidOperationException("handler blew up"));
+
+        var span = Assert.Single(listening.Started);
+
+        Assert.Equal("System.InvalidOperationException", span.GetTagItem("error.type"));
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
+    }
+
+    /// <summary>
+    /// The stack goes on the span as well as in the log line. Logs and traces are sampled and
+    /// retained separately, so a span that says only "it failed" sends whoever is reading it looking
+    /// for a log line that may no longer exist.
+    /// </summary>
+    [Fact]
+    public void AFailureCarriesTheStackOnAnExceptionEvent() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var context = Context();
+
+        logger.RequestBegin(context);
+        logger.RequestFailed(context, new InvalidOperationException("handler blew up"));
+
+        var recorded = Assert.Single(Assert.Single(listening.Started).Events);
+
+        Assert.Equal("exception", recorded.Name);
+        Assert.Equal("System.InvalidOperationException", recorded.Tags.Single(t => t.Key == "exception.type").Value);
+        Assert.Equal("handler blew up", recorded.Tags.Single(t => t.Key == "exception.message").Value);
+        Assert.Contains("InvalidOperationException", (string)recorded.Tags.Single(t => t.Key == "exception.stacktrace").Value!);
+    }
+
+    /// <summary>
+    /// Each request gets its own span, keyed by its own context. Taking the span from
+    /// <c>Activity.Current</c> instead would hand the second request the first one's.
+    /// </summary>
+    [Fact]
+    public void TwoRequestsGetTwoSpans() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        var first = Context(path: "/orders/1", status: 200);
+        var second = Context(path: "/orders/2", status: 201);
+
+        logger.RequestBegin(first);
+        logger.RequestBegin(second);
+        logger.RequestEnd(second);
+        logger.RequestEnd(first);
+
+        Assert.Equal(2, listening.Stopped.Count);
+        Assert.Equal(
+            [201, 200],
+            listening.Stopped.Select(s => s.GetTagItem("http.response.status_code")));
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Diagnostics/HardenedDiagnostics.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Diagnostics/HardenedDiagnostics.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Hardened.Requests.Runtime.Diagnostics;
+
+/// <summary>
+/// The <see cref="System.Diagnostics.ActivitySource"/> and <see cref="System.Diagnostics.Metrics.Meter"/>
+/// the request pipeline reports through.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both types are in the base class library on net8.0, so instrumenting against them adds no
+/// dependency to any application that never collects any of it. OpenTelemetry is one consumer of
+/// these, not the interface to them: an OTel SDK, Application Insights, Datadog, prometheus-net and
+/// <c>dotnet-counters</c> all subscribe to the same two objects. That is why there is no
+/// <c>Hardened.Telemetry.OpenTelemetry</c> package and no OTel type anywhere in this assembly.
+/// </para>
+/// <para>
+/// Nothing here needs an AOT story of its own. ILC disables <c>EventSource</c>
+/// (<c>System.Diagnostics.Tracing.EventSource.IsSupported=false</c>) but leaves <c>Activity</c>,
+/// <c>ActivitySource</c> and <c>Meter</c> alone, so in-process listeners work in a native binary
+/// exactly as they do on the JIT. Out-of-process collection - <c>dotnet-counters</c>,
+/// <c>dotnet-trace</c>, <c>dotnet-monitor</c> - is what stops working, and an application that wants
+/// it sets <c>&lt;EventSourceSupport&gt;true&lt;/EventSourceSupport&gt;</c>. Worth knowing because
+/// AOT also rules out profiler-based auto-instrumentation: a framework that publishes native has to
+/// instrument itself, which is what this is.
+/// </para>
+/// <para>
+/// Neither object is disposed. Both are process-lifetime, and disposing an
+/// <c>ActivitySource</c> stops it producing activities for the rest of the process.
+/// </para>
+/// </remarks>
+public static class HardenedDiagnostics {
+    /// <summary>
+    /// The name to subscribe to, for both signals.
+    /// </summary>
+    /// <remarks>
+    /// A published contract string: it is what an application passes to <c>AddSource</c> and
+    /// <c>AddMeter</c>, and changing it silently stops collection for everyone who already
+    /// configured it. There is a test asserting this exact value for that reason.
+    /// </remarks>
+    public const string SourceName = "Hardened.Requests";
+
+    private static readonly string? AssemblyVersion =
+        typeof(HardenedDiagnostics).Assembly.GetName().Version?.ToString();
+
+    /// <summary>
+    /// Where request spans come from.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="System.Diagnostics.ActivitySource.StartActivity(string, ActivityKind)"/> returns
+    /// <c>null</c> when nothing is listening, so the pipeline can instrument unconditionally and an
+    /// application that collects nothing pays for a null check. That is what makes it reasonable
+    /// for this to live in the runtime rather than behind a flag or an opt-in package.
+    /// </remarks>
+    public static readonly ActivitySource ActivitySource = new(SourceName, AssemblyVersion);
+
+    /// <summary>
+    /// Where request measurements come from.
+    /// </summary>
+    /// <remarks>
+    /// A static instance rather than <c>IMeterFactory</c>, which would give per-container isolation
+    /// but lives in Microsoft.Extensions.Diagnostics.Abstractions - a package, and the whole point
+    /// of this file is that there is not one.
+    /// </remarks>
+    public static readonly Meter Meter = new(SourceName, AssemblyVersion);
+}

--- a/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
@@ -1,13 +1,48 @@
-﻿using DependencyModules.Runtime.Attributes;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Logging;
+using Hardened.Requests.Runtime.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Hardened.Requests.Runtime.Logging;
 
+/// <summary>
+/// Reports the request lifecycle: a log line, and a span.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both, from one type, because they are the same events. <see cref="IRequestLogger"/> is already a
+/// bracketed lifecycle - begin, mapped, end, failed - and <see cref="RequestEnd"/> already computed
+/// an elapsed duration before any of this existed. A span is that same record written to a
+/// different kind of sink, so it needs no second interface, no scope object to thread through the
+/// hosts, and no change at any of the five call sites.
+/// </para>
+/// <para>
+/// Nothing here references OpenTelemetry. <c>ActivitySource</c> is in the base class library and an
+/// OTel SDK is one of several things that can subscribe to it - see
+/// <see cref="HardenedDiagnostics"/>.
+/// </para>
+/// </remarks>
 [SingletonService(Using = RegistrationType.Try)]
 public partial class RequestLogger : IRequestLogger {
-    private static readonly TimeSpan _emptyTimeSpan = new(0);
+    /// <summary>
+    /// The span in flight, keyed by the context it belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Keyed rather than taken from <c>Activity.Current</c>, which is ambient and would hand
+    /// <see cref="RequestEnd"/> whatever the handler happened to leave current - a child span it
+    /// forgot to stop, on the wrong request entirely once a batch forks. The context is the thing
+    /// the span actually belongs to, and it is already passed to every method here.
+    ///
+    /// Weak keys, so a context that is dropped without an end - a host that throws between begin and
+    /// end - takes its entry with it rather than pinning the request forever. Empty whenever nothing
+    /// is listening, because a null activity is never stored, which is what keeps the lookups on the
+    /// uninstrumented path down to a miss on an empty table.
+    /// </remarks>
+    private static readonly ConditionalWeakTable<IExecutionContext, Activity> _spans = new();
+
     private readonly ILogger<RequestLogger> _logger;
 
     public RequestLogger(ILogger<RequestLogger> logger) {
@@ -16,11 +51,40 @@ public partial class RequestLogger : IRequestLogger {
 
     public void RequestBegin(IExecutionContext context) {
         LogRequestStarted(context.Request.Method, context.Request.Path);
+
+        // Null when nothing is listening - no allocation, no work - which is why this is
+        // unconditional and lives in the runtime rather than behind a flag or an opt-in package.
+        //
+        // Named for the method alone: the route is not known yet, and the semantic conventions are
+        // explicit that a raw path must not become a span name. RequestMapped renames it below.
+        var span = HardenedDiagnostics.ActivitySource.StartActivity(
+            context.Request.Method, ActivityKind.Server);
+
+        if (span is null) {
+            return;
+        }
+
+        span.SetTag("http.request.method", context.Request.Method);
+        span.SetTag("url.path", context.Request.Path);
+
+        _spans.AddOrUpdate(context, span);
     }
 
     public void RequestMapped(IExecutionContext context) {
         LogRequestMapped(context.Request.Method, context.Request.Path, context.HandlerInfo!.HandlerType.Name,
              context.HandlerInfo!.InvokeMethod);
+
+        if (!_spans.TryGetValue(context, out var span)) {
+            return;
+        }
+
+        // The low-cardinality template, not the path that arrived. Attached here, before the handler
+        // runs, because this is the moment routing decided - where ASP.NET has to go back and rename
+        // its span after the fact.
+        var route = context.HandlerInfo!.Path;
+
+        span.SetTag("http.route", route);
+        span.DisplayName = context.Request.Method + " " + route;
     }
 
     public void RequestEnd(IExecutionContext context) {
@@ -30,6 +94,34 @@ public partial class RequestLogger : IRequestLogger {
             context.Response.Status,
             context.StartTime.GetElapsedTime()
         );
+
+        if (!_spans.TryGetValue(context, out var span)) {
+            return;
+        }
+
+        _spans.Remove(context);
+
+        // Null means "handled, no opinion": nothing assigns a status on an ordinary success path,
+        // and every transport renders that as 200 when it writes the response. Leaving the tag off
+        // instead would strip a required attribute from every successful span, which is what an
+        // integration test through the real host caught and the unit tests around this could not.
+        //
+        // It is only ever null when no one supplied one. The web responses read through -
+        // `_status ?? (HasStarted ? StatusCode : null)` - so by the time the request ends this is
+        // already the real code, including one that ASP.NET's own pipeline produced after Hardened
+        // declined the request.
+        var status = context.Response.Status ?? 200;
+
+        span.SetTag("http.response.status_code", status);
+
+        // 4xx is the caller's mistake, not the server's. The conventions leave a server span Unset
+        // for those and reserve Error for 5xx, so that a trace backend's error rate means "this
+        // service failed" rather than "someone sent a bad request".
+        if (status >= 500) {
+            span.SetStatus(ActivityStatusCode.Error);
+        }
+
+        span.Stop();
     }
 
     public void RequestParameterBindFailed(IExecutionContext context, Exception? exp) {
@@ -39,6 +131,22 @@ public partial class RequestLogger : IRequestLogger {
 
     public void RequestFailed(IExecutionContext context, Exception exp) {
         _logger.LogError(exp, "{method} {path} request failed", context.Request.Method, context.Request.Path);
+
+        if (!_spans.TryGetValue(context, out var span)) {
+            return;
+        }
+
+        span.SetTag("error.type", exp.GetType().FullName);
+        span.SetStatus(ActivityStatusCode.Error, exp.Message);
+
+        // The stack repeats what the log line above already carries, deliberately: logs and traces
+        // are sampled and retained separately, and a trace that says only "it failed" sends whoever
+        // is reading it looking for a log line that may no longer exist.
+        span.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection {
+            { "exception.type", exp.GetType().FullName },
+            { "exception.message", exp.Message },
+            { "exception.stacktrace", exp.ToString() }
+        }));
     }
 
     public void ResourceNotFound(IExecutionContext context) {


### PR DESCRIPTION
P5.1 and P5.2 of the observability work.

## No second interface, no host changes

`IRequestLogger` was already a bracketed lifecycle — begin, mapped, end, failed — and `RequestEnd` already computed an elapsed duration. A span is that same record written to a different kind of sink, so `RequestLogger` now starts one and the five call sites that already report through it need **no change at all**.

That was your call and it was the right one: I'd initially reached for a scope-returning `IRequestDiagnostics`, which was cargo-culted from libraries that don't already have a lifecycle interface to hang this on.

## No OpenTelemetry dependency — or any dependency

`HardenedDiagnostics` holds an `ActivitySource` and a `Meter`. Both are in the base class library on net8.0, so this adds no `PackageReference`. An OTel SDK, Application Insights, Datadog, prometheus-net and `dotnet-counters` all subscribe to the same two objects — OTel is a *consumer* of `System.Diagnostics`, not the interface to it. Which is why there's no `Hardened.Telemetry.OpenTelemetry` package here.

## AOT needs nothing special, and needs this most

ILC disables `EventSource` but leaves `Activity`, `ActivitySource` and `Meter` alone, so in-process listeners work in a native binary exactly as on the JIT. Verified by publishing the AOT SUT with `-warnaserror`: ILC compiled the whole program with **zero IL2xxx/IL3xxx**. (The local link fails on a macOS SDK mismatch — Homebrew clang wants `MacOSX26.sdk`; CI does the real link on Linux.)

This matters more than usual here: AOT rules out profiler-based auto-instrumentation, so a framework that publishes native has to instrument itself.

## Cost when nobody is looking

`StartActivity` returns `null` with no listener, so the instrumentation is unconditional and an application collecting nothing pays for a null check. The span is keyed by its context in a `ConditionalWeakTable` rather than taken from `Activity.Current` — ambient state would hand `RequestEnd` whatever the handler left current: a child it forgot to stop, or the wrong request entirely once a batch forks.

## Two things only a real host caught

There's an integration test through the real routing table as well as unit tests, and it earned its place twice:

- **Nothing assigns a status on an ordinary success path.** Null means "handled, no opinion" and each transport renders it as 200 when writing the response — so reading it literally stripped `http.response.status_code` off *every successful span*. The unit tests could not have found this.
- **The first version of that test raced.** It collected into a `List` while other tests in the assembly produced spans through the same process-global source, and threw `Collection was modified` about one run in two. It now picks its span out inside the callback. Confirmed over five consecutive runs.

## Semantic conventions

`http.route` is attached at `RequestMapped`, before the handler runs — where ASP.NET has to go back and rename its span at the end of the request. 4xx deliberately leaves the span `Unset` and only 5xx marks it `Error`, so an error rate means "this service failed" rather than "someone asked for something that isn't there".

Attribute names are literals in the tests, not constants shared with the code. They're a contract with every backend that reads them, and a shared constant would let a rename pass here while breaking every consumer.

## Verification

Clean build, 18/18 assemblies green. The one remaining warning is pre-existing — MSB3277 from the `Microsoft.OpenApi` 3.x bump, tracked separately.

`HardenedDiagnostics` is new public surface; the approved API file moves with it.

## Still to come

P5.3 (`Meter`-backed provider), P5.4 (trace context propagation), P5.5 (telemetry conformance across transports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnFd3pmQzm4m41u8vk1mbw