### PR TITLE
Do not read the body of a streamed request already refused

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/AsyncEnumerableIoFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/AsyncEnumerableIoFilterTests.cs
@@ -1,9 +1,11 @@
 using System.Text;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Logging;
+using Hardened.Requests.Abstract.Metrics;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.Filters;
 using Hardened.Requests.Runtime.Tests.Support;
+using Hardened.Shared.Runtime.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
@@ -203,6 +205,71 @@ public class AsyncEnumerableIoFilterTests {
         Assert.False(handlerRan);
 
         logger.Received(1).RequestParameterBindFailed(context, failure);
+    }
+
+    /// <summary>
+    /// A request that something ahead of this filter already refused does not have its body read.
+    ///
+    /// <para>
+    /// This is the streaming route's half of the rule <c>IoFilter</c> follows. A requirement over
+    /// grants alone is settled before serialization so that a request presenting no credential
+    /// never costs a large deserialization before it is rejected; binding here would hand that
+    /// position back for the routes most likely to be carrying a large body.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task ARequestAlreadyRefusedIsNeitherBoundNorStreamed() {
+        var log = new List<string>();
+        var context = Pipeline.Context();
+        var bound = false;
+
+        context.Response.ExceptionValue = new InvalidOperationException("refused upstream");
+
+        var filter = new AsyncEnumerableIoFilter<string>(
+            _ => {
+                bound = true;
+
+                return Task.FromResult(EmptyParameters.Instance);
+            },
+            _ => {
+                log.Add("serialize");
+
+                return Task.CompletedTask;
+            },
+            null);
+
+        await Pipeline.Chain(context, filter,
+            new Pipeline.Inline(c => {
+                log.Add("handler");
+
+                c.Context.Response.ResponseValue = Items("never-written");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.False(bound);
+        Assert.DoesNotContain("handler", log);
+
+        // Still serialized, so the refusal reaches the caller rather than dying in the pipeline.
+        Assert.Contains("serialize", log);
+    }
+
+    /// <summary>
+    /// A bind that never happened is not measured. Recording the duration anyway would put a
+    /// near-zero on the histogram for every refused request, which reads as a very fast
+    /// deserialization rather than as none - and refused requests are exactly the population you
+    /// would go to that histogram to explain.
+    /// </summary>
+    [Fact]
+    public async Task ARequestAlreadyRefusedRecordsNoBindDuration() {
+        var metrics = Substitute.For<IMetricLogger>();
+        var context = Pipeline.Context(metrics: metrics);
+
+        context.Response.ExceptionValue = new InvalidOperationException("refused upstream");
+
+        await Pipeline.Chain(context, Filter<string>()).Next();
+
+        metrics.DidNotReceive().Record(RequestMetrics.ParameterBindDuration, Arg.Any<double>());
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Support/Pipeline.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Support/Pipeline.cs
@@ -3,6 +3,7 @@ using Hardened.Requests.Abstract.Logging;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.QueryString;
 using Hardened.Requests.Testing;
+using Hardened.Shared.Runtime.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -30,13 +31,19 @@ public static class Pipeline {
     /// <c>TestContext.Current.CancellationToken</c>. A test that needs a cancellable context builds
     /// one directly - see <see cref="Cancellable"/>.
     /// </remarks>
+    /// <param name="metrics">
+    /// The sink the pipeline records into. Omitted by almost every test, which does not care and
+    /// gets the null sink; supplied by the few asserting what a filter measured - or, as often,
+    /// that it measured nothing.
+    /// </param>
     public static IExecutionContext Context(
         string method = "GET",
         string path = "/",
         string? accept = "application/json",
         byte[]? body = null,
-        Action<ServiceCollection>? configureServices = null) {
-        return Build(method, path, accept, body, configureServices, CancellationToken.None);
+        Action<ServiceCollection>? configureServices = null,
+        IMetricLogger? metrics = null) {
+        return Build(method, path, accept, body, configureServices, CancellationToken.None, metrics);
     }
 
     /// <summary>
@@ -52,7 +59,7 @@ public static class Pipeline {
         string path = "/",
         byte[]? body = null,
         Action<ServiceCollection>? configureServices = null) {
-        return Build(method, path, "application/json", body, configureServices, cancellationToken);
+        return Build(method, path, "application/json", body, configureServices, cancellationToken, null);
     }
 
     private static IExecutionContext Build(
@@ -61,7 +68,8 @@ public static class Pipeline {
         string? accept,
         byte[]? body,
         Action<ServiceCollection>? configureServices,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken,
+        IMetricLogger? metrics) {
 
         var services = new ServiceCollection();
 
@@ -82,7 +90,8 @@ public static class Pipeline {
             Substitute.For<IKnownServices>(),
             request,
             new TestExecutionResponse(new MemoryStream()),
-            cancellationToken);
+            cancellationToken,
+            metrics);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
@@ -31,22 +31,37 @@ public class AsyncEnumerableIoFilter<TItem> : IExecutionFilter {
 
     public async Task Execute(IExecutionChain chain) {
         var context = chain.Context;
-        var bindParameterStartTimestamp = MachineTimestamp.Now;
 
-        try {
-            if (context.Request.Parameters == null) {
-                context.Request.Parameters = await _deserializeRequest(chain.Context);
+        // A request that is already decided does not have its body read, for the same reason it is
+        // not read in IoFilter: a requirement settled over grants alone refuses before serialization
+        // precisely so that a request presenting no credential does not cost a 10 MB deserialization
+        // before it is rejected. Binding here would hand that position straight back.
+        //
+        // A streamed route is where it matters most. The body is read whole either way - streaming
+        // describes the response, not the request - so the refused request pays the same price here
+        // as anywhere else, and the routes carrying large uploads are disproportionately the ones
+        // that stream their answers back.
+        //
+        // No bind duration is recorded either, because no bind was attempted - a zero would read as
+        // a very fast deserialization rather than none.
+        if (context.Response.ExceptionValue == null) {
+            var bindParameterStartTimestamp = MachineTimestamp.Now;
+
+            try {
+                if (context.Request.Parameters == null) {
+                    context.Request.Parameters = await _deserializeRequest(chain.Context);
+                }
             }
-        }
-        catch (Exception exp) {
-            chain.Context.RequestServices.GetRequiredService<IRequestLogger>()
-                .RequestParameterBindFailed(chain.Context, exp);
+            catch (Exception exp) {
+                chain.Context.RequestServices.GetRequiredService<IRequestLogger>()
+                    .RequestParameterBindFailed(chain.Context, exp);
 
-            chain.Context.Response.ExceptionValue = exp;
-        }
-        finally {
-            context.RequestMetrics.Record(RequestMetrics.ParameterBindDuration,
-                bindParameterStartTimestamp.GetElapsedMilliseconds());
+                chain.Context.Response.ExceptionValue = exp;
+            }
+            finally {
+                context.RequestMetrics.Record(RequestMetrics.ParameterBindDuration,
+                    bindParameterStartTimestamp.GetElapsedMilliseconds());
+            }
         }
 
         if (chain.Context.Response.ExceptionValue == null) {


### PR DESCRIPTION
Authored 2026-08-17 in another session; it landed on an unrelated branch while several sessions shared one checkout, so it is being brought over on a clean branch. Unchanged from the original commit.

## The bug

`IoFilter` guards its parameter bind behind `ExceptionValue == null`. The comment there explains why: a requirement settled over grants alone refuses **before** serialization, precisely so a request presenting no credential does not cost a 10 MB deserialization before it is rejected.

`AsyncEnumerableIoFilter` was written from the same shape and never grew the guard, so streaming routes bound unconditionally and paid exactly the cost the guard exists to avoid.

**A streamed route is the worst place to be missing it.** Streaming describes the *response*, not the request — the refused request's body is read whole either way — and the routes carrying large uploads are disproportionately the ones that stream their answers back.

## The metric, too

The bind timestamp moves inside the guard. Left outside, the `finally` recorded a near-zero `ParameterBindDuration` for every refused request, which reads on the histogram as a very fast deserialization rather than as none — and refused requests are the population you would go to that histogram to explain.

## Tests

`Pipeline.Context` grows an optional metric sink so a test can assert the **absence** of a recording, not just the presence of one.

Verified standalone: `Hardened.Requests.Runtime.Tests` — 645 tests, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKTxo2WLwzvTmJvBCmckVJ