### PR TITLE
Stop apt-getting a symlink before every AOT publish

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -52,13 +52,33 @@ jobs:
       # that works today and stops working once something is trimmed away. It is the MSBuild switch
       # rather than TreatWarningsAsErrors, which Directory.Build.props already sets for CI - that
       # one is the C# compiler's and does not cover what ILC reports.
+      #
+      # No apt-get. ILC needs a C compiler and zlib, and the runner image already has both -
+      # zlib1g-dev reported "already the newest version" on every run, and the only package apt
+      # ever installed was the unversioned `clang` meta-package, a symlink whose payload clang-18
+      # was already present. So the step bought an alias at the price of a network round trip to
+      # the Ubuntu mirrors, and on 2026-08-18 that round trip hung: `apt-get update` stalled after
+      # noble-security InRelease and the job was cancelled 25 minutes later, on a step that
+      # normally takes 24 seconds.
+      #
+      # Discovered rather than pinned, because the image's clang major version moves and a pinned
+      # clang-18 becomes a build break the day it does.
       - name: Publish the integration application with Native AOT
         run: |
-          sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+          # The alias if the image has one, otherwise the highest versioned clang on it.
+          CLANG="$(command -v clang || ls /usr/bin/clang-[0-9]* 2>/dev/null | sort -V | tail -1)"
+
+          if [ -z "$CLANG" ]; then
+            echo "::error::No clang on the runner image, and this step no longer installs one."
+            exit 1
+          fi
+
+          echo "using $CLANG ($("$CLANG" --version | head -1))"
 
           dotnet publish src/IntegrationTests/Aot/Hardened.IntegrationTests.Aot.SUT/Hardened.IntegrationTests.Aot.SUT.csproj \
             --configuration Release \
             --runtime linux-x64 \
+            -p:CppCompilerAndLinker="$CLANG" \
             -p:ContinuousIntegrationBuild=true \
             -warnaserror
 


### PR DESCRIPTION
## What happened

PR #135's CI hung for 25 minutes and was cancelled. Not on ILC — on the first line of the AOT step:

```
sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
```

`apt-get update` stalled after `noble-security InRelease` and never returned. The step's normal duration is **24 seconds**.

## Nothing was being installed

From a successful run's log:

```
zlib1g-dev is already the newest version (1:1.3.dfsg-3.1ubuntu2.1).
0 upgraded, 1 newly installed, 0 to remove and 12 not upgraded.
Setting up clang (1:18.0-59~exp2) ...
```

zlib was already there. The single "newly installed" package was the **unversioned `clang` meta-package** — a thin alias whose payload, `clang-18`, was already on the image, or apt would have installed that too.

So the step contacted the Ubuntu mirrors on every run to obtain a symlink, and that made a package mirror a hard dependency of the build.

## The fix

ILC takes the compiler as an MSBuild property, so the alias is unnecessary:

```bash
CLANG="$(command -v clang || ls /usr/bin/clang-[0-9]* 2>/dev/null | sort -V | tail -1)"
dotnet publish … -p:CppCompilerAndLinker="$CLANG" …
```

**Discovered rather than pinned.** `-p:CppCompilerAndLinker=clang-18` would work today and become a build break the day the runner image moves to clang-19. This takes the alias when the image provides one and the highest `/usr/bin/clang-N` otherwise, and fails with a clear message if there is somehow neither.

This removes the only `apt-get` in CI, and with it the only step that required a package mirror to be reachable.

## Not related to AOT being slow

Worth recording, because the natural reading of a 25-minute AOT step is that AOT is slow. It is not, here: ILC publishes this application in ~24 seconds, and the whole workflow runs in about three minutes. Cross-architecture emulation is not involved either — the publish is `linux-x64` on an x64 runner, so there is no QEMU in the path. If ARM64 is wanted later (Graviton, per `AMZ-FEATURE-REVIEW` item 14), the answer is a native `ubuntu-24.04-arm` runner rather than emulating ILC under QEMU, which would be genuinely slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8FnJTcrhPZGZtoZxvzaL6