### PR TITLE
Authorization: conjoin every requirement, and let conventions add them

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/AuthorizationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/AuthorizationTests.cs
@@ -101,26 +101,40 @@ public class AuthorizationTests {
     }
 
     /// <summary>
-    /// Repeated attributes are alternatives, so either branch admits the request - the shape a
-    /// specification's <c>security</c> list has, exercised end to end.
+    /// Stacked attributes conjoin, so the caller needs everything all of them named.
     /// </summary>
     [HardenedTest]
-    public async Task EitherAlternativeAdmitsTheRequest(ITestWebApp testWebApp) {
-        var viaPets = await testWebApp.Get("/authorization/either", Holding("pets:read"));
-        var viaAdmin = await testWebApp.Get("/authorization/either", Holding("admin:*"));
+    public async Task StackedAttributesAdmitOnlyTheCallerHoldingEverything(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/authorization/stacked", Holding("pets:read admin:*"));
 
-        viaPets.Assert.Ok();
-        viaAdmin.Assert.Ok();
+        response.Assert.Ok();
     }
 
     /// <summary>
-    /// And neither branch does not.
+    /// Holding what one of them named is not enough, which is the whole point: writing the second
+    /// attribute restricted the route rather than opening it.
     /// </summary>
     [HardenedTest]
-    public async Task NeitherAlternativeIsRefused(ITestWebApp testWebApp) {
-        var response = await testWebApp.Get("/authorization/either", Holding("pets:write"));
+    public async Task StackedAttributesRefuseACallerHoldingOnlyOne(ITestWebApp testWebApp) {
+        var viaPets = await testWebApp.Get("/authorization/stacked", Holding("pets:read"));
+        var viaAdmin = await testWebApp.Get("/authorization/stacked", Holding("admin:*"));
 
-        response.Assert.Forbidden();
+        viaPets.Assert.Forbidden();
+        viaAdmin.Assert.Forbidden();
+    }
+
+    /// <summary>
+    /// An application's own attribute, deriving from <c>[AuthorizeGrants]</c>, guards its route.
+    /// </summary>
+    [HardenedTest]
+    public async Task ADerivedAttributeGuardsItsRoute(ITestWebApp testWebApp) {
+        var holding = await testWebApp.Get(
+            "/authorization/derived", Holding("pets:read pets:write"));
+        var lacking = await testWebApp.Get("/authorization/derived", Holding("pets:read"));
+
+        holding.Assert.Ok();
+        lacking.Assert.Forbidden();
     }
 
     #endregion

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/AuthorizationController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/AuthorizationController.cs
@@ -34,10 +34,34 @@ public class AuthorizationController {
     public string Manage() => "managed";
 
     /// <summary>
-    /// Two alternatives, which is what the outer list of a specification's <c>security</c> means.
+    /// Two attributes, which conjoin - so this needs everything both of them named.
     /// </summary>
-    [Get("/either")]
+    /// <remarks>
+    /// Stacking narrows and never widens. Exercised end to end because the rule is only worth
+    /// anything if it survives the whole path: the generator putting both attributes in metadata,
+    /// the handler info conjoining them, and the filter refusing a caller holding one.
+    /// </remarks>
+    [Get("/stacked")]
     [AuthorizeGrants("pets:read")]
     [AuthorizeGrants("admin:*")]
-    public string Either() => "either";
+    public string Stacked() => "stacked";
+
+    /// <summary>
+    /// An attribute of the application's own, deriving from <c>[AuthorizeGrants]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The hand-authored form. It reaches the pipeline the same way the framework's own attributes
+    /// do - recognised by the interface it inherits rather than by its name - and it is the case a
+    /// name-matching build diagnostic used to warn about while the runtime guarded it correctly.
+    /// </remarks>
+    [Get("/derived")]
+    [RequiresPetWrite]
+    public string Derived() => "derived";
+}
+
+/// <summary>
+/// A grant named once and spelled as a type everywhere it is required.
+/// </summary>
+public sealed class RequiresPetWriteAttribute : AuthorizeGrantsAttribute {
+    public RequiresPetWriteAttribute() : base("pets:read", "pets:write") { }
 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -132,6 +132,10 @@ namespace Hardened.Requests.Abstract.Authorization
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.AuthorizationDecision> Authorize(Hardened.Requests.Abstract.Execution.IExecutionContext context, params string[] grants);
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.GrantResolution> Resolve(Hardened.Requests.Abstract.Execution.IExecutionContext context, System.Collections.Generic.IReadOnlyList<string> grants);
     }
+    public interface IAuthorizationConvention
+    {
+        Hardened.Requests.Abstract.Authorization.Requirement? Apply(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo);
+    }
     public interface IAuthorizationPolicy
     {
         Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; }
@@ -275,7 +279,9 @@ namespace Hardened.Requests.Abstract.Execution
         int? NullResponseStatus { get; }
         System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter> Parameters { get; }
         string Path { get; }
+        Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; }
         int? SuccessStatus { get; }
+        Hardened.Requests.Abstract.Authorization.Requirement? RequirementFrom(System.Collections.Generic.IReadOnlyList<object> metadata);
     }
     public interface IExecutionRequestParameter
     {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -56,7 +56,7 @@ namespace Hardened.Requests.Runtime.Authorization
         public Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
-    public sealed class AuthorizeGrantsAttribute : System.Attribute, Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute
+    public class AuthorizeGrantsAttribute : System.Attribute, Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute
     {
         public AuthorizeGrantsAttribute(params string[] grants) { }
         public System.Collections.Generic.IReadOnlyList<string> Grants { get; }
@@ -179,8 +179,8 @@ namespace Hardened.Requests.Runtime.Execution
     }
     public abstract class BaseExecutionHandler<TController> : Hardened.Requests.Abstract.Execution.IExecutionRequestHandler
     {
-        protected BaseExecutionHandler(System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] filters, Hardened.Requests.Abstract.Execution.DefaultOutputFunc? outputFunc = null) { }
-        public abstract Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo HandlerInfo { get; }
+        protected BaseExecutionHandler(Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup setup, Hardened.Requests.Abstract.Execution.DefaultOutputFunc? outputFunc = null) { }
+        public Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo HandlerInfo { get; }
         public Hardened.Requests.Abstract.Execution.IExecutionChain GetExecutionChain(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }
     public static class CookieCollectionExtensions
@@ -206,20 +206,26 @@ namespace Hardened.Requests.Runtime.Execution
         public Hardened.Requests.Abstract.Execution.IExecutionChain Fork(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.Task Next() { }
     }
+    public readonly struct ExecutionHandlerSetup
+    {
+        public ExecutionHandlerSetup(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] filters) { }
+        public System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] Filters { get; }
+        public Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo HandlerInfo { get; }
+    }
     public static class ExecutionHelper
     {
-        public static System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] AsyncEnumerableFilterEmptyParameters<TController, TItem>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeNoParameters<TController> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders) { }
-        public static System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] AsyncEnumerableFilterWithParameters<TController, TParameter, TItem>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequestFunc, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeWithParameters<TController, TParameter> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
+        public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup AsyncEnumerableFilterEmptyParameters<TController, TItem>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeNoParameters<TController> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders) { }
+        public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup AsyncEnumerableFilterWithParameters<TController, TParameter, TItem>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequestFunc, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeWithParameters<TController, TParameter> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
             where TController :  class { }
-        public static System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] AsyncStandardFilterEmptyParameters<TController>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Runtime.Execution.ExecutionHelper.AsyncInvokeNoParameters<TController> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
+        public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup AsyncStandardFilterEmptyParameters<TController>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Runtime.Execution.ExecutionHelper.AsyncInvokeNoParameters<TController> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
             where TController :  class { }
-        public static System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] AsyncStandardFilterWithParameters<TController, TParameter>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequestFunc, Hardened.Requests.Runtime.Execution.ExecutionHelper.AsyncInvokeWithParameters<TController, TParameter> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
+        public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup AsyncStandardFilterWithParameters<TController, TParameter>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequestFunc, Hardened.Requests.Runtime.Execution.ExecutionHelper.AsyncInvokeWithParameters<TController, TParameter> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
             where TController :  class
             where TParameter :  class { }
         public static System.Threading.Tasks.ValueTask<T> CustomAttributeData<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context, object attribute, Hardened.Requests.Abstract.Execution.IExecutionRequestParameter parameter) { }
         public static System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> GetFilterInfo(params object[] attributes) { }
-        public static System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] StandardFilterEmptyParameters<TController>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeNoParameters<TController> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders) { }
-        public static System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter>[] StandardFilterWithParameters<TController, TParameter>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequestFunc, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeWithParameters<TController, TParameter> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
+        public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup StandardFilterEmptyParameters<TController>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeNoParameters<TController> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders) { }
+        public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup StandardFilterWithParameters<TController, TParameter>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequestFunc, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeWithParameters<TController, TParameter> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders)
             where TController :  class { }
         public delegate System.Threading.Tasks.Task AsyncInvokeNoParameters<TController>(Hardened.Requests.Abstract.Execution.IExecutionContext context, TController controller);
         public delegate System.Threading.Tasks.Task AsyncInvokeWithParameters<TController, TParameter>(Hardened.Requests.Abstract.Execution.IExecutionContext context, TController controller, TParameter parameter);
@@ -228,13 +234,14 @@ namespace Hardened.Requests.Runtime.Execution
     }
     public class ExecutionRequestHandlerInfo : Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo
     {
-        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null) { }
+        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null, Hardened.Requests.Abstract.Authorization.Requirement? requirement = null) { }
         public System.Type HandlerType { get; }
         public string InvokeMethod { get; }
         public System.Collections.Generic.IReadOnlyList<object> Metadata { get; }
         public string Method { get; }
         public System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter> Parameters { get; }
         public string Path { get; }
+        public Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; }
     }
     public class ExecutionRequestParameter : Hardened.Requests.Abstract.Execution.IExecutionRequestParameter
     {

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/IAuthorizationConvention.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/IAuthorizationConvention.cs
@@ -1,0 +1,54 @@
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.Requests.Abstract.Authorization;
+
+/// <summary>
+/// Adds a requirement to handlers that did not ask for one by name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The runtime half of declaring authorization. An attribute states what one handler needs at the
+/// place it is written; this states what a whole class of handlers needs, decided from what the
+/// handler already is - "everything under <c>/admin</c> requires <c>admin:access</c>", "every
+/// non-GET on a tenant route requires <c>tenant:write</c>" - without that rule being copied onto
+/// every method it covers, where it would drift the first time somebody adds a route.
+/// </para>
+/// <example>
+/// <code>
+/// public class AdminRoutesAreAdminOnly : IAuthorizationConvention {
+///     public Requirement? Apply(IExecutionRequestHandlerInfo handler) =>
+///         handler.Path.StartsWith("/admin") ? Requirement.Grant("admin:access") : null;
+/// }
+/// </code>
+/// </example>
+/// <para>
+/// <b>Applied while the handler is being constructed, before its info is handed to anything.</b>
+/// What a convention returns is conjoined with what the handler declared, and the combined
+/// requirement is what lands on <see cref="IExecutionRequestHandlerInfo.Requirement"/> - so the
+/// authorization filter, the execution context, and anything else reading a handler all see one
+/// answer. There is no second, effective view for the two to disagree about.
+/// </para>
+/// <para>
+/// <b>It can only narrow.</b> The result is conjoined, never substituted, so a convention cannot
+/// weaken a handler that declared its own requirement and cannot be defeated by one - which is what
+/// makes it safe for a convention to be the thing standing between an unannotated route and the
+/// world. <c>[AllowAnonymous]</c> remains the single exception, for the reason it always was: a
+/// route that reads as public in the source must not refuse in production.
+/// </para>
+/// <para>
+/// Asked once per handler, as its filter chain is built. Returning null is the normal answer for
+/// most handlers and costs nothing.
+/// </para>
+/// </remarks>
+public interface IAuthorizationConvention {
+    /// <summary>
+    /// What this convention requires of <paramref name="handlerInfo"/>, or null if it has nothing
+    /// to say about it.
+    /// </summary>
+    /// <remarks>
+    /// The handler is passed in fully formed - path, method, handler type, parameters and metadata -
+    /// so a convention can key off any of them. It is read-only: a convention inspects and returns,
+    /// it does not amend.
+    /// </remarks>
+    Requirement? Apply(IExecutionRequestHandlerInfo handlerInfo);
+}

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/IAuthorizeAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/IAuthorizeAttribute.cs
@@ -6,16 +6,20 @@ namespace Hardened.Requests.Abstract.Authorization;
 /// <remarks>
 /// <para>
 /// A handler's attributes reach the runtime as an <c>object[]</c> of metadata, so something has to
-/// recognise the authorization ones among the rest. This is that something: one interface both
-/// attribute forms implement, which is what lets the pipeline collect requirements without knowing
+/// recognise the authorization ones among the rest. This is that something: one interface every
+/// attribute form implements, which is what lets the pipeline collect requirements without knowing
 /// the closed type of a <c>[Authorize&lt;T&gt;]</c> - and without reflecting over an open generic,
 /// which would not survive trimming.
 /// </para>
 /// <para>
-/// Two forms implement it. <c>[Authorize&lt;T&gt;]</c> yields the policy's requirement;
-/// <c>[AuthorizeGrants]</c> yields an ad-hoc conjunction, and repeating it yields a disjunction of
-/// those. Both arrive here as one requirement each, and the pipeline combines them the same way
-/// whichever they came from.
+/// <b>Every implementation found on a handler is required.</b> The requirements are conjoined, so
+/// an attribute can only ever narrow what is admitted. That holds however the attribute arrived -
+/// written on the method, written on the controller, derived from another attribute, or added by a
+/// convention - and it is what makes all four compose without a rule per case.
+/// </para>
+/// <para>
+/// It is also why this is the interface a source generator matches on rather than a list of type
+/// names. An interface is visible on a type from a referenced assembly; a constructor body is not.
 /// </para>
 /// </remarks>
 public interface IAuthorizeAttribute {

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace Hardened.Requests.Abstract.Execution;
+﻿using Hardened.Requests.Abstract.Authorization;
+
+namespace Hardened.Requests.Abstract.Execution;
 
 public interface IExecutionRequestHandlerInfo {
     string Path { get; }
@@ -18,4 +20,53 @@ public interface IExecutionRequestHandlerInfo {
     IReadOnlyList<IExecutionRequestParameter> Parameters { get; }
 
     IReadOnlyList<object> Metadata => Array.Empty<object>();
+
+    /// <summary>
+    /// What this handler requires of its caller, or null if nothing does.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// First-class data rather than something the authorization filter re-derives from
+    /// <see cref="Metadata"/> on its own. Attributes are one source of it; a convention applied
+    /// while this info was built is another, and a handler registered by hand can state one without
+    /// inventing an attribute to carry it. One requirement, whatever contributed to it.
+    /// </para>
+    /// <para>
+    /// <b>One rather than a list, because everything conjoins.</b> Contributions are combined with
+    /// <see cref="Requirement.AllOf"/>, which flattens, so ten sources produce one node of ten
+    /// rather than a chain - and a list would carry nothing the combined tree does not. A
+    /// contribution can therefore only narrow what is admitted. Alternatives live inside a single
+    /// requirement, never between two of them.
+    /// </para>
+    /// <para>
+    /// Grants do not appear here. This is the whole authorization answer for the handler, expressed
+    /// the one way the runtime evaluates it, and the grants it names are reachable through
+    /// <see cref="Requirement.RequiredGrants"/> when a refusal has to say what it wanted.
+    /// </para>
+    /// <para>
+    /// The default derives from <see cref="Metadata"/>, so an implementation that carries attributes
+    /// and nothing else is already correct. <c>ExecutionRequestHandlerInfo</c> computes it once
+    /// instead, since it is asked for every handler as its filter chain is built.
+    /// </para>
+    /// </remarks>
+    Requirement? Requirement => RequirementFrom(Metadata);
+
+    /// <summary>
+    /// Conjoins the requirement of every authorization attribute in <paramref name="metadata"/>.
+    /// </summary>
+    /// <remarks>
+    /// Shared with implementations that precompute, so both spellings mean the same thing rather
+    /// than agreeing by inspection.
+    /// </remarks>
+    static Requirement? RequirementFrom(IReadOnlyList<object> metadata) {
+        List<Requirement>? requirements = null;
+
+        foreach (var item in metadata) {
+            if (item is IAuthorizeAttribute authorize) {
+                (requirements ??= []).Add(authorize.Requirement);
+            }
+        }
+
+        return requirements == null ? null : Authorization.Requirement.AllOf([..requirements]);
+    }
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationConventionTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationConventionTests.cs
@@ -1,0 +1,260 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Authorization;
+
+/// <summary>
+/// Requirements added while a handler is being built, rather than written on it.
+///
+/// <para>
+/// Everything here goes through <c>ExecutionHelper</c> rather than calling the filter provider
+/// directly, because the thing under test is <em>when</em> conventions run. They have to be applied
+/// before the global filter registry is consulted - that is what asks for the handler's guard - and
+/// a test that folded them itself would pass whatever the ordering.
+/// </para>
+/// </summary>
+public class AuthorizationConventionTests {
+
+    private class Controller;
+
+    /// <summary>Requires a grant of everything below a path prefix.</summary>
+    private sealed class PrefixConvention : IAuthorizationConvention {
+        private readonly string _prefix;
+        private readonly string _grant;
+
+        public PrefixConvention(string prefix, string grant) {
+            _prefix = prefix;
+            _grant = grant;
+        }
+
+        public Requirement? Apply(IExecutionRequestHandlerInfo handlerInfo) =>
+            handlerInfo.Path.StartsWith(_prefix) ? Requirement.Grant(_grant) : null;
+    }
+
+    #region what a convention contributes
+
+    /// <summary>
+    /// A handler that declared nothing is guarded by the convention alone.
+    /// </summary>
+    [Fact]
+    public async Task AConventionGuardsAnUnannotatedHandler() {
+        var conventions = new[] { new PrefixConvention("/admin", "admin:access") };
+
+        Assert.True(await Admits("/admin/users", conventions, [], "admin:access"));
+        Assert.False(await Admits("/admin/users", conventions, []));
+    }
+
+    /// <summary>
+    /// And says nothing about a handler it does not match, which stays public.
+    /// </summary>
+    [Fact]
+    public async Task AConventionLeavesHandlersItDoesNotMatchAlone() {
+        var conventions = new[] { new PrefixConvention("/admin", "admin:access") };
+
+        Assert.True(await Admits("/pets", conventions, []));
+    }
+
+    /// <summary>
+    /// A convention conjoins with what the handler declared rather than replacing it, so the caller
+    /// needs both.
+    /// </summary>
+    /// <remarks>
+    /// The direction that matters. If a convention substituted, an attribute would be silently
+    /// dropped on every route the convention covered - and the handler would read as guarded by one
+    /// thing while being guarded by another.
+    /// </remarks>
+    [Fact]
+    public async Task AConventionNarrowsAHandlerThatDeclaredItsOwnRequirement() {
+        var conventions = new[] { new PrefixConvention("/admin", "admin:access") };
+        object[] metadata = [new AuthorizeGrantsAttribute("pets:write")];
+
+        Assert.True(await Admits("/admin/pets", conventions, metadata, "admin:access", "pets:write"));
+
+        Assert.False(await Admits("/admin/pets", conventions, metadata, "admin:access"));
+        Assert.False(await Admits("/admin/pets", conventions, metadata, "pets:write"));
+    }
+
+    /// <summary>
+    /// Several conventions all apply, for the same reason several attributes do.
+    /// </summary>
+    [Fact]
+    public async Task EveryConventionThatMatchesApplies() {
+        var conventions = new[] {
+            new PrefixConvention("/admin", "admin:access"),
+            new PrefixConvention("/admin/billing", "billing:read"),
+        };
+
+        Assert.True(await Admits("/admin/billing", conventions, [], "admin:access", "billing:read"));
+        Assert.False(await Admits("/admin/billing", conventions, [], "admin:access"));
+    }
+
+    /// <summary>
+    /// <c>[AllowAnonymous]</c> still wins, so a route that reads as public in the source is public.
+    /// </summary>
+    /// <remarks>
+    /// The one case where a local statement beats a convention, and it is the same reasoning that
+    /// makes it beat an attribute: the alternative is a handler somebody deliberately opened
+    /// refusing in production because of a rule written somewhere else.
+    /// </remarks>
+    [Fact]
+    public async Task AllowAnonymousWinsOverAConvention() {
+        var conventions = new[] { new PrefixConvention("/admin", "admin:access") };
+
+        Assert.True(await Admits("/admin/health", conventions, [new AllowAnonymousAttribute()]));
+    }
+
+    #endregion
+
+    #region what the handler ends up holding
+
+    /// <summary>
+    /// The handler reports the requirement it actually enforces, not the one it declared.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BaseExecutionHandler{TController}"/> takes its info from the setup the chain was
+    /// built from for exactly this reason. If it returned the static field the generator emitted,
+    /// the filter would enforce something <see cref="IExecutionContext.HandlerInfo"/> never
+    /// mentioned - and every consumer of that property, the document included, would be describing a
+    /// different application from the one running.
+    /// </remarks>
+    [Fact]
+    public void TheHandlerCarriesTheAmendedRequirement() {
+        var declared = new ExecutionRequestHandlerInfo(
+            "/admin/users", "GET", typeof(Controller), "List", null,
+            [new AuthorizeGrantsAttribute("users:read")]);
+
+        var setup = Setup(declared, [new PrefixConvention("/admin", "admin:access")]);
+
+        var grants = setup.HandlerInfo.Requirement!.RequiredGrants.ToArray();
+
+        Assert.Contains("users:read", grants);
+        Assert.Contains("admin:access", grants);
+    }
+
+    /// <summary>
+    /// A handler no convention spoke about keeps the instance the generator built.
+    /// </summary>
+    [Fact]
+    public void AHandlerNoConventionMatchesIsNotRebuilt() {
+        var declared = new ExecutionRequestHandlerInfo(
+            "/pets", "GET", typeof(Controller), "List");
+
+        var setup = Setup(declared, [new PrefixConvention("/admin", "admin:access")]);
+
+        Assert.Same(declared, setup.HandlerInfo);
+    }
+
+    /// <summary>
+    /// An application registering no conventions builds handlers as before.
+    /// </summary>
+    /// <remarks>
+    /// Worth its own test because the natural spelling of "resolve them all" -
+    /// <c>GetServices&lt;T&gt;</c> - asks the container for <c>IEnumerable&lt;T&gt;</c> as a
+    /// required service, and this one does not synthesise an empty one. That turned the common case
+    /// into a failure to construct any handler at all.
+    /// </remarks>
+    [Fact]
+    public void NoConventionsRegisteredIsNotAnError() {
+        var declared = new ExecutionRequestHandlerInfo("/pets", "GET", typeof(Controller), "List");
+
+        Assert.Same(declared, Setup(declared, []).HandlerInfo);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Builds a handler's chain the way a generated handler does, through the real helper.
+    /// </summary>
+    private static ExecutionHandlerSetup Setup(
+        IExecutionRequestHandlerInfo declared, IAuthorizationConvention[] conventions) {
+        var context = Pipeline.Context(configureServices: services => {
+            Register(services, conventions);
+            services.AddSingleton<IGlobalFilterRegistry>(
+                new GlobalFilterRegistry(Array.Empty<IRequestFilterProvider>()));
+        });
+
+        return ExecutionHelper.StandardFilterEmptyParameters<Controller>(
+            context.RequestServices,
+            declared,
+            (_, _) => { },
+            Array.Empty<IRequestFilterProvider>());
+    }
+
+    /// <summary>
+    /// The services <c>ExecutionHelper</c> resolves while assembling a chain.
+    /// </summary>
+    /// <remarks>
+    /// The two filter providers are substitutes because neither is on trial here - one serialises
+    /// and one creates the controller, and both would drag a serializer and a container into a test
+    /// about when conventions run. Everything the assertions actually depend on is the production
+    /// type.
+    /// </remarks>
+    private static void Register(
+        IServiceCollection services, IAuthorizationConvention[] conventions) {
+        var ioProvider = Substitute.For<IIOFilterProvider>();
+        ioProvider.ProvideFilter(
+                Arg.Any<IExecutionRequestHandlerInfo>(),
+                Arg.Any<Func<IExecutionContext, Task<IExecutionRequestParameters>>>())
+            .Returns(new Pipeline.Recording([], "io"));
+
+        var instanceProvider = Substitute.For<IInstanceFilterProvider>();
+        instanceProvider.ProvideFilter<Controller>(Arg.Any<IServiceProvider>())
+            .Returns(new Pipeline.Recording([], "instance"));
+
+        services.AddSingleton(ioProvider);
+        services.AddSingleton(instanceProvider);
+        services.AddSingleton<IActivityAuthorizationService, ActivityAuthorizationService>();
+        services.AddSingleton<IActivityAuthorizationHandler, PrincipalGrantAuthorizationHandler>();
+
+        foreach (var convention in conventions) {
+            services.AddSingleton<IAuthorizationConvention>(convention);
+        }
+    }
+
+    /// <summary>
+    /// Runs the chain the helper built and reports whether the request survived it.
+    /// </summary>
+    /// <remarks>
+    /// Through the whole chain rather than the authorization filter alone, because the ordering is
+    /// half of what is being asserted - the registry has to have been handed the amended handler for
+    /// the guard to exist at all.
+    /// </remarks>
+    private static async Task<bool> Admits(
+        string path,
+        IAuthorizationConvention[] conventions,
+        object[] metadata,
+        params string[] grants) {
+        var registry = new GlobalFilterRegistry(Array.Empty<IRequestFilterProvider>());
+        registry.RegisterFilter(new AuthorizationFilterProvider(requireAuthorization: false).GetFilter);
+
+        var context = Pipeline.Context(path: path, configureServices: services => {
+            Register(services, conventions);
+            services.AddSingleton<IGlobalFilterRegistry>(registry);
+        });
+
+        context.CallerPrincipal = new CallerPrincipal("bearer", grants);
+
+        // The substituted IO filter continues the chain, so it reaches the invoke filter - which
+        // reads the controller off the context rather than creating one.
+        context.HandlerInstance = new Controller();
+
+        var declared = new ExecutionRequestHandlerInfo(
+            path, "GET", typeof(Controller), "Invoke", null, metadata);
+
+        var setup = ExecutionHelper.StandardFilterEmptyParameters<Controller>(
+            context.RequestServices, declared, (_, _) => { },
+            Array.Empty<IRequestFilterProvider>());
+
+        await new ExecutionChain(setup.Filters, context).Next();
+
+        return context.Response.ExceptionValue == null;
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
@@ -2,9 +2,9 @@ using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
 using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.Tests.Support;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using Xunit;
 
 namespace Hardened.Requests.Runtime.Tests.Authorization;
@@ -28,12 +28,25 @@ public class AuthorizationFilterProviderTests {
         protected override Requirement Define() => Predicate((_, _) => true, "owns it");
     }
 
-    private static IExecutionRequestHandlerInfo Handler(params object[] metadata) {
-        var info = Substitute.For<IExecutionRequestHandlerInfo>();
-        info.Metadata.Returns(metadata);
-
-        return info;
+    /// <summary>
+    /// The hand-authored form: a grant named once, spelled as a type everywhere it is required.
+    /// </summary>
+    private sealed class RequiresPetWriteAttribute : AuthorizeGrantsAttribute {
+        public RequiresPetWriteAttribute() : base("pets:read", "pets:write") { }
     }
+
+    /// <summary>
+    /// A real handler rather than a substitute.
+    /// </summary>
+    /// <remarks>
+    /// The requirement is derived from metadata by the handler info itself, so a substitute has to
+    /// be told the answer to the very thing under test - and NSubstitute auto-substitutes an
+    /// unconfigured <c>Requirement</c>, which silently guards a handler the test declared nothing
+    /// on. The real type costs nothing here and cannot disagree with what production builds.
+    /// </remarks>
+    private static IExecutionRequestHandlerInfo Handler(params object[] metadata) =>
+        new ExecutionRequestHandlerInfo(
+            "/orders", "GET", typeof(AuthorizationFilterProviderTests), "Handler", null, metadata);
 
     private static RequestFilterInfo? Filter(bool requireAuthorization, params object[] metadata) =>
         new AuthorizationFilterProvider(requireAuthorization).GetFilter(Handler(metadata));
@@ -105,23 +118,65 @@ public class AuthorizationFilterProviderTests {
     }
 
     /// <summary>
-    /// Repeated <c>[AuthorizeGrants]</c> is <em>or</em>, because that attribute is what a
-    /// specification becomes and the outer list of OpenAPI's <c>security</c> is a list of
-    /// alternatives. Either branch admits the request; neither branch does not.
+    /// Repeated <c>[AuthorizeGrants]</c> is <em>and</em>, like every other pair of authorization
+    /// attributes. Writing a second one can only narrow what is admitted.
     /// </summary>
+    /// <remarks>
+    /// This is the rule the whole design rests on. Under the alternative - repeating means
+    /// <em>or</em> - the second attribute here would admit a caller holding only <c>admin:*</c>,
+    /// which means adding a line to a handler granted access rather than restricting it. That makes
+    /// a method-level attribute weaken its controller's, a derived attribute weaken its base, and a
+    /// convention weaken every handler it touched.
+    /// </remarks>
     [Fact]
-    public async Task RepeatedGrantAttributesAreAlternatives() {
+    public async Task RepeatedGrantAttributesMustAllHold() {
         object[] metadata = [
             new AuthorizeGrantsAttribute("pets:read", "pets:write"),
             new AuthorizeGrantsAttribute("admin:*"),
         ];
 
-        Assert.True(await Admits(metadata, "pets:read", "pets:write"));
-        Assert.True(await Admits(metadata, "admin:*"));
+        Assert.True(await Admits(metadata, "pets:read", "pets:write", "admin:*"));
 
-        // Half of one branch is not a branch.
-        Assert.False(await Admits(metadata, "pets:read"));
+        Assert.False(await Admits(metadata, "pets:read", "pets:write"));
+        Assert.False(await Admits(metadata, "admin:*"));
         Assert.False(await Admits(metadata));
+    }
+
+    /// <summary>
+    /// An attribute deriving from <c>[AuthorizeGrants]</c> is honoured as itself, and conjoins with
+    /// everything else exactly like the attribute it derives from.
+    /// </summary>
+    /// <remarks>
+    /// The reason the base attribute is not sealed. Naming a grant once and spelling it as a type
+    /// everywhere is the hand-authored form, and it only works if the pipeline recognises the
+    /// derived type - which it does by interface, not by name.
+    /// </remarks>
+    [Fact]
+    public async Task ADerivedGrantAttributeIsHonoured() {
+        object[] metadata = [new RequiresPetWriteAttribute()];
+
+        Assert.True(await Admits(metadata, "pets:read", "pets:write"));
+        Assert.False(await Admits(metadata, "pets:read"));
+    }
+
+    /// <summary>
+    /// A controller's attribute and a method's conjoin, because a handler's metadata carries both
+    /// and both are requirements like any other.
+    /// </summary>
+    /// <remarks>
+    /// The case the old rule got backwards: a controller-wide guard plus a method-level one meant
+    /// either sufficed, so writing a narrower attribute on one route opened it up.
+    /// </remarks>
+    [Fact]
+    public async Task AControllerAndAMethodRequirementBothApply() {
+        object[] metadata = [
+            new AuthorizeGrantsAttribute("tenant:member"),  // written on the controller
+            new RequiresPetWriteAttribute(),                // written on the method
+        ];
+
+        Assert.True(await Admits(metadata, "tenant:member", "pets:read", "pets:write"));
+        Assert.False(await Admits(metadata, "pets:read", "pets:write"));
+        Assert.False(await Admits(metadata, "tenant:member"));
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterOrderingTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterOrderingTests.cs
@@ -70,7 +70,7 @@ public class FilterOrderingTests {
             context.RequestServices,
             handlerInfo,
             (_, _) => log.Add(Invoke),
-            filterProviders);
+            filterProviders).Filters;
 
         await new ExecutionChain(filters, context).Next();
 

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/InvokeFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/InvokeFilterTests.cs
@@ -330,7 +330,7 @@ public class InvokeFilterTests {
             context.RequestServices,
             new ExecutionRequestHandlerInfo("/orders", "GET", typeof(Controller), "Get"),
             invoke,
-            Array.Empty<IRequestFilterProvider>());
+            Array.Empty<IRequestFilterProvider>()).Filters;
 
         return (context, filters);
     }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/ShortCircuitTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/ShortCircuitTests.cs
@@ -144,7 +144,7 @@ public class ShortCircuitTests {
             context.RequestServices,
             new ExecutionRequestHandlerInfo("/orders", "GET", typeof(Controller), "Get"),
             (_, _) => log.Add("invoke"),
-            Array.Empty<IRequestFilterProvider>());
+            Array.Empty<IRequestFilterProvider>()).Filters;
 
         await new ExecutionChain(filters, context).Next();
 

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizationFilterProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizationFilterProvider.cs
@@ -5,22 +5,26 @@ using Hardened.Requests.Abstract.RequestFilter;
 namespace Hardened.Requests.Runtime.Authorization;
 
 /// <summary>
-/// Reads a handler's attributes once and decides what, if anything, guards it.
+/// Reads a handler's requirements once and decides what, if anything, guards it.
 /// </summary>
 /// <remarks>
 /// <para>
 /// <b>Registered as a global filter rather than making the attributes
 /// <see cref="IRequestFilterProvider"/>s</b>, which is the more obvious route and the wrong one. An
-/// attribute only ever sees itself, and the rules here are about the whole set: repeating
-/// <c>[AuthorizeGrants]</c> means <em>or</em>, <c>[AllowAnonymous]</c> cancels everything, and a
-/// handler carrying nothing at all still needs an answer once the application has opted in. Attribute
-/// providers would also yield one filter each, so a handler with three attributes would evaluate
-/// three times and refuse on the first.
+/// attribute only ever sees itself, and two of the rules here are about the whole handler:
+/// <c>[AllowAnonymous]</c> cancels everything, and a handler carrying nothing at all still needs an
+/// answer once the application has opted in. Attribute providers would also yield one filter each,
+/// so a handler with three attributes would evaluate three times and refuse on the first.
 /// </para>
 /// <para>
-/// The registry hands this the handler and its whole metadata array exactly once, which is the shape
-/// the problem actually has - and the backstop for an unannotated handler falls out of the same
-/// pass instead of needing a second mechanism.
+/// The registry hands this the handler exactly once, which is the shape the problem actually has -
+/// and the backstop for an unannotated handler falls out of the same pass instead of needing a
+/// second mechanism.
+/// </para>
+/// <para>
+/// It reads <see cref="IExecutionRequestHandlerInfo.Requirements"/> rather than walking metadata
+/// itself, so a requirement a convention added while the handler was built is honoured exactly like
+/// one an attribute declared.
 /// </para>
 /// </remarks>
 public class AuthorizationFilterProvider {
@@ -34,20 +38,18 @@ public class AuthorizationFilterProvider {
     }
 
     public RequestFilterInfo? GetFilter(IExecutionRequestHandlerInfo handlerInfo) {
-        var metadata = handlerInfo.Metadata;
-
-        var requirement = Fold(metadata);
+        var requirement = handlerInfo.Requirement;
 
         if (requirement == null) {
             // Nothing said anything about this handler. Public unless the application has said
             // otherwise, in which case being unannotated is the thing being guarded against.
-            if (!_requireAuthorization || IsAnonymous(metadata)) {
+            if (!_requireAuthorization || IsAnonymous(handlerInfo.Metadata)) {
                 return null;
             }
 
             requirement = Requirement.Authenticated();
         }
-        else if (IsAnonymous(metadata)) {
+        else if (IsAnonymous(handlerInfo.Metadata)) {
             // Both a requirement and an opt-out. The opt-out wins, because it is the more explicit
             // statement - somebody wrote it on this handler on purpose - and because the alternative
             // is a route that looks public in the source and refuses in production.
@@ -74,54 +76,5 @@ public class AuthorizationFilterProvider {
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Folds every authorization attribute on a handler into one requirement.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Repeated <c>[AuthorizeGrants]</c> is <b>or</b>, because that attribute is what a specification
-    /// becomes and the outer list of OpenAPI's <c>security</c> is a list of alternatives.
-    /// </para>
-    /// <para>
-    /// Everything else is <b>and</b>. Two hand-written policies on one handler read as two things
-    /// that must both hold - it is the stricter reading of an ambiguous one, and it matches what
-    /// stacking authorization attributes means everywhere else. A generated <c>[AuthorizeGrants]</c>
-    /// alongside a hand-written <c>[Authorize&lt;T&gt;]</c> therefore requires both: the
-    /// specification's answer, and the extra condition somebody added on top of it.
-    /// </para>
-    /// </remarks>
-    private static Requirement? Fold(IReadOnlyList<object> metadata) {
-        List<Requirement>? alternatives = null;
-        List<Requirement>? conjuncts = null;
-
-        foreach (var item in metadata) {
-            switch (item) {
-                case AuthorizeGrantsAttribute grants:
-                    (alternatives ??= []).Add(grants.Requirement);
-                    break;
-
-                case IAuthorizeAttribute authorize:
-                    (conjuncts ??= []).Add(authorize.Requirement);
-                    break;
-            }
-        }
-
-        if (alternatives == null && conjuncts == null) {
-            return null;
-        }
-
-        var parts = new List<Requirement>();
-
-        if (alternatives != null) {
-            parts.Add(Requirement.AnyOf(alternatives.ToArray()));
-        }
-
-        if (conjuncts != null) {
-            parts.AddRange(conjuncts);
-        }
-
-        return Requirement.AllOf(parts.ToArray());
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizeGrantsAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizeGrantsAttribute.cs
@@ -4,29 +4,45 @@ using Combinator = Hardened.Requests.Abstract.Authorization.Requirement;
 namespace Hardened.Requests.Runtime.Authorization;
 
 /// <summary>
-/// Requires the grants named. The form a generator emits from a specification.
+/// Requires the grants named.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Grants within one attribute are <b>AND</b>; repeating the attribute is <b>OR</b>, which is
-/// exactly the shape OpenAPI's <c>security</c> has - a list of requirement objects, any of which
-/// admits the request.
+/// Every grant named here is required, and every authorization attribute on a handler is required.
+/// Writing more of them can only narrow what is admitted, never widen it - which is what makes the
+/// attribute safe to inherit, safe to write on a controller and a method at once, and safe for a
+/// convention to add to.
 /// </para>
 /// <example>
 /// <code>
 /// [AuthorizeGrants("pets:read", "pets:write")]   // both required
-/// [AuthorizeGrants("admin:*")]                   // ...or this instead
+/// [AuthorizeGrants("tenant:member")]             // ...and this as well
 /// </code>
 /// </example>
 /// <para>
-/// <b>Strings are acceptable here precisely because a human never writes them.</b> The generator
-/// read them out of the specification, so they cannot be a typo the way a hand-written one can. The
-/// hand-authored form is <c>[Authorize&lt;T&gt;]</c>, which is typed and rename-safe; this one
-/// trades that for being able to carry arbitrary structure that nobody has to read.
+/// <b>Not sealed, because deriving from it is the hand-authored form.</b> A named attribute reads
+/// better at the call site than a string does, is found by "go to references", and is renamed by a
+/// refactor - so the grant vocabulary can be written once and spelled everywhere as a type:
+/// </para>
+/// <example>
+/// <code>
+/// public sealed class RequiresPetWriteAttribute : AuthorizeGrantsAttribute {
+///     public RequiresPetWriteAttribute() : base(Grants.Pets.Read, Grants.Pets.Write) { }
+/// }
+/// </code>
+/// </example>
+/// <para>
+/// The string form remains what a generator emits from a specification, where a human never reads
+/// the attribute and the values cannot be a typo because the generator read them out of the spec.
+/// </para>
+/// <para>
+/// Alternatives - "this grant <em>or</em> that one" - are not expressible by stacking attributes,
+/// deliberately. They belong inside a single <see cref="IAuthorizationPolicy"/>, where one author
+/// writes one expression, rather than emerging from how many attributes happen to be present.
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
-public sealed class AuthorizeGrantsAttribute : Attribute, IAuthorizeAttribute {
+public class AuthorizeGrantsAttribute : Attribute, IAuthorizeAttribute {
     public AuthorizeGrantsAttribute(params string[] grants) {
         if (grants is null || grants.Length == 0) {
             throw new ArgumentException(
@@ -41,7 +57,7 @@ public sealed class AuthorizeGrantsAttribute : Attribute, IAuthorizeAttribute {
         Requirement = Combinator.AllOf(Array.ConvertAll(grants, Combinator.Grant));
     }
 
-    /// <summary>The grants named, in the order the specification listed them.</summary>
+    /// <summary>The grants named, in the order they were written.</summary>
     public IReadOnlyList<string> Grants { get; }
 
     public Requirement Requirement { get; }

--- a/src/Requests/Hardened.Requests.Runtime/Execution/BaseExecutionHandler.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/BaseExecutionHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Hardened.Requests.Abstract.Execution;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.Requests.Runtime.Execution;
 
@@ -7,13 +6,30 @@ public abstract class BaseExecutionHandler<TController> : IExecutionRequestHandl
     private readonly Func<IExecutionContext, IExecutionFilter>[] _filters;
     private readonly DefaultOutputFunc? _outputFunc;
 
-    protected BaseExecutionHandler(Func<IExecutionContext, IExecutionFilter>[] filters,
-        DefaultOutputFunc? outputFunc = null) {
-        _filters = filters;
+    protected BaseExecutionHandler(ExecutionHandlerSetup setup, DefaultOutputFunc? outputFunc = null) {
+        HandlerInfo = setup.HandlerInfo;
+        _filters = setup.Filters;
         _outputFunc = outputFunc;
     }
 
-    public abstract IExecutionRequestHandlerInfo HandlerInfo { get; }
+    /// <summary>
+    /// The handler this chain was built for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Held here rather than overridden by the generated subclass, which is what makes it the
+    /// amended one.</b> A subclass could only return the static field it declared - the handler as
+    /// written, before conventions were applied - while the filter chain around it was built from
+    /// the amended handler. The two would disagree for any handler a convention touched, and the
+    /// disagreement would surface as a filter enforcing a requirement that
+    /// <see cref="IExecutionContext.HandlerInfo"/> does not mention.
+    /// </para>
+    /// <para>
+    /// Taking it off the setup the chain was built from makes that impossible to get wrong: there is
+    /// one value, produced where the conventions ran.
+    /// </para>
+    /// </remarks>
+    public IExecutionRequestHandlerInfo HandlerInfo { get; }
 
     public IExecutionChain GetExecutionChain(IExecutionContext context) {
         context.HandlerInfo = HandlerInfo;

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHandlerSetup.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHandlerSetup.cs
@@ -1,0 +1,35 @@
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.Requests.Runtime.Execution;
+
+/// <summary>
+/// Everything a handler needs to serve requests: the filter chain, and the handler it was built for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both together because the second is not what the caller passed in. Conventions are applied while
+/// the chain is assembled, so what the generated handler declares and what it actually is are two
+/// values, and only the second may be used from then on. Returning just the filters would leave the
+/// declared one as the only thing the handler could hold - which is exactly the drift this exists to
+/// prevent.
+/// </para>
+/// <para>
+/// A struct, and constructed once per handler at startup. It exists to get two values out of one
+/// call, not to be stored.
+/// </para>
+/// </remarks>
+public readonly struct ExecutionHandlerSetup {
+    public ExecutionHandlerSetup(
+        IExecutionRequestHandlerInfo handlerInfo,
+        Func<IExecutionContext, IExecutionFilter>[] filters) {
+        HandlerInfo = handlerInfo;
+        Filters = filters;
+    }
+
+    /// <summary>
+    /// The handler as it ended up - what it declared, plus whatever conventions added.
+    /// </summary>
+    public IExecutionRequestHandlerInfo HandlerInfo { get; }
+
+    public Func<IExecutionContext, IExecutionFilter>[] Filters { get; }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +25,7 @@ public static class ExecutionHelper {
 
     public delegate void InvokeNoParameters<T>(IExecutionContext context, T controller);
 
-    public static Func<IExecutionContext, IExecutionFilter>[] StandardFilterEmptyParameters<TController>(
+    public static ExecutionHandlerSetup StandardFilterEmptyParameters<TController>(
         IServiceProvider serviceProvider,
         IExecutionRequestHandlerInfo handlerInfo,
         InvokeNoParameters<TController> invokeMethod,
@@ -51,7 +52,7 @@ public static class ExecutionHelper {
     public delegate void InvokeWithParameters<TController, TParameter>(IExecutionContext context,
         TController controller, TParameter parameter);
 
-    public static Func<IExecutionContext, IExecutionFilter>[] StandardFilterWithParameters<TController, TParameter>(
+    public static ExecutionHandlerSetup StandardFilterWithParameters<TController, TParameter>(
         IServiceProvider serviceProvider,
         IExecutionRequestHandlerInfo handlerInfo,
         Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequestFunc,
@@ -79,7 +80,7 @@ public static class ExecutionHelper {
     public delegate Task AsyncInvokeNoParameters<TController>(IExecutionContext context, TController controller)
         where TController : class;
 
-    public static Func<IExecutionContext, IExecutionFilter>[] AsyncStandardFilterEmptyParameters<TController>(
+    public static ExecutionHandlerSetup AsyncStandardFilterEmptyParameters<TController>(
         IServiceProvider serviceProvider,
         IExecutionRequestHandlerInfo handlerInfo,
         AsyncInvokeNoParameters<TController> invokeMethod,
@@ -107,8 +108,8 @@ public static class ExecutionHelper {
         IExecutionContext context, TController controller, TParameter parameter)
         where TController : class where TParameter : class;
 
-    public static Func<IExecutionContext, IExecutionFilter>[]
-        AsyncStandardFilterWithParameters<TController, TParameter>(
+    public static ExecutionHandlerSetup
+AsyncStandardFilterWithParameters<TController, TParameter>(
             IServiceProvider serviceProvider,
             IExecutionRequestHandlerInfo handlerInfo,
             Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequestFunc,
@@ -133,8 +134,8 @@ public static class ExecutionHelper {
 
     #region async enumerable with parameters
 
-    public static Func<IExecutionContext, IExecutionFilter>[]
-        AsyncEnumerableFilterWithParameters<TController, TParameter, TItem>(
+    public static ExecutionHandlerSetup
+AsyncEnumerableFilterWithParameters<TController, TParameter, TItem>(
             IServiceProvider serviceProvider,
             IExecutionRequestHandlerInfo handlerInfo,
             Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequestFunc,
@@ -159,8 +160,8 @@ public static class ExecutionHelper {
 
     #region async enumerable no parameters
 
-    public static Func<IExecutionContext, IExecutionFilter>[]
-        AsyncEnumerableFilterEmptyParameters<TController, TItem>(
+    public static ExecutionHandlerSetup
+AsyncEnumerableFilterEmptyParameters<TController, TItem>(
             IServiceProvider serviceProvider,
             IExecutionRequestHandlerInfo handlerInfo,
             InvokeNoParameters<TController> invokeMethod,
@@ -184,13 +185,28 @@ public static class ExecutionHelper {
 
     #region create filter array
 
-    private static Func<IExecutionContext, IExecutionFilter>[] CreateFilterArray(
+    /// <remarks>
+    /// <para>
+    /// Every overload above funnels through here, which is why conventions are applied at the top of
+    /// it rather than in each of them. It is also the only point at which both halves are available:
+    /// the handler the generator declared, and the service provider the conventions live in.
+    /// </para>
+    /// <para>
+    /// <b>Ahead of the global filter registry, and that ordering is the whole mechanism.</b> The
+    /// registry is what asks <c>AuthorizationFilterProvider</c> for this handler's guard, and it is
+    /// handed the amended handler - so a requirement a convention added is indistinguishable from
+    /// one an attribute declared by the time anything decides what to enforce.
+    /// </para>
+    /// </remarks>
+    private static ExecutionHandlerSetup CreateFilterArray(
         IServiceProvider serviceProvider,
         IExecutionRequestHandlerInfo handlerInfo,
         IEnumerable<IRequestFilterProvider> filterProviders,
         IExecutionFilter ioFilter,
         IExecutionFilter invokeFilter,
         IExecutionFilter instanceFilter) {
+        handlerInfo = ApplyConventions(serviceProvider, handlerInfo);
+
         var filterList =
             serviceProvider.GetRequiredService<IGlobalFilterRegistry>().GetFilters(handlerInfo);
 
@@ -207,7 +223,72 @@ public static class ExecutionHelper {
         filterList.Sort((x, y) =>
             Comparer<int>.Default.Compare(x.Order ?? FilterOrder.DefaultValue, y.Order ?? FilterOrder.DefaultValue));
 
-        return filterList.Select(f => f.FilterFunc).ToArray();
+        return new ExecutionHandlerSetup(handlerInfo, filterList.Select(f => f.FilterFunc).ToArray());
+    }
+
+    /// <summary>
+    /// Conjoins whatever the conventions require onto what the handler declared.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Conjoined rather than substituted, so a convention can only ever narrow. The declared
+    /// requirement goes in first, which costs nothing at evaluation - <c>AllOf</c> flattens, so this
+    /// is one node however many contributed - but keeps the rendered description reading in the
+    /// order somebody would explain it: what the handler asked for, then what was imposed on it.
+    /// </para>
+    /// <para>
+    /// A handler no convention spoke about is returned untouched, which is the common case and the
+    /// case worth not allocating for. Resolving through <c>GetServices</c> rather than requiring a
+    /// registration means an application with no conventions pays one empty enumeration per handler
+    /// at startup and nothing at all per request.
+    /// </para>
+    /// <para>
+    /// The amended handler is a plain <see cref="ExecutionRequestHandlerInfo"/> rather than a
+    /// wrapper delegating to the declared one. Every member of the interface is copied, so the two
+    /// carry the same answers - and the status members, the only ones with default implementations
+    /// an implementation could have overridden, are answered by that default everywhere in the tree.
+    /// A wrapper would be the right shape only once something needs to override one.
+    /// </para>
+    /// </remarks>
+    private static IExecutionRequestHandlerInfo ApplyConventions(
+        IServiceProvider serviceProvider, IExecutionRequestHandlerInfo handlerInfo) {
+        // GetService rather than GetServices, which resolves IEnumerable<T> as *required* and throws
+        // outright on a container that does not synthesise an empty one for an unregistered service.
+        // Hardened's does not, so the convenience overload turns "this application registered no
+        // conventions" - the overwhelmingly common case - into a failure to construct any handler at
+        // all.
+        var conventions = serviceProvider.GetService<IEnumerable<IAuthorizationConvention>>();
+
+        if (conventions == null) {
+            return handlerInfo;
+        }
+
+        List<Requirement>? requirements = null;
+
+        foreach (var convention in conventions) {
+            var requirement = convention.Apply(handlerInfo);
+
+            if (requirement != null) {
+                (requirements ??= []).Add(requirement);
+            }
+        }
+
+        if (requirements == null) {
+            return handlerInfo;
+        }
+
+        if (handlerInfo.Requirement != null) {
+            requirements.Insert(0, handlerInfo.Requirement);
+        }
+
+        return new ExecutionRequestHandlerInfo(
+            handlerInfo.Path,
+            handlerInfo.Method,
+            handlerInfo.HandlerType,
+            handlerInfo.InvokeMethod,
+            handlerInfo.Parameters,
+            handlerInfo.Metadata,
+            Requirement.AllOf([..requirements]));
     }
 
     #endregion

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
@@ -1,4 +1,5 @@
-﻿using Hardened.Requests.Abstract.Execution;
+﻿using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
 
 namespace Hardened.Requests.Runtime.Execution;
 
@@ -9,13 +10,15 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         Type handlerType,
         string invokeMethod,
         IReadOnlyList<IExecutionRequestParameter>? parameters = null,
-        IReadOnlyList<object>? metadata = null) {
+        IReadOnlyList<object>? metadata = null,
+        Requirement? requirement = null) {
         Path = path;
         Method = method;
         HandlerType = handlerType;
         InvokeMethod = invokeMethod;
         Parameters = parameters ?? new List<IExecutionRequestParameter>();
         Metadata = metadata ?? Array.Empty<object>();
+        Requirement = requirement ?? IExecutionRequestHandlerInfo.RequirementFrom(Metadata);
     }
 
     public string Path { get; }
@@ -29,4 +32,11 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
     public IReadOnlyList<IExecutionRequestParameter> Parameters { get; }
 
     public IReadOnlyList<object> Metadata { get; }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Computed once here rather than per read. The generated handler holds this in a static field,
+    /// so the walk over metadata happens once per handler type for the life of the process.
+    /// </remarks>
+    public Requirement? Requirement { get; }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
@@ -80,14 +80,10 @@ public static class HandlerInfoCodeGenerator {
         handlerInfoField.InitializeValue =
             new CodeOutputComponent($"new ExecutionRequestHandlerInfo(\"{handlerModel.Name.Path}\", \"{handlerModel.Name.Method}\", typeof({handlerModel.ControllerType.Name}), \"{handlerModel.HandlerMethod}\"{parameterInfoField}{metadataArg})");
 
-        var handlerProperty =
-            classDefinition.AddProperty(KnownTypes.Requests.IExecutionRequestHandlerInfo, "HandlerInfo");
-
-        handlerProperty.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
-        handlerProperty.Get.LambdaSyntax = true;
-        handlerProperty.Set = null;
-
-        handlerProperty.Get.AddCode("_handlerInfo;");
+        // No HandlerInfo property is emitted, deliberately. The field above is the handler as
+        // written; BaseExecutionHandler exposes the one the chain was actually built from, which is
+        // that plus whatever conventions contributed. A property here would return the wrong one and
+        // shadow the right one - see BaseExecutionHandler.HandlerInfo.
     }
 
     private static void CreateMetadataField(RequestHandlerModel handlerModel, ClassDefinition classDefinition) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Authorization/HandlerAuthorizationSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Authorization/HandlerAuthorizationSelector.cs
@@ -32,13 +32,11 @@ public record HandlerAuthorizationModel(
 }
 
 public static class HandlerAuthorizationSelector {
-    private const string AuthorizationNamespace = "Hardened.Requests.Runtime.Authorization";
+    private const string AuthorizeInterface =
+        "Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute";
 
-    private static readonly string[] SpeaksForItself = {
-        "AuthorizeAttribute",
-        "AuthorizeGrantsAttribute",
-        "AllowAnonymousAttribute"
-    };
+    private const string AllowAnonymous =
+        "Hardened.Requests.Runtime.Authorization.AllowAnonymousAttribute";
 
     /// <summary>
     /// Reads a handler method and its controller, and nothing else.
@@ -67,6 +65,30 @@ public static class HandlerAuthorizationSelector {
             LocationInfo.From(method.Identifier));
     }
 
+    /// <summary>
+    /// Whether any of these attributes is one the authorization pipeline honours.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Matched by interface rather than by type name.</b> The pipeline honours anything
+    /// implementing <c>IAuthorizeAttribute</c>, so that is what has to be asked about here - a name
+    /// list only recognises the framework's own two attributes and reports <c>HAUTH001</c> against
+    /// a handler guarded by an application's own, which is a false positive on the one diagnostic
+    /// whose job is to prevent false negatives. Deriving from <c>[AuthorizeGrants]</c> to give a
+    /// grant a name is the expected way to write authorization, and it must not warn.
+    /// </para>
+    /// <para>
+    /// It is also the only check that works uniformly. An attribute from a referenced assembly
+    /// exposes its interfaces in metadata, so this sees them; its constructor body is not there to
+    /// be read, which is why nothing here tries to learn <em>which</em> grants an attribute names.
+    /// The runtime asks the attribute instance for that.
+    /// </para>
+    /// <para>
+    /// Still exact about what it accepts. Another framework's <c>[Authorize]</c> implements nothing
+    /// of Hardened's and is not honoured by the pipeline, so recognising it by name would silence
+    /// the warning on a handler that is genuinely unguarded.
+    /// </para>
+    /// </remarks>
     private static bool Speaks(
         GeneratorSyntaxContext context,
         SyntaxList<AttributeListSyntax> attributeLists,
@@ -81,14 +103,17 @@ public static class HandlerAuthorizationSelector {
                     continue;
                 }
 
-                // Matched by namespace as well as name. Accepting another framework's [Authorize] -
-                // which Hardened does not honour - would silence the warning on a handler that is
-                // genuinely unguarded, turning a false positive into a false negative.
-                var name = type.Name.EndsWith("Attribute") ? type.Name : type.Name + "Attribute";
-
-                if (SpeaksForItself.Contains(name) &&
-                    type.ContainingNamespace?.ToDisplayString() == AuthorizationNamespace) {
+                if (type.ToDisplayString() == AllowAnonymous) {
                     return true;
+                }
+
+                // AllInterfaces rather than Interfaces, so an attribute that derives from one
+                // implementing it - which is the whole point of the base attribute not being
+                // sealed - is recognised as well as one implementing it directly.
+                foreach (var contract in type.AllInterfaces) {
+                    if (contract.ToDisplayString() == AuthorizeInterface) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Authorization/RequireAuthorizationDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Authorization/RequireAuthorizationDiagnostics.cs
@@ -36,10 +36,11 @@ namespace Hardened.SourceGenerator.Web.Authorization;
 /// reachable.
 /// </para>
 /// <para>
-/// An application writing its own <c>IAuthorizeAttribute</c> is reported even though the pipeline
-/// honours it, because only the framework's own attributes are recognised here. <c>[AllowAnonymous]</c>
-/// is emphatically the wrong answer to that - it would make the route genuinely public - so the
-/// answer is <c>&lt;NoWarn&gt;</c> for the project.
+/// An application's own attribute silences this as long as it implements <c>IAuthorizeAttribute</c>,
+/// directly or by deriving from an attribute that does. That is deliberately the same test the
+/// pipeline applies, so the set of handlers this reports and the set the runtime refuses cannot
+/// disagree - and an attribute written to give a grant a name never has to be excused with
+/// <c>&lt;NoWarn&gt;</c>.
 /// </para>
 /// </remarks>
 public static class RequireAuthorizationDiagnostics {

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Authorization/RequireAuthorizationTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Authorization/RequireAuthorizationTests.cs
@@ -122,6 +122,80 @@ public class RequireAuthorizationTests {
     }
 
     /// <summary>
+    /// An attribute of the application's own, deriving from <c>[AuthorizeGrants]</c>, says as much as
+    /// the attribute it derives from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is why the check is by interface rather than by type name. A name list recognises only
+    /// the framework's own two attributes, so it reported every handler guarded by a derived one -
+    /// a false positive on the diagnostic whose entire purpose is to prevent false negatives, and
+    /// one whose obvious fix, <c>[AllowAnonymous]</c>, would genuinely open the route.
+    /// </para>
+    /// <para>
+    /// Naming a grant once and spelling it as a type is the expected way to write authorization by
+    /// hand, so warning about it would make the diagnostic something to switch off.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void AHandlerGuardedByADerivedAttributeIsNotReported() {
+        Assert.Empty(Reported(
+            "[RequireAuthorization]",
+            """
+                public sealed class RequiresUserReadAttribute : AuthorizeGrantsAttribute {
+                    public RequiresUserReadAttribute() : base("users:read") { }
+                }
+
+                [Get("/users")]
+                [RequiresUserRead]
+                public string All() => "";
+            """));
+    }
+
+    /// <summary>
+    /// So does an attribute implementing <c>IAuthorizeAttribute</c> directly, which the pipeline
+    /// honours without it deriving from anything of the framework's.
+    /// </summary>
+    [Fact]
+    public void AHandlerGuardedByACustomAuthorizeAttributeIsNotReported() {
+        Assert.Empty(Reported(
+            "[RequireAuthorization]",
+            """
+                public sealed class TenantMemberAttribute
+                    : System.Attribute, Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute {
+                    public Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; } =
+                        Hardened.Requests.Abstract.Authorization.Requirement.Grant("tenant:member");
+                }
+
+                [Get("/users")]
+                [TenantMember]
+                public string All() => "";
+            """));
+    }
+
+    /// <summary>
+    /// And an attribute that merely looks like one is still reported.
+    /// </summary>
+    /// <remarks>
+    /// Matching by interface has to stay exact about what it accepts. Another framework's
+    /// <c>[Authorize]</c> imposes nothing the pipeline evaluates, so recognising it would silence the
+    /// warning on a handler that is genuinely unguarded - trading a false positive for the false
+    /// negative this exists to prevent.
+    /// </remarks>
+    [Fact]
+    public void AHandlerCarryingAnUnrelatedAuthorizeAttributeIsStillReported() {
+        Assert.Single(Reported(
+            "[RequireAuthorization]",
+            """
+                public sealed class SomeOtherFrameworksAuthorizeAttribute : System.Attribute { }
+
+                [Get("/users")]
+                [SomeOtherFrameworksAuthorize]
+                public string All() => "";
+            """));
+    }
+
+    /// <summary>
     /// Saying a route is public on purpose is saying something. It is the opt-out, so it has to
     /// silence this as surely as a policy does.
     /// </summary>


### PR DESCRIPTION
Grant combination was AND within one `[AuthorizeGrants]` and OR between repeated ones, mapping OpenAPI's `security` list onto attribute stacking. That reads well for one case and is wrong for the rest.

A handler's metadata carries its controller's attributes as well as its own, so this admitted a caller holding **either**:

```csharp
[BasePath("/pets")]
[AuthorizeGrants("tenant:member")]
public class PetController {
    [Post("/")]
    [AuthorizeGrants("pets:write")]     // ← widened the controller's guard
    public Task Create(Pet pet) => ...;
}
```

Writing a narrower attribute on one route opened it up. It was also inconsistent with the other attribute form already — `[Authorize<T>]` on the controller plus `[AuthorizeGrants]` on the method conjoined, because `Authorize<T>` fell to the `IAuthorizeAttribute` case.

## Everything conjoins

Every `IAuthorizeAttribute` on a handler is now required, however it got there — method, controller, derived attribute, or convention. Adding a declaration can only narrow.

Alternatives stay expressible, but only from inside a single declaration: `Requirement.AnyOf` in a policy body is one author writing one expression, which is a different thing from a meaning that emerges from how many attributes happen to be present.

Nothing depended on the old rule — spec-first `security` parsing isn't built yet, so exactly one test flipped.

## Deriving from `[AuthorizeGrants]`

That makes the attribute safe to inherit, which is the hand-authored form — a grant named once, spelled as a type at every call site:

```csharp
public sealed class RequiresPetWriteAttribute : AuthorizeGrantsAttribute {
    public RequiresPetWriteAttribute() : base(Grants.Pets.Read, Grants.Pets.Write) { }
}
```

The build diagnostic had to stop matching type names for this to work. `HAUTH001` recognised three names in one namespace, so it reported handlers guarded by an application's own attribute — a false positive on the check whose purpose is preventing false negatives, and one whose obvious fix (`[AllowAnonymous]`) would genuinely open the route. It now asks whether the attribute implements `IAuthorizeAttribute`, which is the same test the pipeline applies and the only one that works for a type from a referenced assembly, whose constructor body a generator cannot read.

## Conventions

The folded requirement moves onto `IExecutionRequestHandlerInfo` as one `Requirement`. Attributes are one source; `IAuthorizationConvention` is another:

```csharp
public class AdminRoutesAreAdminOnly : IAuthorizationConvention {
    public Requirement? Apply(IExecutionRequestHandlerInfo handler) =>
        handler.Path.StartsWith("/admin") ? Requirement.Grant("admin:access") : null;
}
```

Applied in `ExecutionHelper.CreateFilterArray` — the choke point every overload funnels through, and where the generated static handler info first meets the service provider. It runs **ahead of** the global filter registry, which is what asks `AuthorizationFilterProvider` for the guard, so a convention's requirement is indistinguishable from an attribute's by the time anything decides what to enforce.

`BaseExecutionHandler` takes its info from the setup the chain was built from rather than the generated subclass overriding it, so `context.HandlerInfo` cannot drift from what the filters enforce. The generator therefore stops emitting a `HandlerInfo` property; nothing else about the generated shape changes, and a derived attribute reaches metadata with no generator work at all.

## Notes

- `GetServices<T>()` resolves `IEnumerable<T>` as a *required* service and this container doesn't synthesise an empty one — it threw on every handler in an app with no conventions registered. It's `GetService<IEnumerable<T>>()` with a null check, pinned by its own test.
- Public API approvals regenerated for `Hardened.Requests.Abstract` and `Hardened.Requests.Runtime`.
- `AUTHORIZATION-PLAN.md` §2.3 rewritten, §2.5 (conventions) added, amendment note at the top. That file lives outside this repo, so it is not in this diff.

## Verification

2887 tests across 19 assemblies pass. `ContinuousIntegrationBuild=true` build exits 0 with no CS warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKFfJTgBVeibASEtiryYBd
