### PR TITLE
Record what the pipeline measures onto a Meter as well

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -71,6 +71,11 @@ namespace Hardened.Requests.Runtime.Diagnostics
         public static readonly System.Diagnostics.ActivitySource ActivitySource;
         public static readonly System.Diagnostics.Metrics.Meter Meter;
     }
+    public class MeterMetricLoggerProvider : Hardened.Shared.Runtime.Metrics.IMetricLoggerProvider
+    {
+        public MeterMetricLoggerProvider() { }
+        public Hardened.Shared.Runtime.Metrics.IMetricLogger CreateLogger(string loggerName) { }
+    }
 }
 namespace Hardened.Requests.Runtime.Errors
 {

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/MeterMetricLoggerProviderTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/MeterMetricLoggerProviderTests.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics.Metrics;
+using Hardened.Requests.Abstract.Metrics;
+using Hardened.Requests.Runtime.Diagnostics;
+using Hardened.Shared.Runtime.Metrics;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Diagnostics;
+
+/// <summary>
+/// What the pipeline's measurements look like once they reach a <c>Meter</c>.
+/// </summary>
+/// <remarks>
+/// Instrument names and units are literals here rather than constants shared with the code under
+/// test — they are what a dashboard query is written against, so a rename has to fail a test rather
+/// than pass one.
+/// </remarks>
+[Collection(DiagnosticsListenerCollection.Name)]
+public class MeterMetricLoggerProviderTests {
+
+    private sealed record Measurement(string Instrument, string? Unit, double Value, KeyValuePair<string, object?>[] Tags);
+
+    /// <summary>
+    /// Collects measurements published by the Hardened meter while it is alive.
+    /// </summary>
+    private sealed class Listening : IDisposable {
+        private readonly MeterListener _listener;
+
+        public Listening() {
+            _listener = new MeterListener {
+                InstrumentPublished = (instrument, listener) => {
+                    if (instrument.Meter.Name == "Hardened.Requests") {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+                Measurements.Add(new Measurement(instrument.Name, instrument.Unit, value, tags.ToArray())));
+
+            _listener.Start();
+        }
+
+        public List<Measurement> Measurements { get; } = [];
+
+        public Measurement Single(string instrument) =>
+            Assert.Single(Measurements, m => m.Instrument == instrument);
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private static IMetricLogger Logger() => new MeterMetricLoggerProvider().CreateLogger("ignored");
+
+    /// <summary>
+    /// The conventions name this one and define it in seconds; <c>RequestMetrics</c> records
+    /// milliseconds. Translating here rather than changing the definition keeps every existing EMF
+    /// dashboard pointing at the same numbers it always did.
+    /// </summary>
+    [Fact]
+    public void TheRequestDurationTakesItsConventionalNameAndUnit() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        logger.Record(RequestMetrics.TotalRequestDuration, 1500);
+        logger.Dispose();
+
+        var measurement = listening.Single("http.server.request.duration");
+
+        Assert.Equal("s", measurement.Unit);
+        Assert.Equal(1.5, measurement.Value, 6);
+    }
+
+    /// <summary>
+    /// There is no convention for how long parameter binding took, so it passes through under its
+    /// own name — as does anything an application defines for itself.
+    /// </summary>
+    [Fact]
+    public void AMetricWithNoConventionPassesThroughUnchanged() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        logger.Record(RequestMetrics.ParameterBindDuration, 12);
+        logger.Dispose();
+
+        var measurement = listening.Single("ParameterBindDuration");
+
+        Assert.Equal("ms", measurement.Unit);
+        Assert.Equal(12, measurement.Value);
+    }
+
+    [Fact]
+    public void UnitsAreTranslatedToUcum() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        logger.Record(new MetricDefinition("ucum.probe.count", MetricUnits.Count), 3);
+        logger.Record(new MetricDefinition("ucum.probe.seconds", MetricUnits.Seconds), 4);
+        logger.Dispose();
+
+        Assert.Equal("{count}", listening.Single("ucum.probe.count").Unit);
+        Assert.Equal("s", listening.Single("ucum.probe.seconds").Unit);
+    }
+
+    /// <summary>
+    /// The reason measurements are buffered rather than recorded as they arrive. Every host records
+    /// the request duration and only then calls <c>RequestEnd</c>, so a dimension attached at the end
+    /// of a request would otherwise arrive after the measurement it describes and be lost.
+    /// </summary>
+    [Fact]
+    public void AMeasurementCarriesTagsSetAfterItWasRecorded() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        logger.Record(RequestMetrics.TotalRequestDuration, 1000);
+        logger.Tag("http.route", "/orders/{id}");
+        logger.Dispose();
+
+        var tag = Assert.Single(listening.Single("http.server.request.duration").Tags);
+
+        Assert.Equal("http.route", tag.Key);
+        Assert.Equal("/orders/{id}", tag.Value);
+    }
+
+    [Fact]
+    public void NothingIsRecordedUntilTheRequestEnds() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        logger.Record(new MetricDefinition("buffering.probe", MetricUnits.Count), 1);
+
+        Assert.DoesNotContain(listening.Measurements, m => m.Instrument == "buffering.probe");
+
+        logger.Dispose();
+
+        Assert.Contains(listening.Measurements, m => m.Instrument == "buffering.probe");
+    }
+
+    /// <summary>
+    /// A host that flushes and then disposes — or disposes twice — records the request once.
+    /// </summary>
+    [Fact]
+    public async Task FlushingAndThenDisposingRecordsOnce() {
+        using var listening = new Listening();
+
+        var logger = Logger();
+        logger.Record(new MetricDefinition("once.probe", MetricUnits.Count), 1);
+
+        await logger.Flush();
+        logger.Dispose();
+        logger.Dispose();
+
+        Assert.Single(listening.Measurements, m => m.Instrument == "once.probe");
+    }
+
+    /// <summary>
+    /// <c>CreateLogger</c> runs once per request. A histogram created per request would publish a
+    /// fresh instrument to every listener on every request, so the instruments are cached against
+    /// the process-lifetime meter instead.
+    /// </summary>
+    [Fact]
+    public void TwoRequestsShareOneInstrument() {
+        var published = new List<Instrument>();
+
+        using var listener = new MeterListener {
+            InstrumentPublished = (instrument, _) => {
+                if (instrument.Name == "sharing.probe") {
+                    published.Add(instrument);
+                }
+            }
+        };
+
+        listener.Start();
+
+        var provider = new MeterMetricLoggerProvider();
+        var definition = new MetricDefinition("sharing.probe", MetricUnits.Count);
+
+        var first = provider.CreateLogger("a");
+        first.Record(definition, 1);
+        first.Dispose();
+
+        var second = provider.CreateLogger("b");
+        second.Record(definition, 2);
+        second.Dispose();
+
+        Assert.Single(published);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Diagnostics/MeterMetricLoggerProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Diagnostics/MeterMetricLoggerProvider.cs
@@ -1,0 +1,157 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Hardened.Shared.Runtime.Metrics;
+
+namespace Hardened.Requests.Runtime.Diagnostics;
+
+/// <summary>
+/// Records what the pipeline measures onto <see cref="HardenedDiagnostics.Meter"/>, so that anything
+/// subscribing to it — an OpenTelemetry SDK, prometheus-net, <c>dotnet-counters</c> — sees the same
+/// numbers CloudWatch does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately not registered. <c>NullMetricLoggerProvider</c> is the framework default and
+/// registers with <c>RegistrationType.Try</c>; the Lambda EMF provider registers unconditionally and
+/// so beats it. A third unconditional registration would mean whichever module happened to be
+/// composed last decided where an application's metrics went. An application asks for this one:
+/// </para>
+/// <code>
+/// services.RemoveAll&lt;IMetricLoggerProvider&gt;();
+/// services.AddSingleton&lt;IMetricLoggerProvider, MeterMetricLoggerProvider&gt;();
+/// </code>
+/// <para>
+/// <c>loggerName</c> is ignored. EMF uses it as a CloudWatch namespace; a <c>Meter</c> already has a
+/// name, and the scope a consumer subscribes to is <see cref="HardenedDiagnostics.SourceName"/>.
+/// Turning a per-request string into a per-request Meter would create one instrument set per request.
+/// </para>
+/// </remarks>
+public class MeterMetricLoggerProvider : IMetricLoggerProvider {
+    /// <summary>
+    /// One instrument per metric name, for the life of the process.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CreateLogger"/> is called once per request, and creating a histogram per request
+    /// would publish a fresh instrument to every listener each time. The instruments belong to the
+    /// static Meter, so they are cached statically alongside it rather than per provider instance.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<string, Histogram<double>> _histograms = new();
+
+    /// <summary>
+    /// Metrics the HTTP semantic conventions already have a name for, and the factor that converts
+    /// what Hardened records into what the conventions expect.
+    /// </summary>
+    /// <remarks>
+    /// The conventions define <c>http.server.request.duration</c> in <em>seconds</em>;
+    /// <c>RequestMetrics</c> is in milliseconds. The translation happens here rather than by
+    /// changing the definition, because the definition is also what EMF emits — renaming it or
+    /// changing its unit would move every existing CloudWatch dashboard underneath a spec those
+    /// dashboards do not care about.
+    ///
+    /// Everything not named here passes through as it is, including an application's own metrics.
+    /// There is no convention for how long a handler took to bind its parameters.
+    /// </remarks>
+    private static readonly Dictionary<string, (string Name, string Unit, double Scale)> _conventions =
+        new() {
+            ["TotalRequestDuration"] = ("http.server.request.duration", "s", 0.001)
+        };
+
+    public IMetricLogger CreateLogger(string loggerName) {
+        return new MeterMetricLogger();
+    }
+
+    private static Histogram<double> HistogramFor(IMetricDefinition metric) {
+        return _histograms.GetOrAdd(
+            metric.Name,
+            static (_, definition) => {
+                var (name, unit, _) = Translate(definition);
+
+                return HardenedDiagnostics.Meter.CreateHistogram<double>(name, unit);
+            },
+            metric);
+    }
+
+    private static (string Name, string Unit, double Scale) Translate(IMetricDefinition metric) {
+        return _conventions.TryGetValue(metric.Name, out var convention)
+            ? convention
+            : (metric.Name, Ucum(metric.Units), 1d);
+    }
+
+    /// <summary>
+    /// <see cref="MetricUnits"/> spells its units the way CloudWatch does. A Meter unit is UCUM.
+    /// </summary>
+    private static string Ucum(MetricUnits units) {
+        return units.Name switch {
+            "Milliseconds" => "ms",
+            "Seconds" => "s",
+            "Count" => "{count}",
+            _ => units.Name
+        };
+    }
+
+    /// <summary>
+    /// Buffers a request's measurements and records them when it ends.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Buffered rather than recorded as they arrive, because a histogram wants its dimensions at the
+    /// moment of recording and the pipeline does not have them yet. Every host records
+    /// <c>TotalRequestDuration</c> and only then calls <c>RequestEnd</c>, so anything tagged with the
+    /// status or the route would arrive after the measurement it belongs to. Buffering also means
+    /// <see cref="IMetricLogger"/> behaves the same way whichever provider is behind it — EMF has
+    /// always accumulated and written one line at the end.
+    /// </para>
+    /// <para>
+    /// The flush point exists because every host disposes its logger. That was not true until
+    /// recently: three of them recorded and never disposed, which is invisible under the null
+    /// provider and would have made this one silently emit nothing.
+    /// </para>
+    /// </remarks>
+    private sealed class MeterMetricLogger : IMetricLogger {
+        private readonly List<(IMetricDefinition Metric, double Value)> _measurements = [];
+        private readonly List<KeyValuePair<string, object?>> _tags = [];
+        private int _disposed;
+
+        public void Record(IMetricDefinition metric, double value) {
+            _measurements.Add((metric, value));
+        }
+
+        public void Tag(string tagName, object tagValue) {
+            _tags.Add(new KeyValuePair<string, object?>(tagName, tagValue));
+        }
+
+        /// <summary>
+        /// Dropped. A Meter measurement carries dimensions, not arbitrary properties, and promoting
+        /// free-form data to dimensions is how a metrics bill becomes a surprise.
+        /// </summary>
+        public void Data(string dataName, object dataValue) { }
+
+        public Task Flush() {
+            Emit();
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose() {
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0) {
+                Emit();
+            }
+        }
+
+        private void Emit() {
+            if (_measurements.Count == 0) {
+                return;
+            }
+
+            var tags = _tags.ToArray();
+
+            foreach (var (metric, value) in _measurements) {
+                var (_, _, scale) = Translate(metric);
+
+                HistogramFor(metric).Record(value * scale, tags);
+            }
+
+            _measurements.Clear();
+        }
+    }
+}


### PR DESCRIPTION
P5.3. `MeterMetricLoggerProvider` puts the pipeline's measurements onto `HardenedDiagnostics.Meter`, so anything subscribing — an OpenTelemetry SDK, prometheus-net, `dotnet-counters` — sees the same numbers CloudWatch does. No new dependency; `Meter` is in the base class library.

## Not registered, on purpose

`NullMetricLoggerProvider` is the framework default and registers with `RegistrationType.Try`; the Lambda EMF provider registers unconditionally and so beats it. A third unconditional registration would mean **whichever module happened to be composed last decided where an application's metrics went**. So an application asks for this one by name.

## Three things the shape of `IMetricLogger` decided

**Measurements are buffered and recorded when the request ends**, not as they arrive. A histogram wants its dimensions at the moment of recording, and every host records `TotalRequestDuration` and *only then* calls `RequestEnd` — so anything tagged with a status or route would arrive after the measurement it describes. Buffering also gives `IMetricLogger` one semantic across providers; EMF has always accumulated and written one line at the end.

That flush point only exists because every host now disposes its logger — which wasn't true a few commits ago, and is invisible under the null provider.

**Instruments are cached against the static meter.** `CreateLogger` runs once per request; a histogram per request would publish a fresh instrument to every listener every time.

**`TotalRequestDuration` becomes `http.server.request.duration` in seconds.** The conventions define it that way; `RequestMetrics` records milliseconds. Translating here rather than changing the definition keeps every existing EMF dashboard pointing at the same numbers — which is what you asked for. Everything else passes through under its own name with its unit mapped to UCUM, including an application's own metrics; there's no convention for how long parameter binding took.

`Data()` is dropped: a Meter measurement carries dimensions, not arbitrary properties, and promoting free-form data to dimensions is how a metrics bill becomes a surprise.

## Dimensions are not here yet — deliberately

The histograms carry no dimensions. The only channel is `IMetricLogger.Tag`, which feeds EMF too, and the default `DimensionSetProvider` promoted **every** tag to a CloudWatch dimension — billed per unique combination. That's handled in the companion Amz PR, which makes the default promote nothing and adds `TagDimensionSetProvider` so each customer names its own.

Tagging the route and status can land once that's in, on a default that can't surprise anyone's bill.

## Verification

Clean build, 18/18 assemblies. `MeterMetricLoggerProvider` is new public surface; the approved API file moves with it.

Two pre-existing issues seen while verifying, both logged rather than touched: the MSB3277 warning from the `Microsoft.OpenApi` 3.x bump, and `MachineTimestampTests.TimeSpanTest`, which asserts a `Thread.Sleep(100)` lands under 200ms and fails under parallel load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnFd3pmQzm4m41u8vk1mbw