### PR TITLE
Make the six ranked constraints real: arguments and chains

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
@@ -309,7 +309,14 @@ namespace Hardened.Web.Runtime.Routing
         public static bool IsGuid(System.ReadOnlySpan<char> value) { }
         public static bool IsHex(System.ReadOnlySpan<char> value) { }
         public static bool IsInt(System.ReadOnlySpan<char> value) { }
+        public static bool IsLength(System.ReadOnlySpan<char> value, int length) { }
+        public static bool IsLength(System.ReadOnlySpan<char> value, int min, int max) { }
         public static bool IsLong(System.ReadOnlySpan<char> value) { }
+        public static bool IsMax(System.ReadOnlySpan<char> value, long max) { }
+        public static bool IsMaxLength(System.ReadOnlySpan<char> value, int max) { }
+        public static bool IsMin(System.ReadOnlySpan<char> value, long min) { }
+        public static bool IsMinLength(System.ReadOnlySpan<char> value, int min) { }
+        public static bool IsRange(System.ReadOnlySpan<char> value, long min, long max) { }
         public static bool IsSlug(System.ReadOnlySpan<char> value) { }
     }
 }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
 using CSharpAuthor;
 using static CSharpAuthor.SyntaxHelpers;
 using Hardened.Idl.Models;
@@ -546,13 +548,45 @@ internal static class SpecRoutingTableGenerator {
             return null;
         }
 
-        var test = RouteConstraintFacts.Test(constraint!);
+        var terms = RouteConstraintFacts.Terms(constraint!);
 
-        // Null only for a name no built-in has, which the diagnostic above has already reported.
-        // Emitting a call to nothing would bury that under a CS0103.
-        return test == null
-            ? null
-            : CodeOutputComponent.Get((negate ? "!" : "") + test + "(" + value + ")");
+        if (terms == null) {
+            return null;
+        }
+
+        // A chain is a conjunction, short-circuiting left to right.
+        var calls = new List<string>();
+
+        foreach (var term in terms) {
+            var test = RouteConstraintFacts.Call(term);
+
+            // Null only for a name no built-in has, or one used at an arity it does not have - both
+            // already reported. Emitting a call to nothing would bury that under a CS0103.
+            if (test == null) {
+                return null;
+            }
+
+            var arguments = new StringBuilder();
+
+            foreach (var argument in term.Arguments) {
+                arguments.Append(", ").Append(argument.ToString(CultureInfo.InvariantCulture));
+            }
+
+            calls.Add(test + "(" + value + arguments + ")");
+        }
+
+        if (calls.Count == 0) {
+            return null;
+        }
+
+        var conjunction = string.Join(" && ", calls);
+
+        // Parentheses only where they change the meaning, as in the attribute-routed twin.
+        if (calls.Count == 1) {
+            return CodeOutputComponent.Get((negate ? "!" : "") + conjunction);
+        }
+
+        return CodeOutputComponent.Get((negate ? "!" : "") + "(" + conjunction + ")");
     }
 
     private static void GenerateWildCardLeafNode(

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecRoutingTableGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecRoutingTableGeneratorTests.cs
@@ -280,6 +280,69 @@ public class SpecRoutingTableGeneratorTests {
         Assert.Contains("currentIndex > index", result);
     }
 
+    /// <summary>A handler whose path carries a parameterised constraint and a chained one.</summary>
+    private static List<RequestHandlerModel> CreateChainedHandlers(string constraint) {
+        var serviceType = TypeDefinition.Get("Test.Api.Services", "IPetService");
+
+        return new List<RequestHandlerModel> {
+            new(new RequestHandlerNameModel("/pets/{petId:" + constraint + "}", "GET"),
+                serviceType, "GetPet",
+                TypeDefinition.Get("Test.Api.Generated", "PetController_GetPet"),
+                Array.Empty<RequestParameterInformation>(),
+                new ResponseInformationModel { IsAsync = true },
+                Array.Empty<AttributeModel>())
+        };
+    }
+
+    private static string Generate(string constraint) =>
+        SpecRoutingTableGenerator.GenerateCSharpRouteFile(
+            CreateAppModel(), CreateChainedHandlers(constraint), ImmutableArray<HandlerInfo?>.Empty,
+            ImmutableArray<string>.Empty, CancellationToken.None);
+
+    /// <summary>Arguments reach the emitted call as literals.</summary>
+    [Theory]
+    [InlineData("length(6)", "IsLength(charSpan.Slice(index), 6)")]
+    [InlineData("length(3,9)", "IsLength(charSpan.Slice(index), 3, 9)")]
+    [InlineData("min(1)", "IsMin(charSpan.Slice(index), 1)")]
+    [InlineData("range(1,500)", "IsRange(charSpan.Slice(index), 1, 500)")]
+    public void GenerateCSharpRouteFile_PassesConstraintArguments(string constraint, string call) {
+        Assert.Contains(call, Generate(constraint));
+    }
+
+    /// <summary>
+    /// A chain is one conjunction, and it is parenthesised because it is negated at a leaf — without
+    /// the brackets <c>!A &amp;&amp; B</c> would negate the first term alone and let the second decide the
+    /// match on its own.
+    /// </summary>
+    [Fact]
+    public void GenerateCSharpRouteFile_JoinsAChainIntoOneNegatedConjunction() {
+        var result = Generate("int:min(1)");
+
+        Assert.Contains("!(global::Hardened.Web.Runtime.Routing.RouteConstraints.IsInt(", result);
+        Assert.Contains("&& global::Hardened.Web.Runtime.Routing.RouteConstraints.IsMin(", result);
+    }
+
+    /// <summary>
+    /// A single term needs no brackets, so the generated code keeps the shape it had before chains
+    /// existed rather than churning every route table that already worked.
+    /// </summary>
+    [Fact]
+    public void GenerateCSharpRouteFile_DoesNotBracketASingleTerm() {
+        Assert.Contains("!global::Hardened.Web.Runtime.Routing.RouteConstraints.IsInt(", Generate("int"));
+    }
+
+    /// <summary>
+    /// A name at an arity it does not have emits nothing, because the diagnostic has already
+    /// reported it — a call to a method that does not exist would bury that under a CS1501.
+    /// </summary>
+    [Theory]
+    [InlineData("length(1,2,3)")]
+    [InlineData("range(1)")]
+    [InlineData("length(")]
+    public void GenerateCSharpRouteFile_EmitsNothingForAConstraintItCannotCompile(string constraint) {
+        Assert.DoesNotContain("RouteConstraints.", Generate(constraint));
+    }
+
     /// <summary>An unconstrained token emits no test, so the common route pays nothing.</summary>
     [Fact]
     public void GenerateCSharpRouteFile_EmitsNoConstraintWhenTheTokenDeclaresNone() {

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/RouteConstraintFactsTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/RouteConstraintFactsTests.cs
@@ -98,6 +98,110 @@ public class RouteConstraintFactsTests {
         }
     }
 
+    /// <summary>
+    /// The reverse of <see cref="NamesTestAndRankAgree"/>, and the check that was missing: every
+    /// ranked name has to be a name the table can actually compile.
+    /// </summary>
+    /// <remarks>
+    /// Ranks for <c>min</c>, <c>max</c>, <c>range</c> and the <c>length</c> family shipped one
+    /// commit before the constraints themselves did, so the table advertised six names that
+    /// <c>Call</c> answered null for and <c>{id:min(1)}</c> was still a build error. Checking only
+    /// that every name has a rank cannot catch that; this direction can.
+    /// </remarks>
+    [Theory]
+    [InlineData("guid")]
+    [InlineData("date")]
+    [InlineData("datetime")]
+    [InlineData("bool")]
+    [InlineData("int")]
+    [InlineData("min")]
+    [InlineData("max")]
+    [InlineData("range")]
+    [InlineData("long")]
+    [InlineData("decimal")]
+    [InlineData("hex")]
+    [InlineData("alpha")]
+    [InlineData("slug")]
+    [InlineData("length")]
+    [InlineData("minlength")]
+    [InlineData("maxlength")]
+    public void EveryRankedNameIsANameTheTableCompiles(string name) {
+        var arities = RouteConstraintFacts.Arities(name);
+
+        if (arities.Count == 0) {
+            Assert.NotNull(RouteConstraintFacts.Test(name));
+            return;
+        }
+
+        foreach (var arity in arities) {
+            var term = new RouteConstraintFacts.Term(name, Enumerable.Repeat(1, arity).ToList());
+
+            Assert.NotNull(RouteConstraintFacts.Call(term));
+        }
+    }
+
+    [Theory]
+    [InlineData("int", 1, 0)]
+    [InlineData("int:min(1)", 2, 1)]
+    [InlineData("length(6)", 1, 1)]
+    [InlineData("length(3,9)", 1, 2)]
+    [InlineData("alpha:length(3)", 2, 1)]
+    public void TermsParsesAChain(string chain, int terms, int lastArgumentCount) {
+        var parsed = RouteConstraintFacts.Terms(chain);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(terms, parsed!.Count);
+        Assert.Equal(lastArgumentCount, parsed[parsed.Count - 1].Arguments.Count);
+    }
+
+    /// <summary>
+    /// Malformed text is null rather than a term list, so the caller reports it instead of the
+    /// generator emitting a call to something that does not exist.
+    /// </summary>
+    [Theory]
+    [InlineData("length(")]
+    [InlineData("length)")]
+    [InlineData("length()")]
+    [InlineData("length(a)")]
+    [InlineData("length(1,)")]
+    [InlineData("(6)")]
+    [InlineData("int::min(1)")]
+    [InlineData("int:")]
+    public void TermsRefusesWhatIsNotAChain(string chain) {
+        Assert.Null(RouteConstraintFacts.Terms(chain));
+    }
+
+    /// <summary>
+    /// <c>length</c> is two different tests — <c>length(6)</c> an equality, <c>length(3,9)</c> a
+    /// pair of bounds — so arity is part of the lookup, not something checked after it.
+    /// </summary>
+    [Theory]
+    [InlineData("length", 1, "IsLength")]
+    [InlineData("length", 2, "IsLength")]
+    [InlineData("minlength", 1, "IsMinLength")]
+    [InlineData("maxlength", 1, "IsMaxLength")]
+    [InlineData("min", 1, "IsMin")]
+    [InlineData("max", 1, "IsMax")]
+    [InlineData("range", 2, "IsRange")]
+    public void AParameterisedNameCompilesAtItsOwnArity(string name, int arity, string method) {
+        var term = new RouteConstraintFacts.Term(name, Enumerable.Repeat(1, arity).ToList());
+
+        Assert.Equal("global::Hardened.Web.Runtime.Routing.RouteConstraints." + method,
+            RouteConstraintFacts.Call(term));
+    }
+
+    [Theory]
+    [InlineData("length", 0)]
+    [InlineData("length", 3)]
+    [InlineData("range", 1)]
+    [InlineData("min", 2)]
+    [InlineData("int", 1)]
+    public void AWrongArityCompilesToNothing(string name, int arity) {
+        var term = new RouteConstraintFacts.Term(name, Enumerable.Repeat(1, arity).ToList());
+
+        Assert.Null(RouteConstraintFacts.Call(term));
+    }
+
     /// <summary>Alphabetical, because this list is read by a person in an error message.</summary>
     [Fact]
     public void NamesAreListedInOrder() {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteConstraintFacts.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteConstraintFacts.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Hardened.SourceGenerator.Web.Routing;
 
 /// <summary>
@@ -96,6 +98,129 @@ public static class RouteConstraintFacts {
     /// route unreachable.
     /// </remarks>
     public const int CustomPrecedence = 90;
+
+    /// <summary>One constraint in a chain: a name, and the integer arguments it was given.</summary>
+    public readonly struct Term {
+        public Term(string name, IReadOnlyList<int> arguments) {
+            Name = name;
+            Arguments = arguments;
+        }
+
+        /// <summary>Lower-cased, as it is written after the colon.</summary>
+        public string Name { get; }
+
+        public IReadOnlyList<int> Arguments { get; }
+    }
+
+    private static readonly int[] NoArguments = new int[0];
+
+    /// <summary>
+    /// The terms in a constraint chain — <c>int:min(1)</c> is two — or null when the text is not a
+    /// chain at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Arguments are integer literals and nothing else. Every parameterised constraint takes
+    /// integers, and admitting strings would bring quoting, escaping and a real parser to a template
+    /// grammar that is otherwise a scan.
+    /// </para>
+    /// <para>
+    /// Null is "this does not parse", which the caller reports. It is deliberately distinct from an
+    /// empty list, because a token can carry no constraint at all and that is not an error.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyList<Term>? Terms(string chain) {
+        if (string.IsNullOrEmpty(chain)) {
+            return null;
+        }
+
+        var terms = new List<Term>();
+
+        foreach (var part in chain.Split(ChainSeparator)) {
+            if (part.Length == 0) {
+                return null;
+            }
+
+            var open = part.IndexOf('(');
+
+            if (open < 0) {
+                // A closing paren with nothing to close is malformed, not a name. Reading it as one
+                // would report "nothing declares a constraint called 'length)'", which sends the
+                // author looking for a missing declaration rather than a missing bracket.
+                if (part.IndexOf(')') >= 0) {
+                    return null;
+                }
+
+                terms.Add(new Term(part, NoArguments));
+                continue;
+            }
+
+            if (part[part.Length - 1] != ')' || open == 0) {
+                return null;
+            }
+
+            var name = part.Substring(0, open);
+            var inside = part.Substring(open + 1, part.Length - open - 2);
+
+            if (inside.Length == 0) {
+                return null;
+            }
+
+            var arguments = new List<int>();
+
+            foreach (var argument in inside.Split(',')) {
+                if (!int.TryParse(
+                        argument, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)) {
+                    return null;
+                }
+
+                arguments.Add(parsed);
+            }
+
+            terms.Add(new Term(name, arguments));
+        }
+
+        return terms;
+    }
+
+    private const char ChainSeparator = ':';
+
+    /// <summary>
+    /// The call that tests <paramref name="term"/>, or null when nothing built in has that name at
+    /// that arity.
+    /// </summary>
+    /// <remarks>
+    /// Arity is part of the lookup rather than checked after it, because <c>length</c> is two
+    /// different tests: <c>length(6)</c> is an equality and <c>length(3,9)</c> is a pair of bounds.
+    /// A name that exists at the wrong arity has to read as a wrong call, not as an unknown name.
+    /// </remarks>
+    public static string? Call(Term term) =>
+        (term.Name, term.Arguments.Count) switch {
+            (_, 0) => Test(term.Name),
+            ("length", 1) => Runtime + "IsLength",
+            ("length", 2) => Runtime + "IsLength",
+            ("minlength", 1) => Runtime + "IsMinLength",
+            ("maxlength", 1) => Runtime + "IsMaxLength",
+            ("min", 1) => Runtime + "IsMin",
+            ("max", 1) => Runtime + "IsMax",
+            ("range", 2) => Runtime + "IsRange",
+            _ => null
+        };
+
+    /// <summary>
+    /// The argument counts a parameterised name accepts, for the diagnostic that has to say so.
+    /// Empty when the name takes none.
+    /// </summary>
+    public static IReadOnlyList<int> Arities(string name) =>
+        name switch {
+            "length" => new[] { 1, 2 },
+            "minlength" => new[] { 1 },
+            "maxlength" => new[] { 1 },
+            "min" => new[] { 1 },
+            "max" => new[] { 1 },
+            "range" => new[] { 2 },
+            _ => new int[0]
+        };
 
     /// <summary>Every built-in name, for a diagnostic that has to list them.</summary>
     /// <remarks>Alphabetical, because this is read by a person in an error message.</remarks>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTokenSyntax.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTokenSyntax.cs
@@ -115,6 +115,15 @@ public static class RouteTokenSyntax {
 
         switch (finding.Form) {
             case Form.UnknownConstraint:
+                // A name that exists at another arity is a wrong call, not an unknown name, and
+                // saying "nothing declares length" to someone who wrote length(1,2,3) sends them
+                // looking for the wrong thing.
+                var arity = WrongArity(finding.Constraint);
+
+                if (arity != null) {
+                    return arity;
+                }
+
                 return
                     $"Nothing declares a route constraint called '{finding.Constraint}'. Built in: " +
                     $"{string.Join(", ", RouteConstraintFacts.Names)}. Declare your own with " +
@@ -141,6 +150,40 @@ public static class RouteTokenSyntax {
     }
 
     /// <summary>
+    /// The message for a real name used with the wrong number of arguments, or null when that is not
+    /// what went wrong.
+    /// </summary>
+    private static string? WrongArity(string? constraint) {
+        var terms = constraint == null ? null : RouteConstraintFacts.Terms(constraint);
+
+        if (terms == null) {
+            return null;
+        }
+
+        foreach (var term in terms) {
+            if (RouteConstraintFacts.Call(term) != null) {
+                continue;
+            }
+
+            var arities = RouteConstraintFacts.Arities(term.Name);
+
+            if (arities.Count == 0) {
+                continue;
+            }
+
+            var forms = string.Join(
+                " or ",
+                arities.Select(count => $"'{term.Name}({string.Join(",", Enumerable.Repeat("n", count))})'"));
+
+            return
+                $"'{term.Name}' takes {forms}, but was given {term.Arguments.Count} argument" +
+                (term.Arguments.Count == 1 ? "" : "s") + ". Arguments are whole numbers.";
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// A catch-all marker is not punctuation to reject: <c>{*path}</c> is supported syntax, and
     /// the asterisk is stripped before the name is read. A colon is supported too, as long as
     /// something declares what follows it.
@@ -162,13 +205,29 @@ public static class RouteTokenSyntax {
             return Form.Supported;
         }
 
-        if (RouteConstraintFacts.Test(constraint) != null) {
-            return Form.Supported;
+        var terms = RouteConstraintFacts.Terms(constraint);
+
+        // Not a chain at all - an unclosed paren, an empty argument list, a non-integer argument.
+        if (terms == null) {
+            return Form.UnknownConstraint;
         }
 
-        return declaredConstraints != null && declaredConstraints.Contains(constraint)
-            ? Form.Supported
-            : Form.UnknownConstraint;
+        foreach (var term in terms) {
+            if (RouteConstraintFacts.Call(term) != null) {
+                continue;
+            }
+
+            // A [RouteConstraint] takes no arguments, so a declared name used with them is not it.
+            if (term.Arguments.Count == 0 &&
+                declaredConstraints != null &&
+                declaredConstraints.Contains(term.Name)) {
+                continue;
+            }
+
+            return Form.UnknownConstraint;
+        }
+
+        return Form.Supported;
     }
 
     private static string Name(string body) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
 using CSharpAuthor;
 using static CSharpAuthor.SyntaxHelpers;
 using Hardened.SourceGenerator.Links;
@@ -812,14 +814,59 @@ public static class RoutingTableGenerator {
             return null;
         }
 
-        var test = RouteConstraintFacts.Test(constraint!) ?? Custom(constraint!);
+        var terms = RouteConstraintFacts.Terms(constraint!);
 
-        // Null only for a name no built-in and no [RouteConstraint] declares, which
-        // RouteTokenDiagnostics has already reported as a build error. Emitting a call to nothing
-        // would bury that under a CS0103.
-        return test == null
-            ? null
-            : CodeOutputComponent.Get((negate ? "!" : "") + test + "(" + value + ")");
+        if (terms == null) {
+            return null;
+        }
+
+        // A chain is a conjunction, short-circuiting left to right, so the narrower term is written
+        // first and the wider ones never run on a value the first has already rejected.
+        var calls = new List<string>();
+
+        foreach (var term in terms) {
+            var test = RouteConstraintFacts.Call(term) ?? Custom(term.Name);
+
+            // Null only for a name no built-in and no [RouteConstraint] declares, or one used at an
+            // arity it does not have - both already reported by RouteTokenDiagnostics. Emitting a
+            // call to nothing would bury that under a CS0103.
+            if (test == null) {
+                return null;
+            }
+
+            calls.Add(test + "(" + value + Arguments(term) + ")");
+        }
+
+        if (calls.Count == 0) {
+            return null;
+        }
+
+        var conjunction = string.Join(" && ", calls);
+
+        // Parentheses only where they change the meaning: !A && B negates the first term alone, and
+        // a bare conjunction joined into a larger one binds wrong. A single term needs neither, and
+        // the single term is the overwhelmingly common route - so the generated code stays the shape
+        // it was before chains existed.
+        if (calls.Count == 1) {
+            return CodeOutputComponent.Get((negate ? "!" : "") + conjunction);
+        }
+
+        return CodeOutputComponent.Get((negate ? "!" : "") + "(" + conjunction + ")");
+    }
+
+    /// <summary>The literal arguments a term carries, ready to append after the span.</summary>
+    private static string Arguments(RouteConstraintFacts.Term term) {
+        if (term.Arguments.Count == 0) {
+            return "";
+        }
+
+        var builder = new StringBuilder();
+
+        foreach (var argument in term.Arguments) {
+            builder.Append(", ").Append(argument.ToString(CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteConstraintTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteConstraintTests.cs
@@ -95,6 +95,46 @@ public class RouteConstraintTests {
     }
 
     /// <summary>
+    /// A constraint that carries arguments, driven through the compiled table.
+    /// </summary>
+    [Theory]
+    [InlineData("length(6)", "abc123", "abc12")]
+    [InlineData("length(3,9)", "abcd", "ab")]
+    [InlineData("minlength(4)", "abcd", "abc")]
+    [InlineData("maxlength(4)", "abcd", "abcde")]
+    [InlineData("min(1)", "1", "0")]
+    [InlineData("max(10)", "10", "11")]
+    [InlineData("range(1,500)", "250", "501")]
+    public void AParameterisedConstraintMatchesOnlyWhatPasses(
+        string constraint, string passes, string fails) {
+        var routing = Routing("/items/{id:" + constraint + "}");
+
+        Assert.Equal("Item", routing.Handler("GET", "/items/" + passes).InvokeMethod);
+        Assert.Null(routing.Route("GET", "/items/" + fails));
+    }
+
+    /// <summary>
+    /// A chain is a conjunction, short-circuiting left to right, so every term has to pass.
+    /// </summary>
+    [Theory]
+    [InlineData("/items/42", true)]
+    [InlineData("/items/0", false)]      // an int, but below the bound
+    [InlineData("/items/abc", false)]    // not an int at all
+    public void AChainRequiresEveryTerm(string path, bool matches) {
+        var routing = Routing("/items/{id:int:min(1)}");
+
+        Assert.Equal(matches, routing.Route("GET", path) != null);
+    }
+
+    /// <summary>The token still binds under its own name, whatever the chain carries.</summary>
+    [Fact]
+    public void AChainedTokenStillBinds() {
+        var tokens = Routing("/items/{id:int:min(1)}").PathTokens("GET", "/items/42");
+
+        Assert.Equal("42", Assert.Contains("id", tokens));
+    }
+
+    /// <summary>
     /// A 404, not a 405. There is no resource at that URL, so reporting which verbs the path
     /// answers would be describing a resource that does not exist.
     /// </summary>

--- a/src/Web/Hardened.Web.Runtime.Tests/Routing/RouteConstraintsTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Routing/RouteConstraintsTests.cs
@@ -132,6 +132,62 @@ public class RouteConstraintsTests {
     public void IsSlug(string value, bool expected) =>
         Assert.Equal(expected, RouteConstraints.IsSlug(value));
 
+    [Theory]
+    [InlineData("abc123", 6, true)]
+    [InlineData("abc12", 6, false)]
+    [InlineData("", 0, true)]
+    public void IsLengthExact(string value, int length, bool expected) =>
+        Assert.Equal(expected, RouteConstraints.IsLength(value, length));
+
+    [Theory]
+    [InlineData("abcd", 3, 9, true)]
+    [InlineData("ab", 3, 9, false)]
+    [InlineData("abcdefghij", 3, 9, false)]
+    [InlineData("abc", 3, 3, true)]
+    public void IsLengthBounded(string value, int min, int max, bool expected) =>
+        Assert.Equal(expected, RouteConstraints.IsLength(value, min, max));
+
+    [Theory]
+    [InlineData("abcd", 4, true)]
+    [InlineData("abc", 4, false)]
+    public void IsMinLength(string value, int min, bool expected) =>
+        Assert.Equal(expected, RouteConstraints.IsMinLength(value, min));
+
+    [Theory]
+    [InlineData("abcd", 4, true)]
+    [InlineData("abcde", 4, false)]
+    public void IsMaxLength(string value, int max, bool expected) =>
+        Assert.Equal(expected, RouteConstraints.IsMaxLength(value, max));
+
+    /// <summary>
+    /// The parse is part of the constraint, so a non-integer fails the bound rather than throwing.
+    /// </summary>
+    [Theory]
+    [InlineData("1", 1, true)]
+    [InlineData("0", 1, false)]
+    [InlineData("-1", 0, false)]
+    [InlineData("abc", 1, false)]
+    [InlineData("", 1, false)]
+    public void IsMin(string value, long min, bool expected) =>
+        Assert.Equal(expected, RouteConstraints.IsMin(value, min));
+
+    [Theory]
+    [InlineData("10", 10, true)]
+    [InlineData("11", 10, false)]
+    [InlineData("abc", 10, false)]
+    public void IsMax(string value, long max, bool expected) =>
+        Assert.Equal(expected, RouteConstraints.IsMax(value, max));
+
+    [Theory]
+    [InlineData("250", 1, 500, true)]
+    [InlineData("1", 1, 500, true)]
+    [InlineData("500", 1, 500, true)]
+    [InlineData("0", 1, 500, false)]
+    [InlineData("501", 1, 500, false)]
+    [InlineData("abc", 1, 500, false)]
+    public void IsRange(string value, long min, long max, bool expected) =>
+        Assert.Equal(expected, RouteConstraints.IsRange(value, min, max));
+
     /// <summary>
     /// A route is part of a URL, which is the same string in every locale. Parsing under an ambient
     /// culture would make the same request match on one machine and not another.

--- a/src/Web/Hardened.Web.Runtime/Routing/RouteConstraints.cs
+++ b/src/Web/Hardened.Web.Runtime/Routing/RouteConstraints.cs
@@ -153,6 +153,40 @@ public static class RouteConstraints {
         return true;
     }
 
+    // ---- parameterised ------------------------------------------------------
+
+    /// <summary>Exactly <paramref name="length"/> characters.</summary>
+    public static bool IsLength(ReadOnlySpan<char> value, int length) =>
+        value.Length == length;
+
+    /// <summary>Between <paramref name="min"/> and <paramref name="max"/> characters, inclusive.</summary>
+    public static bool IsLength(ReadOnlySpan<char> value, int min, int max) =>
+        value.Length >= min && value.Length <= max;
+
+    public static bool IsMinLength(ReadOnlySpan<char> value, int min) =>
+        value.Length >= min;
+
+    public static bool IsMaxLength(ReadOnlySpan<char> value, int max) =>
+        value.Length <= max;
+
+    /// <summary>An integer no smaller than <paramref name="min"/>.</summary>
+    /// <remarks>
+    /// The parse is part of the constraint rather than something assumed of a chain, so
+    /// <c>{id:min(1)}</c> stands alone and means what it means elsewhere. Written
+    /// <c>{id:int:min(1)}</c> it is the same test with the width stated.
+    /// </remarks>
+    public static bool IsMin(ReadOnlySpan<char> value, long min) =>
+        long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) &&
+        parsed >= min;
+
+    public static bool IsMax(ReadOnlySpan<char> value, long max) =>
+        long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) &&
+        parsed <= max;
+
+    public static bool IsRange(ReadOnlySpan<char> value, long min, long max) =>
+        long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) &&
+        parsed >= min && parsed <= max;
+
     /// <summary>
     /// The formats <see cref="IsDateTime"/> accepts, on a nested type so that only a route declaring
     /// <c>:datetime</c> pays for them.


### PR DESCRIPTION
Step 2 of `ROUTE-CONSTRAINTS-PLAN.md`, and a correction to #137.

## What #137 got wrong

It shipped ranks for `min`, `max`, `range`, `length`, `minlength` and `maxlength` **without shipping the constraints**. `Test` returned null for every one, so `{id:min(1)}` was still `HRDR002` and the rank table advertised a vocabulary the framework did not have.

`NamesTestAndRankAgree` could not catch it — it checks that every *name* has a rank, not that every *rank* has a name. Both directions are checked now.

## The grammar

Two new forms, both of which are build errors today, so no template that currently compiles changes meaning:

```csharp
[Get("/codes/{code:length(6)}")]     // arguments, integer literals only
[Get("/users/{id:int:min(1)}")]      // chains, tested left to right
```

Arguments are whole numbers and nothing else. Every parameterised constraint takes integers, and admitting strings would bring quoting, escaping and a real parser to a grammar that is otherwise a scan.

A chain is a conjunction, so it short-circuits and the narrower term goes first. **Brackets appear only where they change the meaning** — a single term is emitted exactly as it was before chains existed, so no route table that already worked churns. Negation needs them (`!A && B` would negate the first term alone).

`min`, `max` and `range` parse the segment themselves rather than assuming a chain put an int in front, so `{id:min(1)}` stands alone and means what it means in other frameworks. `{id:int:min(1)}` is the same test with the width stated.

## Arity is part of the lookup

`length` is two different tests: `length(6)` is an equality, `length(3,9)` a pair of bounds. So arity is looked up, not checked afterwards — and a name used at an arity it does not have says so:

> `'length' takes 'length(n)' or 'length(n,n)', but was given 3 arguments. Arguments are whole numbers.`

rather than claiming nothing declares `length`, which would send the author looking for a missing declaration rather than a missing bracket. A stray close paren is a parse failure for the same reason.

## Verification

- **3,359 tests**, exit 0
- **Coverage gate exit 0** — `Hardened.SourceGenerator` branch 60.4% against a 57.0% baseline; no floors re-baselined
- Public API baseline updated: seven new methods on `RouteConstraints`, all intended

Both generators move in step. Runtime tests reach the edges a compiled table does not.

`Hardened.IntegrationTests.Smithy.SUT` does not build locally — the machine has Smithy CLI 1.56.0 against a 1.73.0 pin. Verified pre-existing on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKTxo2WLwzvTmJvBCmckVJ