### PR TITLE
Typed grant sets: document [AuthorizeGrants<T>], and guard the empty case

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -62,9 +62,21 @@ namespace Hardened.Requests.Runtime.Authorization
         public System.Collections.Generic.IReadOnlyList<string> Grants { get; }
         public Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
+    public class AuthorizeGrantsAttribute<T> : System.Attribute, Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute
+        where T : Hardened.Requests.Runtime.Authorization.IGrantProvider, new ()
+    {
+        public AuthorizeGrantsAttribute() { }
+        public System.Collections.Generic.IReadOnlyList<string> Grants { get; }
+        public Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; }
+    }
     public interface IAuthorizationConfiguration
     {
         bool RequireAuthorization { get; }
+    }
+    public interface IGrantProvider
+    {
+        string[] Grants { get; }
     }
     [DependencyModules.Runtime.Attributes.SingletonService]
     public class PrincipalGrantAuthorizationHandler : Hardened.Requests.Abstract.Authorization.IActivityAuthorizationHandler

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
@@ -35,6 +35,20 @@ public class AuthorizationFilterProviderTests {
         public RequiresPetWriteAttribute() : base("pets:read", "pets:write") { }
     }
 
+    /// <summary>The other hand-authored form: a set of grants named as a type.</summary>
+    private sealed class PetsReadWrite : IGrantProvider {
+        public string[] Grants => ["pets:read", "pets:write"];
+    }
+
+    private sealed class TenantMember : IGrantProvider {
+        public string[] Grants => ["tenant:member"];
+    }
+
+    /// <summary>A provider that names nothing, which is the one thing it must not do.</summary>
+    private sealed class NamesNothing : IGrantProvider {
+        public string[] Grants => [];
+    }
+
     /// <summary>
     /// A real handler rather than a substitute.
     /// </summary>
@@ -157,6 +171,76 @@ public class AuthorizationFilterProviderTests {
 
         Assert.True(await Admits(metadata, "pets:read", "pets:write"));
         Assert.False(await Admits(metadata, "pets:read"));
+    }
+
+    /// <summary>
+    /// A grant set named as a type is honoured exactly like the grants written inline.
+    /// </summary>
+    [Fact]
+    public async Task ATypedGrantSetIsHonoured() {
+        object[] metadata = [new AuthorizeGrantsAttribute<PetsReadWrite>()];
+
+        Assert.True(await Admits(metadata, "pets:read", "pets:write"));
+        Assert.False(await Admits(metadata, "pets:read"));
+    }
+
+    /// <summary>
+    /// Two sets on one handler require both, like every other pair of authorization attributes.
+    /// </summary>
+    /// <remarks>
+    /// Worth pinning because these are two closed generic types rather than two instances of one,
+    /// so nothing about <c>AllowMultiple</c> is doing the work - the conjunction is the pipeline's
+    /// one rule applying to them like anything else.
+    /// </remarks>
+    [Fact]
+    public async Task TwoTypedGrantSetsMustBothHold() {
+        object[] metadata = [
+            new AuthorizeGrantsAttribute<PetsReadWrite>(),
+            new AuthorizeGrantsAttribute<TenantMember>(),
+        ];
+
+        Assert.True(await Admits(metadata, "pets:read", "pets:write", "tenant:member"));
+        Assert.False(await Admits(metadata, "pets:read", "pets:write"));
+        Assert.False(await Admits(metadata, "tenant:member"));
+    }
+
+    /// <summary>
+    /// Every spelling reaches the same place, so they conjoin with each other.
+    /// </summary>
+    /// <remarks>
+    /// The point of there being several forms: the variety is at the point of declaration, and by
+    /// the time anything enforces there is one requirement whatever wrote it.
+    /// </remarks>
+    [Fact]
+    public async Task TheDifferentSpellingsConjoinWithEachOther() {
+        object[] metadata = [
+            new AuthorizeGrantsAttribute("tenant:member"),
+            new AuthorizeGrantsAttribute<PetsReadWrite>(),
+            new AuthorizeAttribute<CanManagePets>(),
+        ];
+
+        Assert.True(await Admits(
+            metadata, "tenant:member", "pets:read", "pets:write", "pets:manage"));
+
+        Assert.False(await Admits(metadata, "tenant:member", "pets:read", "pets:write"));
+        Assert.False(await Admits(metadata, "pets:read", "pets:write", "pets:manage"));
+    }
+
+    /// <summary>
+    /// A provider naming no grants throws, rather than producing an attribute that requires nothing
+    /// while looking like it requires something.
+    /// </summary>
+    /// <remarks>
+    /// The message has to name the provider. This runs inside a generated handler's static
+    /// initializer, so what a developer sees is a <c>TypeInitializationException</c> wrapping it -
+    /// and the inner message is the only part that says which type was at fault.
+    /// </remarks>
+    [Fact]
+    public void AGrantProviderNamingNothingThrows() {
+        var exception = Assert.Throws<ArgumentException>(
+            () => new AuthorizeGrantsAttribute<NamesNothing>());
+
+        Assert.Contains(nameof(NamesNothing), exception.Message);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizeGrantsAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizeGrantsAttribute.cs
@@ -20,9 +20,9 @@ namespace Hardened.Requests.Runtime.Authorization;
 /// </code>
 /// </example>
 /// <para>
-/// <b>Not sealed, because deriving from it is the hand-authored form.</b> A named attribute reads
-/// better at the call site than a string does, is found by "go to references", and is renamed by a
-/// refactor - so the grant vocabulary can be written once and spelled everywhere as a type:
+/// <b>Not sealed, because deriving from it is one of the hand-authored forms.</b> A named attribute
+/// reads better at the call site than a string does, is found by "go to references", and is renamed
+/// by a refactor - so the grant vocabulary can be written once and spelled everywhere as a type:
 /// </para>
 /// <example>
 /// <code>
@@ -31,6 +31,10 @@ namespace Hardened.Requests.Runtime.Authorization;
 /// }
 /// </code>
 /// </example>
+/// <para>
+/// <see cref="AuthorizeGrantsAttribute{T}"/> is the other, and wants one type rather than one type
+/// per attribute. Both end at the same place - see that type's remarks.
+/// </para>
 /// <para>
 /// The string form remains what a generator emits from a specification, where a human never reads
 /// the attribute and the values cannot be a typo because the generator read them out of the spec.
@@ -58,6 +62,107 @@ public class AuthorizeGrantsAttribute : Attribute, IAuthorizeAttribute {
     }
 
     /// <summary>The grants named, in the order they were written.</summary>
+    public IReadOnlyList<string> Grants { get; }
+
+    public Requirement Requirement { get; }
+}
+
+/// <summary>
+/// A named set of grants, declared once and required wherever it is named.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The vocabulary an application authorizes in, as a type rather than as strings repeated at call
+/// sites. What the set contains is written in one place, so widening or narrowing it is one edit
+/// and every handler requiring it follows.
+/// </para>
+/// <example>
+/// <code>
+/// public sealed class PetsReadWrite : IGrantProvider {
+///     public string[] Grants => [Grants.Pets.Read, Grants.Pets.Write];
+/// }
+/// </code>
+/// </example>
+/// <para>
+/// Read once, when the attribute naming it is constructed - which happens in the generated
+/// handler's static initializer, so a provider is instantiated once per handler type and never on a
+/// request. It follows that the set must be a constant of the application rather than something
+/// read from configuration or a store: nothing re-reads it, and a grant that can change at run time
+/// belongs behind <see cref="IActivityAuthorizationHandler"/>, which exists for exactly that.
+/// </para>
+/// </remarks>
+public interface IGrantProvider {
+    /// <summary>Every grant in the set. All of them are required.</summary>
+    string[] Grants { get; }
+}
+
+/// <summary>
+/// Requires the grants <typeparamref name="T"/> names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The typed spelling of <see cref="AuthorizeGrantsAttribute"/>. One
+/// <see cref="IGrantProvider"/> describes a set of grants, and every handler needing that set names
+/// the same type:
+/// </para>
+/// <example>
+/// <code>
+/// [AuthorizeGrants&lt;PetsReadWrite&gt;]
+/// [Post("/pets")]
+/// public Task&lt;Pet&gt; Create(Pet pet) => ...;
+/// </code>
+/// </example>
+/// <para>
+/// <b>Where it wins over deriving an attribute.</b> A derived attribute is a type per <em>call-site
+/// spelling</em>; this is a type per <em>set of grants</em>, reused by every handler that needs it.
+/// Nothing is generated, nothing is registered, and the grants are a compile-time reference rather
+/// than a string - so a renamed constant is a build error rather than a 403 in staging.
+/// </para>
+/// <para>
+/// <b>Lots of ways in, one way out.</b> Strings from a specification, a derived attribute, this,
+/// <c>[Authorize&lt;TPolicy&gt;]</c>, and an <c>IAuthorizationConvention</c> are five ways to say
+/// what a handler needs, and they exist because they suit different situations - generated versus
+/// hand-written, one route versus a whole class of them. They converge before anything acts on
+/// them: each produces a <see cref="Requirement"/>, every requirement on a handler is conjoined
+/// into the one on <c>IExecutionRequestHandlerInfo</c>, and the authorization filter reads only
+/// that. There is one thing to reason about at the point it matters, however it was written.
+/// </para>
+/// <para>
+/// It conjoins like every other authorization attribute, so naming two sets requires both:
+/// </para>
+/// <example>
+/// <code>
+/// [AuthorizeGrants&lt;PetsReadWrite&gt;]
+/// [AuthorizeGrants&lt;TenantMember&gt;]   // ...and this as well
+/// </code>
+/// </example>
+/// </remarks>
+/// <typeparam name="T">
+/// The set of grants required. Constructed once, when this attribute is.
+/// </typeparam>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+public class AuthorizeGrantsAttribute<T> : Attribute, IAuthorizeAttribute where T : IGrantProvider, new() {
+    public AuthorizeGrantsAttribute() {
+        var grants = new T().Grants;
+
+        // Checked rather than left to AllOf, which would throw about "a requirement" naming no
+        // conditions - true, and no help at all in finding the provider that returned nothing. This
+        // runs in a generated handler's static initializer, so the exception a developer actually
+        // sees is a TypeInitializationException wrapping whatever is thrown here; the inner message
+        // is the only part naming the cause.
+        if (grants is null || grants.Length == 0) {
+            throw new ArgumentException(
+                $"[AuthorizeGrants<{typeof(T).Name}>] requires at least one grant, and " +
+                $"{typeof(T).Name}.Grants returned none. An empty set would require nothing while " +
+                "looking like it requires something, which is the one failure mode an authorization " +
+                "attribute must not have. Use [AllowAnonymous] to make an operation public on purpose.");
+        }
+
+        Grants = grants;
+        Requirement = Combinator.AllOf(Array.ConvertAll(grants, Combinator.Grant));
+    }
+
+    /// <summary>The grants named, in the order the provider returned them.</summary>
     public IReadOnlyList<string> Grants { get; }
 
     public Requirement Requirement { get; }


### PR DESCRIPTION
Follow-up to #128. `[AuthorizeGrants<T>]` and `IGrantProvider` landed undocumented; this documents them and fixes two things found while writing it up.

## The shape

```csharp
public sealed class PetsReadWrite : IGrantProvider {
    public string[] Grants => [Grants.Pets.Read, Grants.Pets.Write];
}
```

```csharp
[Post("/pets")]
[AuthorizeGrants<PetsReadWrite>]
public Task<Pet> Create(Pet pet) => ...;
```

A type per **set of grants**, reused by every handler needing that set — where a derived `AuthorizeGrantsAttribute` gives a type per **call-site spelling**. Both avoid the string; they differ in what the type is *for*. Widening `PetsReadWrite` is one edit and every handler naming it follows.

Nothing generated, nothing registered. The pipeline can't tell the two apart — each is an `IAuthorizeAttribute` yielding a `Requirement`, and every requirement on a handler conjoins into the one the filter reads.

## Two fixes

**An empty provider threw a useless message.** It already failed, but through `AllOf` reporting *"a requirement must name at least one condition"* — true, and no help finding the provider at fault. This runs in a generated handler's static initializer, so what a developer sees is a `TypeInitializationException` and the inner message is the only part naming a cause. It now names the provider type.

**No `[AttributeUsage]`.** The generic attribute defaulted to `AttributeTargets.All` — writable on an assembly, a parameter or a field, none of which the pipeline reads. Now `Class | Method, AllowMultiple = true`, matching the non-generic. `AllowMultiple` only affects repeating the same closed type; `<A>` and `<B>` are distinct types and always stacked fine.

## Also

Both types were undocumented. They now carry the same reasoning as the rest of the authorization surface, including why a provider must be a constant of the application — it is read once when the attribute is constructed, so nothing re-reads it, and grants that vary per caller belong behind `IActivityAuthorizationHandler`.

Four new tests: typed set honoured; two sets conjoin; all three spellings (string, typed set, policy) conjoin with each other; empty provider throws naming the type. Public API approvals regenerated.

The guide and reference pages for this go up separately in `Hardened.Docs`.

## Verification

2891 tests across 19 assemblies pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKFfJTgBVeibASEtiryYBd
