### PR TITLE
Finish the observability story, and find a header whatever case it arrived in

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -303,6 +303,7 @@ namespace Hardened.Requests.Runtime.Headers
         public System.Collections.Generic.IDictionary<string, string> ToStringDictionary() { }
         public bool TryGet(string key, out Microsoft.Extensions.Primitives.StringValues value) { }
         public bool TryGetValue(string key, out Microsoft.Extensions.Primitives.StringValues value) { }
+        public static System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> EnsureCaseInsensitive(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
     }
     public class HeaderCookieSetCollection : Hardened.Requests.Abstract.Headers.ICookieSetCollection
     {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
@@ -14,6 +14,16 @@ namespace Hardened.Requests.Testing.Conformance
     {
         protected ExecutionRequestConformanceTests() { }
         protected abstract Hardened.Requests.Testing.Conformance.IExecutionRequestConformanceAdapter Adapter { get; }
+        [Xunit.InlineData(new object[] {
+                "CONTENT-TYPE",
+                "Content-Type"})]
+        [Xunit.InlineData(new object[] {
+                "Content-Type",
+                "content-type"})]
+        [Xunit.InlineData(new object[] {
+                "content-type",
+                "Content-Type"})]
+        public void AHeaderIsFoundUnderAnySpelling(string written, string read) { }
         public void AcceptComesFromTheAcceptHeader() { }
         public void AcceptReflectsANonJsonValue() { }
         public void BodyIsReadable() { }
@@ -26,6 +36,7 @@ namespace Hardened.Requests.Testing.Conformance
         public void CloneReplacesHeadersWhenHeadersAreProvided() { }
         public void CloneReplacesMethodWhenMethodIsProvided() { }
         public void CloneReplacesPathWhenPathIsProvided() { }
+        public void ContentTypeAndAcceptIgnoreTheCaseTheyArriveIn() { }
         public void ContentTypeComesFromTheContentTypeHeader() { }
         public void CookiesAreEmptyRatherThanNullWhenNoneWereSent() { }
         public void CookiesAreSurfaced() { }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
@@ -88,6 +88,11 @@ namespace Hardened.Requests.Testing.Conformance
         System.Threading.Tasks.Task<Hardened.Requests.Testing.Conformance.ObservedResponse> Complete(Hardened.Requests.Abstract.Execution.IExecutionResponse response);
         Hardened.Requests.Abstract.Execution.IExecutionResponse CreateResponse();
     }
+    public interface IRequestTelemetryConformanceAdapter
+    {
+        string TransportName { get; }
+        System.Threading.Tasks.Task Dispatch(Hardened.Requests.Testing.Conformance.TelemetryConformanceRequest request);
+    }
     public class ObservedResponse : System.IEquatable<Hardened.Requests.Testing.Conformance.ObservedResponse>
     {
         public ObservedResponse(int StatusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IReadOnlyList<string>> Headers, System.Collections.Generic.IReadOnlyList<string> SetCookies, byte[] Body) { }
@@ -97,6 +102,33 @@ namespace Hardened.Requests.Testing.Conformance
         public int StatusCode { get; init; }
         public string BodyAsText() { }
         public string? Header(string name) { }
+    }
+    public abstract class RequestTelemetryConformanceTests
+    {
+        protected RequestTelemetryConformanceTests() { }
+        protected abstract Hardened.Requests.Testing.Conformance.IRequestTelemetryConformanceAdapter Adapter { get; }
+        [Xunit.InlineData(new object[] {
+                400})]
+        [Xunit.InlineData(new object[] {
+                404})]
+        public System.Threading.Tasks.Task AClientErrorLeavesTheSpanUnset(int status) { }
+        public System.Threading.Tasks.Task ARequestProducesAServerSpan() { }
+        public System.Threading.Tasks.Task ARequestWithNoTraceparentStartsANewTrace() { }
+        public System.Threading.Tasks.Task AServerErrorMarksTheSpanErrored() { }
+        public System.Threading.Tasks.Task AStatusSetByTheHandlerIsRecorded() { }
+        public System.Threading.Tasks.Task ASuccessThatSetNoStatusIsRecordedAsTwoHundred() { }
+        public System.Threading.Tasks.Task TheSpanCarriesTheMethod() { }
+        public System.Threading.Tasks.Task TheSpanIsStopped() { }
+        public System.Threading.Tasks.Task TheSpanJoinsTheTraceItsCallerSent() { }
+        public System.Threading.Tasks.Task TheTraceparentIsFoundWhateverCaseItArrivedIn() { }
+    }
+    public sealed class TelemetryConformanceRequest
+    {
+        public TelemetryConformanceRequest() { }
+        public System.Action<Hardened.Requests.Abstract.Execution.IExecutionContext>? Handler { get; init; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> Headers { get; init; }
+        public required string Method { get; init; }
+        public required string Path { get; init; }
     }
 }
 namespace Hardened.Requests.Testing

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/RequestLoggerSpanTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Diagnostics/RequestLoggerSpanTests.cs
@@ -1,6 +1,9 @@
 using System.Diagnostics;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Runtime.Logging;
+using Hardened.Requests.Runtime.Headers;
+using Hardened.Shared.Runtime.Metrics;
+using Microsoft.Extensions.Primitives;
 using Hardened.Shared.Runtime.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -25,11 +28,17 @@ public class RequestLoggerSpanTests {
         string method = "GET",
         string path = "/orders/42",
         int? status = null,
-        string? route = null) {
+        string? route = null,
+        IDictionary<string, StringValues>? headers = null) {
 
         var request = Substitute.For<IExecutionRequest>();
         request.Method.Returns(method);
         request.Path.Returns(path);
+
+        // A real header collection rather than a substitute, so lookups behave the way they do on a
+        // transport - case-insensitively.
+        request.Headers.Returns(new HeaderCollectionStringValues(
+            headers ?? new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)));
 
         var response = Substitute.For<IExecutionResponse>();
         response.Status.Returns(status);
@@ -37,6 +46,7 @@ public class RequestLoggerSpanTests {
         var context = Substitute.For<IExecutionContext>();
         context.Request.Returns(request);
         context.Response.Returns(response);
+        context.RequestMetrics.Returns(Substitute.For<IMetricLogger>());
         context.StartTime.Returns(MachineTimestamp.Now);
 
         if (route != null) {
@@ -287,5 +297,157 @@ public class RequestLoggerSpanTests {
         Assert.Equal(
             [201, 200],
             listening.Stopped.Select(s => s.GetTagItem("http.response.status_code")));
+    }
+
+    // ---- metric dimensions -------------------------------------------------------------------
+
+    /// <summary>
+    /// Without these, <c>http.server.request.duration</c> is one histogram for the whole service.
+    /// </summary>
+    /// <remarks>
+    /// Attached whether or not anything is tracing, because metrics and traces are collected
+    /// independently — a service exporting metrics and no traces still needs to group by route.
+    /// Safe to attach unconditionally because a provider decides what becomes of a tag: the Meter
+    /// bridge makes it a histogram dimension, and EMF promotes nothing unless the application opted
+    /// the tag in, since a CloudWatch dimension is billed per distinct value.
+    /// </remarks>
+    [Fact]
+    public void TheDimensionsAreTaggedWithNothingListening() {
+        var logger = Logger();
+        var context = Context(method: "POST", route: "/orders/{id}", status: 201);
+
+        logger.RequestBegin(context);
+        logger.RequestMapped(context);
+        logger.RequestEnd(context);
+
+        context.RequestMetrics.Received(1).Tag("http.request.method", "POST");
+        context.RequestMetrics.Received(1).Tag("http.route", "/orders/{id}");
+        context.RequestMetrics.Received(1).Tag("http.response.status_code", 201);
+    }
+
+    [Fact]
+    public void ARequestThatSetNoStatusIsTaggedAsTwoHundred() {
+        var logger = Logger();
+        var context = Context(status: null);
+
+        logger.RequestBegin(context);
+        logger.RequestEnd(context);
+
+        context.RequestMetrics.Received(1).Tag("http.response.status_code", 200);
+    }
+
+    // ---- trace context propagation -----------------------------------------------------------
+
+    private const string CallerTraceId = "0af7651916cd43dd8448eb211c80319c";
+    private const string CallerSpanId = "b7ad6b7169203331";
+    private const string CallerTraceparent = "00-" + CallerTraceId + "-" + CallerSpanId + "-01";
+
+    private static Dictionary<string, StringValues> Headers(params (string Name, string Value)[] headers) {
+        var dictionary = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (name, value) in headers) {
+            dictionary[name] = value;
+        }
+
+        return dictionary;
+    }
+
+    /// <summary>
+    /// The span joins the caller's trace rather than starting a second one that looks unrelated.
+    /// </summary>
+    [Fact]
+    public void ASpanJoinsTheTraceItsCallerSent() {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context(headers: Headers(("traceparent", CallerTraceparent))));
+
+        var span = Assert.Single(listening.Started);
+
+        Assert.Equal(CallerTraceId, span.TraceId.ToHexString());
+        Assert.Equal(CallerSpanId, span.ParentSpanId.ToHexString());
+    }
+
+    /// <summary>
+    /// Header names are case-insensitive and no two transports spell them alike, so the lookup has to
+    /// be too — API Gateway lowercases, and a hand-written client may not.
+    /// </summary>
+    [Theory]
+    [InlineData("traceparent")]
+    [InlineData("Traceparent")]
+    [InlineData("TRACEPARENT")]
+    public void TheTraceparentIsFoundUnderAnySpelling(string spelling) {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context(headers: Headers((spelling, CallerTraceparent))));
+
+        Assert.Equal(CallerTraceId, Assert.Single(listening.Started).TraceId.ToHexString());
+    }
+
+    [Fact]
+    public void TracestateRidesAlongUnparsed() {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context(headers: Headers(
+            ("traceparent", CallerTraceparent),
+            ("tracestate", "vendor=opaque-value"))));
+
+        Assert.Equal("vendor=opaque-value", Assert.Single(listening.Started).TraceStateString);
+    }
+
+    /// <summary>
+    /// A caller that sends nothing gets a root span, which is the ordinary case for a public
+    /// endpoint.
+    /// </summary>
+    [Fact]
+    public void NoTraceparentStartsANewTrace() {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context());
+
+        var span = Assert.Single(listening.Started);
+
+        Assert.Equal(default(ActivitySpanId).ToHexString(), span.ParentSpanId.ToHexString());
+    }
+
+    /// <summary>
+    /// And so does a caller that sends nonsense. ActivityContext.TryParse validates rather than
+    /// trusts, so a span never claims a parent it does not have — anything else would attach this
+    /// request to a trace that does not exist, or to somebody else's.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-traceparent")]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c")]
+    [InlineData("00-00000000000000000000000000000000-b7ad6b7169203331-01")]
+    [InlineData("ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")]
+    public void AMalformedTraceparentStartsANewTrace(string traceparent) {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context(headers: Headers(("traceparent", traceparent))));
+
+        var span = Assert.Single(listening.Started);
+
+        Assert.Equal(default(ActivitySpanId).ToHexString(), span.ParentSpanId.ToHexString());
+        Assert.NotEqual(CallerTraceId, span.TraceId.ToHexString());
+    }
+
+    /// <summary>
+    /// A version this code has never heard of is still honoured. W3C trace context is deliberately
+    /// forward-compatible — an implementation that meets a higher version parses the fields it knows
+    /// rather than discarding the trace — and only <c>ff</c> is reserved as invalid. Worth an
+    /// assertion because the obvious reading is that an unknown version is malformed, and dropping
+    /// the parent would quietly break tracing against any future caller.
+    /// </summary>
+    [Fact]
+    public void AFutureTraceContextVersionIsStillHonoured() {
+        using var listening = new Listening();
+
+        Logger().RequestBegin(Context(headers: Headers(
+            ("traceparent", "99-" + CallerTraceId + "-" + CallerSpanId + "-01"))));
+
+        var span = Assert.Single(listening.Started);
+
+        Assert.Equal(CallerTraceId, span.TraceId.ToHexString());
+        Assert.Equal(CallerSpanId, span.ParentSpanId.ToHexString());
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Headers/HeaderCollectionStringValuesTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Headers/HeaderCollectionStringValuesTests.cs
@@ -35,14 +35,119 @@ public class HeaderCollectionStringValuesTests {
         Assert.Empty(new HeaderCollectionStringValues());
     }
 
+    /// <summary>
+    /// A dictionary that already compares names without regard to case is wrapped by reference, so a
+    /// caller that hands one over and reads its own copy back — which is how the Lambda transports
+    /// collect response headers — still sees the writes.
+    /// </summary>
     [Fact]
-    public void WrapsAnExistingStringValuesDictionaryByReference() {
-        var backing = new Dictionary<string, StringValues> { { "X-Trace", "abc" } };
+    public void WrapsACaseInsensitiveDictionaryByReference() {
+        var backing = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase) {
+            { "X-Trace", "abc" }
+        };
+
         var headers = new HeaderCollectionStringValues(backing);
 
         headers.Set("X-Extra", "value");
 
         Assert.True(backing.ContainsKey("X-Extra"));
+    }
+
+    /// <summary>
+    /// One that does not is copied, and the reference is deliberately given up to get the lookups
+    /// right. A case-sensitive store is how <c>content-type</c> from API Gateway failed to answer to
+    /// <c>Content-Type</c>, which is what <c>KnownHeaders</c> asks for.
+    /// </summary>
+    [Fact]
+    public void CopiesACaseSensitiveDictionaryRatherThanInheritingIt() {
+        var backing = new Dictionary<string, StringValues> { { "content-type", "text/csv" } };
+
+        var headers = new HeaderCollectionStringValues(backing);
+
+        Assert.Equal("text/csv", headers.Get("Content-Type").ToString());
+
+        headers.Set("X-Extra", "value");
+
+        Assert.False(backing.ContainsKey("X-Extra"));
+    }
+
+    /// <summary>
+    /// HTTP header names are case-insensitive, and every transport spells them differently: API
+    /// Gateway lowercases, Kestrel preserves what arrived, a hand-written test writes whatever reads
+    /// best. Every accessor has to agree.
+    /// </summary>
+    [Theory]
+    [InlineData("content-type")]
+    [InlineData("Content-Type")]
+    [InlineData("CONTENT-TYPE")]
+    [InlineData("cOnTeNt-TyPe")]
+    public void EveryAccessorIgnoresCase(string spelling) {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> {
+            { "content-type", "text/csv" }
+        });
+
+        Assert.Equal("text/csv", headers.Get(spelling).ToString());
+        Assert.Equal("text/csv", headers[spelling].ToString());
+        Assert.True(headers.ContainsKey(spelling));
+        Assert.True(headers.TryGet(spelling, out var viaTryGet));
+        Assert.Equal("text/csv", viaTryGet.ToString());
+        Assert.True(headers.TryGetValue(spelling, out var viaTryGetValue));
+        Assert.Equal("text/csv", viaTryGetValue.ToString());
+    }
+
+    [Fact]
+    public void AppendingIgnoresCase() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> {
+            { "accept", "text/csv" }
+        });
+
+        headers.Append("Accept", "text/html");
+
+        Assert.Equal("text/csv,text/html", headers.Get("ACCEPT").ToString());
+        Assert.Single(headers);
+    }
+
+    [Fact]
+    public void RemovingIgnoresCase() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> {
+            { "x-gone", "here" }
+        });
+
+        Assert.True(headers.Remove("X-Gone"));
+        Assert.Empty(headers);
+    }
+
+    [Fact]
+    public void SettingAnExistingHeaderInAnotherCaseReplacesIt() {
+        var headers = new HeaderCollectionStringValues(new Dictionary<string, string> {
+            { "accept", "text/csv" }
+        });
+
+        headers.Set("Accept", "text/html");
+
+        Assert.Single(headers);
+        Assert.Equal("text/html", headers.Get("accept").ToString());
+    }
+
+    /// <summary>
+    /// The helper the transports use when they hold a raw dictionary rather than this collection —
+    /// the header override a forked request carries on ASP.NET and Kestrel.
+    /// </summary>
+    [Fact]
+    public void EnsureCaseInsensitiveKeepsADictionaryThatAlreadyIs() {
+        var backing = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Same(backing, HeaderCollectionStringValues.EnsureCaseInsensitive(backing));
+    }
+
+    [Fact]
+    public void EnsureCaseInsensitiveCopiesOneThatIsNot() {
+        var backing = new Dictionary<string, StringValues> { { "content-type", "text/csv" } };
+
+        var ensured = HeaderCollectionStringValues.EnsureCaseInsensitive(backing);
+
+        Assert.NotSame(backing, ensured);
+        Assert.Equal("text/csv", ensured["Content-Type"].ToString());
     }
 
     [Fact]

--- a/src/Requests/Hardened.Requests.Runtime/Headers/HeaderCollectionStringValues.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Headers/HeaderCollectionStringValues.cs
@@ -5,13 +5,35 @@ using Microsoft.Extensions.Primitives;
 
 namespace Hardened.Requests.Runtime.Headers;
 
+/// <summary>
+/// An <see cref="IHeaderCollection"/> over a dictionary, looked up the way HTTP defines header
+/// names: without regard to case.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every lookup here used to run against a dictionary built with the default, case-sensitive
+/// comparer, while <c>KnownHeaders</c> asks for canonical spellings - <c>Content-Type</c>,
+/// <c>Accept</c>, <c>Cookie</c>. API Gateway's HTTP API delivers header names lowercased, so on
+/// Lambda those two never met: every request was read as <c>application/json</c> whatever its
+/// content type, and <c>Accept</c> was ignored, which meant content negotiation did not work on
+/// that transport at all.
+/// </para>
+/// <para>
+/// It was invisible because every header test wrote canonical casing, so the harnesses were kinder
+/// than the transports they stood in for. ASP.NET and Kestrel were unaffected on the ordinary path -
+/// they hand over their own <c>IHeaderDictionary</c>, which is already case-insensitive - but a
+/// forked request there took an override dictionary and lost the property.
+/// </para>
+/// </remarks>
 public class HeaderCollectionStringValues : IHeaderCollection {
     private readonly IDictionary<string, StringValues> _headers;
 
-    public HeaderCollectionStringValues() : this(new Dictionary<string, StringValues>()) { }
+    public HeaderCollectionStringValues() {
+        _headers = NewCaseInsensitive();
+    }
 
     public HeaderCollectionStringValues(IDictionary<string, string>? values) {
-        _headers = new Dictionary<string, StringValues>();
+        _headers = NewCaseInsensitive();
 
         if (values != null) {
             foreach (var pair in values) {
@@ -20,8 +42,58 @@ public class HeaderCollectionStringValues : IHeaderCollection {
         }
     }
 
+    /// <summary>
+    /// Wraps <paramref name="headers"/> when it already compares names without regard to case, and
+    /// copies it when it does not.
+    /// </summary>
+    /// <remarks>
+    /// Wrapping by reference is deliberate where it is safe: a caller that hands over a dictionary
+    /// and then reads its own copy back - which is how the Lambda transports collect response
+    /// headers - depends on writes landing in it. Copying unconditionally would have taken that
+    /// away, so the reference survives for a dictionary that was built correctly and the copy is the
+    /// fallback for one that was not.
+    /// </remarks>
     public HeaderCollectionStringValues(IDictionary<string, StringValues> headers) {
-        _headers = headers;
+        _headers = EnsureCaseInsensitive(headers);
+    }
+
+    /// <summary>
+    /// <paramref name="headers"/> if it already compares names without regard to case, otherwise a
+    /// case-insensitive copy of it.
+    /// </summary>
+    /// <remarks>
+    /// Public because a transport holding a raw dictionary needs the same guarantee without wrapping
+    /// it in a collection - the header override a forked request carries on ASP.NET and Kestrel is
+    /// exactly that case.
+    /// </remarks>
+    public static IDictionary<string, StringValues> EnsureCaseInsensitive(
+        IDictionary<string, StringValues> headers) {
+        if (IsCaseInsensitive(headers)) {
+            return headers;
+        }
+
+        var copy = NewCaseInsensitive();
+
+        foreach (var pair in headers) {
+            copy[pair.Key] = pair.Value;
+        }
+
+        return copy;
+    }
+
+    private static Dictionary<string, StringValues> NewCaseInsensitive() {
+        return new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Only a <see cref="Dictionary{TKey,TValue}"/> exposes the comparer it was built with, so
+    /// anything else - including ASP.NET's own header dictionary, which is case-insensitive but not
+    /// a <c>Dictionary</c> - is copied rather than trusted. Those transports do not construct this
+    /// type on the path that matters, so the copy lands where it is affordable.
+    /// </summary>
+    private static bool IsCaseInsensitive(IDictionary<string, StringValues> headers) {
+        return headers is Dictionary<string, StringValues> dictionary &&
+               ReferenceEquals(dictionary.Comparer, StringComparer.OrdinalIgnoreCase);
     }
 
     public IEnumerator<KeyValuePair<string, StringValues>> GetEnumerator() {

--- a/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
@@ -52,13 +52,25 @@ public partial class RequestLogger : IRequestLogger {
     public void RequestBegin(IExecutionContext context) {
         LogRequestStarted(context.Request.Method, context.Request.Path);
 
+        // A dimension for whatever provider is behind IMetricLogger, independent of tracing. What
+        // becomes of it is the provider's decision: the Meter bridge makes it a histogram dimension,
+        // and EMF promotes nothing unless the application opted the tag in, because a CloudWatch
+        // dimension is billed per distinct value.
+        context.RequestMetrics.Tag("http.request.method", context.Request.Method);
+
         // Null when nothing is listening - no allocation, no work - which is why this is
         // unconditional and lives in the runtime rather than behind a flag or an opt-in package.
         //
         // Named for the method alone: the route is not known yet, and the semantic conventions are
         // explicit that a raw path must not become a span name. RequestMapped renames it below.
-        var span = HardenedDiagnostics.ActivitySource.StartActivity(
-            context.Request.Method, ActivityKind.Server);
+        //
+        // Parented on the caller's traceparent when there is one, so this span joins their trace
+        // rather than starting a second one that looks unrelated.
+        var span = TryGetParent(context.Request, out var parent)
+            ? HardenedDiagnostics.ActivitySource.StartActivity(
+                context.Request.Method, ActivityKind.Server, parent)
+            : HardenedDiagnostics.ActivitySource.StartActivity(
+                context.Request.Method, ActivityKind.Server);
 
         if (span is null) {
             return;
@@ -70,18 +82,56 @@ public partial class RequestLogger : IRequestLogger {
         _spans.AddOrUpdate(context, span);
     }
 
+    /// <summary>
+    /// The W3C trace context the caller sent, if it sent a usable one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Extraction only. Hardened issues no outbound requests, so there is nothing here to inject a
+    /// context into - which is the whole of the propagation story on this side.
+    /// </para>
+    /// <para>
+    /// ActivityContext.TryParse does the parsing and the validating, so a malformed traceparent - a
+    /// wrong version, a zero trace id, a truncated field - is rejected rather than turned into a span
+    /// that claims a parent it does not have. A caller that sends nothing, or sends nonsense, gets a
+    /// root span.
+    /// </para>
+    /// </remarks>
+    private static bool TryGetParent(IExecutionRequest request, out ActivityContext parent) {
+        parent = default;
+
+        if (!request.Headers.TryGetValue("traceparent", out var traceparent)) {
+            return false;
+        }
+
+        var value = traceparent.ToString();
+
+        if (string.IsNullOrEmpty(value)) {
+            return false;
+        }
+
+        // tracestate is vendor data that rides along unparsed. Absent is normal and not a failure.
+        request.Headers.TryGetValue("tracestate", out var tracestate);
+
+        return ActivityContext.TryParse(value, tracestate.ToString(), out parent);
+    }
+
     public void RequestMapped(IExecutionContext context) {
         LogRequestMapped(context.Request.Method, context.Request.Path, context.HandlerInfo!.HandlerType.Name,
              context.HandlerInfo!.InvokeMethod);
-
-        if (!_spans.TryGetValue(context, out var span)) {
-            return;
-        }
 
         // The low-cardinality template, not the path that arrived. Attached here, before the handler
         // runs, because this is the moment routing decided - where ASP.NET has to go back and rename
         // its span after the fact.
         var route = context.HandlerInfo!.Path;
+
+        // Outside the span check: a metric dimension is wanted whether or not anything is tracing,
+        // and without it http.server.request.duration is one histogram for the whole service.
+        context.RequestMetrics.Tag("http.route", route);
+
+        if (!_spans.TryGetValue(context, out var span)) {
+            return;
+        }
 
         span.SetTag("http.route", route);
         span.DisplayName = context.Request.Method + " " + route;
@@ -95,12 +145,6 @@ public partial class RequestLogger : IRequestLogger {
             context.StartTime.GetElapsedTime()
         );
 
-        if (!_spans.TryGetValue(context, out var span)) {
-            return;
-        }
-
-        _spans.Remove(context);
-
         // Null means "handled, no opinion": nothing assigns a status on an ordinary success path,
         // and every transport renders that as 200 when it writes the response. Leaving the tag off
         // instead would strip a required attribute from every successful span, which is what an
@@ -111,6 +155,17 @@ public partial class RequestLogger : IRequestLogger {
         // already the real code, including one that ASP.NET's own pipeline produced after Hardened
         // declined the request.
         var status = context.Response.Status ?? 200;
+
+        // Tagged whether or not anything is tracing. Buffered by the Meter provider until the logger
+        // is disposed, which is what lets a dimension be attached after the measurement it describes -
+        // every host records TotalRequestDuration and only then calls this.
+        context.RequestMetrics.Tag("http.response.status_code", status);
+
+        if (!_spans.TryGetValue(context, out var span)) {
+            return;
+        }
+
+        _spans.Remove(context);
 
         span.SetTag("http.response.status_code", status);
 

--- a/src/Requests/Hardened.Requests.Testing/Conformance/ExecutionRequestConformanceTests.cs
+++ b/src/Requests/Hardened.Requests.Testing/Conformance/ExecutionRequestConformanceTests.cs
@@ -94,6 +94,50 @@ public abstract class ExecutionRequestConformanceTests {
         Assert.DoesNotContain("application/json", request.Accept!);
     }
 
+    /// <summary>
+    /// Header names are case-insensitive, and no two transports agree on how to spell them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// API Gateway's HTTP API lowercases every name it delivers. Kestrel and ASP.NET pass through
+    /// whatever arrived. <c>KnownHeaders</c> — which is what the framework itself looks up with —
+    /// spells them canonically: <c>Content-Type</c>, <c>Accept</c>, <c>Cookie</c>.
+    /// </para>
+    /// <para>
+    /// Every test above this one writes canonical casing, which is why a case-sensitive header store
+    /// on the Lambda transports went unnoticed: it made <c>ContentType</c> come back as
+    /// <c>application/json</c> for every request whatever it actually carried, and disabled content
+    /// negotiation entirely on that transport. Asserting the spelling a transport does not use is the
+    /// only version of this test that could have caught it.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("content-type", "Content-Type")]
+    [InlineData("Content-Type", "content-type")]
+    [InlineData("CONTENT-TYPE", "Content-Type")]
+    public void AHeaderIsFoundUnderAnySpelling(string written, string read) {
+        var request = Create(s => s.Headers[written] = "text/csv");
+
+        Assert.True(request.Headers.TryGetValue(read, out var value),
+            Because($"a header written as '{written}' has to answer to '{read}'"));
+        Assert.Equal("text/csv", value.ToString());
+    }
+
+    /// <summary>
+    /// And the derived properties have to agree, because they are what the pipeline actually reads.
+    /// </summary>
+    [Fact]
+    public void ContentTypeAndAcceptIgnoreTheCaseTheyArriveIn() {
+        var request = Create(s => {
+            s.Headers["content-type"] = "text/csv";
+            s.Headers["accept"] = "text/html";
+        });
+
+        Assert.Equal("text/csv", request.ContentType);
+        Assert.NotNull(request.Accept);
+        Assert.Contains("text/html", request.Accept!);
+    }
+
     [Fact]
     public void QueryStringIsSurfaced() {
         var request = Create(s => {

--- a/src/Requests/Hardened.Requests.Testing/Conformance/IRequestTelemetryConformanceAdapter.cs
+++ b/src/Requests/Hardened.Requests.Testing/Conformance/IRequestTelemetryConformanceAdapter.cs
@@ -1,0 +1,58 @@
+using Hardened.Requests.Abstract.Execution;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Testing.Conformance;
+
+/// <summary>
+/// One request, as the suite wants it dispatched.
+/// </summary>
+public sealed class TelemetryConformanceRequest {
+    public required string Method { get; init; }
+
+    public required string Path { get; init; }
+
+    public IDictionary<string, StringValues> Headers { get; init; } =
+        new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// What the pipeline should do where a handler would run. The adapter arranges for this to run
+    /// inside the chain, which is how the suite asks for a particular status without knowing how this
+    /// transport produces one.
+    /// </summary>
+    public Action<IExecutionContext>? Handler { get; init; }
+}
+
+/// <summary>
+/// Implemented once per host to plug it into <see cref="RequestTelemetryConformanceTests"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A host, not an adapter object. The other two suites test an <see cref="IExecutionRequest"/> or an
+/// <see cref="IExecutionResponse"/> in isolation, and neither would have caught the defect this one
+/// exists for: the two Lambda streaming engines ran requests without telling
+/// <c>IRequestLogger</c> anything at all, so those runtimes produced no request logging and would
+/// have produced no spans. Every object involved was correct. Nothing called them.
+/// </para>
+/// <para>
+/// So the contract is deliberately about the host's own lifecycle: receive a request, run it, finish
+/// it. What the suite then asserts is what an observer sees, which is the only place that omission
+/// shows up.
+/// </para>
+/// </remarks>
+public interface IRequestTelemetryConformanceAdapter {
+    /// <summary>
+    /// Name used in assertion messages so a failure identifies the host.
+    /// </summary>
+    string TransportName { get; }
+
+    /// <summary>
+    /// Runs one request from whatever this host calls "received" to whatever it calls "finished",
+    /// returning once it considers the request complete.
+    /// </summary>
+    /// <remarks>
+    /// Including the completion step, whatever it is called - <c>DisposeContext</c> on Kestrel, the
+    /// end of the request delegate on ASP.NET. A host that reports a beginning and never an end is
+    /// exactly the kind of thing this is looking for, so the adapter must not stop early.
+    /// </remarks>
+    Task Dispatch(TelemetryConformanceRequest request);
+}

--- a/src/Requests/Hardened.Requests.Testing/Conformance/RequestTelemetryConformanceTests.cs
+++ b/src/Requests/Hardened.Requests.Testing/Conformance/RequestTelemetryConformanceTests.cs
@@ -1,0 +1,194 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Hardened.Requests.Testing.Conformance;
+
+/// <summary>
+/// The telemetry every host must produce, expressed once and executed against each of them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The third contract, beside <see cref="ExecutionRequestConformanceTests"/> and
+/// <see cref="ExecutionResponseConformanceTests"/>. Those two test an object; this one tests that a
+/// host calls it. The distinction is the whole point: the two Lambda streaming engines ran requests
+/// and told <c>IRequestLogger</c> nothing whatsoever, so they produced no request logging and would
+/// have produced no spans. Every object involved was correct — nothing invoked them — and no
+/// object-level suite could have noticed.
+/// </para>
+/// <para>
+/// Attribute names are literals rather than constants shared with the code under test. They are the
+/// contract a trace backend reads, so a rename has to fail here rather than pass.
+/// </para>
+/// <para>
+/// To enrol a host, derive from this class and supply an adapter:
+/// </para>
+/// <code>
+/// public class MyHostTelemetryConformanceTests : RequestTelemetryConformanceTests {
+///     protected override IRequestTelemetryConformanceAdapter Adapter { get; } = new MyAdapter();
+/// }
+/// </code>
+/// </summary>
+public abstract class RequestTelemetryConformanceTests {
+    private static int _discriminator;
+
+    protected abstract IRequestTelemetryConformanceAdapter Adapter { get; }
+
+    private string Because(string what) => $"[{Adapter.TransportName}] {what}";
+
+    /// <summary>
+    /// Dispatches one request and returns the span it produced.
+    /// </summary>
+    /// <remarks>
+    /// An <c>ActivitySource</c> is process-global and the rest of a host's test assembly runs in
+    /// parallel through the same one, so the span is picked out inside the callback by a path no other
+    /// request uses. Collecting everything and filtering afterwards writes a shared list while
+    /// reading it, which fails intermittently rather than honestly.
+    /// </remarks>
+    private async Task<Activity> Dispatch(
+        string method = "GET",
+        Action<Hardened.Requests.Abstract.Execution.IExecutionContext>? handler = null,
+        params (string Name, string Value)[] headers) {
+
+        var path = "/conformance/telemetry/" + Interlocked.Increment(ref _discriminator);
+
+        Activity? captured = null;
+
+        using var listener = new ActivityListener {
+            ShouldListenTo = source => source.Name == "Hardened.Requests",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = span => {
+                if ((string?)span.GetTagItem("url.path") == path) {
+                    captured = span;
+                }
+            }
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        var headerCollection = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (name, value) in headers) {
+            headerCollection[name] = value;
+        }
+
+        await Adapter.Dispatch(new TelemetryConformanceRequest {
+            Method = method,
+            Path = path,
+            Headers = headerCollection,
+            Handler = handler
+        });
+
+        Assert.True(captured is not null,
+            Because("a request produced no server span that was started and stopped — the host has to " +
+                    "report both a beginning and an end"));
+
+        return captured!;
+    }
+
+    [Fact]
+    public async Task ARequestProducesAServerSpan() {
+        var span = await Dispatch();
+
+        Assert.Equal(ActivityKind.Server, span.Kind);
+    }
+
+    [Fact]
+    public async Task TheSpanCarriesTheMethod() {
+        var span = await Dispatch(method: "POST");
+
+        Assert.Equal("POST", span.GetTagItem("http.request.method"));
+    }
+
+    /// <summary>
+    /// Stopped, not merely started. A span that is never stopped is never exported.
+    /// </summary>
+    [Fact]
+    public async Task TheSpanIsStopped() {
+        var span = await Dispatch();
+
+        Assert.NotEqual(TimeSpan.Zero, span.Duration);
+    }
+
+    [Fact]
+    public async Task AStatusSetByTheHandlerIsRecorded() {
+        var span = await Dispatch(handler: context => context.Response.Status = 201);
+
+        Assert.Equal(201, span.GetTagItem("http.response.status_code"));
+    }
+
+    /// <summary>
+    /// Nothing assigns a status on an ordinary success path — null means "handled, no opinion", and
+    /// each transport renders it as 200 when it writes the response. A span that omitted the attribute
+    /// for that case would omit it for almost every successful request.
+    /// </summary>
+    [Fact]
+    public async Task ASuccessThatSetNoStatusIsRecordedAsTwoHundred() {
+        var span = await Dispatch();
+
+        Assert.Equal(200, span.GetTagItem("http.response.status_code"));
+    }
+
+    /// <summary>
+    /// 5xx is the server failing and belongs in a backend's error rate.
+    /// </summary>
+    [Fact]
+    public async Task AServerErrorMarksTheSpanErrored() {
+        var span = await Dispatch(handler: context => context.Response.Status = 503);
+
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
+    }
+
+    /// <summary>
+    /// 4xx is the caller's mistake and deliberately is not, so that an error rate means "this service
+    /// is failing" rather than "someone asked for something that is not there".
+    /// </summary>
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    public async Task AClientErrorLeavesTheSpanUnset(int status) {
+        var span = await Dispatch(handler: context => context.Response.Status = status);
+
+        Assert.Equal(ActivityStatusCode.Unset, span.Status);
+    }
+
+    /// <summary>
+    /// The span joins the caller's trace rather than starting a second one that looks unrelated.
+    /// </summary>
+    [Fact]
+    public async Task TheSpanJoinsTheTraceItsCallerSent() {
+        const string traceId = "0af7651916cd43dd8448eb211c80319c";
+        const string spanId = "b7ad6b7169203331";
+
+        var span = await Dispatch(
+            headers: ("traceparent", $"00-{traceId}-{spanId}-01"));
+
+        Assert.Equal(traceId, span.TraceId.ToHexString());
+        Assert.Equal(spanId, span.ParentSpanId.ToHexString());
+    }
+
+    /// <summary>
+    /// And finds it whatever case it arrived in. API Gateway lowercases every header name it
+    /// delivers; Kestrel passes through whatever the client sent.
+    /// </summary>
+    [Fact]
+    public async Task TheTraceparentIsFoundWhateverCaseItArrivedIn() {
+        const string traceId = "0af7651916cd43dd8448eb211c80319c";
+
+        var span = await Dispatch(
+            headers: ("TraceParent", $"00-{traceId}-b7ad6b7169203331-01"));
+
+        Assert.Equal(traceId, span.TraceId.ToHexString());
+    }
+
+    /// <summary>
+    /// A caller that sends nothing gets a root span, which is the ordinary case for a public
+    /// endpoint.
+    /// </summary>
+    [Fact]
+    public async Task ARequestWithNoTraceparentStartsANewTrace() {
+        var span = await Dispatch();
+
+        Assert.Equal(default(ActivitySpanId).ToHexString(), span.ParentSpanId.ToHexString());
+    }
+}

--- a/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Conformance/AspNetTelemetryConformanceTests.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Conformance/AspNetTelemetryConformanceTests.cs
@@ -1,0 +1,88 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Requests.Runtime.Logging;
+using Hardened.Requests.Testing.Conformance;
+using Hardened.Shared.Runtime.Metrics;
+using Hardened.Web.AspNetCore.Runtime.Impl;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Hardened.Web.AspNetCore.Runtime.Tests.Conformance;
+
+/// <summary>
+/// ASP.NET's half of <see cref="RequestTelemetryConformanceTests"/>.
+/// </summary>
+public class AspNetTelemetryConformanceTests : RequestTelemetryConformanceTests {
+    protected override IRequestTelemetryConformanceAdapter Adapter { get; } = new AspNetAdapter();
+
+    private sealed class AspNetAdapter : IRequestTelemetryConformanceAdapter {
+        public string TransportName => "ASP.NET Core";
+
+        /// <summary>
+        /// One trip through <see cref="AspNetCoreRequestHandler.HandleRequest"/>, which is the whole
+        /// of this host's request lifecycle.
+        /// </summary>
+        /// <remarks>
+        /// The terminal delegate is a no-op. A chain that answers nothing falls through to the rest of
+        /// the ASP.NET pipeline, which is deliberate here: the suite is asserting that the request is
+        /// reported either way, and a host that only reported the ones it handled itself would be
+        /// wrong in exactly the way that is hard to notice.
+        /// </remarks>
+        public async Task Dispatch(TelemetryConformanceRequest request) {
+            IExecutionContext? executionContext = null;
+
+            var chain = Substitute.For<IExecutionChain>();
+            chain.Next().Returns(_ => {
+                request.Handler?.Invoke(executionContext!);
+
+                return Task.CompletedTask;
+            });
+
+            var middlewareService = Substitute.For<IMiddlewareService>();
+            middlewareService.GetExecutionChain(Arg.Any<IExecutionContext>()).Returns(callInfo => {
+                executionContext = callInfo.Arg<IExecutionContext>();
+
+                return chain;
+            });
+
+            var handler = new AspNetCoreRequestHandler(
+                new NullMetricLoggerProvider(),
+                middlewareService,
+                new RequestLogger(NullLogger<RequestLogger>.Instance));
+
+            await handler.HandleRequest(HttpContextFor(request), _ => Task.CompletedTask);
+        }
+
+        /// <summary>
+        /// Built here rather than through the project's other helper, which fixes the method and path
+        /// it produces — the suite needs a distinct path per request so its listener can tell one
+        /// from another while the rest of the assembly runs in parallel.
+        /// </summary>
+        private static HttpContext HttpContextFor(TelemetryConformanceRequest request) {
+            var requestFeature = new HttpRequestFeature {
+                Method = request.Method,
+                Path = request.Path
+            };
+
+            foreach (var header in request.Headers) {
+                requestFeature.Headers[header.Key] = header.Value;
+            }
+
+            var features = new FeatureCollection();
+            features.Set<IHttpRequestFeature>(requestFeature);
+            features.Set<IHttpResponseFeature>(new HttpResponseFeature());
+            features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(new MemoryStream()));
+
+            // AspNetExecutionContext resolves IKnownServices out of RequestServices as it is built.
+            var services = new ServiceCollection();
+            services.AddSingleton(Substitute.For<IKnownServices>());
+
+            return new DefaultHttpContext(features) {
+                RequestServices = services.BuildServiceProvider()
+            };
+        }
+    }
+}

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
@@ -103,7 +103,13 @@ public class AspNetExecutionRequest : IExecutionRequest {
         _httpRequest = httpRequest;
         _methodOverride = methodOverride;
         _pathOverride = pathOverride;
-        _headersOverride = headersOverride;
+
+        // A fork is handed a plain dictionary, which is very likely case-sensitive, while the
+        // request it forked from was reading ASP.NET's own case-insensitive header collection. Left
+        // alone the override silently changes how header names resolve for the rest of that chain.
+        _headersOverride = headersOverride is null
+            ? null
+            : HeaderCollectionStringValues.EnsureCaseInsensitive(headersOverride);
         _queryStringOverride = queryStringOverride;
         _cookiesOverride = cookiesOverride;
     }

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Conformance/FeatureTelemetryConformanceTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/Conformance/FeatureTelemetryConformanceTests.cs
@@ -1,0 +1,71 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Requests.Runtime.Logging;
+using Hardened.Requests.Testing.Conformance;
+using Hardened.Shared.Runtime.Metrics;
+using Hardened.Web.Kestrel.Runtime.Impl;
+using Hardened.Web.Kestrel.Runtime.Tests.Impl;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests.Conformance;
+
+/// <summary>
+/// Kestrel's half of <see cref="RequestTelemetryConformanceTests"/>.
+/// </summary>
+public class FeatureTelemetryConformanceTests : RequestTelemetryConformanceTests {
+    protected override IRequestTelemetryConformanceAdapter Adapter { get; } = new KestrelAdapter();
+
+    private sealed class KestrelAdapter : IRequestTelemetryConformanceAdapter {
+        public string TransportName => "Kestrel";
+
+        /// <summary>
+        /// The whole three-step contract Kestrel drives: create, process, dispose.
+        /// </summary>
+        /// <remarks>
+        /// A real <see cref="RequestLogger"/>, unlike the substitute the rest of this project's
+        /// harness uses — the suite is asserting what an observer of the real one sees. The
+        /// middleware is still a substitute, because what is under test is whether the host reports
+        /// the request at all, not what a handler does inside it.
+        /// </remarks>
+        public async Task Dispatch(TelemetryConformanceRequest request) {
+            IExecutionContext? executionContext = null;
+
+            var chain = Substitute.For<IExecutionChain>();
+            chain.Next().Returns(_ => {
+                request.Handler?.Invoke(executionContext!);
+
+                return Task.CompletedTask;
+            });
+
+            var middlewareService = Substitute.For<IMiddlewareService>();
+            middlewareService.GetExecutionChain(Arg.Any<IExecutionContext>()).Returns(callInfo => {
+                executionContext = callInfo.Arg<IExecutionContext>();
+
+                return chain;
+            });
+
+            var services = new ServiceCollection();
+            services.AddSingleton(Substitute.For<IKnownServices>());
+
+            var application = new HardenedHttpApplication(
+                services.BuildServiceProvider(),
+                middlewareService,
+                new NullMetricLoggerProvider(),
+                new RequestLogger(NullLogger<RequestLogger>.Instance));
+
+            var features = new ServerFeatures(request.Method, request.Path);
+
+            foreach (var header in request.Headers) {
+                features.Request.Headers[header.Key] = header.Value;
+            }
+
+            var context = application.CreateContext(features.Collection);
+
+            await application.ProcessRequestAsync(context);
+
+            application.DisposeContext(context, null);
+        }
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionRequest.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionRequest.cs
@@ -7,6 +7,7 @@ using Hardened.Requests.Runtime.QueryString;
 using Hardened.Shared.Runtime.Collections;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
+using Hardened.Requests.Runtime.Headers;
 
 namespace Hardened.Web.Kestrel.Runtime.Impl;
 
@@ -47,7 +48,13 @@ public sealed class FeatureExecutionRequest : IExecutionRequest {
         _feature = feature;
         _methodOverride = methodOverride;
         _pathOverride = pathOverride;
-        _headersOverride = headersOverride;
+
+        // A fork is handed a plain dictionary, which is very likely case-sensitive, while the
+        // request it forked from was reading the feature's own case-insensitive collection. Left
+        // alone the override silently changes how header names resolve for the rest of that chain.
+        _headersOverride = headersOverride is null
+            ? null
+            : HeaderCollectionStringValues.EnsureCaseInsensitive(headersOverride);
         _queryStringOverride = queryStringOverride;
         _cookiesOverride = cookiesOverride;
     }


### PR DESCRIPTION
Two concerns, two commits. The first is a correctness bug I hit while building the second and is separable — it's the first commit, so it cherry-picks cleanly if you'd rather split it.

---

# 1. Header lookups were case-sensitive

`HeaderCollectionStringValues` ran every lookup against a default-comparer dictionary. `KnownHeaders` asks for canonical spellings. **API Gateway's HTTP API delivers header names lowercased.** Those never met.

Demonstrated, not deduced — a request through the real API Gateway processor carrying `content-type: text/csv`:

```
Expected: "text/csv"
Actual:   "application/json"
```

So on Lambda every request was read as JSON whatever it carried, `Accept` was ignored, and **content negotiation didn't work on that transport at all**.

It survived because every header test wrote canonical casing — the harnesses were kinder than the transports they stood in for, the same defect `ApiGatewayHarness` already documents about cookies. So the assertion went into the **request conformance suite**, where a transport has to pass it rather than a test author having to think of it.

**Wrap-vs-copy:** I told you nothing depended on write-through and that was wrong — there's a test named for it. A dictionary that already compares case-insensitively is wrapped, so the Lambda transports that hand one over and read their own copy back still see writes. One that doesn't is copied, and the reference is given up to get lookups right. Only `Dictionary<,>` exposes its comparer, so anything else is copied rather than trusted; ASP.NET and Kestrel don't construct this type on the path that matters.

Those two were fine on the ordinary path — they pass their native `IHeaderDictionary` — but `Clone` stores a plain dictionary as a header override, so a **forked** request silently lost the property. Both now normalise it.

**The fix can't reach the broken transport yet.** It's in the framework; Hardened.Amz pins a released framework. Lambda keeps the bug until a release lands and that pin moves. Verified against a sibling checkout in the meantime.

---

# 2. P5 finished

**Dimensions.** The Meter histograms had none, so `http.server.request.duration` was one series for the whole service. `RequestLogger` now tags method, route template and status — *outside* the span checks, since metrics and traces are collected independently. Safe unconditionally now that the default `DimensionSetProvider` promotes nothing. Depends on the Meter provider buffering until disposal, because every host records the duration and *only then* calls `RequestEnd`.

**Propagation.** `traceparent` is parsed and the span joins the caller's trace; `tracestate` rides along unparsed. Extraction only — there's no outbound client to inject into. `ActivityContext.TryParse` validates rather than trusts, so a malformed header yields a root span instead of one claiming a parent it doesn't have.

*The tests taught me the spec here.* Version `99` is **honoured**, not rejected: W3C trace context is deliberately forward-compatible and only `ff` is reserved invalid. My first test asserted the opposite. Dropping the parent would have quietly broken tracing against any future caller, so it's now asserted rather than assumed.

**Conformance.** `RequestTelemetryConformanceTests` — the third contract, and the first about a *host* rather than an object. That's the point: the two Lambda streaming engines ran requests and told `IRequestLogger` nothing, so they produced no logging and would have produced no spans. Every object was correct; nothing called them, and no object-level suite could notice.

Kestrel and ASP.NET are enrolled and pass all fifteen. Each adapter builds its host with a **real** `RequestLogger` rather than the substitute those projects otherwise use.

---

## Verification

Clean build, 18/18 assemblies, 0 errors. ILC compiles the AOT SUT with `-warnaserror` and no IL2xxx/IL3xxx.

The one warning is pre-existing: MSB3277 from the `Microsoft.OpenApi` 3.x bump.

## Not included

- **Lambda telemetry and header conformance** — the Lambda adapters aren't enrolled in any conformance suite (R04), which needs a published `Hardened.Requests.Testing`.
- **Route in the conformance suite** — those host harnesses use substitute middleware, so there's no real routing to produce a template. `http.route` is covered end-to-end by the integration test through the real routing table instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnFd3pmQzm4m41u8vk1mbw