### PR TITLE
Pin the Smithy CLI where it publishes, warn where it does not

### DIFF
--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/GenerateSmithyAstTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/GenerateSmithyAstTests.cs
@@ -75,7 +75,7 @@ public class GenerateSmithyAstTests : IDisposable {
     }
 
     private (bool Result, SmithyTaskHarness.RecordingBuildEngine Engine, string Output) Run(
-        string? toolPath, string expectedVersion = "") {
+        string? toolPath, string expectedVersion = "", bool pinVersion = true) {
         var engine = new SmithyTaskHarness.RecordingBuildEngine();
         var output = Path.Combine(_root, "out", "ast.json");
 
@@ -84,7 +84,8 @@ public class GenerateSmithyAstTests : IDisposable {
             Models = new ITaskItem[] { new Microsoft.Build.Utilities.TaskItem(Model()) },
             OutputPath = output,
             ToolPath = toolPath ?? "",
-            ExpectedVersion = expectedVersion
+            ExpectedVersion = expectedVersion,
+            PinVersion = pinVersion
         };
 
         return (task.Execute(), engine, output);
@@ -107,8 +108,8 @@ public class GenerateSmithyAstTests : IDisposable {
     }
 
     /// <summary>
-    /// The pin is the point. A different CLI can produce a different AST from identical sources, so
-    /// a mismatch stops the build rather than generating against whatever is installed.
+    /// Where the pin is enforced, a different CLI stops the build: it can produce a different AST
+    /// from identical sources, and that is not something to discover downstream of a publish.
     /// </summary>
     [Fact]
     public void Execute_RefusesACliThatIsNotThePinnedVersion() {
@@ -122,6 +123,34 @@ public class GenerateSmithyAstTests : IDisposable {
 
         Assert.Contains("1.56.0", message);
         Assert.Contains("1.73.0", message);
+    }
+
+    /// <summary>
+    /// And where it is not - a developer machine - the same mismatch is a warning and the build
+    /// carries on.
+    /// </summary>
+    /// <remarks>
+    /// The pin belongs on the build that produces artefacts other people consume. Requiring an exact
+    /// CLI locally means every developer has to chase a version before the repo builds at all, and
+    /// "I pulled and it does not build" is not answered by "install this specific tool first". What
+    /// CI publishes is still produced by exactly one version, so nothing about reproducibility
+    /// changes.
+    /// </remarks>
+    [Fact]
+    public void Execute_WarnsButBuildsWhenTheVersionIsNotPinned() {
+        var (result, engine, output) = Run(
+            FakeCli("1.56.0", output: "{\"smithy\":\"2.0\",\"shapes\":{}}"),
+            expectedVersion: "1.73.0",
+            pinVersion: false);
+
+        Assert.True(result, string.Join("\n", engine.Errors.Select(error => error.Message)));
+        Assert.False(HasError(engine, "HSMT011"));
+        Assert.True(File.Exists(output));
+
+        var warning = engine.Warnings.Single(entry => entry.Code == "HSMT011").Message;
+
+        Assert.Contains("1.56.0", warning);
+        Assert.Contains("1.73.0", warning);
     }
 
     [Fact]

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/GenerateSmithyAst.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/GenerateSmithyAst.cs
@@ -57,6 +57,22 @@ public sealed class GenerateSmithyAst : Microsoft.Build.Utilities.Task {
     /// </remarks>
     public string ExpectedVersion { get; set; } = "";
 
+    /// <summary>
+    /// Whether a version mismatch fails the build. False on a developer machine.
+    /// </summary>
+    /// <remarks>
+    /// The pin is worth having on the build that produces artefacts other people consume, and is
+    /// only an obstacle on the one that does not. Requiring an exact CLI locally means every
+    /// developer, and every machine, has to chase a version to build at all - and the answer to
+    /// "I pulled and it does not build" cannot be "install this specific tool first".
+    /// <para>
+    /// So the mismatch is a warning locally and an error in CI. The reproducibility argument is
+    /// unchanged: what CI publishes is still produced by exactly one CLI version, and a local AST
+    /// that came out different is a warning the developer has already seen.
+    /// </para>
+    /// </remarks>
+    public bool PinVersion { get; set; }
+
     [Output]
     public ITaskItem? AstFile { get; set; }
 
@@ -141,13 +157,22 @@ public sealed class GenerateSmithyAst : Microsoft.Build.Utilities.Task {
         var actual = result.StandardOutput.Trim();
 
         if (!string.Equals(actual, ExpectedVersion.Trim(), StringComparison.Ordinal)) {
-            Log.LogError(null, "HSMT011", null, FirstModel(), 0, 0, 0, 0,
+            const string message =
                 "The Smithy CLI at '{0}' is version {1}, but this build is pinned to {2}. The AST a " +
-                "different version produces can differ, so the generated code would differ with it. " +
-                "Install {2}, or change $(HardenedSmithyCliVersion) deliberately.",
-                tool, actual, ExpectedVersion.Trim());
+                "different version produces can differ, so the generated code would differ with it.";
 
-            return false;
+            if (PinVersion) {
+                Log.LogError(null, "HSMT011", null, FirstModel(), 0, 0, 0, 0,
+                    message + " Install {2}, or change $(HardenedSmithyCliVersion) deliberately.",
+                    tool, actual, ExpectedVersion.Trim());
+
+                return false;
+            }
+
+            Log.LogWarning(null, "HSMT011", null, FirstModel(), 0, 0, 0, 0,
+                message + " Building anyway, because the pin is enforced on the build that publishes " +
+                "rather than on yours. Set $(HardenedSmithyPinCliVersion) to make this an error here too.",
+                tool, actual, ExpectedVersion.Trim());
         }
 
         Log.LogMessage(MessageImportance.Low, "Smithy CLI {0} at {1}.", actual, tool);

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
@@ -104,6 +104,21 @@
             deliberate one-line change rather than whatever the machine happens to have.
         -->
         <HardenedSmithyCliVersion Condition="'$(HardenedSmithyCliVersion)' == ''">1.73.0</HardenedSmithyCliVersion>
+
+        <!--
+            Whether a mismatch fails the build, or only warns.
+
+            Pinned where it matters and advisory where it does not. A developer pulls the repo and
+            builds with the CLI they have; the build that publishes uses exactly the pinned one. The
+            reproducibility argument is untouched - what ships is still produced by one version - and
+            the cost it was imposing was that nobody could build at all without chasing a version
+            first, which is not a trade worth making on a machine that publishes nothing.
+
+            Defaults to $(ContinuousIntegrationBuild), which CI already sets and a local build does
+            not. Set it explicitly to pin locally too.
+        -->
+        <HardenedSmithyPinCliVersion Condition="'$(HardenedSmithyPinCliVersion)' == ''">$(ContinuousIntegrationBuild)</HardenedSmithyPinCliVersion>
+        <HardenedSmithyPinCliVersion Condition="'$(HardenedSmithyPinCliVersion)' == ''">false</HardenedSmithyPinCliVersion>
     </PropertyGroup>
 
     <!--
@@ -198,7 +213,8 @@
         <GenerateSmithyAst Models="@(HardenedSmithyModel)"
                            OutputPath="$(IntermediateOutputPath)smithy/ast/$(HardenedSmithyModelName).json"
                            ToolPath="$(HardenedSmithyCliPath)"
-                           ExpectedVersion="$(HardenedSmithyCliVersion)"/>
+                           ExpectedVersion="$(HardenedSmithyCliVersion)"
+                           PinVersion="$(HardenedSmithyPinCliVersion)"/>
 
         <Touch Files="$(IntermediateOutputPath)smithy/ast/$(HardenedSmithyModelName).stamp"
                AlwaysCreate="true"/>


### PR DESCRIPTION
Pulling the repo and building it required Smithy CLI **1.73.0 exactly**, or the build stopped with `HSMT011`. That is a hard failure on a machine that publishes nothing, and "I pulled and it does not build" is not answered by "install this specific tool first". It cost several people a build today.

## The change

The version mismatch is an **error** when `$(ContinuousIntegrationBuild)` is set and a **warning** otherwise. `$(HardenedSmithyPinCliVersion)` overrides either way, so a developer who wants the pin locally can have it.

## The pin still does its job

What CI publishes is still produced by exactly one CLI version — that is the build the pin was ever about. A local AST that came out different is a warning the developer has already read. Before this, the pin was buying determinism on the one build where nobody consumes the output, at the cost of nobody being able to build at all.

Nothing about the design changes: `petstore.smithy` still runs the CLI into `obj/` so its AST cannot drift, and `bank.json` still exercises the hermetic path that needs no CLI.

## Verified on a machine with the wrong version

This box has 1.56.0 against the 1.73.0 pin — the exact failing case:

| | |
|---|---|
| `dotnet test src/Hardened.Framework.sln -c Release` | **exit 0**, all **21** projects, 3,389 tests |
| same, with `-p:ContinuousIntegrationBuild=true` | **exit 1**, `HSMT011`, pin fires |

Before this change the first row could not build `Hardened.IntegrationTests.Smithy.SUT` at all, so it ran 20 projects.

Coverage gate exit 0, no floors re-baselined. The task's own test suite keeps the refuses-a-mismatch test and gains its counterpart for the unpinned path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKTxo2WLwzvTmJvBCmckVJ