### PR TITLE
Serialize a streamed item, which nothing could

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/StreamingTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/StreamingTests.cs
@@ -1,0 +1,118 @@
+using Hardened.IntegrationTests.WebApp.SUT.Controllers;
+using Hardened.Requests.Abstract.Headers;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// Streamed responses driven through the real pipeline.
+///
+/// <para>
+/// <b><see cref="AStreamOfModelsIsOneJsonDocumentPerLine"/> is the test this file exists for.</b>
+/// <c>AsyncEnumerableIoFilterTests</c> covers the framing well, but it builds the filter directly
+/// with a stand-in serializer and does so as <c>AsyncEnumerableIoFilter&lt;string&gt;</c>. Neither
+/// choice is wrong for what that file asserts, and together they meant the serializer lookup was
+/// never exercised: a string was already answerable by <c>RawResponseSerializer</c>, so the one
+/// item type under test was the one that happened to work, and a handler streaming a model threw
+/// with "Response committed to content type 'application/x-ndjson' but no registered serializer can
+/// produce it".
+/// </para>
+///
+/// <para>
+/// So what these assert is deliberately the wiring rather than the framing: that a real handler
+/// returning a real model reaches a serializer at all, that the content type on the wire is the
+/// stream's rather than the per-item one, and that the empty case still terminates.
+/// </para>
+/// </summary>
+public class StreamingTests {
+
+    [HardenedTest]
+    public async Task AStreamOfModelsIsOneJsonDocumentPerLine(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/models");
+
+        response.Assert.Ok();
+
+        var measurements = new List<StreamingController.Measurement>();
+
+        await foreach (var measurement in
+                       response.DeserializeAsyncEnumerable<StreamingController.Measurement>()) {
+            measurements.Add(measurement);
+        }
+
+        Assert.Equal(3, measurements.Count);
+        Assert.Equal(new StreamingController.Measurement("north", 12, false), measurements[0]);
+        Assert.Equal(new StreamingController.Measurement("south", 41, true), measurements[1]);
+        Assert.Equal(new StreamingController.Measurement("east", -3, false), measurements[2]);
+    }
+
+    /// <summary>
+    /// The stream's content type, not the item's.
+    /// </summary>
+    /// <remarks>
+    /// Every other JSON serializer assigns <c>application/json</c> on entry, so a stream routed
+    /// through one would have each item overwrite what the filter committed. This is what pins the
+    /// streaming serializer leaving the content type alone - and it is the property server-sent
+    /// events will depend on outright, since an <c>EventSource</c> refuses anything that is not
+    /// <c>text/event-stream</c>.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AStreamKeepsItsOwnContentType(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/models");
+
+        response.Assert.Ok();
+
+        Assert.Equal(KnownContentType.NdJson, response.Headers[KnownHeaders.ContentType].ToString());
+    }
+
+    /// <summary>
+    /// Every line is a JSON document, including when the item is a string.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is a deliberate behaviour change and the assertion is the point of recording it. A
+    /// stream of strings used to resolve to <c>RawResponseSerializer</c>, which writes a string's
+    /// characters - so the body read <c>alpha\nbeta</c>, and neither line was a JSON document, in a
+    /// format whose whole contract is one JSON document per line. No NDJSON reader could parse it.
+    /// </para>
+    /// <para>
+    /// <c>StreamingJsonResponseSerializer</c> sits at <c>Specialized</c>, ahead of it, so the same
+    /// handler now emits quoted strings and every line parses whatever the item type is. Nothing
+    /// depended on the old shape - it was unreachable for any item type but string, and untested
+    /// through a real response for that one.
+    /// </para>
+    /// </remarks>
+    [HardenedTest]
+    public async Task EvenAStreamOfStringsIsValidJsonPerLine(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/strings");
+
+        response.Assert.Ok();
+
+        var values = new List<string>();
+
+        await foreach (var value in response.DeserializeAsyncEnumerable<string>()) {
+            values.Add(value);
+        }
+
+        Assert.Equal(["alpha", "beta"], values);
+    }
+
+    /// <summary>
+    /// A stream that produces nothing is a newline, not an empty body.
+    /// </summary>
+    /// <remarks>
+    /// The trailing write exists because Lambda Function URLs do not close a zero-byte body
+    /// promptly and a reader waiting on one hangs. It has been in the filter from the start and has
+    /// never been asserted through a real response until now.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnEmptyStreamStillTerminates(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/empty");
+
+        response.Assert.Ok();
+
+        response.Body.Position = 0;
+
+        using var reader = new StreamReader(response.Body, leaveOpen: true);
+
+        Assert.Equal("\n", await reader.ReadToEndAsync());
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/StreamingController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/StreamingController.cs
@@ -1,0 +1,74 @@
+using Hardened.Web.Runtime.Attributes;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// Handlers returning <c>IAsyncEnumerable&lt;T&gt;</c>, which the pipeline answers as
+/// newline-delimited JSON.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b><see cref="Models"/> is the handler that matters, and it is the one that did not exist.</b>
+/// Streaming was covered only by <c>AsyncEnumerableIoFilterTests</c>, which constructs the filter
+/// directly with a stand-in serializer and does so as <c>AsyncEnumerableIoFilter&lt;string&gt;</c>.
+/// A string is the one item type <c>RawResponseSerializer</c> already answered for, so the suite
+/// was green while every handler streaming a model threw at the serializer lookup. Covering a
+/// model here, through the real pipeline, is what stops that returning.
+/// </para>
+/// <para>
+/// <see cref="Strings"/> is kept alongside it because the two resolve through different serializers
+/// - a string still goes to <c>RawResponseSerializer</c> - and only exercising the new one would
+/// leave the path that used to work uncovered.
+/// </para>
+/// <para>
+/// <b>No <c>CancellationToken</c> parameter, deliberately.</b> The filter already passes
+/// <c>context.CancellationToken</c> to <c>WithCancellation</c> at the enumeration site, so a
+/// handler gets cancellation without asking for it. Writing the idiomatic
+/// <c>[EnumeratorCancellation] CancellationToken</c> here compiles and then throws at run time -
+/// see STREAMING-PLAN.md item 9.
+/// </para>
+/// </remarks>
+[BasePath("/streaming")]
+public class StreamingController {
+
+    public record Measurement(string Sensor, int Reading, bool Settled);
+
+    /// <summary>A model per line, which is the case that used to throw.</summary>
+    [Get("/models")]
+    public async IAsyncEnumerable<Measurement> Models() {
+        yield return new Measurement("north", 12, false);
+
+        await Task.Yield();
+
+        yield return new Measurement("south", 41, true);
+
+        await Task.Yield();
+
+        yield return new Measurement("east", -3, false);
+    }
+
+    /// <summary>The shape that already worked, so it keeps being checked.</summary>
+    [Get("/strings")]
+    public async IAsyncEnumerable<string> Strings() {
+        yield return "alpha";
+
+        await Task.Yield();
+
+        yield return "beta";
+    }
+
+    /// <summary>
+    /// Produces nothing, so the trailing write is the entire body.
+    /// </summary>
+    /// <remarks>
+    /// The filter writes a newline after the loop whether or not anything was produced, because
+    /// Lambda Function URLs do not close a zero-byte body promptly and a reader waiting on one
+    /// hangs. That behaviour has never had a test through the real pipeline.
+    /// </remarks>
+    [Get("/empty")]
+    public async IAsyncEnumerable<Measurement> Empty() {
+        await Task.CompletedTask;
+
+        yield break;
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -360,13 +360,17 @@ namespace Hardened.Requests.Abstract.Headers
     public class KnownContentType
     {
         public const string Css = "text/css";
+        public const string EventStream = "text/event-stream";
         public const string Html = "text/html";
         public const string Js = "text/js";
         public const string Json = "application/json";
+        public const string NdJson = "application/x-ndjson";
         public static Microsoft.Extensions.Primitives.StringValues CssStringValues;
+        public static Microsoft.Extensions.Primitives.StringValues EventStreamStringValues;
         public static Microsoft.Extensions.Primitives.StringValues HtmlStringValues;
         public static Microsoft.Extensions.Primitives.StringValues JsStringValues;
         public static Microsoft.Extensions.Primitives.StringValues JsonStringValues;
+        public static Microsoft.Extensions.Primitives.StringValues NdJsonStringValues;
         public KnownContentType() { }
     }
     public static class KnownEncoding

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -639,6 +639,15 @@ namespace Hardened.Requests.Runtime.Serializer
         public Hardened.Requests.Abstract.Serializer.IRequestDeserializer FindRequestDeserializer(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public Hardened.Requests.Abstract.Serializer.IResponseSerializer FindResponseSerializer(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }
+    [DependencyModules.Runtime.Attributes.SingletonService(Using=DependencyModules.Runtime.Attributes.RegistrationType.Add)]
+    public class StreamingJsonResponseSerializer : Hardened.Requests.Abstract.Serializer.IResponseSerializer
+    {
+        public StreamingJsonResponseSerializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
+        public bool IsDefaultSerializer { get; }
+        public int Order { get; }
+        public bool CanProduce(string mediaType, Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.Task SerializeResponse(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+    }
     [DependencyModules.Runtime.Attributes.SingletonService(Using=DependencyModules.Runtime.Attributes.RegistrationType.Try)]
     public class StringConverterService : Hardened.Requests.Abstract.Serializer.IStringConverterService
     {

--- a/src/Requests/Hardened.Requests.Abstract/Headers/KnownContentType.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Headers/KnownContentType.cs
@@ -14,4 +14,26 @@ public class KnownContentType {
 
     public const string Css = "text/css";
     public static StringValues CssStringValues = new StringValues(Css);
+
+    /// <summary>
+    /// Newline-delimited JSON: one document per line, separated by <c>0x0A</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>application/jsonl</c> is the same wire format under a different name, and OpenAPI 3.2
+    /// treats the two as equivalent. Only this spelling is emitted, because it is the one the
+    /// streaming filter has always committed to.
+    /// </remarks>
+    public const string NdJson = "application/x-ndjson";
+    public static StringValues NdJsonStringValues = new StringValues(NdJson);
+
+    /// <summary>
+    /// Server-sent events.
+    /// </summary>
+    /// <remarks>
+    /// Unlike the others here, a client enforces this one: a browser <c>EventSource</c> refuses a
+    /// response whose content type is anything else. That is why a stream's serializer must not
+    /// restate the content type per item the way the JSON serializers do.
+    /// </remarks>
+    public const string EventStream = "text/event-stream";
+    public static StringValues EventStreamStringValues = new StringValues(EventStream);
 }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
@@ -1,4 +1,5 @@
 using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Logging;
 using Hardened.Requests.Abstract.Metrics;
 using Hardened.Shared.Runtime.Diagnostics;
@@ -60,8 +61,16 @@ public class AsyncEnumerableIoFilter<TItem> : IExecutionFilter {
                 chain.Context.Response.ShouldSerialize = false;
             }
             else if (chain.Context.Response.ResponseValue is IAsyncEnumerable<TItem> asyncEnumerable) {
-                context.Response.ContentType = "application/x-ndjson";
+                context.Response.ContentType = KnownContentType.NdJson;
                 context.Response.ShouldSerialize = false;
+
+                // Off for the whole stream, not per item. The buffered serializers open a
+                // GZipStream per SerializeResponse call, so leaving this on would put a separate
+                // gzip member on the wire for every item - legal concatenated gzip that no
+                // streaming reader unpacks incrementally, which is the opposite of what a caller
+                // reading a stream wants. Compressing a stream properly means one compressor
+                // around the whole body, which is a different change.
+                context.Response.ShouldCompress = false;
 
                 await foreach (var item in asyncEnumerable.WithCancellation(context.CancellationToken)) {
                     context.Response.ResponseValue = item;

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/StreamingJsonResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/StreamingJsonResponseSerializer.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using DependencyModules.Runtime.Attributes;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Hardened.Requests.Runtime.Serializer;
+
+/// <summary>
+/// One item of a streamed response, as JSON. The framing around it belongs to the filter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Without this, a streamed response of anything but a string throws.</b>
+/// <c>AsyncEnumerableIoFilter</c> commits <c>application/x-ndjson</c> before the loop, and a
+/// committed content type sends <c>SerializationLocatorService</c> looking for a serializer that
+/// can produce it. Nothing could: the JSON serializers answer only for
+/// <see cref="KnownContentType.Json"/>, and <see cref="RawResponseSerializer"/> requires the value
+/// to already be a <c>string</c>, <c>byte[]</c> or <c>Stream</c>. So every handler returning
+/// <c>IAsyncEnumerable&lt;SomeModel&gt;</c> failed with "Response committed to content type
+/// 'application/x-ndjson' but no registered serializer can produce it", while
+/// <c>IAsyncEnumerable&lt;string&gt;</c> worked - which is the one shape the tests covered.
+/// </para>
+/// <para>
+/// <b>It deliberately does not assign <c>ContentType</c>.</b> Every other JSON serializer here sets
+/// <c>application/json</c> on entry, which is right when it is writing the whole response and wrong
+/// when it is writing one item of a stream - the filter has already said what the stream is, and an
+/// item does not get to restate it. For <see cref="KnownContentType.EventStream"/> that is not a
+/// cosmetic difference: a browser <c>EventSource</c> rejects any other content type.
+/// </para>
+/// <para>
+/// <b>It does not compress either</b>, and the filter turns compression off for the whole stream.
+/// The buffered serializers open a <c>GZipStream</c> per call, so compressing per item would put a
+/// separate gzip member on the wire for each one - legal concatenated gzip that no streaming reader
+/// unpacks incrementally, which defeats the point of streaming.
+/// </para>
+/// <para>
+/// Resolution goes through <c>JsonTypeInfoLookup</c> rather than the reflection overload, so
+/// one class serves both hosts: an AOT application answers out of its registered
+/// <c>JsonSerializerContext</c>, and a JIT application falls back to reflection through the chain
+/// <c>WithReflectionFallback</c> installs. There is no <c>Aot</c> twin of this type for that reason.
+/// </para>
+/// </remarks>
+[SingletonService(Using = RegistrationType.Add)]
+public class StreamingJsonResponseSerializer : IResponseSerializer {
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    public StreamingJsonResponseSerializer(
+        IOptions<IJsonSerializerConfiguration> configuration,
+        IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        _serializerOptions =
+            configuration.Value.SerializeOptions ??
+            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithReflectionFallback(
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        foreach (var resolver in resolvers) {
+            _serializerOptions.TypeInfoResolverChain.Add(resolver);
+        }
+    }
+
+    /// <summary>
+    /// Never the fallback. A response nothing committed to a stream media type is not this
+    /// serializer's business.
+    /// </summary>
+    public bool IsDefaultSerializer => false;
+
+    /// <summary>
+    /// A serializer for two specific media types, which is what <c>Specialized</c> is for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Ahead of <see cref="RawResponseSerializer"/>, and the difference is observable. That one
+    /// claims <em>any</em> committed content type when the value is a <c>string</c>, so at equal
+    /// order the two contest a stream of strings and the winner comes down to registration order -
+    /// exactly the fragility <c>ResponseSerializerOrder</c>'s own remarks were written about.
+    /// </para>
+    /// <para>
+    /// Resolving it this way round is also the correct one. <c>RawResponseSerializer</c> writes a
+    /// string's characters, so <c>IAsyncEnumerable&lt;string&gt;</c> produced lines reading
+    /// <c>alpha</c> - which is not a JSON document, in a format whose entire contract is one JSON
+    /// document per line. Through this serializer the same handler emits <c>"alpha"</c>, and every
+    /// line parses regardless of item type.
+    /// </para>
+    /// </remarks>
+    public int Order => (int)ResponseSerializerOrder.Specialized;
+
+    /// <summary>
+    /// Only for a response that has already committed to a stream content type - never for one a
+    /// client asked for.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The committed type is the question, not <paramref name="mediaType"/>.</b>
+    /// <see cref="MediaType.Matches"/> answers true for <c>*/*</c> and for an absent <c>Accept</c>,
+    /// on the reasoning that a client expressing no preference will take anything. Asking it about
+    /// this serializer's media types therefore claims every indifferent request - which, at
+    /// <c>Specialized</c>, is most of them, and is ahead of the JSON serializers. Written that way
+    /// it broke plain-text fallback and the content type <c>HEAD</c> carries over from its
+    /// <c>GET</c>.
+    /// </para>
+    /// <para>
+    /// Gating on the commitment is also the honest rule. Streaming is the handler's decision, taken
+    /// by returning <c>IAsyncEnumerable&lt;T&gt;</c>, and the filter records it before any item is
+    /// written. There is no <c>Accept</c> a client can send that should turn a buffered handler
+    /// into a streaming one.
+    /// </para>
+    /// </remarks>
+    public bool CanProduce(string mediaType, IExecutionContext context) {
+        var committed = context.Response.ContentType;
+
+        return !string.IsNullOrEmpty(committed) &&
+               (MediaType.Matches(committed, KnownContentType.NdJson) ||
+                MediaType.Matches(committed, KnownContentType.EventStream));
+    }
+
+    public Task SerializeResponse(IExecutionContext context) {
+        var value = context.Response.ResponseValue;
+
+        if (value == null) {
+            return Task.CompletedTask;
+        }
+
+        return JsonSerializer.SerializeAsync(
+            context.Response.Body,
+            value,
+            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.For(_serializerOptions, value));
+    }
+}


### PR DESCRIPTION
A handler returning `IAsyncEnumerable<T>` answered 500 for every `T` except `string`.

`AsyncEnumerableIoFilter` commits `application/x-ndjson` before the loop, and a committed content type sends `SerializationLocatorService` looking for a serializer that can produce it — which nothing did. The JSON serializers answer only for `application/json`, and `RawResponseSerializer` requires the value to already be a `string`, `byte[]` or `Stream`. Reproduced against the real locator before writing anything:

```
ndjson+model  => THREW Exception: Response committed to content type
                 'application/x-ndjson' but no registered serializer can produce it.
ndjson+string => RawResponseSerializer
json+model    => SystemTextJsonResponseSerializer
```

**Why the suite was green.** The one item type covered was the one that worked. `AsyncEnumerableIoFilterTests` builds the filter directly with a stand-in serializer — correctly, for the framing it asserts — and does so as `AsyncEnumerableIoFilter<string>`. Together those meant the serializer lookup was never exercised, and no integration application returned `IAsyncEnumerable<T>` at all.

## What is here

**`StreamingJsonResponseSerializer`** answers for the two stream media types and, unlike every other JSON serializer here, does not assign `ContentType` — the filter has already said what the stream is, and an item does not get to restate it. It resolves through `JsonTypeInfoLookup.For`, so one class serves JIT and AOT with no `Aot` twin.

**It gates on the committed content type, not the requested one.** Written the obvious way it claimed every request sending no `Accept` header, because `MediaType.Matches` answers true for `*/*` and for an absent header by design. At `Specialized` that sits ahead of the JSON serializers, and it broke plain-text fallback and the content type `HEAD` carries from its `GET`. Streaming is the handler's decision; no `Accept` should turn a buffered handler into a streaming one.

**`Specialized`, not `Deferred`.** `RawResponseSerializer` claims *any* committed type for a `string`, so at equal order a stream of strings resolved by registration order — the fragility `ResponseSerializerOrder`'s own remarks were written about.

**Behaviour change, deliberate.** Resolving that contest toward the streaming serializer is also correct. `RawResponseSerializer` writes a string's characters, so `IAsyncEnumerable<string>` emitted lines reading `alpha` — not a JSON document, in a format whose contract is one JSON document per line. Lines now read `"alpha"` and parse whatever the item type is. Pinned by `EvenAStreamOfStringsIsValidJsonPerLine`.

**Compression off for the whole stream.** The buffered serializers open a `GZipStream` per call, so leaving it on put a separate gzip member on the wire per item — legal concatenated gzip that no reader unpacks incrementally.

**`StreamingController` / `StreamingTests`** are the coverage that was missing: a model, a string, and an empty stream, through the real pipeline. The empty case pins the trailing newline the filter has always written for Lambda Function URLs and never had a test for.

## Found on the way, not fixed here

`[EnumeratorCancellation] CancellationToken` on a streaming handler throws at run time — `ExecutionHelper.cs:301`, "does not implement ICustomBindingAttribute". The framework binds no `CancellationToken` parameter at all, and does not need to (the filter supplies cancellation at the enumeration site), but that is the spelling every C# author reaches for on an async iterator. It also escapes to run time in a framework that reports unbindable parameters at build. Recorded in `StreamingController`'s remarks and as item 9 of the plan.

## Verification

`dotnet test src/Hardened.Framework.sln --configuration Release -p:ContinuousIntegrationBuild=true` — **2,895 passing across 19 projects, no failures, no compiler warnings.**

The two approved public-API files are regenerated; the diff is exactly the two `KnownContentType` constants and the new serializer.

Remaining items — selectable OpenAPI version, SSE framing, `itemSchema` emission — are scoped in `STREAMING-PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8FnJTcrhPZGZtoZxvzaL6