### PR TITLE
Replay the payloads each description publishes, and fix what that found

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -39,6 +39,16 @@ namespace Hardened.Requests.Abstract.Attributes
         public RawResponseAttribute(string contentType = "text/plain") { }
         public string ContentType { get; }
     }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
+    public sealed class RequestOnlyAttribute : System.Attribute
+    {
+        public RequestOnlyAttribute() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
+    public sealed class ResponseOnlyAttribute : System.Attribute
+    {
+        public ResponseOnlyAttribute() { }
+    }
 }
 namespace Hardened.Requests.Abstract.Authorization
 {

--- a/src/Requests/Hardened.Requests.Abstract/Attributes/DirectionAttributes.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Attributes/DirectionAttributes.cs
@@ -1,0 +1,38 @@
+namespace Hardened.Requests.Abstract.Attributes;
+
+/// <summary>
+/// The server owns this value: it appears in responses, and a client must not send it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// OpenAPI's <c>readOnly</c>. It says which direction a value travels, which is a fact about the
+/// contract rather than about the type - the same C# property carries the value in both directions,
+/// and the description is only constraining one of them.
+/// </para>
+/// <para>
+/// Documentation today. The generated model reads and writes the property normally, which is what
+/// lets a response containing it round-trip: withholding the setter instead made the value
+/// unreadable, so a client deserializing a response silently lost every <c>created_at</c> and
+/// <c>id</c> the server sent - the shape being guarded against on the way in, dropped on the way
+/// out.
+/// </para>
+/// <para>
+/// Enforcement belongs to validation, where a request that sets one can be rejected with the reason
+/// and the property name, rather than to serialization, where it can only be dropped in silence.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+public sealed class ResponseOnlyAttribute : Attribute {
+}
+
+/// <summary>
+/// The client owns this value: it is accepted in requests, and never returned.
+/// </summary>
+/// <remarks>
+/// OpenAPI's <c>writeOnly</c>, and the mirror of <see cref="ResponseOnlyAttribute"/> - a password
+/// on a create request being the usual one. Withholding the getter made such a property
+/// unserializable, so a model could not write the request body it exists to describe.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+public sealed class RequestOnlyAttribute : Attribute {
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/EnumConverterEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/EnumConverterEmitter.cs
@@ -111,7 +111,10 @@ internal static class EnumConverterEmitter {
         method.AddParameter(
             TypeDefinition.Get("System.Text.Json", "JsonSerializerOptions"), "options");
 
-        var lines = new List<string> { "writer.WriteStringValue(value switch", "{" };
+        // Assigned to a typed local rather than passed straight in: a document may declare an enum
+        // with no values at all, leaving a switch whose only arm throws, and an expression with no
+        // natural type cannot pick between the WriteStringValue overloads - CS0121.
+        var lines = new List<string> { "string text = value switch", "{" };
 
         for (var index = 0; index < schema.EnumValues.Count; index++) {
             lines.Add($"    {qualified}.{Member(schema, index)} => \"{Escape(schema.EnumValues[index])}\",");
@@ -122,7 +125,9 @@ internal static class EnumConverterEmitter {
         lines.Add("    _ => throw new global::System.Text.Json.JsonException(");
         lines.Add(
             $"        \"The value is not one {NamingHelper.ToPascalCase(schema.Name)} declares.\")");
-        lines.Add("});");
+        lines.Add("};");
+        lines.Add("");
+        lines.Add("writer.WriteStringValue(text);");
 
         Write(method, lines);
     }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/EnumConverterEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/EnumConverterEmitter.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using CSharpAuthor;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+
+namespace Hardened.Idl.Emitters;
+
+/// <summary>
+/// Reads and writes an enum as the values the description declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The resolver used to hand an enum to <c>JsonMetadataServices.GetEnumConverter</c>, which is the
+/// numeric converter: a property typed <c>Currency</c> wrote <c>1</c> where the API expects
+/// <c>"USD"</c>, and could not read <c>"USD"</c> back at all. Every enum-typed property of every
+/// generated model, in every description - and none of it visible from a build, because integers
+/// are perfectly good JSON.
+/// </para>
+/// <para>
+/// A string converter alone would not have fixed it either. The C# member is a sanitized form of
+/// the wire value - <c>SELLER_CANCELED</c> reaches C# as <c>SELLERCANCELED</c>, <c>+1</c> as
+/// <c>Plus1</c>, the empty value as <c>Empty</c> - so matching by member name is matching against
+/// a name the wire never carries. The mapping has to be written out, and this writes it.
+/// </para>
+/// <para>
+/// Not <c>[JsonStringEnumMemberName]</c>, which would express exactly this: it arrived in .NET 9
+/// and the generated code has to compile for consumers on net8.0. When that is the floor this
+/// becomes an attribute on the member and the converter goes away.
+/// </para>
+/// </remarks>
+internal static class EnumConverterEmitter {
+
+    /// <summary>The converter's type name, which the allocator reserves alongside the type.</summary>
+    public static string ConverterName(string schemaName) =>
+        NamingHelper.ToPascalCase(schemaName) + "Converter";
+
+    public static ClassDefinition Emit(
+        IConstructContainer container, SchemaModel schema, string modelsNamespace) {
+        var name = NamingHelper.ToPascalCase(schema.Name);
+        var converterName = ConverterName(schema.Name);
+        var enumType = TypeDefinition.Get(modelsNamespace, name);
+        var qualified = TypeMapper.QualifiedName(modelsNamespace, name, false);
+
+        var converter = container.AddClass(converterName);
+
+        converter.Modifiers |= ComponentModifier.Public | ComponentModifier.Sealed;
+        converter.AddBaseType(
+            new GenericTypeDefinition(
+                TypeDefinitionEnum.ClassDefinition,
+                "System.Text.Json.Serialization",
+                "JsonConverter",
+                new[] { enumType }));
+
+        converter.Comment = $"Reads and writes {name} as the values the description declares.";
+
+        var instance = converter.AddField(
+            TypeDefinition.Get(modelsNamespace, converterName), "Instance");
+
+        instance.Modifiers |=
+            ComponentModifier.Public | ComponentModifier.Static | ComponentModifier.Readonly;
+        instance.InitializeValue = new CodeOutputComponent("new()") { Indented = false };
+
+        EmitRead(converter, schema, enumType, qualified);
+        EmitWrite(converter, schema, enumType, qualified);
+
+        return converter;
+    }
+
+    private static void EmitRead(
+        ClassDefinition converter, SchemaModel schema, ITypeDefinition enumType, string qualified) {
+        var method = converter.AddMethod("Read");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        method.SetReturnType(enumType);
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json", "Utf8JsonReader"), "reader").Modifier =
+            ParameterModifier.Ref;
+        method.AddParameter(TypeDefinition.Get(typeof(System.Type)), "typeToConvert");
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json", "JsonSerializerOptions"), "options");
+
+        var lines = new List<string> {
+            "var value = reader.GetString();",
+            "",
+            "return value switch",
+            "{"
+        };
+
+        for (var index = 0; index < schema.EnumValues.Count; index++) {
+            lines.Add($"    \"{Escape(schema.EnumValues[index])}\" => {qualified}.{Member(schema, index)},");
+        }
+
+        // A value the description does not declare is the server saying something the contract does
+        // not allow, and guessing at it would put an arbitrary member into the model.
+        lines.Add("    _ => throw new global::System.Text.Json.JsonException(");
+        lines.Add(
+            $"        \"'\" + value + \"' is not a value {NamingHelper.ToPascalCase(schema.Name)} declares.\")");
+        lines.Add("};");
+
+        Write(method, lines);
+    }
+
+    private static void EmitWrite(
+        ClassDefinition converter, SchemaModel schema, ITypeDefinition enumType, string qualified) {
+        var method = converter.AddMethod("Write");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json", "Utf8JsonWriter"), "writer");
+        method.AddParameter(enumType, "value");
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json", "JsonSerializerOptions"), "options");
+
+        var lines = new List<string> { "writer.WriteStringValue(value switch", "{" };
+
+        for (var index = 0; index < schema.EnumValues.Count; index++) {
+            lines.Add($"    {qualified}.{Member(schema, index)} => \"{Escape(schema.EnumValues[index])}\",");
+        }
+
+        // Reachable by casting an undeclared number to the enum, which writes a value the contract
+        // does not describe - worth refusing rather than putting on the wire.
+        lines.Add("    _ => throw new global::System.Text.Json.JsonException(");
+        lines.Add(
+            $"        \"The value is not one {NamingHelper.ToPascalCase(schema.Name)} declares.\")");
+        lines.Add("});");
+
+        Write(method, lines);
+    }
+
+    /// <summary>
+    /// The C# member for a value, which the allocator decided and which is not the value itself.
+    /// </summary>
+    private static string Member(SchemaModel schema, int index) =>
+        index < schema.EnumMembers.Count
+            ? schema.EnumMembers[index]
+            : NamingHelper.ToPascalCase(schema.EnumValues[index]);
+
+    private static void Write(MethodDefinition method, List<string> lines) {
+        foreach (var line in lines) {
+            method.Add(new CodeOutputComponent(line) { Indented = true });
+        }
+    }
+
+    private static string Escape(string value) =>
+        value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -217,7 +217,7 @@ internal static class JsonTypeInfoEmitter {
         sb.AppendLine("            PropertyMetadataInitializer = _ => new JsonPropertyInfo[]");
         sb.AppendLine("            {");
 
-        foreach (var prop in schema.Properties.OrderByDescending(p => p.IsRequired)) {
+        foreach (var prop in schema.Properties.OrderByDescending(p => !p.HasDefault)) {
             EmitPropertyInfo(sb, prop, typeName, allSchemas, ns);
         }
 

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -131,6 +131,16 @@ internal static class JsonTypeInfoEmitter {
             if (schema.Kind != SchemaKind.Object && schema.Kind != SchemaKind.Enum) continue;
 
             sb.AppendLine($"        if (type == typeof({typeName})) return Create{name}TypeInfo(options);");
+
+            // A generated enum is a value type, so an optional property of one is T? - and the
+            // property info asks the resolver for exactly that. Without this line it answers null
+            // and the payload cannot be read at all: every optional enum property in every
+            // description, which compiled, passed every test, and refused 339 of Square's 453
+            // published examples the first time any of them was replayed.
+            if (schema.Kind == SchemaKind.Enum) {
+                sb.AppendLine(
+                    $"        if (type == typeof({typeName}?)) return JsonMetadataServices.CreateValueInfo<{typeName}?>(options, JsonMetadataServices.GetNullableConverter<{typeName}>(options));");
+            }
         }
 
         EmitPrimitiveTypeEntries(sb);
@@ -303,9 +313,9 @@ internal static class JsonTypeInfoEmitter {
         var genericType = GetPropertyInfoGenericType(prop, allSchemas, ns);
         var propName = prop.MemberName;
 
-        var getter = prop.IsWriteOnly
-            ? "null"
-            : $"static obj => (({declaringTypeName})obj).{propName}";
+        // Both directions read and write. A writeOnly property used to have no getter, which made
+        // the request body it describes unserializable; see ResponseOnlyAttribute.
+        var getter = $"static obj => (({declaringTypeName})obj).{propName}";
 
         sb.AppendLine($"                JsonMetadataServices.CreatePropertyInfo<{genericType}>(options, new JsonPropertyInfoValues<{genericType}>");
         sb.AppendLine("                {");
@@ -343,7 +353,12 @@ internal static class JsonTypeInfoEmitter {
         var method = CreateTypeInfoMethod(resolver, name);
         var sb = new StringBuilder();
 
-        sb.AppendLine($"        return JsonMetadataServices.CreateValueInfo<{typeName}>(options, JsonMetadataServices.GetEnumConverter<{typeName}>(options));");
+        // Not GetEnumConverter: that is the numeric one, and an OpenAPI enum travels as the string
+        // the description declares. See EnumConverterEmitter.
+        var converter = TypeMapper.QualifiedName(
+            ns, EnumConverterEmitter.ConverterName(schema.Name), false);
+
+        sb.AppendLine($"        return JsonMetadataServices.CreateValueInfo<{typeName}>(options, {converter}.Instance);");
 
         AddStatements(method, sb);
     }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -162,6 +162,7 @@ internal static class JsonTypeInfoEmitter {
         sb.AppendLine("        if (type == typeof(float)) return JsonMetadataServices.CreateValueInfo<float>(options, JsonMetadataServices.SingleConverter);");
         sb.AppendLine("        if (type == typeof(double)) return JsonMetadataServices.CreateValueInfo<double>(options, JsonMetadataServices.DoubleConverter);");
         sb.AppendLine("        if (type == typeof(global::System.DateTime)) return JsonMetadataServices.CreateValueInfo<global::System.DateTime>(options, JsonMetadataServices.DateTimeConverter);");
+        sb.AppendLine("        if (type == typeof(global::System.DateTimeOffset)) return JsonMetadataServices.CreateValueInfo<global::System.DateTimeOffset>(options, JsonMetadataServices.DateTimeOffsetConverter);");
         sb.AppendLine("        if (type == typeof(global::System.DateOnly)) return JsonMetadataServices.CreateValueInfo<global::System.DateOnly>(options, JsonMetadataServices.DateOnlyConverter);");
         sb.AppendLine("        if (type == typeof(byte[])) return JsonMetadataServices.CreateValueInfo<byte[]>(options, JsonMetadataServices.ByteArrayConverter);");
         sb.AppendLine("        if (type == typeof(global::System.Text.Json.JsonElement)) return JsonMetadataServices.CreateValueInfo<global::System.Text.Json.JsonElement>(options, JsonMetadataServices.JsonElementConverter);");
@@ -174,6 +175,7 @@ internal static class JsonTypeInfoEmitter {
         sb.AppendLine("        if (type == typeof(float?)) return JsonMetadataServices.CreateValueInfo<float?>(options, JsonMetadataServices.GetNullableConverter<float>(options));");
         sb.AppendLine("        if (type == typeof(double?)) return JsonMetadataServices.CreateValueInfo<double?>(options, JsonMetadataServices.GetNullableConverter<double>(options));");
         sb.AppendLine("        if (type == typeof(global::System.DateTime?)) return JsonMetadataServices.CreateValueInfo<global::System.DateTime?>(options, JsonMetadataServices.GetNullableConverter<global::System.DateTime>(options));");
+        sb.AppendLine("        if (type == typeof(global::System.DateTimeOffset?)) return JsonMetadataServices.CreateValueInfo<global::System.DateTimeOffset?>(options, JsonMetadataServices.GetNullableConverter<global::System.DateTimeOffset>(options));");
         sb.AppendLine("        if (type == typeof(global::System.DateOnly?)) return JsonMetadataServices.CreateValueInfo<global::System.DateOnly?>(options, JsonMetadataServices.GetNullableConverter<global::System.DateOnly>(options));");
         sb.AppendLine("        if (type == typeof(global::System.Text.Json.JsonElement?)) return JsonMetadataServices.CreateValueInfo<global::System.Text.Json.JsonElement?>(options, JsonMetadataServices.GetNullableConverter<global::System.Text.Json.JsonElement>(options));");
     }
@@ -208,16 +210,18 @@ internal static class JsonTypeInfoEmitter {
             }
         }
 
-        if (schema.Properties.Count > 0) {
-            // Every property, including the readOnly ones the constructor does not take: they are
-            // serialized, and the property list is what carries a getter for them.
-            sb.AppendLine("            PropertyMetadataInitializer = _ => new JsonPropertyInfo[]");
-            sb.AppendLine("            {");
-            foreach (var prop in schema.Properties.OrderByDescending(p => p.IsRequired)) {
-                EmitPropertyInfo(sb, prop, typeName, allSchemas, ns);
-            }
-            sb.AppendLine("            },");
+        // Always, even for a schema that declares none. System.Text.Json requires the initializer
+        // to be present and refuses the type outright without it - "did not provide property
+        // metadata" - so a free-form `type: object` could not be deserialized at all. Cloudflare
+        // declares 57 of those, and every one of them threw.
+        sb.AppendLine("            PropertyMetadataInitializer = _ => new JsonPropertyInfo[]");
+        sb.AppendLine("            {");
+
+        foreach (var prop in schema.Properties.OrderByDescending(p => p.IsRequired)) {
+            EmitPropertyInfo(sb, prop, typeName, allSchemas, ns);
         }
+
+        sb.AppendLine("            },");
 
         if (parameters.Count > 0) {
             // ConstructorParameterMetadataInitializer
@@ -472,6 +476,7 @@ internal static class JsonTypeInfoEmitter {
             case "float":
             case "double":
             case "bool":
+            case "DateTimeOffset":
             case "DateTime":
             case "DateOnly":
             case "JsonElement":

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
@@ -27,10 +27,22 @@ internal static class SchemaEmitter {
         IReadOnlyList<SchemaModel>? allSchemas = null) =>
         schema.Kind switch {
             SchemaKind.Object => EmitRecord(container, schema, modelsNamespace, patterns, allSchemas),
-            SchemaKind.Enum => EmitEnum(container, schema),
+            SchemaKind.Enum => EmitEnumWithConverter(container, schema, modelsNamespace),
             SchemaKind.OneOf => EmitOneOf(container, schema, modelsNamespace, allSchemas),
             _ => null,
         };
+
+    /// <summary>
+    /// The enum and the converter that maps it to the values the description declares.
+    /// </summary>
+    private static IOutputComponent EmitEnumWithConverter(
+        IConstructContainer container, SchemaModel schema, string modelsNamespace) {
+        var type = EmitEnum(container, schema);
+
+        EnumConverterEmitter.Emit(container, schema, modelsNamespace);
+
+        return type;
+    }
 
     /// <summary>
     /// The choice type and the converter that resolves it, which are one thing in two declarations.
@@ -115,6 +127,9 @@ internal static class SchemaEmitter {
         // syntactic position. Without the target the attribute stays on the parameter, where a
         // generator reading properties never sees it - which is what VM0051 warns about.
         EmitJsonPropertyName(parameter, property).Target = "property";
+        if (EmitDirection(parameter, property) is { } direction) {
+            direction.Target = "property";
+        }
 
         // Required, except where the type already guarantees it - see
         // TypeMapper.IsNonNullableValueType.
@@ -164,6 +179,7 @@ internal static class SchemaEmitter {
         }
 
         EmitJsonPropertyName(member, property);
+        EmitDirection(member, property);
     }
 
     /// <summary>
@@ -243,6 +259,27 @@ internal static class SchemaEmitter {
     /// The caller sets <c>Target</c>: a positional record parameter needs <c>property:</c> to reach
     /// the property it declares, while a member declared in the body is already the property.
     /// </remarks>
+    /// <summary>
+    /// Which direction the description says the value travels, where it says so.
+    /// </summary>
+    /// <remarks>
+    /// Documentation rather than a missing accessor. Withholding one was how this used to be
+    /// expressed, and it made the value unreachable in the direction the contract does allow - a
+    /// response's <c>created_at</c> was dropped on the way in, a request's password could not be
+    /// written on the way out. See <c>ResponseOnlyAttribute</c>.
+    /// </remarks>
+    private static AttributeDefinition? EmitDirection(
+        BaseOutputComponent target, PropertyModel property) {
+        if (!property.IsReadOnly && !property.IsWriteOnly) {
+            return null;
+        }
+
+        return target.AddAttribute(
+            TypeDefinition.Get(
+                "Hardened.Requests.Abstract.Attributes",
+                property.IsReadOnly ? "ResponseOnlyAttribute" : "RequestOnlyAttribute"));
+    }
+
     private static AttributeDefinition EmitJsonPropertyName(
         BaseOutputComponent parameter, PropertyModel property) =>
         parameter.AddAttribute(

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaShape.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaShape.cs
@@ -35,7 +35,11 @@ internal static class SchemaShape {
     public static List<PropertyModel> Constructor(SchemaModel schema) =>
         schema.Properties
             .Where(property => property.IsConstructorParameter)
-            .OrderByDescending(property => property.IsRequired)
+            // Ordered by whether the parameter carries a default, not by whether the description
+            // calls the property required. A read-only property is required in a response and
+            // optional in C#, so ordering by the description put an optional parameter before a
+            // required one - CS1737, and a generated file that does not compile.
+            .OrderByDescending(property => !property.HasDefault)
             .ToList();
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Idl.Emit/Filtering/SpecSlicer.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Filtering/SpecSlicer.cs
@@ -186,6 +186,13 @@ internal static class SpecSlicer {
                 Reach(mapping.Ref);
             }
 
+            // A choice type's own branches. Without this the choice survives and the schemas it
+            // reads into do not, so the generated converter names types nothing declares - CS0234
+            // from a file the generator wrote.
+            foreach (var branch in schema.OneOf) {
+                Reach(branch.Ref);
+            }
+
             if (!string.IsNullOrEmpty(schema.DiscriminatorPropertyName) &&
                 derived.TryGetValue(schema.Name, out var subtypes)) {
                 foreach (var subtype in subtypes) {

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
@@ -9,7 +9,7 @@ namespace Hardened.Idl;
 /// </summary>
 /// <remarks>
 /// <para>
-/// There are twelve of them, and every pass that walks references needs all twelve. Two passes used
+/// There are thirteen of them, and every pass that walks references needs all thirteen. Two passes used
 /// to enumerate them by hand and one listed five: Cloudflare and PagerDuty reference hundreds of
 /// schemas that produce no type, and the references the incomplete pass never visited - parameters,
 /// declared error responses, base types, discriminator branches - each became a CS0234 naming
@@ -43,6 +43,12 @@ internal static class ModelRefs {
 
             yield return new Handle(schema.BaseRef, value => captured.BaseRef = value);
             yield return new Handle(schema.ArrayItemsRef, value => captured.ArrayItemsRef = value);
+
+            foreach (var branch in schema.OneOf) {
+                var branchCaptured = branch;
+
+                yield return new Handle(branch.Ref, value => branchCaptured.Ref = value);
+            }
 
             foreach (var mapping in schema.DiscriminatorMapping) {
                 var mappingCaptured = mapping;

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
@@ -178,7 +178,7 @@ internal static class NameAllocator {
 
             // Same argument for a choice type: the converter is named after it and has nowhere
             // else to go. See OneOfConverterEmitter.
-            if (schema.Kind == SchemaKind.OneOf) {
+            if (schema.Kind is SchemaKind.OneOf or SchemaKind.Enum) {
                 scope.Reserve(allocated + "Converter");
             }
 

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
@@ -160,7 +160,7 @@ internal static class NameAllocator {
             // not a moment. The keyword forms (int, string) cannot collide because a pascal-cased
             // name never produces one, and reserving ordinary words like Type or Object would
             // rename a great many schemas to no purpose.
-            "DateTime", "DateOnly", "JsonElement"
+            "DateTime", "DateTimeOffset", "DateOnly", "JsonElement"
         });
 
         var ordered = new List<SchemaModel>(model.Schemas);

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/PropertyModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/PropertyModel.cs
@@ -69,11 +69,14 @@ internal class PropertyModel : IEquatable<PropertyModel>, IConstraintFacets {
     /// Whether the generated record declares this positionally.
     /// </summary>
     /// <remarks>
-    /// A <c>readOnly</c> property is declared as an init-only member instead, which is what keeps it
-    /// out of deserialization: it is not a constructor parameter, and the resolver gives it no
-    /// setter, so a client sending it has the value discarded rather than honoured.
+    /// Every property, including the <c>readOnly</c> ones. They used to be init-only members the
+    /// resolver gave no setter, which kept a client from sending them - and also kept anything from
+    /// reading them, so a response's <c>created_at</c> and <c>id</c> were dropped on the way in.
+    /// Direction is a fact about the contract rather than about the type, so it is documented with
+    /// <c>[ResponseOnly]</c> and enforced where it can name the property, not by withholding an
+    /// accessor.
     /// </remarks>
-    public bool IsConstructorParameter => !IsReadOnly;
+    public bool IsConstructorParameter => true;
 
     /// <summary>
     /// Whether validation constraints are emitted for this property at all.

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/PropertyModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/PropertyModel.cs
@@ -38,20 +38,31 @@ internal class PropertyModel : IEquatable<PropertyModel>, IConstraintFacets {
     /// <summary>
     /// Whether the generated C# type is nullable — required-and-nullable is <c>string?</c> too.
     /// </summary>
-    public bool IsCSharpNullable => !IsRequired || IsNullable;
+    /// <remarks>
+    /// A <c>readOnly</c> property is nullable whatever the description says about it, because
+    /// <c>required</c> there means "always present in a response" and the same type is what a client
+    /// sends in a request. Non-nullable, it became a positional parameter with no default and a
+    /// create call that correctly omitted the server-owned id was answered 400.
+    /// </remarks>
+    public bool IsCSharpNullable => !IsRequired || IsNullable || IsReadOnly;
 
     /// <summary>
     /// Whether the generated parameter carries <c>= default</c>. Requiredness alone decides this:
     /// a required-but-nullable value still has to be supplied.
     /// </summary>
-    public bool HasDefault => !IsRequired;
+    public bool HasDefault => !IsRequired || IsReadOnly;
 
     /// <summary>
     /// Whether a <c>[Required]</c> constraint applies. It does not when the spec permits null —
     /// ValidationModules' <c>[Required]</c> rejects null, which would refuse a value the spec
     /// allows.
     /// </summary>
-    public bool ConstrainedAsRequired => IsRequired && !IsNullable;
+    /// <remarks>
+    /// Never for a <c>readOnly</c> property. <c>required</c> on one means "always present in a
+    /// response", and validation runs on request binding - so demanding it rejects the create call
+    /// of a client that correctly omitted a value the server assigns.
+    /// </remarks>
+    public bool ConstrainedAsRequired => IsRequired && !IsNullable && !IsReadOnly;
 
     /// <summary>
     /// The schema's <c>readOnly</c>: the property appears in responses and must not be sent in a

--- a/src/SourceGenerators/Hardened.Idl.Shared/TypeMapper.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/TypeMapper.cs
@@ -10,7 +10,12 @@ internal static class TypeMapper {
         }
 
         return (type?.ToLowerInvariant(), format?.ToLowerInvariant()) switch {
-            ("string", "date-time") => "DateTime",
+            // DateTimeOffset, not DateTime, because RFC 3339 date-time carries an offset and
+            // DateTime cannot hold one. Reading "2020-06-05T22:47:53+00:00" into a DateTime
+            // converts it to the host's local time and writes the host's offset back, so the same
+            // response left a server in New York and a server in Berlin as different bytes -
+            // which replaying Plaid's published examples is what caught.
+            ("string", "date-time") => "DateTimeOffset",
             ("string", "date") => "DateOnly",
             ("string", "uuid") => "string",
             ("string", "byte") => "byte[]",
@@ -146,6 +151,7 @@ internal static class TypeMapper {
             "byte" => TypeDefinition.Get(typeof(byte)),
             "sbyte" => TypeDefinition.Get(typeof(sbyte)),
             "DateTime" => TypeDefinition.Get(typeof(DateTime)),
+            "DateTimeOffset" => TypeDefinition.Get(typeof(DateTimeOffset)),
             "DateOnly" => TypeDefinition.Get("System", "DateOnly"),
             "JsonElement" => TypeDefinition.Get("System.Text.Json", "JsonElement"),
             _ => null

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/JsonTypeInfoEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/JsonTypeInfoEmitterTests.cs
@@ -138,11 +138,11 @@ public class JsonTypeInfoEmitterTests {
 
         var result = EmitterHarness.JsonTypeInfo(schemas, "petstore");
 
-        Assert.Contains("CreatePropertyInfo<global::System.DateTime>(options", result);
+        Assert.Contains("CreatePropertyInfo<global::System.DateTimeOffset>(options", result);
         Assert.Contains("CreatePropertyInfo<global::System.DateOnly>(options", result);
         Assert.Contains("CreatePropertyInfo<global::System.Byte[]>(options", result);
         Assert.Contains("CreatePropertyInfo<string>(options", result);
-        Assert.Contains("(global::System.DateTime)args[0]", result);
+        Assert.Contains("(global::System.DateTimeOffset)args[0]", result);
         Assert.Contains("(global::System.DateOnly)args[1]", result);
         Assert.Contains("(global::System.Byte[])args[2]", result);
     }
@@ -357,8 +357,8 @@ public class JsonTypeInfoEmitterTests {
         Assert.Contains("(bool?)args[2]", result);
 
         // Optional DateTime: nullable
-        Assert.Contains("CreatePropertyInfo<global::System.DateTime?>(options", result);
-        Assert.Contains("(global::System.DateTime?)args[3]", result);
+        Assert.Contains("CreatePropertyInfo<global::System.DateTimeOffset?>(options", result);
+        Assert.Contains("(global::System.DateTimeOffset?)args[3]", result);
     }
 
     [Fact]

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ScenarioTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ScenarioTests.cs
@@ -118,7 +118,7 @@ public class ScenarioTests {
 
         Assert.Equal("byte[]", TypeOf(model, "Thing", "avatar"));
         Assert.Equal("byte[]", TypeOf(model, "Thing", "blob"));
-        Assert.Equal("DateTime", TypeOf(model, "Thing", "when"));
+        Assert.Equal("DateTimeOffset", TypeOf(model, "Thing", "when"));
         Assert.Equal("DateOnly", TypeOf(model, "Thing", "day"));
     }
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/TypeMapperTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/TypeMapperTests.cs
@@ -7,7 +7,7 @@ namespace Hardened.OpenApi.BuildTask.Tests;
 public class TypeMapperTests {
     [Theory]
     [InlineData("string", null, "string")]
-    [InlineData("string", "date-time", "DateTime")]
+    [InlineData("string", "date-time", "DateTimeOffset")]
     [InlineData("string", "date", "DateOnly")]
     [InlineData("string", "uuid", "string")]
     [InlineData("string", "byte", "byte[]")]

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -277,12 +277,34 @@ internal static class OpenApiSpecParser {
     private static void DropUndecidableChoices(ServiceSpecModel model) {
         var dropped = new HashSet<string>(StringComparer.Ordinal);
 
+        // The schemas that will emit a type, which is not every schema in the model: an array
+        // alias or a primitive one is a name for something else and produces no record, so a branch
+        // naming one names nothing the converter can read into.
+        var declared = new HashSet<string>(StringComparer.Ordinal);
+
         foreach (var schema in model.Schemas) {
-            if (schema.Kind != SchemaKind.OneOf || schema.DiscriminatorPropertyName != null) {
+            if (schema.Kind is SchemaKind.Object or SchemaKind.Enum or SchemaKind.OneOf) {
+                declared.Add(schema.Name);
+            }
+        }
+
+        foreach (var schema in model.Schemas) {
+            if (schema.Kind != SchemaKind.OneOf) {
                 continue;
             }
 
-            if (!ChoiceResolution.Resolve(schema.OneOf, model.Schemas).Usable) {
+            // A branch naming a schema nothing declares cannot be read into anything, and the
+            // converter would name a type that does not exist - CS0234 in a generated file.
+            // Checked for every choice, discriminated or not: a discriminator says which branch a
+            // payload is, not that the branch was generated.
+            schema.OneOf.RemoveAll(
+                branch => branch.Ref != null && !declared.Contains(TypeMapper.GetRefName(branch.Ref)));
+            schema.DiscriminatorMapping.RemoveAll(
+                mapping => !declared.Contains(TypeMapper.GetRefName(mapping.Ref)));
+
+            if (schema.OneOf.Count < 2 ||
+                (schema.DiscriminatorPropertyName == null &&
+                 !ChoiceResolution.Resolve(schema.OneOf, model.Schemas).Usable)) {
                 dropped.Add(schema.Name);
             }
         }
@@ -589,38 +611,74 @@ internal static class OpenApiSpecParser {
             Required = schema.Required?.ToList() ?? new List<string>()
         };
 
-        foreach (var allOfSchema in schema.AllOf ?? Enumerable.Empty<IOpenApiSchema>()) {
-            if (allOfSchema.Required != null) {
-                foreach (var req in allOfSchema.Required) {
-                    if (!model.Required.Contains(req)) {
-                        model.Required.Add(req);
+        MergeBranches(schema, model, name, collector, new HashSet<string>(StringComparer.Ordinal));
+
+        return model;
+    }
+
+    /// <summary>
+    /// Folds every branch of an <c>allOf</c> into the derived schema, following branches that are
+    /// themselves compositions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The recursion is the point. A branch that is itself an <c>allOf</c> declares no properties of
+    /// its own - they are in <em>its</em> branches - so reading only the direct ones merges nothing
+    /// from it and loses everything above it. Box builds every resource that way:
+    /// <c>File--Full</c> extends <c>File</c>, which extends <c>File--Mini</c>, which extends
+    /// <c>File--Base</c>, and <c>id</c>, <c>type</c> and <c>etag</c> are declared at the bottom. They
+    /// were absent from the generated type entirely, which replaying Box's own published examples is
+    /// what surfaced.
+    /// </para>
+    /// <para>
+    /// Depth first, so the deepest ancestor is merged before anything that narrows it and
+    /// <see cref="MergeProperty"/> sees them in the order the document layers them.
+    /// </para>
+    /// </remarks>
+    private static void MergeBranches(
+        IOpenApiSchema schema, SchemaModel model, string name, SchemaCollector collector,
+        HashSet<string> visited) {
+        foreach (var branch in schema.AllOf ?? Enumerable.Empty<IOpenApiSchema>()) {
+            // A composition may name itself somewhere up its own chain, and a document is not
+            // required to be acyclic just because a type system is.
+            var reference = SchemaRef(branch);
+
+            if (reference != null && !visited.Add(reference)) {
+                continue;
+            }
+
+            MergeBranches(branch, model, name, collector, visited);
+
+            if (branch.Required != null) {
+                foreach (var required in branch.Required) {
+                    if (!model.Required.Contains(required)) {
+                        model.Required.Add(required);
                     }
                 }
             }
 
-            if (allOfSchema.Properties != null) {
-                foreach (var propKvp in allOfSchema.Properties) {
-                    var isRequired = model.Required.Contains(propKvp.Key) ||
-                                     (allOfSchema.Required?.Contains(propKvp.Key) ?? false);
-                    var parsed =
-                        ParseProperty(propKvp.Key, propKvp.Value, isRequired, name, collector);
+            if (branch.Properties == null) {
+                continue;
+            }
 
-                    // allOf is an intersection, so a property named by more than one branch is one
-                    // property described twice - most often a base declaring it and a later branch
-                    // narrowing a constraint on it. Appending both produced two record parameters
-                    // of the same name: CS0100 and CS0102, from a document that is entirely legal.
-                    var existing = model.Properties.FindIndex(p => p.Name == parsed.Name);
+            foreach (var propKvp in branch.Properties) {
+                var isRequired = model.Required.Contains(propKvp.Key) ||
+                                 (branch.Required?.Contains(propKvp.Key) ?? false);
+                var parsed = ParseProperty(propKvp.Key, propKvp.Value, isRequired, name, collector);
 
-                    if (existing >= 0) {
-                        model.Properties[existing] = MergeProperty(model.Properties[existing], parsed);
-                    } else {
-                        model.Properties.Add(parsed);
-                    }
+                // allOf is an intersection, so a property named by more than one branch is one
+                // property described twice - most often a base declaring it and a later branch
+                // narrowing a constraint on it. Appending both produced two record parameters of
+                // the same name: CS0100 and CS0102, from a document that is entirely legal.
+                var existing = model.Properties.FindIndex(p => p.Name == parsed.Name);
+
+                if (existing >= 0) {
+                    model.Properties[existing] = MergeProperty(model.Properties[existing], parsed);
+                } else {
+                    model.Properties.Add(parsed);
                 }
             }
         }
-
-        return model;
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DefaultValueTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DefaultValueTests.cs
@@ -74,7 +74,7 @@ public class DefaultValueTests {
         var generated = OpenApiGenerator.Run(Specs.DeclaredDefaults).AssertNoErrors()
             .SourceContaining("petstore.g.cs");
 
-        Assert.Contains("DateTime? Since = default", generated);
+        Assert.Contains("DateTimeOffset? Since = default", generated);
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ReadOnlyWriteOnlyTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ReadOnlyWriteOnlyTests.cs
@@ -66,18 +66,23 @@ public class ReadOnlyWriteOnlyTests {
     }
 
     /// <summary>
-    /// The property that would otherwise be a required constructor parameter is declared in the
-    /// record body instead, initialized so the non-nullable type holds.
+    /// A read-only property is an ordinary parameter, marked with the direction it travels.
     /// </summary>
+    /// <remarks>
+    /// It used to be an init-only member the resolver gave no setter, which did keep a client from
+    /// sending it - and also kept anything from reading it. Replaying Square's published examples
+    /// through the generated models showed the cost: every <c>created_at</c>, <c>updated_at</c> and
+    /// <c>id</c> in a response was dropped on the way in, which is the direction the description
+    /// does allow. Direction is documented now and enforced where it can name the property.
+    /// </remarks>
     [Fact]
-    public void AReadOnlyPropertyIsAnInitOnlyMember() {
+    public void AReadOnlyPropertyIsPositionalAndMarked() {
         var generated = Generated(Specs.ReadOnlyAndWriteOnly);
-
-        Assert.Contains("public string Id { get; init; } = default!;", generated);
 
         var record = generated.Split('\n').First(line => line.Contains("record Pet("));
 
-        Assert.DoesNotContain("Id", record);
+        Assert.Contains("Id", record);
+        Assert.Contains("ResponseOnly", record);
     }
 
     /// <summary>
@@ -98,15 +103,15 @@ public class ReadOnlyWriteOnlyTests {
     /// of them is reachable.
     /// </summary>
     [Fact]
-    public void TheResolverDropsEachPropertyInOneDirection() {
+    public void TheResolverCarriesEachPropertyInBothDirections() {
         var generated = Generated(Specs.ReadOnlyAndWriteOnly);
 
-        // Serialized: a response carries the server-assigned id.
+        // Both are read and written. Dropping one direction was how this used to be expressed, and
+        // it broke the direction the description allows - a response's id could not be read back,
+        // and a write-only secret could not be written into the request it belongs to.
         Assert.Contains("PropertyName = \"id\"", generated);
         Assert.Contains("Getter = static obj => ((global::TestNamespace.Models.Pet)obj).Id,", generated);
-
-        // Never serialized: the secret does not come back.
-        Assert.Contains("Getter = null,", Between(generated, "PropertyName = \"secret\"", "}),"));
+        Assert.DoesNotContain("Getter = null,", Between(generated, "PropertyName = \"secret\"", "}),"));
     }
 
     /// <summary>
@@ -122,7 +127,10 @@ public class ReadOnlyWriteOnlyTests {
         var creator = Between(
             generated, "ObjectWithParameterizedConstructorCreator = static args => new global::TestNamespace.Models.Pet(", "),");
 
-        Assert.DoesNotContain("Id", creator);
+        // The creator is positional casts, so what it says about read-only properties is its
+        // arity: four arguments means the read-only id is one of them. The old assertion looked
+        // for "Id" in a block that never contains a property name, and so could not have failed.
+        Assert.Contains("args[3]", creator);
 
         // To the close of CreateObjectInfo, which the parameter list is the last member of. Its own
         // entries each end in "}," so that cannot be the terminator.
@@ -131,7 +139,7 @@ public class ReadOnlyWriteOnlyTests {
             "ConstructorParameterMetadataInitializer = static () => new JsonParameterInfoValues[]",
             "});");
 
-        Assert.DoesNotContain("Name = \"id\",", parameters);
+        Assert.Contains("Name = \"id\",", parameters);
 
         // The parameters it does describe are the ones the constructor takes, in order.
         Assert.Contains("Name = \"petType\",", parameters);
@@ -150,10 +158,12 @@ public class ReadOnlyWriteOnlyTests {
 
         var generated = Generated(Specs.ReadOnlyAndWriteOnly);
 
-        var member = generated.Split('\n').First(line => line.Contains("public string Id"));
+        var record = generated.Split('\n').First(line => line.Contains("record Pet("));
+        var member = record[record.IndexOf("Id", System.StringComparison.Ordinal)..];
 
-        Assert.DoesNotContain("Required", member);
-        Assert.DoesNotContain("StringLength", member);
+        // The parameter carries its direction and nothing else: a constraint on it would be checked
+        // against a request that correctly omitted a value the server owns.
+        Assert.DoesNotContain("StringLength", member[..System.Math.Min(80, member.Length)]);
 
         // The constrained sibling still is, so this is not just an empty spec.
         Assert.Contains("StringLength", generated);
@@ -169,10 +179,9 @@ public class ReadOnlyWriteOnlyTests {
     public void ADerivedRecordDoesNotRedeclareTheBaseMember() {
         var generated = Generated(Specs.ReadOnlyAndWriteOnly);
 
-        Assert.Single(
-            generated.Split('\n'), line => line.Contains("public string Id { get; init; }"));
-
-        // And it still forwards the base's real constructor parameters.
+        // Nothing is declared in the body any more, so the hiding this guarded against cannot
+        // happen - the derived record forwards the base's parameters.
+        Assert.DoesNotContain("public string Id { get; init; }", generated);
         Assert.Contains("record Dog(", generated);
     }
 
@@ -181,13 +190,14 @@ public class ReadOnlyWriteOnlyTests {
     /// resolver needs the parameterless creator rather than an empty positional one.
     /// </summary>
     [Fact]
-    public void ASchemaOfOnlyReadOnlyPropertiesGetsAParameterlessCreator() {
+    public void ASchemaOfOnlyReadOnlyPropertiesIsStillConstructed() {
         var generated = Generated(Specs.ReadOnlyOnly);
 
-        Assert.Contains("ObjectCreator = static () => new global::TestNamespace.Models.Receipt(),", generated);
-        Assert.DoesNotContain("ObjectWithParameterizedConstructorCreator = static args => new global::TestNamespace.Models.Receipt(", generated);
-
-        // Still serialized - the property exists, it just cannot be sent.
+        // Read-only properties are constructor parameters like any other, so a schema made only of
+        // them has a constructor and a response carrying them can be read back.
+        Assert.Contains(
+            "ObjectWithParameterizedConstructorCreator = static args => new global::TestNamespace.Models.Receipt(",
+            generated);
         Assert.Contains("Getter = static obj => ((global::TestNamespace.Models.Receipt)obj).Id,", generated);
     }
 }


### PR DESCRIPTION
Compiling proves the generated C# is C#. Tests written from what the generator looks like it should emit assert an expectation, and an expectation can be wrong twice in the same direction. Neither had ever put a payload through a generated model.

The descriptions carry **1,182 of them** — `example` on a schema, or beside a response. That is the people who own the API saying what travels. `openapi-eval` now extracts those and replays each one: deserialize into the generated type, serialize back, report anything that came back missing or different.

## What it found

Seven bugs, none visible to a build, 2,458 tests, or 76 of 76 corpus builds.

| bug | effect |
|---|---|
| no `JsonTypeInfo` for `Nullable<GeneratedEnum>` | every optional enum property undeserializable |
| enums written as **integers** | `1` instead of `"SELLER_CANCELED"`, unreadable both ways |
| `readOnly`/`writeOnly` withheld an accessor | responses dropped `created_at`, `updated_at`, `id` |
| `allOf` never followed its own chain | Box's `id`, `type`, `etag` absent entirely |
| `date-time` → `System.DateTime` | timestamps rewritten to the **host's** timezone |
| property metadata omitted when a schema declares none | free-form `type: object` refused outright |
| a choice could name a type nothing declared | CS0234 from a generated file |

Two of those — the last two — were regressions from earlier work on this same branch, found by the harness rather than by review.

## Results

| spec | clean before | clean now | of |
|---|---|---|---|
| Square | 66 | **398** | 453 |
| Plaid | 84 | **182** | 199 |
| Twilio | 35 | **54** | 56 |
| Box | 1 | **4** | 4 |
| Cloudflare | 60 | 61 (refused 57→26) | 122 |

## Notable

**Enums.** A string converter alone would not have fixed them: the C# member is a sanitized form of the wire value — `SELLER_CANCELED` reaches C# as `SELLERCANCELED`, `+1` as `Plus1` — so matching by member name matches a name the wire never carries. Each enum gets a generated converter with the mapping written out. Not `[JsonStringEnumMemberName]`, which says exactly this and arrived in .NET 9; generated code has to compile for consumers on net8.0.

**Direction.** `readOnly` is documented with `[ResponseOnly]` and `[RequestOnly]` rather than expressed by withholding an accessor. Withholding one does stop a client sending a server-owned field, and it also stops anything reading it — so the shape being guarded against on the way in was dropped on the way out. Enforcement belongs to validation, where a request can be rejected *with the property named*, rather than to serialization, where it can only be dropped in silence. No BCL attribute fits: `ReadOnlyAttribute` and `EditableAttribute` both mean design-time editability, and neither has a `writeOnly` counterpart.

**`date-time`.** `DateTimeOffset` is the type RFC 3339 describes. `DateTime` has no offset, so the same response left a server in New York and a server in Berlin as different bytes.

## What remains is mostly the documents

The long tail is largely the vendors disagreeing with themselves: Square's example nests a map key one level too high, Plaid writes `canonical_desription`, Cloudflare uses `foo` and camelCase in an otherwise snake_case document. 31 of Square's examples and 10 of Intercom's carry top-level fields their own schema does not declare.

**2,544 tests pass**; solution builds clean under `ContinuousIntegrationBuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kk8qzFFvJKGrEoHG9aeywL