### PR TITLE
One correlation id per request, logged and returned

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/CorrelationIdTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/CorrelationIdTests.cs
@@ -1,0 +1,65 @@
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// The correlation id, end to end through a real application.
+/// </summary>
+/// <remarks>
+/// Nothing in this application asks for any of it: the id is issued by the context, put in scope by
+/// the request logger and returned by a filter the middleware service seeds itself. So what is under
+/// test is largely that none of those need wiring up per host.
+/// </remarks>
+public class CorrelationIdTests {
+
+    private const string Header = "X-Correlation-Id";
+
+    [HardenedTest]
+    public async Task EveryResponseCarriesACorrelationId(ITestWebApp testWebApp) {
+        var response = await testWebApp.Request("GET", null, "/binding/path/42");
+
+        Assert.False(string.IsNullOrEmpty(response.Headers[Header].ToString()));
+    }
+
+    /// <summary>Shaped like a trace id whether or not one was in play.</summary>
+    [HardenedTest]
+    public async Task TheIdIsThirtyTwoHexCharacters(ITestWebApp testWebApp) {
+        var response = await testWebApp.Request("GET", null, "/binding/path/42");
+
+        var id = response.Headers[Header].ToString();
+
+        Assert.Equal(32, id.Length);
+        Assert.All(id, c => Assert.True(Uri.IsHexDigit(c), $"'{c}' is not hex"));
+    }
+
+    /// <summary>Two requests are two ids, or it would group unrelated work together.</summary>
+    [HardenedTest]
+    public async Task TwoRequestsGetTwoIds(ITestWebApp testWebApp) {
+        var first = await testWebApp.Request("GET", null, "/binding/path/42");
+        var second = await testWebApp.Request("GET", null, "/binding/path/42");
+
+        Assert.NotEqual(first.Headers[Header].ToString(), second.Headers[Header].ToString());
+    }
+
+    /// <summary>
+    /// A request nothing routed still gets one. A 404 is a thing people ask about, and an id that
+    /// only appears on successful responses is missing from every interesting case.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnUnroutedRequestStillCarriesAnId(ITestWebApp testWebApp) {
+        var response = await testWebApp.Request("GET", null, "/nothing/is/here");
+
+        Assert.Equal(404, response.StatusCode);
+        Assert.False(string.IsNullOrEmpty(response.Headers[Header].ToString()));
+    }
+
+    /// <summary>
+    /// So does a refused verb. The header is set on the way in precisely so that a response
+    /// produced without reaching a handler still carries it.
+    /// </summary>
+    [HardenedTest]
+    public async Task A405StillCarriesAnId(ITestWebApp testWebApp) {
+        var response = await testWebApp.Request("PUT", null, "/binding/path/42");
+
+        Assert.Equal(405, response.StatusCode);
+        Assert.False(string.IsNullOrEmpty(response.Headers[Header].ToString()));
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -164,6 +164,13 @@ namespace Hardened.Requests.Abstract.Authorization
         public static Hardened.Requests.Abstract.Authorization.Requirement operator |(Hardened.Requests.Abstract.Authorization.Requirement left, Hardened.Requests.Abstract.Authorization.Requirement right) { }
     }
 }
+namespace Hardened.Requests.Abstract.Diagnostics
+{
+    public static class CorrelationIdentifier
+    {
+        public static string ForCurrentTrace() { }
+    }
+}
 namespace Hardened.Requests.Abstract.Errors
 {
     public class ErrorModel
@@ -222,6 +229,7 @@ namespace Hardened.Requests.Abstract.Execution
     {
         Hardened.Requests.Abstract.Authorization.ICallerPrincipal CallerPrincipal { get; set; }
         System.Threading.CancellationToken CancellationToken { get; }
+        string CorrelationId { get; }
         Hardened.Requests.Abstract.Execution.DefaultOutputFunc? DefaultOutput { get; set; }
         Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo? HandlerInfo { get; set; }
         object? HandlerInstance { get; set; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -430,6 +430,12 @@ namespace Hardened.Requests.Runtime.Logging
 }
 namespace Hardened.Requests.Runtime.Middleware
 {
+    public class CorrelationHeaderFilter : Hardened.Requests.Abstract.Execution.IExecutionFilter
+    {
+        public const string HeaderName = "X-Correlation-Id";
+        public CorrelationHeaderFilter(string? headerName = null) { }
+        public System.Threading.Tasks.Task Execute(Hardened.Requests.Abstract.Execution.IExecutionChain chain) { }
+    }
     [DependencyModules.Runtime.Attributes.SingletonService(Using=DependencyModules.Runtime.Attributes.RegistrationType.Try)]
     public class MiddlewareService : Hardened.Requests.Abstract.Middleware.IMiddlewareService
     {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
@@ -138,6 +138,7 @@ namespace Hardened.Requests.Testing
         public TestExecutionContext(System.IServiceProvider rootServiceProvider, System.IServiceProvider requestServices, Hardened.Requests.Abstract.Execution.IKnownServices knownServices, Hardened.Requests.Abstract.Execution.IExecutionRequest request, Hardened.Requests.Abstract.Execution.IExecutionResponse response, System.Threading.CancellationToken cancellationToken, Hardened.Shared.Runtime.Metrics.IMetricLogger? metricLogger = null) { }
         public Hardened.Requests.Abstract.Authorization.ICallerPrincipal CallerPrincipal { get; set; }
         public System.Threading.CancellationToken CancellationToken { get; }
+        public string CorrelationId { get; init; }
         public Hardened.Requests.Abstract.Execution.DefaultOutputFunc? DefaultOutput { get; set; }
         public Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo? HandlerInfo { get; set; }
         public object? HandlerInstance { get; set; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.AspNetCore.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.AspNetCore.Runtime.approved.txt
@@ -36,6 +36,7 @@ namespace Hardened.Web.AspNetCore.Runtime.Impl
         public AspNetExecutionContext(Microsoft.AspNetCore.Http.HttpContext httpContext, Hardened.Shared.Runtime.Metrics.IMetricLogger logger) { }
         public Hardened.Requests.Abstract.Authorization.ICallerPrincipal CallerPrincipal { get; set; }
         public System.Threading.CancellationToken CancellationToken { get; }
+        public string CorrelationId { get; init; }
         public Hardened.Requests.Abstract.Execution.DefaultOutputFunc? DefaultOutput { get; set; }
         public Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo? HandlerInfo { get; set; }
         public object? HandlerInstance { get; set; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Kestrel.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Kestrel.Runtime.approved.txt
@@ -53,6 +53,7 @@ namespace Hardened.Web.Kestrel.Runtime.Impl
         public FeatureExecutionContext(System.IServiceProvider rootServiceProvider, System.IServiceProvider requestServices, Microsoft.AspNetCore.Http.Features.IFeatureCollection features, Hardened.Shared.Runtime.Metrics.IMetricLogger metricLogger) { }
         public Hardened.Requests.Abstract.Authorization.ICallerPrincipal CallerPrincipal { get; set; }
         public System.Threading.CancellationToken CancellationToken { get; }
+        public string CorrelationId { get; init; }
         public Hardened.Requests.Abstract.Execution.DefaultOutputFunc? DefaultOutput { get; set; }
         public Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo? HandlerInfo { get; set; }
         public object? HandlerInstance { get; set; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
@@ -164,6 +164,7 @@ namespace Hardened.Web.Runtime.Cors
         public void AllowOrigin(string origin) { }
         public void AllowOriginSuffix(string domain) { }
         public bool AreHeadersAllowed(System.Collections.Generic.IEnumerable<string> requested) { }
+        public void ClearExposedHeaders() { }
         public void ExposeHeader(string header) { }
         public bool IsOriginAllowed(string origin) { }
         public void LoadFromEnvironment() { }

--- a/src/Requests/Hardened.Requests.Abstract/Diagnostics/CorrelationIdentifier.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Diagnostics/CorrelationIdentifier.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+
+namespace Hardened.Requests.Abstract.Diagnostics;
+
+/// <summary>
+/// Where a request's correlation id comes from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The trace id when there is one, a fresh one when there is not.</b> The pipeline already starts
+/// a span per request and already joins the caller's trace when they sent a <c>traceparent</c>, so
+/// when anything is collecting traces the correlation id and the trace id should be the same string
+/// - two identities for one request is how a log line and a span end up impossible to line up.
+/// </para>
+/// <para>
+/// But <c>ActivitySource.StartActivity</c> returns null when nothing is listening, which is
+/// deliberate and is what makes instrumenting the pipeline unconditional. So on any deployment
+/// without a collector - every developer machine, most test runs, plenty of production - there is no
+/// trace id in existence, and that is exactly when someone reading logs most wants an id to group
+/// them by. Hence the fallback.
+/// </para>
+/// <para>
+/// <b>Shaped like a trace id either way.</b> <see cref="ActivityTraceId"/> generates it, so the
+/// value is the same 32 hex characters whether it came from a trace or not, and nothing downstream
+/// has to care which. It is also why this is not a <c>Guid</c>: a correlation id that is sometimes a
+/// trace id and sometimes a GUID makes every log query two queries.
+/// </para>
+/// </remarks>
+public static class CorrelationIdentifier {
+
+    /// <summary>
+    /// The current trace's id, or a new one when nothing is tracing.
+    /// </summary>
+    /// <remarks>
+    /// Read lazily by the contexts rather than at construction, because the host builds the context
+    /// before <c>IRequestLogger.RequestBegin</c> starts the span - so anything eager would mint an
+    /// id and then be contradicted a moment later by a span carrying a different one.
+    /// </remarks>
+    public static string ForCurrentTrace() {
+        var current = Activity.Current;
+
+        return current is null
+            ? ActivityTraceId.CreateRandom().ToHexString()
+            : current.TraceId.ToHexString();
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionContext.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionContext.cs
@@ -60,6 +60,30 @@ public interface IExecutionContext {
     ICallerPrincipal CallerPrincipal { get; set; }
 
     /// <summary>
+    /// One id for this request, for grouping everything it produced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Never null and never empty. It is the trace id when anything is collecting traces - so a log
+    /// line and a span line up without anyone correlating two different identifiers - and a freshly
+    /// generated value of the same shape when nothing is, because
+    /// <c>ActivitySource.StartActivity</c> returns null with no listener and an id that only exists
+    /// under a collector is missing exactly when it is most wanted.
+    /// See <see cref="Diagnostics.CorrelationIdentifier"/>.
+    /// </para>
+    /// <para>
+    /// Realized on first read rather than at construction: the host builds the context and only then
+    /// calls <c>RequestBegin</c>, which is where the span starts.
+    /// </para>
+    /// <para>
+    /// <c>Clone</c> carries it, for the same reason it carries
+    /// <see cref="CallerPrincipal"/> - a fork is the same request, and a retried or forked chain
+    /// that reported a second id would split one request's logs in two.
+    /// </para>
+    /// </remarks>
+    string CorrelationId { get; }
+
+    /// <summary>
     /// Handler for the call, will be null for middleware handlers
     /// </summary>
     object? HandlerInstance { get; set; }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Logging/CorrelationIdTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Logging/CorrelationIdTests.cs
@@ -1,0 +1,335 @@
+using System.Diagnostics;
+using Hardened.Requests.Abstract.Diagnostics;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Diagnostics;
+using Hardened.Requests.Runtime.Logging;
+using Hardened.Requests.Runtime.Middleware;
+using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Logging;
+
+/// <summary>
+/// One id per request: what it is, where it survives to, and what happens to it when nothing is
+/// collecting traces.
+///
+/// <para>
+/// The last is the whole reason this exists rather than "read the trace id".
+/// <c>ActivitySource.StartActivity</c> returns null with no listener, so on a machine with no
+/// collector there is no trace id at all - which is exactly when somebody reading logs wants an id
+/// to group them by.
+/// </para>
+/// </summary>
+public class CorrelationIdTests {
+
+    /// <summary>
+    /// Listens to the pipeline's source so that spans are actually created, since without a
+    /// listener <c>StartActivity</c> returns null and there is nothing to read a trace id from.
+    /// </summary>
+    private static ActivityListener Listening() {
+        var listener = new ActivityListener {
+            ShouldListenTo = source => source.Name == HardenedDiagnostics.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        return listener;
+    }
+
+    // ------------------------------------------------------------ the value
+
+    /// <summary>Always present, whatever else is or is not configured.</summary>
+    [Fact]
+    public void CorrelationId_IsNeverEmpty() {
+        Assert.False(string.IsNullOrEmpty(Pipeline.Context().CorrelationId));
+    }
+
+    /// <summary>
+    /// Stable across reads. A property that minted a new value each time would put a different id
+    /// on every log line of the same request.
+    /// </summary>
+    [Fact]
+    public void CorrelationId_IsTheSameOnEveryRead() {
+        var context = Pipeline.Context();
+
+        Assert.Equal(context.CorrelationId, context.CorrelationId);
+    }
+
+    /// <summary>Two requests are two ids.</summary>
+    [Fact]
+    public void CorrelationId_DiffersBetweenRequests() {
+        Assert.NotEqual(Pipeline.Context().CorrelationId, Pipeline.Context().CorrelationId);
+    }
+
+    /// <summary>
+    /// Shaped like a trace id whether or not it came from one, so a log query does not have to
+    /// handle two formats.
+    /// </summary>
+    [Fact]
+    public void CorrelationId_IsThirtyTwoHexCharacters() {
+        var id = Pipeline.Context().CorrelationId;
+
+        Assert.Equal(32, id.Length);
+        Assert.All(id, c => Assert.True(Uri.IsHexDigit(c), $"'{c}' is not hex"));
+    }
+
+    /// <summary>
+    /// With a collector attached, the correlation id <em>is</em> the trace id - so a log line and
+    /// the span for the same request carry the same string and nobody has to join two identifiers.
+    /// </summary>
+    [Fact]
+    public void CorrelationId_IsTheTraceIdWhenSomethingIsTracing() {
+        using var listener = Listening();
+
+        var context = Pipeline.Context();
+        var logger = new RequestLogger(Pipeline.Logger<RequestLogger>());
+
+        logger.RequestBegin(context);
+
+        var traceId = Activity.Current?.TraceId.ToHexString();
+
+        Assert.NotNull(traceId);
+        Assert.Equal(traceId, context.CorrelationId);
+
+        logger.RequestEnd(context);
+    }
+
+    /// <summary>
+    /// And with nothing listening there is still an id. This is the case the trace id cannot cover.
+    /// </summary>
+    [Fact]
+    public void CorrelationId_IsStillIssuedWhenNothingIsTracing() {
+        var context = Pipeline.Context();
+        var logger = new RequestLogger(Pipeline.Logger<RequestLogger>());
+
+        logger.RequestBegin(context);
+
+        Assert.False(string.IsNullOrEmpty(context.CorrelationId));
+
+        logger.RequestEnd(context);
+    }
+
+    /// <summary>
+    /// A fork is the same request. <c>Clone</c> carries the id for the same reason it carries the
+    /// caller - a retried or forked chain reporting a second id would split one request's logs.
+    /// </summary>
+    [Fact]
+    public void CorrelationId_SurvivesClone() {
+        var context = Pipeline.Context();
+
+        Assert.Equal(context.CorrelationId, context.Clone().CorrelationId);
+    }
+
+    /// <summary>Including when the clone replaces the request and response.</summary>
+    [Fact]
+    public void CorrelationId_SurvivesCloneThatReplacesRequestAndResponse() {
+        var context = Pipeline.Context();
+        var clone = context.Clone(request: context.Request.Clone(path: "/elsewhere"));
+
+        Assert.Equal(context.CorrelationId, clone.CorrelationId);
+    }
+
+    // ------------------------------------------------------------- the scope
+
+    /// <summary>
+    /// Every line written while the request runs carries the id, including lines this class knows
+    /// nothing about - which is the point of using a scope rather than a message parameter.
+    /// </summary>
+    [Fact]
+    public void RequestBegin_PutsTheCorrelationIdInScopeForEveryLogLine() {
+        var provider = new ScopeCapturingProvider();
+        using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+
+        var context = Pipeline.Context();
+        var logger = new RequestLogger(factory.CreateLogger<RequestLogger>());
+
+        logger.RequestBegin(context);
+
+        // Something the framework did not write.
+        factory.CreateLogger("Application").LogInformation("charging card");
+
+        logger.RequestEnd(context);
+
+        Assert.Contains(context.CorrelationId, provider.ScopesFor("charging card"));
+    }
+
+    /// <summary>
+    /// The scope closes when the request ends, so the id does not leak onto whatever the thread
+    /// does next.
+    /// </summary>
+    [Fact]
+    public void RequestEnd_ClosesTheScope() {
+        var provider = new ScopeCapturingProvider();
+        using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+
+        var context = Pipeline.Context();
+        var logger = new RequestLogger(factory.CreateLogger<RequestLogger>());
+
+        logger.RequestBegin(context);
+        logger.RequestEnd(context);
+
+        factory.CreateLogger("Application").LogInformation("after the request");
+
+        Assert.DoesNotContain(context.CorrelationId, provider.ScopesFor("after the request"));
+    }
+
+    /// <summary>
+    /// Closed on the uninstrumented path too. The end used to return early when there was no span,
+    /// and a request with no span is precisely the one that has a scope worth closing.
+    /// </summary>
+    [Fact]
+    public void RequestEnd_ClosesTheScopeEvenWithNoSpan() {
+        var provider = new ScopeCapturingProvider();
+        using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+
+        var context = Pipeline.Context();
+        var logger = new RequestLogger(factory.CreateLogger<RequestLogger>());
+
+        // No listener, so StartActivity returns null and no span is stored.
+        logger.RequestBegin(context);
+        logger.RequestEnd(context);
+
+        factory.CreateLogger("Application").LogInformation("afterwards");
+
+        Assert.DoesNotContain(context.CorrelationId, provider.ScopesFor("afterwards"));
+    }
+
+    // ------------------------------------------------------------ the header
+
+    /// <summary>The caller gets the id back, so they can quote it.</summary>
+    [Fact]
+    public async Task CorrelationHeaderFilter_PutsTheIdOnTheResponse() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, new CorrelationHeaderFilter()).Next();
+
+        Assert.Equal(
+            context.CorrelationId,
+            context.Response.Headers[CorrelationHeaderFilter.HeaderName].ToString());
+    }
+
+    /// <summary>
+    /// Set on the way in, so a filter that refuses the request without calling <c>Next</c> - a rate
+    /// limiter's 429, a rejected preflight - still comes back with an id. Those are the responses
+    /// somebody is most likely to ask about.
+    /// </summary>
+    [Fact]
+    public async Task CorrelationHeaderFilter_SetsTheHeaderEvenWhenTheRequestIsRefused() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(
+            context,
+            new CorrelationHeaderFilter(),
+            new Pipeline.Inline(chain => {
+                chain.Context.Response.Status = 429;
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal(429, context.Response.Status);
+        Assert.Equal(
+            context.CorrelationId,
+            context.Response.Headers[CorrelationHeaderFilter.HeaderName].ToString());
+    }
+
+    /// <summary>The header name is configurable for a deployment that already has a convention.</summary>
+    [Fact]
+    public async Task CorrelationHeaderFilter_HonoursAConfiguredHeaderName() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, new CorrelationHeaderFilter("X-Request-Id")).Next();
+
+        Assert.Equal(context.CorrelationId, context.Response.Headers["X-Request-Id"].ToString());
+    }
+
+    /// <summary>
+    /// Seeded into every middleware chain, so no host has to remember - the same reason the
+    /// response finalizer is.
+    /// </summary>
+    [Fact]
+    public async Task MiddlewareService_ReturnsTheIdWithoutAnyHostRegisteringTheFilter() {
+        var context = Pipeline.Context();
+        var service = new MiddlewareService();
+
+        await service.GetExecutionChain(context).Next();
+
+        Assert.Equal(
+            context.CorrelationId,
+            context.Response.Headers[CorrelationHeaderFilter.HeaderName].ToString());
+    }
+
+    // ----------------------------------------------------------- the generator
+
+    /// <summary>
+    /// Outside any activity the generator issues a fresh id rather than the all-zero trace id an
+    /// absent activity would otherwise imply.
+    /// </summary>
+    [Fact]
+    public void ForCurrentTrace_DoesNotIssueTheZeroTraceId() {
+        var zero = default(ActivityTraceId).ToHexString();
+
+        Assert.NotEqual(zero, CorrelationIdentifier.ForCurrentTrace());
+    }
+
+    /// <summary>Captures the scopes in force when each message was written.</summary>
+    private sealed class ScopeCapturingProvider : ILoggerProvider {
+        private readonly List<(string Message, List<string> Scopes)> _written = new();
+        private readonly AsyncLocal<Stack<object>> _scopes = new();
+
+        public IEnumerable<string> ScopesFor(string message) =>
+            _written.Where(w => w.Message == message).SelectMany(w => w.Scopes);
+
+        public ILogger CreateLogger(string categoryName) => new Capturing(this);
+
+        public void Dispose() { }
+
+        private Stack<object> Current => _scopes.Value ??= new Stack<object>();
+
+        private sealed class Capturing : ILogger {
+            private readonly ScopeCapturingProvider _provider;
+
+            public Capturing(ScopeCapturingProvider provider) {
+                _provider = provider;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull {
+                _provider.Current.Push(state);
+
+                return new Pop(_provider);
+            }
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter) {
+                var scopes = _provider.Current
+                    .SelectMany(Values)
+                    .ToList();
+
+                _provider._written.Add((formatter(state, exception), scopes));
+            }
+
+            private static IEnumerable<string> Values(object scope) =>
+                scope is IReadOnlyList<KeyValuePair<string, object>> pairs
+                    ? pairs.Select(p => p.Value?.ToString() ?? "")
+                    : new[] { scope.ToString() ?? "" };
+
+            private sealed class Pop : IDisposable {
+                private readonly ScopeCapturingProvider _provider;
+
+                public Pop(ScopeCapturingProvider provider) {
+                    _provider = provider;
+                }
+
+                public void Dispose() {
+                    if (_provider.Current.Count > 0) {
+                        _provider.Current.Pop();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
@@ -43,6 +43,25 @@ public partial class RequestLogger : IRequestLogger {
     /// </remarks>
     private static readonly ConditionalWeakTable<IExecutionContext, Activity> _spans = new();
 
+    /// <summary>
+    /// The logging scope carrying this request's correlation id, keyed the same way as the span.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A scope rather than a parameter on each message, because the point is the lines this class
+    /// does <em>not</em> write: a handler logging "charging card" should carry the id without
+    /// knowing there is one. Every provider that renders scopes picks it up - Serilog and the
+    /// OpenTelemetry logger natively, the console with <c>IncludeScopes = true</c>.
+    /// </para>
+    /// <para>
+    /// The other half of this arrives for free and is worth knowing about: <c>StartActivity</c> sets
+    /// <c>Activity.Current</c>, so a trace-aware provider already stamps TraceId and SpanId on every
+    /// line without a scope at all. The scope is what covers the case that one does not - no
+    /// collector attached, so no span, which is exactly when there is no trace id to stamp.
+    /// </para>
+    /// </remarks>
+    private static readonly ConditionalWeakTable<IExecutionContext, IDisposable> _scopes = new();
+
     private readonly ILogger<RequestLogger> _logger;
 
     public RequestLogger(ILogger<RequestLogger> logger) {
@@ -50,14 +69,12 @@ public partial class RequestLogger : IRequestLogger {
     }
 
     public void RequestBegin(IExecutionContext context) {
-        LogRequestStarted(context.Request.Method, context.Request.Path);
-
-        // A dimension for whatever provider is behind IMetricLogger, independent of tracing. What
-        // becomes of it is the provider's decision: the Meter bridge makes it a histogram dimension,
-        // and EMF promotes nothing unless the application opted the tag in, because a CloudWatch
-        // dimension is billed per distinct value.
-        context.RequestMetrics.Tag("http.request.method", context.Request.Method);
-
+        // The span is started before anything else here, and the order is load-bearing rather than
+        // stylistic. Starting it sets Activity.Current, and the context's correlation id reads from
+        // there on first access - so opening the scope first would realize an id with no trace to
+        // read, and the span created a moment later would carry a different one. A log line and a
+        // span for the same request would then disagree, which is the one thing this is for.
+        //
         // Null when nothing is listening - no allocation, no work - which is why this is
         // unconditional and lives in the runtime rather than behind a flag or an opt-in package.
         //
@@ -72,14 +89,102 @@ public partial class RequestLogger : IRequestLogger {
             : HardenedDiagnostics.ActivitySource.StartActivity(
                 context.Request.Method, ActivityKind.Server);
 
-        if (span is null) {
+        if (span is not null) {
+            span.SetTag("http.request.method", context.Request.Method);
+            span.SetTag("url.path", context.Request.Path);
+
+            _spans.AddOrUpdate(context, span);
+        }
+
+        // After the span, so the id is that span's trace id when there is one; before the first
+        // line, so the framework's own lifecycle messages are not the only ones without it.
+        OpenCorrelationScope(context);
+
+        LogRequestStarted(context.Request.Method, context.Request.Path);
+
+        // A dimension for whatever provider is behind IMetricLogger, independent of tracing. What
+        // becomes of it is the provider's decision: the Meter bridge makes it a histogram dimension,
+        // and EMF promotes nothing unless the application opted the tag in, because a CloudWatch
+        // dimension is billed per distinct value.
+        context.RequestMetrics.Tag("http.request.method", context.Request.Method);
+    }
+
+    /// <summary>
+    /// Puts this request's correlation id on every log line written while it runs.
+    /// </summary>
+    /// <remarks>
+    /// Read from the context rather than from <c>Activity.Current</c>, because the context is what
+    /// guarantees an id exists at all: with no collector attached there is no span, and the context
+    /// generates one of the same shape instead.
+    /// </remarks>
+    private void OpenCorrelationScope(IExecutionContext context) {
+        var correlationId = context.CorrelationId;
+
+        // Substituted contexts in a test hand back null for a property they were never set up with.
+        // A scope keyed to nothing is worse than no scope.
+        if (string.IsNullOrEmpty(correlationId)) {
             return;
         }
 
-        span.SetTag("http.request.method", context.Request.Method);
-        span.SetTag("url.path", context.Request.Path);
+        var scope = _logger.BeginScope(new CorrelationScope(correlationId));
 
-        _spans.AddOrUpdate(context, span);
+        if (scope is not null) {
+            _scopes.AddOrUpdate(context, scope);
+        }
+    }
+
+    /// <summary>
+    /// Closes the scope opened at the start of the request.
+    /// </summary>
+    /// <remarks>
+    /// Every host calls <c>RequestEnd</c> from a <c>finally</c>, so a request that threw still
+    /// closes its scope. Leaking one matters more than leaking a span: the scope stacks are
+    /// <c>AsyncLocal</c> in every provider that implements them, and an undisposed scope can leave
+    /// the id attached to whatever the thread does next.
+    /// </remarks>
+    private void CloseCorrelationScope(IExecutionContext context) {
+        if (!_scopes.TryGetValue(context, out var scope)) {
+            return;
+        }
+
+        _scopes.Remove(context);
+
+        scope.Dispose();
+    }
+
+    /// <summary>
+    /// One key and one value, shaped the way structured providers expect a scope to be.
+    /// </summary>
+    /// <remarks>
+    /// <c>IReadOnlyList&lt;KeyValuePair&lt;string, object&gt;&gt;</c> is what Serilog, the
+    /// OpenTelemetry logger and the console's <c>IncludeScopes</c> all look for; a provider that
+    /// finds anything else falls back to <c>ToString</c>, which is why that is overridden rather
+    /// than left to print a type name.
+    /// </remarks>
+    private sealed class CorrelationScope : IReadOnlyList<KeyValuePair<string, object>> {
+        public const string Key = "CorrelationId";
+
+        private readonly string _correlationId;
+
+        public CorrelationScope(string correlationId) {
+            _correlationId = correlationId;
+        }
+
+        public int Count => 1;
+
+        public KeyValuePair<string, object> this[int index] =>
+            index == 0
+                ? new KeyValuePair<string, object>(Key, _correlationId)
+                : throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() {
+            yield return new KeyValuePair<string, object>(Key, _correlationId);
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+
+        public override string ToString() => Key + ":" + _correlationId;
     }
 
     /// <summary>
@@ -161,22 +266,25 @@ public partial class RequestLogger : IRequestLogger {
         // every host records TotalRequestDuration and only then calls this.
         context.RequestMetrics.Tag("http.response.status_code", status);
 
-        if (!_spans.TryGetValue(context, out var span)) {
-            return;
+        if (_spans.TryGetValue(context, out var span)) {
+            _spans.Remove(context);
+
+            span.SetTag("http.response.status_code", status);
+
+            // 4xx is the caller's mistake, not the server's. The conventions leave a server span
+            // Unset for those and reserve Error for 5xx, so that a trace backend's error rate means
+            // "this service failed" rather than "someone sent a bad request".
+            if (status >= 500) {
+                span.SetStatus(ActivityStatusCode.Error);
+            }
+
+            span.Stop();
         }
 
-        _spans.Remove(context);
-
-        span.SetTag("http.response.status_code", status);
-
-        // 4xx is the caller's mistake, not the server's. The conventions leave a server span Unset
-        // for those and reserve Error for 5xx, so that a trace backend's error rate means "this
-        // service failed" rather than "someone sent a bad request".
-        if (status >= 500) {
-            span.SetStatus(ActivityStatusCode.Error);
-        }
-
-        span.Stop();
+        // Last, so every line above is still written inside it - and outside the span check, which
+        // used to return early here. A request with no span is the uninstrumented path, and that is
+        // the one whose scope most needs closing, because it is the one that has one.
+        CloseCorrelationScope(context);
     }
 
     public void RequestParameterBindFailed(IExecutionContext context, Exception? exp) {

--- a/src/Requests/Hardened.Requests.Runtime/Middleware/CorrelationHeaderFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Middleware/CorrelationHeaderFilter.cs
@@ -1,0 +1,56 @@
+using Hardened.Requests.Abstract.Execution;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Runtime.Middleware;
+
+/// <summary>
+/// Puts the request's correlation id on the response, so the caller can quote it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An id nobody outside the process can see only helps whoever is already reading the logs. The
+/// value of this one is that a client, a support ticket or a failing test can name the request, and
+/// that requires it to come back.
+/// </para>
+/// <para>
+/// <b>Set on the way in, not on the way out.</b> A filter that annotated the response after
+/// <c>Next</c> would miss every short circuit - a rate limiter's 429 and a rejected CORS preflight
+/// are exactly the responses somebody wants to ask about - and would also be too late on a
+/// transport that has already begun writing. Setting it first costs one header assignment and is
+/// correct on every path.
+/// </para>
+/// <para>
+/// Reading <c>CorrelationId</c> here is also what realizes it, which is deliberate: this runs after
+/// the host has called <c>RequestBegin</c>, so a span exists if one is going to and the id is that
+/// span's trace id rather than an unrelated value minted a moment earlier.
+/// </para>
+/// </remarks>
+public class CorrelationHeaderFilter : IExecutionFilter {
+
+    /// <summary>
+    /// The header the id comes back on.
+    /// </summary>
+    /// <remarks>
+    /// No standard exists. <c>X-Correlation-Id</c> is the spelling most log aggregators already know
+    /// how to pick up, and it does not collide with the <c>traceparent</c> a trace-aware caller is
+    /// separately entitled to read.
+    /// </remarks>
+    public const string HeaderName = "X-Correlation-Id";
+
+    private readonly string _headerName;
+
+    public CorrelationHeaderFilter(string? headerName = null) {
+        _headerName = string.IsNullOrEmpty(headerName) ? HeaderName : headerName;
+    }
+
+    public Task Execute(IExecutionChain chain) {
+        var context = chain.Context;
+        var correlationId = context.CorrelationId;
+
+        if (!string.IsNullOrEmpty(correlationId)) {
+            context.Response.Headers[_headerName] = new StringValues(correlationId);
+        }
+
+        return chain.Next();
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Middleware/MiddlewareService.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Middleware/MiddlewareService.cs
@@ -9,16 +9,20 @@ namespace Hardened.Requests.Runtime.Middleware;
 public class MiddlewareService : IMiddlewareService {
     private static readonly ResponseFinalizerFilter Finalizer = new();
 
+    private static readonly CorrelationHeaderFilter CorrelationHeader = new();
+
     /// <summary>
-    /// The finalizer first, so it wraps everything a host or an application registers after it.
+    /// The finalizer first, so it wraps everything a host or an application registers after it, then
+    /// the correlation header, so the id is on the response before anything can short-circuit.
     /// </summary>
     /// <remarks>
     /// Seeded here rather than added by each host because there are five of them, and a host that
-    /// forgot would silently go back to answering middleware refusals with an empty body. It holds
-    /// no state, so one instance serves every request.
+    /// forgot would silently go back to answering middleware refusals with an empty body - or, for
+    /// the second one, stop returning an id on exactly the refusals somebody wants to ask about.
+    /// Neither holds state, so one instance of each serves every request.
     /// </remarks>
     private readonly List<Func<IExecutionContext, IExecutionFilter>> _filters =
-        new() { _ => Finalizer };
+        new() { _ => Finalizer, _ => CorrelationHeader };
 
     public void Use(Func<IExecutionContext, IExecutionFilter> middlewareFunc) {
         _filters.Add(middlewareFunc);

--- a/src/Requests/Hardened.Requests.Testing/TestExecutionContext.cs
+++ b/src/Requests/Hardened.Requests.Testing/TestExecutionContext.cs
@@ -1,4 +1,5 @@
 ﻿using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Diagnostics;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Shared.Runtime.Diagnostics;
 using Hardened.Shared.Runtime.Metrics;
@@ -50,6 +51,8 @@ public class TestExecutionContext : IExecutionContext {
             HandlerInfo = HandlerInfo,
             // The reference, not a copy: a fork is the same caller.
             CallerPrincipal = CallerPrincipal,
+            // And the same request, so it reports one id rather than two.
+            CorrelationId = CorrelationId,
         };
     }
 
@@ -64,6 +67,14 @@ public class TestExecutionContext : IExecutionContext {
     public IExecutionResponse Response { get; }
 
     public ICallerPrincipal CallerPrincipal { get; set; } = AnonymousCallerPrincipal.Instance;
+
+    private string? _correlationId;
+
+    /// <inheritdoc />
+    public string CorrelationId {
+        get => _correlationId ??= CorrelationIdentifier.ForCurrentTrace();
+        init => _correlationId = value;
+    }
 
     public object? HandlerInstance { get; set; }
 

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetExecutionContext.cs
@@ -1,4 +1,5 @@
 using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Diagnostics;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.PathTokens;
@@ -60,6 +61,8 @@ public class AspNetExecutionContext : IExecutionContext {
             HandlerInfo = HandlerInfo,
             // The reference, not a copy: a fork is the same caller.
             CallerPrincipal = CallerPrincipal,
+            // And the same request, so it reports one id rather than two.
+            CorrelationId = CorrelationId,
         };
     }
 
@@ -76,6 +79,20 @@ public class AspNetExecutionContext : IExecutionContext {
     /// how it authenticates.
     /// </summary>
     public ICallerPrincipal CallerPrincipal { get; set; } = AnonymousCallerPrincipal.Instance;
+
+    private string? _correlationId;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads the trace id rather than <c>HttpContext.TraceIdentifier</c>. ASP.NET's hosting layer
+    /// has already started an activity by the time this is built, so the trace id is both available
+    /// and the one the rest of the trace is filed under - where TraceIdentifier is a
+    /// connection-scoped string in a different shape that nothing else here would recognise.
+    /// </remarks>
+    public string CorrelationId {
+        get => _correlationId ??= CorrelationIdentifier.ForCurrentTrace();
+        init => _correlationId = value;
+    }
 
     public object? HandlerInstance { get; set; }
     public IExecutionRequestHandlerInfo? HandlerInfo { get; set; }

--- a/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionContext.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/Impl/FeatureExecutionContext.cs
@@ -1,4 +1,5 @@
 using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Diagnostics;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Shared.Runtime.Diagnostics;
 using Hardened.Shared.Runtime.Metrics;
@@ -84,7 +85,9 @@ public sealed class FeatureExecutionContext : IExecutionContext {
             HandlerInstance = HandlerInstance,
             HandlerInfo = HandlerInfo,
             // The reference, not a copy: a fork is the same caller.
-            CallerPrincipal = CallerPrincipal
+            CallerPrincipal = CallerPrincipal,
+            // And the same request, so it reports one id rather than two.
+            CorrelationId = CorrelationId
         };
     }
 
@@ -99,6 +102,14 @@ public sealed class FeatureExecutionContext : IExecutionContext {
     public IExecutionResponse Response { get; }
 
     public ICallerPrincipal CallerPrincipal { get; set; } = AnonymousCallerPrincipal.Instance;
+
+    private string? _correlationId;
+
+    /// <inheritdoc />
+    public string CorrelationId {
+        get => _correlationId ??= CorrelationIdentifier.ForCurrentTrace();
+        init => _correlationId = value;
+    }
 
     public object? HandlerInstance { get; set; }
 

--- a/src/Web/Hardened.Web.Kestrel.Runtime/README.md
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/README.md
@@ -73,11 +73,22 @@ every hosted option — see `src/Benchmarks/README.md` for why that boundary was
 This is additive. `Hardened.Web.AspNetCore.Runtime` remains the right choice when any of the
 following matter — and the first one matters more often than teams expect.
 
-- **Hosting diagnostics.** `Activity`, `DiagnosticSource` and `EventSource` events are not raised.
-  The standard OpenTelemetry instrumentation subscribes to the `Microsoft.AspNetCore.Hosting`
-  names, so an existing OTel setup observes **nothing** from an application hosted this way.
-  Hardened's own `IRequestLogger` and `IMetricLogger` are called, so per-request logging and
-  metrics still work; distributed tracing does not.
+- **ASP.NET's own hosting diagnostics.** The `Microsoft.AspNetCore.Hosting` `DiagnosticSource` and
+  `EventSource` events are not raised, so instrumentation packages that subscribe to *those names*
+  see nothing.
+
+  Tracing itself does work, and has since the request pipeline began reporting spans. Hardened
+  publishes its own `ActivitySource` and `Meter`, both named `Hardened.Requests` — a server span per
+  request, parented on an inbound `traceparent`, tagged with route and status, plus a correlation id
+  on every response. Point a collector at that name rather than at the ASP.NET one:
+
+  ```csharp
+  builder.AddSource("Hardened.Requests");   // and .AddMeter("Hardened.Requests")
+  ```
+
+  This bullet used to say distributed tracing did not work at all. It was written before the spans
+  existed and outlived them, which is worth knowing because it sends people to
+  `Hardened.Web.AspNetCore.Runtime` for a reason that no longer holds.
 - **ASP.NET authentication and authorization** middleware.
 - **General response compression.** Hardened's `GZipStaticContentCompressor` covers static content
   only, so dynamic responses have no equivalent.

--- a/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsFilterTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsFilterTests.cs
@@ -2,6 +2,7 @@ using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.PathTokens;
 using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Middleware;
 using Hardened.Requests.Runtime.PathTokens;
 using Hardened.Requests.Runtime.QueryString;
 using Hardened.Requests.Testing;
@@ -209,6 +210,7 @@ public class CorsFilterTests {
     public async Task Execute_ExposesTheConfiguredResponseHeaders() {
         var config = ConfigAllowing(Allowed);
 
+        config.ClearExposedHeaders();
         config.ExposeHeader("X-Request-Id");
         config.ExposeHeader("X-Total-Count");
 
@@ -219,6 +221,37 @@ public class CorsFilterTests {
         Assert.Equal(
             "X-Request-Id, X-Total-Count",
             context.Response.Headers[KnownHeaders.Cors.AccessControlExposeHeaders].ToString());
+    }
+
+    /// <summary>
+    /// The correlation header is exposed out of the box. The pipeline puts it on every response, and
+    /// it is not CORS-safelisted - so without this it would come back on every response and be
+    /// unreadable to exactly the browser client most likely to want to report it.
+    /// </summary>
+    [Fact]
+    public async Task Execute_ExposesTheCorrelationHeaderByDefault() {
+        var context = Context("GET", Allowed);
+
+        await Run(new CorsFilter(ConfigAllowing(Allowed)), context);
+
+        Assert.Contains(
+            CorrelationHeaderFilter.HeaderName,
+            context.Response.Headers[KnownHeaders.Cors.AccessControlExposeHeaders].ToString());
+    }
+
+    /// <summary>An application that wants none of it can say so.</summary>
+    [Fact]
+    public async Task Execute_ExposesNothingOnceTheListIsCleared() {
+        var config = ConfigAllowing(Allowed);
+
+        config.ClearExposedHeaders();
+
+        var context = Context("GET", Allowed);
+
+        await Run(new CorsFilter(config), context);
+
+        Assert.False(
+            context.Response.Headers.ContainsKey(KnownHeaders.Cors.AccessControlExposeHeaders));
     }
 
     // ------------------------------------------------------------- preflight

--- a/src/Web/Hardened.Web.Runtime/Cors/CorsConfiguration.cs
+++ b/src/Web/Hardened.Web.Runtime/Cors/CorsConfiguration.cs
@@ -1,3 +1,5 @@
+using Hardened.Requests.Runtime.Middleware;
+
 namespace Hardened.Web.Runtime.Cors;
 
 /// <summary>
@@ -12,7 +14,16 @@ public class CorsConfiguration {
         new(StringComparer.OrdinalIgnoreCase) {
             "Authorization", "Content-Type", "Accept", "x-auth-token", "x-amz-content-sha256"
         };
-    private readonly List<string> _exposedHeaders = new();
+    /// <summary>
+    /// Seeded with the correlation header, which the pipeline puts on every response.
+    /// </summary>
+    /// <remarks>
+    /// Without this a cross-origin script cannot read it - the CORS-safelisted response headers are
+    /// a short list and this is not on it - so the id would come back on every response and be
+    /// invisible to exactly the browser client most likely to want to report it. Remove it with
+    /// <see cref="ClearExposedHeaders"/> if that is not wanted.
+    /// </remarks>
+    private readonly List<string> _exposedHeaders = new() { CorrelationHeaderFilter.HeaderName };
 
     public string EnvironmentVariable { get; set; } = DefaultEnvironmentVariable;
 
@@ -72,6 +83,13 @@ public class CorsConfiguration {
 
     public void AllowHeader(string header) {
         _allowedHeaders.Add(header);
+    }
+
+    /// <summary>
+    /// Stop exposing anything, including the correlation header this starts with.
+    /// </summary>
+    public void ClearExposedHeaders() {
+        _exposedHeaders.Clear();
     }
 
     /// <summary>


### PR DESCRIPTION
`IExecutionContext` gains `CorrelationId`, and the pipeline logs it and returns it.

## What it is

The **trace id whenever anything is collecting traces**, so a log line and a span for the same
request carry the same string rather than two identifiers somebody has to join by hand. The request
pipeline already starts a server span and already joins an inbound `traceparent`, so there was no
reason to invent a second identity next to it.

And a **freshly generated value of the same shape when nothing is collecting**. That fallback is the
whole reason this is not simply "read the trace id": `ActivitySource.StartActivity` returns null with
no listener — deliberately, it is what makes instrumenting the pipeline free — so an id derived only
from a trace is absent on every machine without a collector. Which is exactly when someone reading
logs wants an id to group them by.

Generated by `ActivityTraceId` rather than `Guid`, so the value is 32 hex characters either way and a
log query does not have to handle two formats.

## Two orderings that are load-bearing

**Realized on first read, not at construction.** The host builds the context and only then calls
`RequestBegin`, which is where the span starts — so anything eager would mint an id and be
contradicted a moment later.

**The span now starts before the logging scope opens**, inside `RequestBegin`. Getting this backwards
produced a correlation id the span then disagreed with, which is the single failure this feature
exists to prevent. A test caught it.

`Clone` carries the id, like `CallerPrincipal`, because a fork is the same request and a retried
chain reporting a second id would split one request's logs in two.

## Where it gets logged

Through an **`ILogger` scope**, not a message parameter, so lines this framework never writes carry
it too — a handler logging `"charging card"` gets the id without knowing there is one. Providers that
render scopes pick it up: Serilog and the OpenTelemetry logger natively, console with
`IncludeScopes = true`.

The other half arrives free and is worth knowing about: `StartActivity` sets `Activity.Current`, so a
trace-aware provider already stamps TraceId and SpanId with no scope at all. The scope covers the
case where that does not happen — no collector, so no span — which is the same uninstrumented case
the generated id covers.

The scope is closed **outside** the span check in `RequestEnd`. That path used to return early when
there was no span, and a request with no span is precisely the one that has a scope worth closing.

## Where it comes back

`X-Correlation-Id`, from a filter seeded into the middleware chain next to the response finalizer, so
no host has to register it. Set **on the way in** rather than the way out, so a rate limiter's 429 or
a rejected CORS preflight — the responses somebody actually opens a ticket about — come back with an
id. CORS exposes it by default, since it is not CORS-safelisted and would otherwise arrive on every
response and be unreadable to the browser client most likely to want to quote it.

## Also here

The Kestrel README said an existing OpenTelemetry setup observes **nothing** and that distributed
tracing does not work. That was true when written and stopped being true when the spans landed. What
is actually given up is narrower — the `Microsoft.AspNetCore.Hosting` names are not raised — and
subscribing to `Hardened.Requests` works. Corrected, with the call shown. Worth fixing because it
sends people to the ASP.NET host for a reason that no longer holds.

## Follow-up

`Hardened.Amz` implements the new interface member once this publishes: `StreamingRequestMapper`,
`ApiGatewayV2ExecutionContext` and `LambdaExecutionContext`. Separate repo, separate PR, sequenced
after this merges.

## Verification

2873 tests, all green. Builds clean under `ContinuousIntegrationBuild=true`. End-to-end coverage
through the real host asserts an id on a 200, a 404 and a 405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLRmBx1sgVGqySaCUF4eqb
