### PR TITLE
Answer the JSON leaf types once, in the runtime

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
@@ -266,6 +266,11 @@ namespace Hardened.Shared.Runtime.Json
             "ranch.")]
         public static System.Text.Json.JsonSerializerOptions WithReflectionFallback(System.Text.Json.JsonSerializerOptions options) { }
     }
+    public sealed class PrimitiveJsonTypeInfoResolver : System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
+    {
+        public static readonly Hardened.Shared.Runtime.Json.PrimitiveJsonTypeInfoResolver Instance;
+        public System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type, System.Text.Json.JsonSerializerOptions options) { }
+    }
 }
 namespace Hardened.Shared.Runtime.Logging
 {

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotJsonSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotJsonSerializer.cs
@@ -19,6 +19,13 @@ public class AotJsonSerializer : IJsonSerializer {
             _serializerOptions.TypeInfoResolverChain.Add(resolver);
             _prettyOptions.TypeInfoResolverChain.Add(resolver);
         }
+
+        // Last, so a registered context still answers first for anything it knows. Without it the
+        // chain cannot answer typeof(string), and a generated resolver's every string property
+        // throws - the property infos resolve their converter by asking the options, which walks
+        // this chain. See PrimitiveJsonTypeInfoResolver.
+        _serializerOptions.TypeInfoResolverChain.Add(PrimitiveJsonTypeInfoResolver.Instance);
+        _prettyOptions.TypeInfoResolverChain.Add(PrimitiveJsonTypeInfoResolver.Instance);
     }
 
     public async Task<T> DeserializeAsync<T>(Stream jsonStream, CancellationToken cancellationToken = default) {

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotRequestDeserializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotRequestDeserializer.cs
@@ -49,11 +49,22 @@ public class AotRequestDeserializer : IRequestDeserializer {
                         _serializerOptions.Converters.Add(converter);
                     }
                 }
-
-        // Reflection last, and only where it is available - see WithReflectionFallback.
-        Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithReflectionFallback(_serializerOptions);
             }
         }
+
+        // Reflection last, and only where it is available - see WithReflectionFallback.
+        //
+        // This call used to sit inside the `resolver is JsonSerializerContext` branch above, nested
+        // in the loop. That put it two mistakes deep: it ran only when a resolver happened to be a
+        // JsonSerializerContext, and by then the chain was non-empty, so its `TypeInfoResolver is
+        // null` guard was already false. It could never install anything. Out here it runs once,
+        // after the chain is built, which is what the guard is written for - reflection only when
+        // nothing else was registered at all.
+        Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithReflectionFallback(_serializerOptions);
+
+        // After that call, because it is guarded on the chain being empty and this would fill it.
+        _serializerOptions.TypeInfoResolverChain.Add(
+            Hardened.Shared.Runtime.Json.PrimitiveJsonTypeInfoResolver.Instance);
     }
 
     public bool IsDefaultSerializer => true;

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
@@ -22,6 +22,10 @@ public class AotResponseSerializer : IResponseSerializer {
         foreach (var resolver in resolvers) {
             _serializerOptions.TypeInfoResolverChain.Add(resolver);
         }
+
+        // Last, so a registered context still answers first - see PrimitiveJsonTypeInfoResolver.
+        _serializerOptions.TypeInfoResolverChain.Add(
+            Hardened.Shared.Runtime.Json.PrimitiveJsonTypeInfoResolver.Instance);
     }
 
     public bool IsDefaultSerializer => true;

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/StreamingJsonResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/StreamingJsonResponseSerializer.cs
@@ -59,6 +59,10 @@ public class StreamingJsonResponseSerializer : IResponseSerializer {
         foreach (var resolver in resolvers) {
             _serializerOptions.TypeInfoResolverChain.Add(resolver);
         }
+
+        // Last, so a registered context still answers first - see PrimitiveJsonTypeInfoResolver.
+        _serializerOptions.TypeInfoResolverChain.Add(
+            Hardened.Shared.Runtime.Json.PrimitiveJsonTypeInfoResolver.Instance);
     }
 
     /// <summary>

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Json/PrimitiveJsonTypeInfoResolverTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Json/PrimitiveJsonTypeInfoResolverTests.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Shared.Runtime.Json;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Json;
+
+public class PrimitiveJsonTypeInfoResolverTests {
+
+    private static JsonSerializerOptions Options(params JsonConverter[] converters) {
+        var options = new JsonSerializerOptions();
+
+        foreach (var converter in converters) {
+            options.Converters.Add(converter);
+        }
+
+        options.TypeInfoResolverChain.Add(PrimitiveJsonTypeInfoResolver.Instance);
+
+        return options;
+    }
+
+    public static TheoryData<Type> LeafTypes() => new() {
+        typeof(string), typeof(bool), typeof(int), typeof(long), typeof(double),
+        typeof(DateTimeOffset), typeof(JsonElement), typeof(DateOnly), typeof(float),
+        typeof(uint), typeof(byte[]), typeof(decimal), typeof(Guid), typeof(DateTime),
+        typeof(TimeSpan), typeof(TimeOnly), typeof(byte), typeof(sbyte), typeof(short),
+        typeof(ushort), typeof(ulong), typeof(char), typeof(Uri), typeof(Version),
+        typeof(bool?), typeof(int?), typeof(long?), typeof(double?), typeof(DateTimeOffset?),
+        typeof(JsonElement?), typeof(DateOnly?), typeof(float?), typeof(uint?), typeof(decimal?),
+        typeof(Guid?), typeof(DateTime?), typeof(TimeSpan?), typeof(TimeOnly?), typeof(byte?),
+        typeof(sbyte?), typeof(short?), typeof(ushort?), typeof(ulong?), typeof(char?),
+    };
+
+    [Theory]
+    [MemberData(nameof(LeafTypes))]
+    public void GetTypeInfo_AnswersEveryLeafType(Type type) {
+        var info = PrimitiveJsonTypeInfoResolver.Instance.GetTypeInfo(type, Options());
+
+        Assert.NotNull(info);
+        Assert.Equal(type, info.Type);
+    }
+
+    [Fact]
+    public void GetTypeInfo_ReturnsNullForATypeItDoesNotOwn() {
+        Assert.Null(PrimitiveJsonTypeInfoResolver.Instance.GetTypeInfo(typeof(Uri[]), Options()));
+    }
+
+    /// <summary>
+    /// <c>object</c> is deliberately not answered: a type info for it would shadow the polymorphic
+    /// handling a generated resolver sets up on the base of a hierarchy.
+    /// </summary>
+    [Fact]
+    public void GetTypeInfo_DoesNotAnswerForObject() {
+        Assert.Null(PrimitiveJsonTypeInfoResolver.Instance.GetTypeInfo(typeof(object), Options()));
+    }
+
+    /// <summary>
+    /// The reason a property info can be created at all - it resolves its converter by asking the
+    /// options, which walks the chain, so a chain that cannot answer <c>typeof(string)</c> throws on
+    /// every string property rather than degrading.
+    /// </summary>
+    [Fact]
+    public void GetTypeInfo_SuppliesTheLeafMetadataAPropertyInfoResolves() {
+        var options = Options();
+
+        var info = JsonMetadataServices.CreateObjectInfo<Leaf>(options, new JsonObjectInfoValues<Leaf> {
+            ObjectWithParameterizedConstructorCreator = static args => new Leaf((string)args[0], (int?)args[1]),
+            PropertyMetadataInitializer = _ => new JsonPropertyInfo[] {
+                JsonMetadataServices.CreatePropertyInfo<string>(options, new JsonPropertyInfoValues<string> {
+                    IsProperty = true, IsPublic = true, DeclaringType = typeof(Leaf),
+                    PropertyName = "name", Getter = static o => ((Leaf)o).Name, Setter = null,
+                }),
+                JsonMetadataServices.CreatePropertyInfo<int?>(options, new JsonPropertyInfoValues<int?> {
+                    IsProperty = true, IsPublic = true, DeclaringType = typeof(Leaf),
+                    PropertyName = "count", Getter = static o => ((Leaf)o).Count, Setter = null,
+                }),
+            },
+            ConstructorParameterMetadataInitializer = static () => new JsonParameterInfoValues[] {
+                new() { Name = "name", ParameterType = typeof(string), Position = 0 },
+                new() { Name = "count", ParameterType = typeof(int?), Position = 1, DefaultValue = null },
+            },
+        });
+
+        Assert.Equal("""{"name":"a","count":2}""", JsonSerializer.Serialize(new Leaf("a", 2), info));
+        Assert.Equal(new Leaf("a", 2), JsonSerializer.Deserialize("""{"name":"a","count":2}""", info));
+    }
+
+    [Fact]
+    public void GetTypeInfo_PrefersARegisteredConverterOverTheBuiltInOne() {
+        var options = Options(new UnixSecondsDateTimeConverter());
+
+        var info = (JsonTypeInfo<DateTime>)options.GetTypeInfo(typeof(DateTime));
+
+        Assert.IsType<UnixSecondsDateTimeConverter>(info.Converter);
+        Assert.Equal("1755388800", JsonSerializer.Serialize(Timestamp, info));
+    }
+
+    [Fact]
+    public void GetTypeInfo_FallsBackToTheBuiltInConverterWhenNoneIsRegistered() {
+        var info = (JsonTypeInfo<DateTime>)Options().GetTypeInfo(typeof(DateTime));
+
+        Assert.Equal("\"2025-08-17T00:00:00Z\"", JsonSerializer.Serialize(Timestamp, info));
+    }
+
+    /// <summary>
+    /// <c>GetNullableConverter&lt;T&gt;</c> resolves the underlying converter through the options, so
+    /// the nullable form picks up a registered converter without the lookup the non-nullable form
+    /// needs.
+    /// </summary>
+    [Fact]
+    public void GetTypeInfo_RoutesTheNullableFormThroughARegisteredConverter() {
+        var options = Options(new UnixSecondsDateTimeConverter());
+
+        var info = (JsonTypeInfo<DateTime?>)options.GetTypeInfo(typeof(DateTime?));
+
+        Assert.Equal("1755388800", JsonSerializer.Serialize((DateTime?)Timestamp, info));
+    }
+
+    [Fact]
+    public void GetTypeInfo_PrefersAConverterAFactoryProduces() {
+        var options = Options(new ShoutingStringConverterFactory());
+
+        var info = (JsonTypeInfo<string>)options.GetTypeInfo(typeof(string));
+
+        Assert.Equal("\"ABC\"", JsonSerializer.Serialize("abc", info));
+    }
+
+    private static readonly DateTime Timestamp = new(2025, 8, 17, 0, 0, 0, DateTimeKind.Utc);
+
+    private record Leaf(string Name, int? Count);
+
+    private sealed class UnixSecondsDateTimeConverter : JsonConverter<DateTime> {
+        public override DateTime Read(ref Utf8JsonReader reader, Type type, JsonSerializerOptions options) =>
+            DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64()).UtcDateTime;
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options) =>
+            writer.WriteNumberValue(new DateTimeOffset(value, TimeSpan.Zero).ToUnixTimeSeconds());
+    }
+
+    private sealed class ShoutingStringConverterFactory : JsonConverterFactory {
+        public override bool CanConvert(Type type) => type == typeof(string);
+
+        public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options) =>
+            new ShoutingStringConverter();
+
+        private sealed class ShoutingStringConverter : JsonConverter<string> {
+            public override string Read(ref Utf8JsonReader reader, Type type, JsonSerializerOptions options) =>
+                reader.GetString() ?? "";
+
+            public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) =>
+                writer.WriteStringValue(value.ToUpperInvariant());
+        }
+    }
+}

--- a/src/Shared/Hardened.Shared.Runtime/Json/PrimitiveJsonTypeInfoResolver.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Json/PrimitiveJsonTypeInfoResolver.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Hardened.Shared.Runtime.Json;
+
+/// <summary>
+/// Metadata for the BCL leaf types every generated resolver's property infos bottom out in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>These entries are load-bearing, not a convenience.</b> A resolver chain is asked for far more
+/// than the types a specification declares. <c>JsonMetadataServices.CreatePropertyInfo&lt;T&gt;</c>
+/// carries no converter of its own - it resolves one when the type info is configured, by asking the
+/// options, which walks the chain. So serializing a record with one <c>string</c> property asks the
+/// chain for <c>string</c> as well as for the record. Nothing in System.Text.Json answers that
+/// implicitly: the only built-in resolver that would is <see cref="DefaultJsonTypeInfoResolver"/>,
+/// which is the reflection path this design exists to avoid. With no entry for <c>string</c> the
+/// chain returns null and every string property throws <c>NotSupportedException</c>.
+/// </para>
+/// <para>
+/// <b>They used to be emitted into every generated resolver.</b> One copy per specification file, in
+/// a chain that already holds one resolver per specification file - so N copies of a table that
+/// cannot vary, each a place for the set to drift. It lives here once instead. What stays generated
+/// is what is actually specification-specific: the schema types, their enums and choice types, and
+/// the collections whose element type is one of those.
+/// </para>
+/// <para>
+/// <b>The set is deliberately wider than the generator currently needs.</b> <c>TypeMapper</c> maps
+/// <c>uuid</c> to <c>string</c> and every <c>number</c> to <c>double</c> today, so <see cref="Guid"/>
+/// and <see cref="decimal"/> are unreachable from a specification. That is a fact about one switch
+/// expression, not about the format, and the failure when it changes is silent at build time and
+/// throws at run time on the first payload. Covering the leaf types the BCL has converters for costs
+/// one comparison each and removes the coupling.
+/// </para>
+/// <para>
+/// Registered last in the chain by the serializers, so a hand-written
+/// <see cref="JsonSerializerContext"/> that answers for one of these still wins.
+/// </para>
+/// </remarks>
+public sealed class PrimitiveJsonTypeInfoResolver : IJsonTypeInfoResolver {
+
+    /// <summary>
+    /// The chain holds this in several places at once and it carries no state, so there is one.
+    /// </summary>
+    public static readonly PrimitiveJsonTypeInfoResolver Instance = new();
+
+    private PrimitiveJsonTypeInfoResolver() { }
+
+    /// <summary>
+    /// A value type info bound to whichever converter the options actually want.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The generated resolvers passed <c>JsonMetadataServices.StringConverter</c> and friends
+    /// straight through, which pins the converter and silently discards a registered one:
+    /// an application that added a <c>JsonConverter&lt;DateTime&gt;</c> to
+    /// <see cref="JsonSerializerOptions.Converters"/> got ISO-8601 anyway, because
+    /// <c>CreateValueInfo</c> uses the converter it is handed and never consults the options.
+    /// <c>AotRequestDeserializer</c> makes that worse by going out of its way to copy converters
+    /// from the configured options and from every registered <see cref="JsonSerializerContext"/>
+    /// into the options it builds - all of which were then ignored for exactly these types.
+    /// </para>
+    /// <para>
+    /// Nullables did not have the bug and do not need the lookup: <c>GetNullableConverter&lt;T&gt;</c>
+    /// resolves the underlying converter through the options already, so a custom
+    /// <c>JsonConverter&lt;DateTime&gt;</c> reaches <c>DateTime?</c> on its own.
+    /// </para>
+    /// <para>
+    /// <see cref="JsonConverterFactory"/> is handled because that is what an unbounded generic
+    /// converter registers as, and a factory that claims the type is as much a deliberate
+    /// registration as a closed converter is.
+    /// </para>
+    /// </remarks>
+    private static JsonTypeInfo<T> Value<T>(JsonSerializerOptions options, JsonConverter<T> builtIn) =>
+        JsonMetadataServices.CreateValueInfo<T>(options, Converter(options, builtIn));
+
+    private static JsonConverter<T> Converter<T>(JsonSerializerOptions options, JsonConverter<T> builtIn) {
+        // Registration order, first match wins - the same rule System.Text.Json applies itself.
+        foreach (var converter in options.Converters) {
+            if (converter is JsonConverter<T> direct) {
+                return direct;
+            }
+
+            if (converter is JsonConverterFactory factory &&
+                factory.CanConvert(typeof(T)) &&
+                factory.CreateConverter(typeof(T), options) is JsonConverter<T> created) {
+                return created;
+            }
+        }
+
+        return builtIn;
+    }
+
+    public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options) {
+        // Ordered by how often a description actually produces the type, because the chain is walked
+        // linearly - though only once per type per options instance, since JsonSerializerOptions
+        // caches what the chain returns. This is a cold-start cost, not a per-request one.
+        if (type == typeof(string)) return Value(options, JsonMetadataServices.StringConverter);
+        if (type == typeof(bool)) return Value(options, JsonMetadataServices.BooleanConverter);
+        if (type == typeof(int)) return Value(options, JsonMetadataServices.Int32Converter);
+        if (type == typeof(long)) return Value(options, JsonMetadataServices.Int64Converter);
+        if (type == typeof(double)) return Value(options, JsonMetadataServices.DoubleConverter);
+        if (type == typeof(DateTimeOffset)) return Value(options, JsonMetadataServices.DateTimeOffsetConverter);
+        if (type == typeof(JsonElement)) return Value(options, JsonMetadataServices.JsonElementConverter);
+        if (type == typeof(DateOnly)) return Value(options, JsonMetadataServices.DateOnlyConverter);
+        if (type == typeof(float)) return Value(options, JsonMetadataServices.SingleConverter);
+        if (type == typeof(uint)) return Value(options, JsonMetadataServices.UInt32Converter);
+        if (type == typeof(byte[])) return Value(options, JsonMetadataServices.ByteArrayConverter);
+        if (type == typeof(decimal)) return Value(options, JsonMetadataServices.DecimalConverter);
+        if (type == typeof(Guid)) return Value(options, JsonMetadataServices.GuidConverter);
+        if (type == typeof(DateTime)) return Value(options, JsonMetadataServices.DateTimeConverter);
+        if (type == typeof(TimeSpan)) return Value(options, JsonMetadataServices.TimeSpanConverter);
+        if (type == typeof(TimeOnly)) return Value(options, JsonMetadataServices.TimeOnlyConverter);
+        if (type == typeof(byte)) return Value(options, JsonMetadataServices.ByteConverter);
+        if (type == typeof(sbyte)) return Value(options, JsonMetadataServices.SByteConverter);
+        if (type == typeof(short)) return Value(options, JsonMetadataServices.Int16Converter);
+        if (type == typeof(ushort)) return Value(options, JsonMetadataServices.UInt16Converter);
+        if (type == typeof(ulong)) return Value(options, JsonMetadataServices.UInt64Converter);
+        if (type == typeof(char)) return Value(options, JsonMetadataServices.CharConverter);
+        if (type == typeof(Uri)) return Value(options, JsonMetadataServices.UriConverter);
+        if (type == typeof(Version)) return Value(options, JsonMetadataServices.VersionConverter);
+
+        // Every value type above, as T?. An optional property of one is what the generated property
+        // info asks for by name, so a missing entry here is not a degraded answer - it is null, and
+        // the payload cannot be read at all.
+        if (type == typeof(bool?)) return Nullable<bool>(options);
+        if (type == typeof(int?)) return Nullable<int>(options);
+        if (type == typeof(long?)) return Nullable<long>(options);
+        if (type == typeof(double?)) return Nullable<double>(options);
+        if (type == typeof(DateTimeOffset?)) return Nullable<DateTimeOffset>(options);
+        if (type == typeof(JsonElement?)) return Nullable<JsonElement>(options);
+        if (type == typeof(DateOnly?)) return Nullable<DateOnly>(options);
+        if (type == typeof(float?)) return Nullable<float>(options);
+        if (type == typeof(uint?)) return Nullable<uint>(options);
+        if (type == typeof(decimal?)) return Nullable<decimal>(options);
+        if (type == typeof(Guid?)) return Nullable<Guid>(options);
+        if (type == typeof(DateTime?)) return Nullable<DateTime>(options);
+        if (type == typeof(TimeSpan?)) return Nullable<TimeSpan>(options);
+        if (type == typeof(TimeOnly?)) return Nullable<TimeOnly>(options);
+        if (type == typeof(byte?)) return Nullable<byte>(options);
+        if (type == typeof(sbyte?)) return Nullable<sbyte>(options);
+        if (type == typeof(short?)) return Nullable<short>(options);
+        if (type == typeof(ushort?)) return Nullable<ushort>(options);
+        if (type == typeof(ulong?)) return Nullable<ulong>(options);
+        if (type == typeof(char?)) return Nullable<char>(options);
+
+        return null;
+    }
+
+    private static JsonTypeInfo<T?> Nullable<T>(JsonSerializerOptions options) where T : struct =>
+        JsonMetadataServices.CreateValueInfo<T?>(
+            options, JsonMetadataServices.GetNullableConverter<T>(options));
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -143,41 +143,19 @@ internal static class JsonTypeInfoEmitter {
             }
         }
 
-        EmitPrimitiveTypeEntries(sb);
         EmitCollectionTypeEntries(sb, schemas, modelsNamespace);
 
+        // No primitive entries. The BCL leaf types every property info bottoms out in - string, int,
+        // DateTimeOffset, their nullable forms - are answered once by
+        // Hardened.Shared.Runtime.Json.PrimitiveJsonTypeInfoResolver, which the serializers put at
+        // the end of the chain. They are still required (a chain that cannot answer typeof(string)
+        // throws on every string property); they were simply emitted once per specification file
+        // into a chain that already holds one resolver per specification file, and each copy pinned
+        // JsonMetadataServices.StringConverter and friends in a way that silently discarded a
+        // converter the application had registered.
         sb.AppendLine("        return null;");
 
         AddStatements(method, sb);
-    }
-
-    private static void EmitPrimitiveTypeEntries(StringBuilder sb) {
-        sb.AppendLine();
-        sb.AppendLine("        // Primitive types");
-        sb.AppendLine("        if (type == typeof(string)) return JsonMetadataServices.CreateValueInfo<string>(options, JsonMetadataServices.StringConverter);");
-        sb.AppendLine("        if (type == typeof(bool)) return JsonMetadataServices.CreateValueInfo<bool>(options, JsonMetadataServices.BooleanConverter);");
-        sb.AppendLine("        if (type == typeof(int)) return JsonMetadataServices.CreateValueInfo<int>(options, JsonMetadataServices.Int32Converter);");
-        sb.AppendLine("        if (type == typeof(uint)) return JsonMetadataServices.CreateValueInfo<uint>(options, JsonMetadataServices.UInt32Converter);");
-        sb.AppendLine("        if (type == typeof(long)) return JsonMetadataServices.CreateValueInfo<long>(options, JsonMetadataServices.Int64Converter);");
-        sb.AppendLine("        if (type == typeof(float)) return JsonMetadataServices.CreateValueInfo<float>(options, JsonMetadataServices.SingleConverter);");
-        sb.AppendLine("        if (type == typeof(double)) return JsonMetadataServices.CreateValueInfo<double>(options, JsonMetadataServices.DoubleConverter);");
-        sb.AppendLine("        if (type == typeof(global::System.DateTime)) return JsonMetadataServices.CreateValueInfo<global::System.DateTime>(options, JsonMetadataServices.DateTimeConverter);");
-        sb.AppendLine("        if (type == typeof(global::System.DateTimeOffset)) return JsonMetadataServices.CreateValueInfo<global::System.DateTimeOffset>(options, JsonMetadataServices.DateTimeOffsetConverter);");
-        sb.AppendLine("        if (type == typeof(global::System.DateOnly)) return JsonMetadataServices.CreateValueInfo<global::System.DateOnly>(options, JsonMetadataServices.DateOnlyConverter);");
-        sb.AppendLine("        if (type == typeof(byte[])) return JsonMetadataServices.CreateValueInfo<byte[]>(options, JsonMetadataServices.ByteArrayConverter);");
-        sb.AppendLine("        if (type == typeof(global::System.Text.Json.JsonElement)) return JsonMetadataServices.CreateValueInfo<global::System.Text.Json.JsonElement>(options, JsonMetadataServices.JsonElementConverter);");
-        sb.AppendLine();
-        sb.AppendLine("        // Nullable value types");
-        sb.AppendLine("        if (type == typeof(bool?)) return JsonMetadataServices.CreateValueInfo<bool?>(options, JsonMetadataServices.GetNullableConverter<bool>(options));");
-        sb.AppendLine("        if (type == typeof(int?)) return JsonMetadataServices.CreateValueInfo<int?>(options, JsonMetadataServices.GetNullableConverter<int>(options));");
-        sb.AppendLine("        if (type == typeof(uint?)) return JsonMetadataServices.CreateValueInfo<uint?>(options, JsonMetadataServices.GetNullableConverter<uint>(options));");
-        sb.AppendLine("        if (type == typeof(long?)) return JsonMetadataServices.CreateValueInfo<long?>(options, JsonMetadataServices.GetNullableConverter<long>(options));");
-        sb.AppendLine("        if (type == typeof(float?)) return JsonMetadataServices.CreateValueInfo<float?>(options, JsonMetadataServices.GetNullableConverter<float>(options));");
-        sb.AppendLine("        if (type == typeof(double?)) return JsonMetadataServices.CreateValueInfo<double?>(options, JsonMetadataServices.GetNullableConverter<double>(options));");
-        sb.AppendLine("        if (type == typeof(global::System.DateTime?)) return JsonMetadataServices.CreateValueInfo<global::System.DateTime?>(options, JsonMetadataServices.GetNullableConverter<global::System.DateTime>(options));");
-        sb.AppendLine("        if (type == typeof(global::System.DateTimeOffset?)) return JsonMetadataServices.CreateValueInfo<global::System.DateTimeOffset?>(options, JsonMetadataServices.GetNullableConverter<global::System.DateTimeOffset>(options));");
-        sb.AppendLine("        if (type == typeof(global::System.DateOnly?)) return JsonMetadataServices.CreateValueInfo<global::System.DateOnly?>(options, JsonMetadataServices.GetNullableConverter<global::System.DateOnly>(options));");
-        sb.AppendLine("        if (type == typeof(global::System.Text.Json.JsonElement?)) return JsonMetadataServices.CreateValueInfo<global::System.Text.Json.JsonElement?>(options, JsonMetadataServices.GetNullableConverter<global::System.Text.Json.JsonElement>(options));");
     }
 
     private static void AddObjectTypeInfo(

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/JsonTypeInfoEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/JsonTypeInfoEmitterTests.cs
@@ -620,8 +620,19 @@ public class JsonTypeInfoEmitterTests {
         Assert.Contains("(global::Test.Api.Models.Address?)args[1]", result);
     }
 
+    /// <summary>
+    /// The BCL leaf types are answered by <c>PrimitiveJsonTypeInfoResolver</c> in the runtime, not by
+    /// each generated resolver.
+    /// </summary>
+    /// <remarks>
+    /// One copy per specification file, in a chain that already holds one resolver per specification
+    /// file, is a table that cannot vary duplicated N times - and every copy pinned
+    /// <c>JsonMetadataServices.StringConverter</c> and friends, which discards a converter the
+    /// application registered. Emitting them again would not be wrong so much as unreachable: the
+    /// runtime resolver is last in the chain, so a duplicate here only shadows it.
+    /// </remarks>
     [Fact]
-    public void Emit_IncludesPrimitiveTypeEntries() {
+    public void Emit_OmitsPrimitiveTypeEntries() {
         var schemas = new List<SchemaModel> {
             new() {
                 Name = "Minimal",
@@ -634,40 +645,26 @@ public class JsonTypeInfoEmitterTests {
 
         var result = EmitterHarness.JsonTypeInfo(schemas, "petstore");
 
-        // Primitive types
-        Assert.Contains("if (type == typeof(string)) return JsonMetadataServices.CreateValueInfo<string>(options, JsonMetadataServices.StringConverter);", result);
-        Assert.Contains("if (type == typeof(bool))", result);
-        Assert.Contains("if (type == typeof(int))", result);
-        Assert.Contains("if (type == typeof(long))", result);
-        Assert.Contains("if (type == typeof(float))", result);
-        Assert.Contains("if (type == typeof(double))", result);
-        Assert.Contains("if (type == typeof(global::System.DateTime))", result);
-        Assert.Contains("if (type == typeof(global::System.DateOnly))", result);
-        Assert.Contains("if (type == typeof(byte[]))", result);
-        Assert.Contains("BooleanConverter", result);
-        Assert.Contains("Int32Converter", result);
-        Assert.Contains("Int64Converter", result);
-        Assert.Contains("SingleConverter", result);
-        Assert.Contains("DoubleConverter", result);
-        Assert.Contains("DateTimeConverter", result);
-        Assert.Contains("DateOnlyConverter", result);
-        Assert.Contains("ByteArrayConverter", result);
+        Assert.DoesNotContain("if (type == typeof(string))", result);
+        Assert.DoesNotContain("if (type == typeof(bool))", result);
+        Assert.DoesNotContain("if (type == typeof(int))", result);
+        Assert.DoesNotContain("if (type == typeof(long))", result);
+        Assert.DoesNotContain("if (type == typeof(float))", result);
+        Assert.DoesNotContain("if (type == typeof(double))", result);
+        Assert.DoesNotContain("if (type == typeof(byte[]))", result);
+        Assert.DoesNotContain("StringConverter", result);
+        Assert.DoesNotContain("BooleanConverter", result);
+        Assert.DoesNotContain("Int32Converter", result);
+        Assert.DoesNotContain("ByteArrayConverter", result);
 
-        // Nullable value types
-        Assert.Contains("if (type == typeof(bool?))", result);
-        Assert.Contains("if (type == typeof(int?))", result);
-        Assert.Contains("if (type == typeof(long?))", result);
-        Assert.Contains("if (type == typeof(float?))", result);
-        Assert.Contains("if (type == typeof(double?))", result);
-        Assert.Contains("if (type == typeof(global::System.DateTime?))", result);
-        Assert.Contains("if (type == typeof(global::System.DateOnly?))", result);
-        Assert.Contains("GetNullableConverter<bool>", result);
-        Assert.Contains("GetNullableConverter<int>", result);
-        Assert.Contains("GetNullableConverter<long>", result);
-        Assert.Contains("GetNullableConverter<float>", result);
-        Assert.Contains("GetNullableConverter<double>", result);
-        Assert.Contains("GetNullableConverter<global::System.DateTime>", result);
-        Assert.Contains("GetNullableConverter<global::System.DateOnly>", result);
+        Assert.DoesNotContain("if (type == typeof(bool?))", result);
+        Assert.DoesNotContain("if (type == typeof(int?))", result);
+        Assert.DoesNotContain("GetNullableConverter<bool>", result);
+        Assert.DoesNotContain("GetNullableConverter<int>", result);
+
+        // What the resolver is still for: its own schema types, and the fallthrough.
+        Assert.Contains("if (type == typeof(global::Test.Api.Models.Minimal)) return CreateMinimalTypeInfo(options);", result);
+        Assert.Contains("return null;", result);
 
         // using directive
         Assert.Contains("using System.Text.Json.Serialization;", result);
@@ -797,8 +794,12 @@ public class JsonTypeInfoEmitterTests {
         Assert.Contains("if (type == typeof(global::System.Collections.Generic.List<global::System.Text.Json.JsonElement>))", result);
     }
 
+    /// <summary>
+    /// <c>JsonElement</c> is what an unmapped schema falls to, so it is the leaf type most likely to
+    /// appear without anyone asking for it - and it moved to the runtime resolver with the rest.
+    /// </summary>
     [Fact]
-    public void Emit_IncludesJsonElementPrimitiveEntries() {
+    public void Emit_OmitsJsonElementPrimitiveEntries() {
         var schemas = new List<SchemaModel> {
             new() {
                 Name = "Minimal",
@@ -811,8 +812,9 @@ public class JsonTypeInfoEmitterTests {
 
         var result = EmitterHarness.JsonTypeInfo(schemas, "petstore");
 
-        Assert.Contains("if (type == typeof(global::System.Text.Json.JsonElement)) return JsonMetadataServices.CreateValueInfo<global::System.Text.Json.JsonElement>(options, JsonMetadataServices.JsonElementConverter);", result);
-        Assert.Contains("if (type == typeof(global::System.Text.Json.JsonElement?)) return JsonMetadataServices.CreateValueInfo<global::System.Text.Json.JsonElement?>(options, JsonMetadataServices.GetNullableConverter<global::System.Text.Json.JsonElement>(options));", result);
+        Assert.DoesNotContain("if (type == typeof(global::System.Text.Json.JsonElement))", result);
+        Assert.DoesNotContain("if (type == typeof(global::System.Text.Json.JsonElement?))", result);
+        Assert.DoesNotContain("JsonElementConverter", result);
     }
 
     [Fact]


### PR DESCRIPTION
Every generated `IJsonTypeInfoResolver` carried its own copy of a table of BCL primitives — `string`, `int`, `DateTimeOffset`, their nullable forms. One copy per specification file, in a chain that already holds one resolver per specification file.

## The entries are load-bearing, not redundant

`JsonMetadataServices.CreatePropertyInfo<T>` carries no converter of its own; it resolves one when the type info is configured, by asking the options, which walks the resolver chain. Serializing a record with one `string` property asks the chain for `string` as well as for the record:

```
asked for: Pet, System.String, System.Int32, System.Nullable`1[System.Boolean],
           System.Boolean, System.Collections.Generic.List`1[System.String]
```

Nothing in System.Text.Json answers that implicitly — the only built-in resolver that would is `DefaultJsonTypeInfoResolver`, the reflection path this design exists to avoid. Without an entry for `string`, every string property throws `NotSupportedException`.

What was wrong was where they lived, and what each copy did to converters.

## Hardcoded converters silently discarded registered ones

`CreateValueInfo(options, JsonMetadataServices.StringConverter)` pins the converter. An application that added a `JsonConverter<DateTime>` to `JsonSerializerOptions.Converters` got ISO-8601 anyway:

```
resolved converter : DateTimeConverter          <- built-in wins
serialized         : "2026-08-17T00:00:00Z"     <- wanted 1786924800
```

`AotRequestDeserializer` makes that sharper: it goes out of its way to copy converters from the configured options and from every registered `JsonSerializerContext` into the options it builds — all of which were then ignored for exactly these types.

`PrimitiveJsonTypeInfoResolver` consults `options.Converters` first, factories included, and falls back to the built-in. Nullables never had the bug: `GetNullableConverter<T>` resolves the underlying converter through the options already.

## The set is wider than the generator can currently reach

`TypeMapper` maps `uuid` to `string` and every `number` to `double`, so `Guid` and `decimal` are unreachable from a specification today. That is a fact about one switch expression, not about the format, and the failure when it changes is silent at build time and throws at run time on the first payload. Covering the leaf types the BCL has converters for costs one comparison each and removes the coupling.

## Also fixed

`WithReflectionFallback` in `AotRequestDeserializer` sat inside the `resolver is JsonSerializerContext` branch, nested in the resolver loop. It ran only when a resolver happened to be a context, and by then the chain was non-empty, so its `TypeInfoResolver is null` guard was already false — it could never install anything. It now runs once after the chain is built, which is what the guard is written for, with the primitive resolver added after it so the guard still sees an empty chain when nothing was registered.

## Deliberately not changed

Collections stay generated. Those are specification-driven and exact; moving `List<T>`/`Dictionary<string,T>` to the runtime would put generic instantiations in every AOT binary for element types the specification never mentions.

## Lookup cost

Not a concern either way. `JsonSerializerOptions` caches what the chain returns, so a resolver is consulted once per type per options instance — 10,000 round trips after the first cost zero further calls. The linear walk is a cold-start cost, measured at ~0.3 ns per comparison (1000 entries, full miss: ~305 ns, once).

The resolver goes last in every chain, so a hand-written `JsonSerializerContext` still answers first for anything it knows.

## Verification

Full solution build and test: 19/19 suites, 2946 tests, exit 0, no new warnings. The generated petstore resolver is now just its five schema types and `return null;`, and the OpenAPI integration tests still pass — which is what shows the runtime resolver carries the primitives end to end rather than something falling back to reflection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6ge5acbRQNiF66vZnKMZB