### PR TITLE
Run the code nothing was running, and fix what that found

### DIFF
--- a/src/Hardened.Framework.sln
+++ b/src/Hardened.Framework.sln
@@ -149,6 +149,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Requests.Serializers.Newtonsoft.Tests", "Requests\Serializers\Hardened.Requests.Serializers.Newtonsoft.Tests\Hardened.Requests.Serializers.Newtonsoft.Tests.csproj", "{5B900FD8-30B6-4BCC-877A-862497ECD2B9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Validation.SourceGenerator.Tests", "SourceGenerators\Hardened.Validation.SourceGenerator.Tests\Hardened.Validation.SourceGenerator.Tests.csproj", "{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -879,6 +881,18 @@ Global
 		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|x64.Build.0 = Release|Any CPU
 		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|x86.ActiveCfg = Release|Any CPU
 		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|x86.Build.0 = Release|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Debug|x64.Build.0 = Debug|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Debug|x86.Build.0 = Debug|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Release|x64.ActiveCfg = Release|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Release|x64.Build.0 = Release|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Release|x86.ActiveCfg = Release|Any CPU
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -949,6 +963,7 @@ Global
 		{8630F787-B753-41DC-BD9A-9A322C4CFB6E} = {2E68F00D-3E37-96B7-F386-FEFB84E6D00F}
 		{CBECAACE-2614-40A6-9B42-4275131BE6AD} = {2E68F00D-3E37-96B7-F386-FEFB84E6D00F}
 		{5B900FD8-30B6-4BCC-877A-862497ECD2B9} = {9F568319-5401-46D0-BD04-A51B1566A963}
+		{564B85B9-9A8A-4170-9AC7-0420B9F5D98D} = {EABCDDC0-6E72-43FB-9AF7-04E6681B83FD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF6CD1AB-6B41-427D-BA1B-C4803CF67E97}

--- a/src/Hardened.Framework.sln
+++ b/src/Hardened.Framework.sln
@@ -147,6 +147,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.Smithy.SUT.Tests", "IntegrationTests\Smithy\Hardened.IntegrationTests.Smithy.SUT.Tests\Hardened.IntegrationTests.Smithy.SUT.Tests.csproj", "{CBECAACE-2614-40A6-9B42-4275131BE6AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Requests.Serializers.Newtonsoft.Tests", "Requests\Serializers\Hardened.Requests.Serializers.Newtonsoft.Tests\Hardened.Requests.Serializers.Newtonsoft.Tests.csproj", "{5B900FD8-30B6-4BCC-877A-862497ECD2B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -865,6 +867,18 @@ Global
 		{CBECAACE-2614-40A6-9B42-4275131BE6AD}.Release|x64.Build.0 = Release|Any CPU
 		{CBECAACE-2614-40A6-9B42-4275131BE6AD}.Release|x86.ActiveCfg = Release|Any CPU
 		{CBECAACE-2614-40A6-9B42-4275131BE6AD}.Release|x86.Build.0 = Release|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Debug|x86.Build.0 = Debug|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|x64.Build.0 = Release|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -934,6 +948,7 @@ Global
 		{2E68F00D-3E37-96B7-F386-FEFB84E6D00F} = {592F787C-E5FC-4C0C-8F2F-2DC8559C326B}
 		{8630F787-B753-41DC-BD9A-9A322C4CFB6E} = {2E68F00D-3E37-96B7-F386-FEFB84E6D00F}
 		{CBECAACE-2614-40A6-9B42-4275131BE6AD} = {2E68F00D-3E37-96B7-F386-FEFB84E6D00F}
+		{5B900FD8-30B6-4BCC-877A-862497ECD2B9} = {9F568319-5401-46D0-BD04-A51B1566A963}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BF6CD1AB-6B41-427D-BA1B-C4803CF67E97}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -598,6 +598,7 @@ namespace Hardened.Requests.Abstract.Serializer
     public interface IRequestDeserializer
     {
         bool IsDefaultSerializer { get; }
+        int Order { get; }
         bool CanProcessContext(Hardened.Requests.Abstract.Execution.IExecutionContext context);
         System.Threading.Tasks.ValueTask<T?> DeserializeRequestBody<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context);
     }
@@ -641,6 +642,12 @@ namespace Hardened.Requests.Abstract.Serializer
     {
         public const string Any = "*/*";
         public static bool Matches(string? requested, string? produced) { }
+    }
+    public enum RequestDeserializerOrder
+    {
+        Specialized = -100,
+        Normal = 0,
+        Deferred = 1000,
     }
     public enum ResponseSerializerOrder
     {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -631,6 +631,7 @@ namespace Hardened.Requests.Runtime.Serializer
     {
         public AotRequestDeserializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration, Microsoft.Extensions.Logging.ILogger<Hardened.Requests.Runtime.Serializer.AotRequestDeserializer> logger, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
         public bool IsDefaultSerializer { get; }
+        public int Order { get; }
         public bool CanProcessContext(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.ValueTask<T?> DeserializeRequestBody<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Serializers.Newtonsoft.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Serializers.Newtonsoft.approved.txt
@@ -27,6 +27,7 @@ namespace Hardened.Requests.Serializers.Newtonsoft.Impl
     {
         public NewtonsoftDeserializer(Hardened.Shared.Runtime.Collections.IMemoryStreamPool memoryStreamPool, Hardened.Requests.Serializers.Newtonsoft.Impl.ISharedSerializer sharedSerializer, Microsoft.Extensions.Logging.ILogger<Hardened.Requests.Serializers.Newtonsoft.Impl.NewtonsoftDeserializer> logger) { }
         public bool IsDefaultSerializer { get; }
+        public int Order { get; }
         public bool CanProcessContext(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.ValueTask<T?> DeserializeRequestBody<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }
@@ -35,6 +36,7 @@ namespace Hardened.Requests.Serializers.Newtonsoft.Impl
     {
         public NewtonsoftSerializer(Hardened.Requests.Serializers.Newtonsoft.Impl.ISharedSerializer sharedSerializer, Hardened.Shared.Runtime.Collections.IMemoryStreamPool memoryStreamPool) { }
         public bool IsDefaultSerializer { get; }
+        public int Order { get; }
         public bool CanProduce(string mediaType, Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.Task SerializeResponse(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }

--- a/src/Requests/Hardened.Requests.Abstract/Serializer/IRequestDeserializer.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Serializer/IRequestDeserializer.cs
@@ -2,8 +2,65 @@
 
 namespace Hardened.Requests.Abstract.Serializer;
 
+/// <summary>
+/// Where a request deserializer sits relative to the others. Lower is asked first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The mirror of <see cref="ResponseSerializerOrder"/>, and it exists for the same reason: the
+/// alternative is registration order, and registration order is not something an application can
+/// steer. Within a module DependencyModules sorts by whether a registration is conditional and then
+/// by implementation type name, so which deserializer read a body came down to how two class names
+/// happened to sort.
+/// </para>
+/// <para>
+/// Separate from <see cref="ResponseSerializerOrder"/> rather than shared, because the two do not
+/// have the same tiers — there is no request-side equivalent of
+/// <see cref="ResponseSerializerOrder.Template"/>. Values line up with the response enum where the
+/// tiers do correspond, so a serializer pair can state one precedence for both directions.
+/// </para>
+/// <para>
+/// Values are spaced so a deserializer can be slotted between two of them without renumbering.
+/// </para>
+/// </remarks>
+public enum RequestDeserializerOrder {
+    /// <summary>
+    /// A deserializer for one specific content type, or one an application installed to replace the
+    /// default. Ahead of the general-purpose ones.
+    /// </summary>
+    Specialized = -100,
+
+    /// <summary>The default, and where the built-in JSON deserializer sits.</summary>
+    Normal = 0,
+
+    /// <summary>
+    /// Behind the general-purpose deserializers. One here reads a body only when nothing else
+    /// claimed the content type.
+    /// </summary>
+    Deferred = 1000
+}
+
 public interface IRequestDeserializer {
     bool IsDefaultSerializer { get; }
+
+    /// <summary>
+    /// Lower is asked first. Defaults to <see cref="RequestDeserializerOrder.Normal"/>, so an
+    /// existing deserializer that does not care keeps working unchanged.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Separate from <see cref="IsDefaultSerializer"/> on purpose, exactly as on
+    /// <see cref="IResponseSerializer"/>: order decides who is asked first;
+    /// <c>IsDefaultSerializer</c> decides who reads a body nobody claimed.
+    /// </para>
+    /// <para>
+    /// Added 2026-08-18. Before it, two deserializers both claiming <c>application/json</c> — which
+    /// is what installing <c>Hardened.Requests.Serializers.Newtonsoft</c> produces — were separated
+    /// only by reverse registration order, so the package that exists to replace the default JSON
+    /// reader could not reliably do it.
+    /// </para>
+    /// </remarks>
+    int Order => (int)RequestDeserializerOrder.Normal;
 
     bool CanProcessContext(IExecutionContext context);
 

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Configuration/ResponseHeaderConfigurationTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Configuration/ResponseHeaderConfigurationTests.cs
@@ -1,0 +1,115 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Configuration;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Configuration;
+
+/// <summary>
+/// What an application adds to every response.
+/// </summary>
+/// <remarks>
+/// The configuration object itself was at 25% — only the string overload of <c>Add</c> was ever
+/// called. <c>IOFilterProviderTests</c> covers how these reach a response; this covers the
+/// collection, including that the two <c>Add</c> families accumulate independently and keep the
+/// order they were declared in. Order matters for the common security headers, where a later
+/// entry under the same name is meant to win.
+/// </remarks>
+public class ResponseHeaderConfigurationTests {
+
+    [Fact]
+    public void AFreshConfigurationHasNothing() {
+        var configuration = new ResponseHeaderConfiguration();
+
+        Assert.Empty(configuration.CommonHeaders);
+        Assert.Empty(configuration.HeaderActions);
+    }
+
+    [Fact]
+    public void AStringHeaderIsRecorded() {
+        var configuration = new ResponseHeaderConfiguration();
+
+        configuration.Add("X-Frame-Options", "DENY");
+
+        var header = Assert.Single(configuration.CommonHeaders);
+
+        Assert.Equal("X-Frame-Options", header.Key);
+        Assert.Equal("DENY", header.Value.ToString());
+    }
+
+    [Fact]
+    public void AMultiValueHeaderKeepsEveryValue() {
+        var configuration = new ResponseHeaderConfiguration();
+
+        configuration.Add("Vary", new StringValues(["Accept", "Accept-Encoding"]));
+
+        var vary = Assert.Single(configuration.CommonHeaders).Value;
+
+        Assert.Equal(2, vary.Count);
+        Assert.Equal("Accept", vary[0]);
+        Assert.Equal("Accept-Encoding", vary[1]);
+    }
+
+    /// <summary>
+    /// Recorded rather than merged — the writer assigns in order, so the later entry wins.
+    /// </summary>
+    [Fact]
+    public void TheSameHeaderAddedTwiceIsRecordedTwiceInOrder() {
+        var configuration = new ResponseHeaderConfiguration();
+
+        configuration.Add("X-Frame-Options", "SAMEORIGIN");
+        configuration.Add("X-Frame-Options", "DENY");
+
+        Assert.Equal(2, configuration.CommonHeaders.Count);
+        Assert.Equal("DENY", configuration.CommonHeaders[1].Value.ToString());
+    }
+
+    [Fact]
+    public void AnActionIsRecorded() {
+        var configuration = new ResponseHeaderConfiguration();
+
+        configuration.Add(_ => { });
+
+        Assert.Single(configuration.HeaderActions);
+    }
+
+    [Fact]
+    public void ActionsKeepTheOrderTheyWereAddedIn() {
+        var configuration = new ResponseHeaderConfiguration();
+        var log = new List<string>();
+
+        configuration.Add(_ => log.Add("first"));
+        configuration.Add(_ => log.Add("second"));
+
+        foreach (var action in configuration.HeaderActions) {
+            action.Invoke(null!);
+        }
+
+        Assert.Equal(["first", "second"], log);
+    }
+
+    [Fact]
+    public void ActionsAndCommonHeadersAccumulateIndependently() {
+        var configuration = new ResponseHeaderConfiguration();
+
+        configuration.Add("X-Frame-Options", "DENY");
+        configuration.Add((IExecutionContext _) => { });
+
+        Assert.Single(configuration.CommonHeaders);
+        Assert.Single(configuration.HeaderActions);
+    }
+
+    /// <summary>
+    /// The interface is what <c>IOFilterProvider</c> reads. It must see the same lists rather than
+    /// a copy taken when the configuration was built.
+    /// </summary>
+    [Fact]
+    public void TheInterfaceSeesLaterAdditions() {
+        var configuration = new ResponseHeaderConfiguration();
+        IResponseHeaderConfiguration asInterface = configuration;
+
+        configuration.Add("X-Frame-Options", "DENY");
+
+        Assert.Single(asInterface.CommonHeaders);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/EmptyParametersTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/EmptyParametersTests.cs
@@ -1,0 +1,76 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Execution;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Execution;
+
+/// <summary>
+/// What a handler taking no parameters binds to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every no-parameter handler in every application resolves this, and it was at 22% — the shared
+/// instance was constructed and nothing asked it anything.
+/// </para>
+/// <para>
+/// The property worth pinning is <see cref="EmptyParameters.Clone"/> returning <c>this</c>. A
+/// forked chain clones the parameters, so a <c>Clone</c> that allocated would allocate once per
+/// retry attempt per no-parameter handler; and because the instance is shared process-wide, a
+/// <c>Clone</c> that returned something writable would let one request's fork hand state to
+/// another's.
+/// </para>
+/// </remarks>
+public class EmptyParametersTests {
+
+    [Fact]
+    public void ParameterCountIsZero() {
+        Assert.Equal(0, EmptyParameters.Instance.ParameterCount);
+    }
+
+    [Fact]
+    public void InfoIsEmptyRatherThanNull() {
+        Assert.Empty(EmptyParameters.Instance.Info);
+    }
+
+    [Fact]
+    public void TryGetParameterFindsNothingAndYieldsNull() {
+        Assert.False(EmptyParameters.Instance.TryGetParameter("anything", out var value));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TrySetParameterRefusesRatherThanThrowing() {
+        Assert.False(EmptyParameters.Instance.TrySetParameter("anything", "value"));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    public void IndexingThrowsAtEveryIndex(int index) {
+        Assert.Throws<IndexOutOfRangeException>(() => EmptyParameters.Instance[index]);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void AssigningByIndexThrows(int index) {
+        Assert.Throws<IndexOutOfRangeException>(() => EmptyParameters.Instance[index] = "value");
+    }
+
+    [Fact]
+    public void InstanceIsShared() {
+        Assert.Same(EmptyParameters.Instance, EmptyParameters.Instance);
+    }
+
+    /// <summary>
+    /// A fork clones the parameters. There is nothing to copy, so cloning must not allocate — and
+    /// must not hand back something a second request could write into.
+    /// </summary>
+    [Fact]
+    public void CloneIsTheSameInstance() {
+        IExecutionRequestParameters parameters = EmptyParameters.Instance;
+
+        Assert.Same(parameters, parameters.Clone());
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/IOFilterProviderTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/IOFilterProviderTests.cs
@@ -1,0 +1,229 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Configuration;
+using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Execution;
+
+/// <summary>
+/// What builds the filter that reads a request body and writes a response.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The provider was at 31% line / 25% branch, and the untaken branches are all in
+/// <c>SetupHeaderActions</c> — which collapses four configurations into one delegate, or none.
+/// Only the "nothing configured" shape was ever exercised, so the composition every application
+/// setting a security header depends on was never run.
+/// </para>
+/// <para>
+/// Asserted through a real filter rather than by reflecting on the returned delegate: the
+/// observable behaviour is which headers are on the response after the filter has run, and the
+/// collapsing is an optimisation underneath that.
+/// </para>
+/// </remarks>
+public class IOFilterProviderTests {
+
+    private static IOFilterProvider Provider(Action<ResponseHeaderConfiguration>? configure = null) {
+        var configuration = new ResponseHeaderConfiguration();
+
+        configure?.Invoke(configuration);
+
+        var serialization = Substitute.For<IContextSerializationService>();
+
+        serialization.SerializeResponse(Arg.Any<IExecutionContext>()).Returns(Task.CompletedTask);
+
+        return new IOFilterProvider(
+            serialization, Options.Create<IResponseHeaderConfiguration>(configuration));
+    }
+
+    private static IExecutionRequestHandlerInfo HandlerInfo() =>
+        Substitute.For<IExecutionRequestHandlerInfo>();
+
+    private static Task<IExecutionRequestParameters> NoParameters(IExecutionContext _) =>
+        Task.FromResult<IExecutionRequestParameters>(EmptyParameters.Instance);
+
+    /// <summary>Runs the provided filter over a real context and hands back that context.</summary>
+    private static async Task<IExecutionContext> Run(IExecutionFilter filter) {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, filter).Next();
+
+        return context;
+    }
+
+    [Fact]
+    public async Task NoConfiguredHeadersLeavesTheResponseHeadersAlone() {
+        var context = await Run(Provider().ProvideFilter(HandlerInfo(), NoParameters));
+
+        Assert.Empty(context.Response.Headers);
+    }
+
+    [Fact]
+    public async Task ACommonHeaderReachesTheResponse() {
+        var filter = Provider(configuration => configuration.Add("X-Frame-Options", "DENY"))
+            .ProvideFilter(HandlerInfo(), NoParameters);
+
+        var context = await Run(filter);
+
+        Assert.Equal("DENY", context.Response.Headers["X-Frame-Options"].ToString());
+    }
+
+    [Fact]
+    public async Task EveryCommonHeaderReachesTheResponse() {
+        var filter = Provider(configuration => {
+                configuration.Add("X-Frame-Options", "DENY");
+                configuration.Add("X-Content-Type-Options", "nosniff");
+            })
+            .ProvideFilter(HandlerInfo(), NoParameters);
+
+        var context = await Run(filter);
+
+        Assert.Equal("DENY", context.Response.Headers["X-Frame-Options"].ToString());
+        Assert.Equal("nosniff", context.Response.Headers["X-Content-Type-Options"].ToString());
+    }
+
+    [Fact]
+    public async Task AConfiguredActionRunsAgainstTheResponse() {
+        var filter = Provider(configuration =>
+                configuration.Add(context => context.Response.Headers["X-Trace"] = "on"))
+            .ProvideFilter(HandlerInfo(), NoParameters);
+
+        var context = await Run(filter);
+
+        Assert.Equal("on", context.Response.Headers["X-Trace"].ToString());
+    }
+
+    /// <summary>
+    /// A single action is returned unwrapped rather than inside a loop. Behaviourally identical,
+    /// which is the point — the optimisation must not change what runs.
+    /// </summary>
+    [Fact]
+    public async Task ASingleActionRunsExactlyOnce() {
+        var calls = 0;
+
+        var filter = Provider(configuration => configuration.Add(_ => calls++))
+            .ProvideFilter(HandlerInfo(), NoParameters);
+
+        await Run(filter);
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task SeveralActionsAllRunInOrder() {
+        var log = new List<string>();
+
+        var filter = Provider(configuration => {
+                configuration.Add(_ => log.Add("first"));
+                configuration.Add(_ => log.Add("second"));
+            })
+            .ProvideFilter(HandlerInfo(), NoParameters);
+
+        await Run(filter);
+
+        Assert.Equal(["first", "second"], log);
+    }
+
+    /// <summary>
+    /// Both families configured. The common headers are appended after the actions, so an action
+    /// that sets the same name is overwritten by the configured value.
+    /// </summary>
+    [Fact]
+    public async Task ActionsAndCommonHeadersBothApply() {
+        var filter = Provider(configuration => {
+                configuration.Add(context => context.Response.Headers["X-Trace"] = "on");
+                configuration.Add("X-Frame-Options", "DENY");
+            })
+            .ProvideFilter(HandlerInfo(), NoParameters);
+
+        var context = await Run(filter);
+
+        Assert.Equal("on", context.Response.Headers["X-Trace"].ToString());
+        Assert.Equal("DENY", context.Response.Headers["X-Frame-Options"].ToString());
+    }
+
+    [Fact]
+    public async Task AMultiValueCommonHeaderKeepsEveryValue() {
+        var filter = Provider(configuration =>
+                configuration.Add("Vary", new StringValues(["Accept", "Accept-Encoding"])))
+            .ProvideFilter(HandlerInfo(), NoParameters);
+
+        var context = await Run(filter);
+
+        var vary = context.Response.Headers["Vary"];
+
+        Assert.Equal(2, vary.Count);
+        Assert.Equal("Accept", vary[0]);
+        Assert.Equal("Accept-Encoding", vary[1]);
+    }
+
+    #region streamed filters
+
+    [Fact]
+    public void TheStreamedFilterIsBuiltForTheItemType() {
+        var filter = Provider()
+            .ProvideAsyncEnumerableFilter<string>(HandlerInfo(), NoParameters);
+
+        Assert.IsType<AsyncEnumerableIoFilter<string>>(filter);
+    }
+
+    /// <summary>
+    /// The two-argument overload exists for generated code that predates framings, and must keep
+    /// answering newline-delimited JSON.
+    /// </summary>
+    [Fact]
+    public async Task TheTwoArgumentStreamedOverloadFramesAsNdjson() {
+        var filter = Provider()
+            .ProvideAsyncEnumerableFilter<string>(HandlerInfo(), NoParameters);
+
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = Values();
+
+        await Pipeline.Chain(context, filter).Next();
+
+        Assert.Equal(NdjsonFraming.Instance.ContentType, context.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task ANamedFramingIsUsedInsteadOfTheDefault() {
+        var filter = Provider()
+            .ProvideAsyncEnumerableFilter<string>(HandlerInfo(), NoParameters, SseFraming.Instance);
+
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = Values();
+
+        await Pipeline.Chain(context, filter).Next();
+
+        Assert.Equal(SseFraming.Instance.ContentType, context.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task ConfiguredHeadersReachAStreamedResponseToo() {
+        var filter = Provider(configuration => configuration.Add("X-Frame-Options", "DENY"))
+            .ProvideAsyncEnumerableFilter<string>(HandlerInfo(), NoParameters);
+
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = Values();
+
+        await Pipeline.Chain(context, filter).Next();
+
+        Assert.Equal("DENY", context.Response.Headers["X-Frame-Options"].ToString());
+    }
+
+    private static async IAsyncEnumerable<string> Values() {
+        yield return "alpha";
+
+        await Task.CompletedTask;
+    }
+
+    #endregion
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Headers/CookieSetCollectionImplTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Headers/CookieSetCollectionImplTests.cs
@@ -1,0 +1,109 @@
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Runtime.Headers;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Headers;
+
+/// <summary>
+/// The collection a handler appends response cookies to.
+/// </summary>
+/// <remarks>
+/// <c>CookieSetOptionsTests</c> covers what an option set renders as; this covers the collection
+/// underneath it, which was at 20%. The behaviour that is not obvious from the signature is that
+/// <c>Append</c> indexes rather than adds — a second append under the same name replaces the first
+/// instead of emitting two <c>Set-Cookie</c> headers for it. That is the right answer (a browser
+/// keeps the last one anyway) and it is worth being deliberate about.
+/// </remarks>
+public class CookieSetCollectionImplTests {
+
+    [Fact]
+    public void AnAppendedCookieIsReadableByName() {
+        var collection = new CookieSetCollectionImpl();
+
+        collection.Append("session", "abc123");
+
+        var (value, _) = collection.Cookies["session"];
+
+        Assert.Equal("abc123", value);
+    }
+
+    /// <summary>
+    /// Omitting options must not leave a null on the entry — <c>AppendSettings</c> is called on it
+    /// unconditionally when the header is rendered.
+    /// </summary>
+    [Fact]
+    public void AnAppendWithoutOptionsGetsTheEmptyOptions() {
+        var collection = new CookieSetCollectionImpl();
+
+        collection.Append("session", "abc123");
+
+        var (_, options) = collection.Cookies["session"];
+
+        Assert.Same(CookieSetOptions.Empty, options);
+    }
+
+    [Fact]
+    public void SuppliedOptionsAreKept() {
+        var collection = new CookieSetCollectionImpl();
+        var options = new CookieSetOptions(Path: "/admin", SameSite: SameSite.Strict);
+
+        collection.Append("session", "abc123", options);
+
+        Assert.Same(options, collection.Cookies["session"].Item2);
+    }
+
+    [Fact]
+    public void SeveralNamesAreAllKept() {
+        var collection = new CookieSetCollectionImpl();
+
+        collection.Append("session", "abc123");
+        collection.Append("theme", "dark");
+
+        Assert.Equal(2, collection.Cookies.Count);
+        Assert.Equal("abc123", collection.Cookies["session"].Item1);
+        Assert.Equal("dark", collection.Cookies["theme"].Item1);
+    }
+
+    /// <summary>
+    /// Appending the same name twice replaces rather than accumulating.
+    /// </summary>
+    [Fact]
+    public void AppendingTheSameNameTwiceKeepsTheLastValue() {
+        var collection = new CookieSetCollectionImpl();
+
+        collection.Append("session", "first");
+        collection.Append("session", "second");
+
+        Assert.Single(collection.Cookies);
+        Assert.Equal("second", collection.Cookies["session"].Item1);
+    }
+
+    /// <summary>
+    /// Replacing a value must replace its options too, or a cookie re-issued without a
+    /// <c>Path</c> silently keeps the earlier one's scope.
+    /// </summary>
+    [Fact]
+    public void AppendingTheSameNameTwiceReplacesTheOptionsAsWell() {
+        var collection = new CookieSetCollectionImpl();
+
+        collection.Append("session", "first", new CookieSetOptions(Path: "/admin"));
+        collection.Append("session", "second");
+
+        Assert.Same(CookieSetOptions.Empty, collection.Cookies["session"].Item2);
+    }
+
+    [Fact]
+    public void CookieNamesAreCaseSensitive() {
+        var collection = new CookieSetCollectionImpl();
+
+        collection.Append("Session", "upper");
+        collection.Append("session", "lower");
+
+        Assert.Equal(2, collection.Cookies.Count);
+    }
+
+    [Fact]
+    public void AFreshCollectionHasNoCookies() {
+        Assert.Empty(new CookieSetCollectionImpl().Cookies);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/PathTokens/PathTokenCollectionTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/PathTokens/PathTokenCollectionTests.cs
@@ -1,0 +1,191 @@
+using Hardened.Requests.Abstract.PathTokens;
+using Hardened.Requests.Runtime.PathTokens;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.PathTokens;
+
+/// <summary>
+/// Path token values for a matched route.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The class carries two constructors that mean different things, and the difference is the whole
+/// design: the route-supplied names array is <em>shared across every request that matches that
+/// route</em>, so it must never be written to, while the legacy constructor allocates its own and
+/// may be. <c>_ownsNames</c> is what separates them, and the branch it guards was untaken —
+/// the type sat at 76% line and 68% branch.
+/// </para>
+/// <para>
+/// <see cref="SetOnARouteSuppliedCollectionDoesNotWriteTheSharedNamesArray"/> is the one that
+/// matters. If that guard were dropped, one request could rename a token for every other request
+/// matching the same route, concurrently, and nothing else in the suite would notice.
+/// </para>
+/// </remarks>
+public class PathTokenCollectionTests {
+
+    [Fact]
+    public void EmptyHasNoTokens() {
+        Assert.Equal(0, PathTokenCollection.Empty.Count);
+    }
+
+    [Fact]
+    public void CountIsTheCountItWasBuiltWith() {
+        Assert.Equal(3, new PathTokenCollection(3, ["a", "b", "c"]).Count);
+    }
+
+    [Fact]
+    public void AValueSetPositionallyReadsBackUnderTheRoutesName() {
+        var tokens = new PathTokenCollection(2, ["id", "postId"]);
+
+        tokens.SetValue(0, "7");
+        tokens.SetValue(1, "42");
+
+        Assert.Equal("id", tokens.Get(0).TokenName);
+        Assert.Equal("7", tokens.Get(0).TokenValue);
+        Assert.Equal("42", tokens.Get(1).TokenValue);
+    }
+
+    /// <summary>
+    /// The last value is filled in by the constructor because the match unwinds from the leaf.
+    /// </summary>
+    [Fact]
+    public void TheLastValueMayBeSuppliedAtConstruction() {
+        var tokens = new PathTokenCollection(2, ["id", "postId"], "42");
+
+        Assert.Equal("42", tokens.Get(1).TokenValue);
+    }
+
+    [Fact]
+    public void ALastValueOnAnEmptyCollectionIsIgnoredRatherThanThrowing() {
+        Assert.Equal(0, new PathTokenCollection(0, [], "42").Count);
+    }
+
+    [Fact]
+    public void LookupByNameFindsTheValue() {
+        var tokens = new PathTokenCollection(2, ["id", "postId"]);
+
+        tokens.SetValue(0, "7");
+        tokens.SetValue(1, "42");
+
+        Assert.Equal("42", tokens.Get("postId").ToString());
+    }
+
+    [Fact]
+    public void LookupByAnUnknownNameIsEmptyRatherThanThrowing() {
+        var tokens = new PathTokenCollection(1, ["id"]);
+
+        tokens.SetValue(0, "7");
+
+        Assert.Equal(StringValues.Empty, tokens.Get("nope"));
+    }
+
+    /// <summary>
+    /// A token position that matched nothing reads as empty, not null — the callers treat the
+    /// result as a string.
+    /// </summary>
+    [Fact]
+    public void AnUnsetValueReadsAsAnEmptyStringByIndex() {
+        Assert.Equal("", new PathTokenCollection(1, ["id"]).Get(0).TokenValue);
+    }
+
+    [Fact]
+    public void AnUnsetValueReadsAsEmptyByName() {
+        Assert.Equal(StringValues.Empty, new PathTokenCollection(1, ["id"]).Get("id"));
+    }
+
+    /// <summary>
+    /// More values than the route named. <c>NameAt</c> falls back rather than indexing past the
+    /// end of a shared array.
+    /// </summary>
+    [Fact]
+    public void AValueBeyondTheSuppliedNamesHasAnEmptyName() {
+        var tokens = new PathTokenCollection(2, ["id"]);
+
+        tokens.SetValue(1, "42");
+
+        Assert.Equal("", tokens.Get(1).TokenName);
+        Assert.Equal("42", tokens.Get(1).TokenValue);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    [InlineData(int.MaxValue)]
+    public void SetValueOutsideTheRangeThrows(int index) {
+        var tokens = new PathTokenCollection(2, ["id", "postId"]);
+
+        Assert.Throws<IndexOutOfRangeException>(() => tokens.SetValue(index, "value"));
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void GetOutsideTheRangeThrows(int index) {
+        var tokens = new PathTokenCollection(2, ["id", "postId"]);
+
+        Assert.Throws<IndexOutOfRangeException>(() => tokens.Get(index));
+    }
+
+    [Fact]
+    public void AnyIndexIntoAnEmptyCollectionThrows() {
+        Assert.Throws<IndexOutOfRangeException>(() => PathTokenCollection.Empty.Get(0));
+    }
+
+    #region the legacy constructor, which owns its names
+
+    [Fact]
+    public void ACollectionThatOwnsItsNamesRecordsWhatSetIsGiven() {
+        var tokens = new PathTokenCollection(2);
+
+        tokens.Set(0, new PathToken("id", "7"));
+
+        Assert.Equal("id", tokens.Get(0).TokenName);
+        Assert.Equal("7", tokens.Get(0).TokenValue);
+    }
+
+    [Fact]
+    public void TheLastTokenMayBeSuppliedAtConstruction() {
+        var tokens = new PathTokenCollection(2, new PathToken("postId", "42"));
+
+        Assert.Equal("postId", tokens.Get(1).TokenName);
+        Assert.Equal("42", tokens.Get(1).TokenValue);
+    }
+
+    [Fact]
+    public void ALastTokenOnAnEmptyCollectionIsIgnoredRatherThanThrowing() {
+        Assert.Equal(0, new PathTokenCollection(0, new PathToken("postId", "42")).Count);
+    }
+
+    /// <summary>
+    /// The guard the whole <c>_ownsNames</c> flag exists for.
+    /// </summary>
+    /// <remarks>
+    /// The names array belongs to the matched route and is shared by every request through it.
+    /// <c>Set</c> is retained for generated code that still passes a name with each value, and it
+    /// must take the value and discard the name — writing it would rename the token for every
+    /// concurrent request on that route.
+    /// </remarks>
+    [Fact]
+    public void SetOnARouteSuppliedCollectionDoesNotWriteTheSharedNamesArray() {
+        var routeNames = new[] { "id", "postId" };
+        var tokens = new PathTokenCollection(2, routeNames);
+
+        tokens.Set(0, new PathToken("somethingElse", "7"));
+
+        Assert.Equal("id", routeNames[0]);
+        Assert.Equal("id", tokens.Get(0).TokenName);
+        Assert.Equal("7", tokens.Get(0).TokenValue);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void SetOutsideTheRangeThrows(int index) {
+        var tokens = new PathTokenCollection(2);
+
+        Assert.Throws<IndexOutOfRangeException>(() => tokens.Set(index, new PathToken("id", "7")));
+    }
+
+    #endregion
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/AotSerializerModuleTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/AotSerializerModuleTests.cs
@@ -1,0 +1,137 @@
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime;
+using Hardened.Requests.Runtime.Serializer;
+using Hardened.Shared.Runtime.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Serializer;
+
+/// <summary>
+/// What <c>[AotSerializerModule]</c> puts in the container.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The module was at 0% — nothing in the suite applied the attribute or called the module, so an
+/// application published with Native AOT ran a code path no test had executed. The AOT integration
+/// fixture exercises it end to end, and CI publishes that fixture, but a publish check cannot say
+/// <em>which</em> serializer answered.
+/// </para>
+/// <para>
+/// <see cref="TheTwoRegistrationMethodsRegisterTheSameThings"/> exists because the class carries
+/// two methods with byte-identical bodies — <c>PopulateServiceCollection</c> from
+/// <c>IDependencyModule</c> and <c>InternalApplyServices</c>, which the module infrastructure calls.
+/// Duplicated bodies drift; this fails when one is edited and the other is not.
+/// </para>
+/// </remarks>
+public class AotSerializerModuleTests {
+
+    private static ServiceCollection Applied() {
+        var services = new ServiceCollection();
+
+        new AotSerializerModule().PopulateServiceCollection(services);
+
+        return services;
+    }
+
+    private static ServiceDescriptor DescriptorFor<TService>(IServiceCollection services) =>
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(TService));
+
+    [Fact]
+    public void TheResponseSerializerIsTheAotOne() {
+        Assert.Equal(
+            typeof(AotResponseSerializer), DescriptorFor<IResponseSerializer>(Applied()).ImplementationType);
+    }
+
+    [Fact]
+    public void TheRequestDeserializerIsTheAotOne() {
+        Assert.Equal(
+            typeof(AotRequestDeserializer), DescriptorFor<IRequestDeserializer>(Applied()).ImplementationType);
+    }
+
+    [Fact]
+    public void TheJsonSerializerIsTheAotOne() {
+        Assert.Equal(
+            typeof(AotJsonSerializer), DescriptorFor<IJsonSerializer>(Applied()).ImplementationType);
+    }
+
+    /// <summary>
+    /// Singletons, not transients. The AOT serializers build their resolver chain in the
+    /// constructor, so a transient rebuilds it per resolution.
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(IResponseSerializer))]
+    [InlineData(typeof(IRequestDeserializer))]
+    [InlineData(typeof(IJsonSerializer))]
+    public void EveryRegistrationIsASingleton(Type serviceType) {
+        var descriptor = Assert.Single(Applied(), item => item.ServiceType == serviceType);
+
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+    }
+
+    [Fact]
+    public void NothingElseIsRegistered() {
+        Assert.Equal(3, Applied().Count);
+    }
+
+    /// <summary>
+    /// Two identical bodies on one class. This is what notices when only one of them is edited.
+    /// </summary>
+    [Fact]
+    public void TheTwoRegistrationMethodsRegisterTheSameThings() {
+        var viaInterface = new ServiceCollection();
+        var viaInternal = new ServiceCollection();
+
+        new AotSerializerModule().PopulateServiceCollection(viaInterface);
+        new AotSerializerModule().InternalApplyServices(viaInternal);
+
+        Assert.Equal(
+            viaInterface.Select(descriptor => (descriptor.ServiceType, descriptor.ImplementationType, descriptor.Lifetime)),
+            viaInternal.Select(descriptor => (descriptor.ServiceType, descriptor.ImplementationType, descriptor.Lifetime)));
+    }
+
+    #region module identity
+
+    /// <summary>
+    /// Modules are de-duplicated by equality, so an application reaching this one down two
+    /// different import paths must apply it once. Registering twice would put two
+    /// <c>IResponseSerializer</c>s of the same type in the container.
+    /// </summary>
+    [Fact]
+    public void AnyTwoInstancesAreEqual() {
+        Assert.Equal(new AotSerializerModule(), new AotSerializerModule());
+    }
+
+    [Fact]
+    public void EqualInstancesShareAHashCode() {
+        Assert.Equal(new AotSerializerModule().GetHashCode(), new AotSerializerModule().GetHashCode());
+    }
+
+    [Fact]
+    public void AnotherTypeIsNotEqual() {
+        Assert.False(new AotSerializerModule().Equals(new object()));
+    }
+
+    [Fact]
+    public void NullIsNotEqual() {
+        Assert.False(new AotSerializerModule().Equals(null));
+    }
+
+    #endregion
+
+    [Fact]
+    public void TheAttributeProvidesTheModule() {
+        Assert.IsType<AotSerializerModule>(new AotSerializerModuleAttribute().GetModule());
+    }
+
+    /// <summary>
+    /// The attribute hands back a module equal to any other, so applying it in two places in an
+    /// application still de-duplicates.
+    /// </summary>
+    [Fact]
+    public void ModulesFromTwoAttributesAreEqual() {
+        Assert.Equal(
+            new AotSerializerModuleAttribute().GetModule(),
+            new AotSerializerModuleAttribute().GetModule());
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Validation/ValidatorResolutionTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Validation/ValidatorResolutionTests.cs
@@ -1,0 +1,182 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Tests.Filters;
+using Hardened.Requests.Runtime.Tests.Support;
+using Hardened.Requests.Runtime.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using ValidationModules;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Validation;
+
+/// <summary>
+/// How a validation filter gets its validators.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ValidationFilterTests</c> covers the filter once it has them. This covers the two types that
+/// find them — <see cref="ValidateAttribute{T}"/>, which an author writes by hand, and
+/// <see cref="ValidationFilterProvider{T}"/>, which a generator emits against a handler's nested
+/// <c>Parameters</c> class. Both sat at 55% line / 50% branch, and the untaken branch in each was
+/// the throw.
+/// </para>
+/// <para>
+/// <b>The throw is the behaviour worth having a test for.</b> Both classes carry a paragraph
+/// explaining that an empty validator set must fail loudly rather than read as "nothing to check",
+/// because the filter is only ever attached when something declared constraints — so an empty set
+/// means the application was wired against a different entry point, and passing silently would turn
+/// validation off on a build that otherwise looks fine. Neither had a test proving it does.
+/// </para>
+/// </remarks>
+public class ValidatorResolutionTests {
+
+    private static IExecutionRequestHandlerInfo HandlerInfo() =>
+        Substitute.For<IExecutionRequestHandlerInfo>();
+
+    private static IExecutionContext ContextWith(params IValidatorFor<ValidationFilterTests.Payload>[] validators) =>
+        Pipeline.Context(configureServices: services => {
+            foreach (var validator in validators) {
+                services.AddSingleton(validator);
+            }
+        });
+
+    #region ValidateAttribute
+
+    [Fact]
+    public void TheAttributeYieldsOneFilterAtTheValidationPosition() {
+        var info = Assert.Single(
+            new ValidateAttribute<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        Assert.Equal(FilterOrder.Validation, info.Order);
+    }
+
+    [Fact]
+    public void TheAttributeBuildsAValidationFilterForItsType() {
+        var info = Assert.Single(
+            new ValidateAttribute<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        var filter = info.FilterFunc(ContextWith(ValidationFilterTests.PayloadValidator.Instance));
+
+        Assert.IsType<ValidationFilter<ValidationFilterTests.Payload>>(filter);
+    }
+
+    /// <summary>
+    /// An empty set is a wiring fault, not an absence of work.
+    /// </summary>
+    [Fact]
+    public void TheAttributeThrowsWhenNoValidatorIsRegistered() {
+        var info = Assert.Single(
+            new ValidateAttribute<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        var exception =
+            Assert.Throws<InvalidOperationException>(() => info.FilterFunc(ContextWith()));
+
+        Assert.Contains(nameof(ValidationFilterTests.Payload), exception.Message);
+        Assert.Contains("entry point", exception.Message);
+    }
+
+    /// <summary>
+    /// <c>GetFilters</c> runs from the handler's constructor, which has no service provider, so the
+    /// filter is built on the first request and kept. Rebuilding it would put a container lookup on
+    /// the steady-state request path of every validated handler.
+    /// </summary>
+    [Fact]
+    public void TheAttributeBuildsItsFilterOnceAcrossRequests() {
+        var info = Assert.Single(
+            new ValidateAttribute<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        var first = info.FilterFunc(ContextWith(ValidationFilterTests.PayloadValidator.Instance));
+        var second = info.FilterFunc(ContextWith(ValidationFilterTests.PayloadValidator.Instance));
+
+        Assert.Same(first, second);
+    }
+
+    /// <summary>
+    /// Two attributes are two filters, and they do not share a cached instance.
+    /// </summary>
+    [Fact]
+    public void TwoAttributesBuildTheirOwnFilters() {
+        var context = ContextWith(ValidationFilterTests.PayloadValidator.Instance);
+
+        var first = Assert.Single(
+            new ValidateAttribute<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+        var second = Assert.Single(
+            new ValidateAttribute<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        Assert.NotSame(first.FilterFunc(context), second.FilterFunc(context));
+    }
+
+    #endregion
+
+    #region ValidationFilterProvider
+
+    [Fact]
+    public void TheProviderYieldsOneFilterAtTheValidationPosition() {
+        var info = Assert.Single(
+            new ValidationFilterProvider<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        Assert.Equal(FilterOrder.Validation, info.Order);
+    }
+
+    [Fact]
+    public void TheProviderBuildsAValidationFilterForItsType() {
+        var info = Assert.Single(
+            new ValidationFilterProvider<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        var filter = info.FilterFunc(ContextWith(ValidationFilterTests.PayloadValidator.Instance));
+
+        Assert.IsType<ValidationFilter<ValidationFilterTests.Payload>>(filter);
+    }
+
+    /// <summary>
+    /// The generated route into the same failure. A generator emits the provider alongside a
+    /// validator registration in one run, so an empty set means the application was built against
+    /// a different entry point.
+    /// </summary>
+    [Fact]
+    public void TheProviderThrowsWhenNoValidatorIsRegistered() {
+        var info = Assert.Single(
+            new ValidationFilterProvider<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        var exception =
+            Assert.Throws<InvalidOperationException>(() => info.FilterFunc(ContextWith()));
+
+        Assert.Contains(nameof(ValidationFilterTests.Payload), exception.Message);
+    }
+
+    [Fact]
+    public void TheProviderBuildsItsFilterOnceAcrossRequests() {
+        var info = Assert.Single(
+            new ValidationFilterProvider<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        var first = info.FilterFunc(ContextWith(ValidationFilterTests.PayloadValidator.Instance));
+        var second = info.FilterFunc(ContextWith(ValidationFilterTests.PayloadValidator.Instance));
+
+        Assert.Same(first, second);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Every registered validator reaches the filter, so a hand-written one runs alongside the
+    /// generated one rather than one replacing the other.
+    /// </summary>
+    [Fact]
+    public async Task EveryRegisteredValidatorReachesTheFilter() {
+        var info = Assert.Single(
+            new ValidateAttribute<ValidationFilterTests.Payload>().GetFilters(HandlerInfo()));
+
+        var context = ContextWith(
+            ValidationFilterTests.PayloadValidator.Instance,
+            ValidationFilterTests.SecondPayloadValidator.Instance);
+
+        context.Request.Parameters = new ValidationFilterTests.Payload { Name = "" };
+
+        var exception = await Assert.ThrowsAsync<Hardened.Requests.Runtime.Validation.ValidationException>(
+            () => Pipeline.Chain(context, info.FilterFunc(context)).Next());
+
+        Assert.Contains(exception.ValidationResult.Errors, error => error.Field == "name");
+        Assert.Contains(exception.ValidationResult.Errors, error => error.Field == "second");
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotRequestDeserializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotRequestDeserializer.cs
@@ -69,6 +69,18 @@ public class AotRequestDeserializer : IRequestDeserializer {
 
     public bool IsDefaultSerializer => true;
 
+    /// <summary>
+    /// Ahead of <see cref="SystemTextJsonRequestDeserializer"/>, which is how an AOT application
+    /// ends up reading bodies with its own deserializer rather than the reflection-based one.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart to <see cref="AotResponseSerializer.Order"/>, and stated for the same reason.
+    /// This used to be arranged by <c>TryAddSingleton</c> on the reflection-based registration, which
+    /// keys on the service type rather than on that class - so it fired for any
+    /// <c>IRequestDeserializer</c> registered first, not only this one.
+    /// </remarks>
+    public int Order => (int)RequestDeserializerOrder.Specialized;
+
     public bool CanProcessContext(IExecutionContext context) {
         return context.Request.ContentType?.Contains("application/json") ?? false;
     }

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/SerializationLocatorService.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/SerializationLocatorService.cs
@@ -12,8 +12,15 @@ public class SerializationLocatorService : ISerializationLocatorService {
     public SerializationLocatorService(
         IEnumerable<IRequestDeserializer> requestDeserializers,
         IEnumerable<IResponseSerializer> responseSerializers) {
-        // reverse lists so user registered serializers are tested first
-        _requestDeserializers = requestDeserializers.Reverse().ToArray();
+        // Reversed so an application's own registrations are tested before the framework's, then
+        // ordered ahead of that for the reason given below. Same treatment as the response side,
+        // and for the same reason: two deserializers both claiming application/json - which is
+        // what installing Hardened.Requests.Serializers.Newtonsoft produces - were previously
+        // separated only by which module happened to register last.
+        _requestDeserializers = requestDeserializers
+            .Reverse()
+            .OrderBy(deserializer => deserializer.Order)
+            .ToArray();
 
         // Ordered ahead of that, because reverse-registration order alone is not something an
         // application can steer: within a module DependencyModules sorts by implementation type

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/Hardened.Requests.Serializers.Newtonsoft.Tests.csproj
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/Hardened.Requests.Serializers.Newtonsoft.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2"/>
+        <PackageReference Include="NSubstitute" Version="5.1.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Hardened.Requests.Serializers.Newtonsoft\Hardened.Requests.Serializers.Newtonsoft.csproj"/>
+
+        <!--
+            The in-memory transport, so the serializers are driven through a real request and
+            response rather than a mocked context. Both sides here read and write streams that the
+            caller owns, and a substituted context cannot fail when that ownership is broken.
+        -->
+        <ProjectReference Include="..\..\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/NewtonsoftDeserializerTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/NewtonsoftDeserializerTests.cs
@@ -1,0 +1,212 @@
+using System.Text;
+using Hardened.Requests.Serializers.Newtonsoft.Tests.Support;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.Newtonsoft.Tests;
+
+/// <summary>
+/// Reading a request body with Newtonsoft.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Every test in this file failed when it was written.</b> <c>DeserializeRequestBody</c> returned
+/// <c>default(T)</c> for every request and had done since the package shipped: it took one
+/// reservation from the memory stream pool, copied the body into a second, seeked a third, and read
+/// the first — which was empty. Two of the three were never returned to the pool. Fixed 2026-08-18;
+/// see the method's own remarks.
+/// </para>
+/// <para>
+/// The assembly was at 0% line coverage with no test project, which is exactly why a shipped
+/// package could be entirely non-functional without anything going red.
+/// </para>
+/// </remarks>
+public class NewtonsoftDeserializerTests {
+
+    [Fact]
+    public async Task AJsonBodyIsRead() {
+        var payload = await Pipeline.Deserializer(Pipeline.Pool())
+            .DeserializeRequestBody<Pipeline.Payload>(
+                Pipeline.Context("""{"Name":"first","Count":2}"""));
+
+        Assert.NotNull(payload);
+        Assert.Equal("first", payload.Name);
+        Assert.Equal(2, payload.Count);
+    }
+
+    [Fact]
+    public async Task ABodyLargerThanThePoolsInitialBufferIsReadWhole() {
+        var name = new string('a', 8192);
+
+        var payload = await Pipeline.Deserializer(Pipeline.Pool())
+            .DeserializeRequestBody<Pipeline.Payload>(
+                Pipeline.Context($$"""{"Name":"{{name}}","Count":2}"""));
+
+        Assert.NotNull(payload);
+        Assert.Equal(name, payload.Name);
+    }
+
+    [Fact]
+    public async Task AnEmptyBodyIsNull() {
+        Assert.Null(
+            await Pipeline.Deserializer(Pipeline.Pool())
+                .DeserializeRequestBody<Pipeline.Payload>(Pipeline.Context()));
+    }
+
+    [Fact]
+    public async Task AJsonNullBodyIsNull() {
+        Assert.Null(
+            await Pipeline.Deserializer(Pipeline.Pool())
+                .DeserializeRequestBody<Pipeline.Payload>(Pipeline.Context("null")));
+    }
+
+    [Fact]
+    public async Task AMalformedBodyThrows() {
+        await Assert.ThrowsAsync<JsonReaderException>(
+            () => Pipeline.Deserializer(Pipeline.Pool())
+                .DeserializeRequestBody<Pipeline.Payload>(Pipeline.Context("{not json")).AsTask());
+    }
+
+    /// <summary>
+    /// The configured serializer is the one that runs, which is the whole reason the package exists.
+    /// </summary>
+    [Fact]
+    public async Task TheConfiguredNamingStrategyIsHonoured() {
+        var serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings {
+            ContractResolver = new DefaultContractResolver {
+                NamingStrategy = new SnakeCaseNamingStrategy()
+            }
+        });
+
+        var payload = await Pipeline.Deserializer(Pipeline.Pool(), serializer)
+            .DeserializeRequestBody<SnakePayload>(
+                Pipeline.Context("""{"first_name":"ada"}"""));
+
+        Assert.NotNull(payload);
+        Assert.Equal("ada", payload.FirstName);
+    }
+
+    /// <summary>
+    /// One reservation per request, and it goes back.
+    /// </summary>
+    /// <remarks>
+    /// A leaked reservation is invisible through the pool's own interface — it just makes another
+    /// stream — so this counts instead. The original took three per request and returned one, which
+    /// is a <c>MemoryStream</c> leaked per request per two of them, growing with traffic.
+    /// </remarks>
+    [Fact]
+    public async Task OneReservationIsTakenPerRequestAndReturned() {
+        var pool = new Pipeline.CountingPool();
+
+        await Pipeline.Deserializer(pool)
+            .DeserializeRequestBody<Pipeline.Payload>(
+                Pipeline.Context("""{"Name":"first","Count":2}"""));
+
+        Assert.Equal(1, pool.Taken);
+        Assert.Equal(1, pool.Returned);
+    }
+
+    /// <summary>
+    /// A body that failed to parse still gives its reservation back — the <c>using</c> has to hold
+    /// on the throwing path, or a malformed-request flood drains the pool.
+    /// </summary>
+    [Fact]
+    public async Task AReservationIsReturnedEvenWhenParsingThrows() {
+        var pool = new Pipeline.CountingPool();
+
+        await Assert.ThrowsAsync<JsonReaderException>(
+            () => Pipeline.Deserializer(pool)
+                .DeserializeRequestBody<Pipeline.Payload>(Pipeline.Context("{not json")).AsTask());
+
+        Assert.Equal(1, pool.Taken);
+        Assert.Equal(1, pool.Returned);
+    }
+
+    /// <summary>
+    /// The returned stream is reset on its way back, so a borrower never sees the last request's
+    /// bytes.
+    /// </summary>
+    [Fact]
+    public async Task AReturnedStreamCarriesNothingFromTheLastRequest() {
+        var pool = Pipeline.Pool();
+
+        await Pipeline.Deserializer(pool)
+            .DeserializeRequestBody<Pipeline.Payload>(
+                Pipeline.Context("""{"Name":"first","Count":2}"""));
+
+        using var reservation = pool.Get();
+
+        Assert.Equal(0, reservation.Item.Length);
+    }
+
+    /// <summary>
+    /// Two calls on one instance must not interfere — the deserializer is registered transient but
+    /// nothing stops a scope resolving it once and using it twice.
+    /// </summary>
+    [Fact]
+    public async Task TwoCallsOnOneInstanceEachReadTheirOwnBody() {
+        var deserializer = Pipeline.Deserializer(Pipeline.Pool());
+
+        var first = await deserializer.DeserializeRequestBody<Pipeline.Payload>(
+            Pipeline.Context("""{"Name":"first","Count":1}"""));
+        var second = await deserializer.DeserializeRequestBody<Pipeline.Payload>(
+            Pipeline.Context("""{"Name":"second","Count":2}"""));
+
+        Assert.Equal("first", first!.Name);
+        Assert.Equal("second", second!.Name);
+    }
+
+    /// <summary>
+    /// The request body belongs to the transport. Closing it here would break a host that reads
+    /// anything after binding — and a retry, which rewinds and reads it again.
+    /// </summary>
+    [Fact]
+    public async Task TheRequestBodyIsLeftOpen() {
+        var context = Pipeline.Context("""{"Name":"first","Count":2}""");
+
+        await Pipeline.Deserializer(Pipeline.Pool())
+            .DeserializeRequestBody<Pipeline.Payload>(context);
+
+        Assert.True(context.Request.Body.CanRead, "the deserializer closed a body it was handed");
+    }
+
+    #region content type
+
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData("application/json; charset=utf-8")]
+    public void AJsonContentTypeIsClaimed(string contentType) {
+        Assert.True(
+            Pipeline.Deserializer(Pipeline.Pool())
+                .CanProcessContext(Pipeline.Context(contentType: contentType)));
+    }
+
+    [Theory]
+    [InlineData("text/plain")]
+    [InlineData("application/xml")]
+    [InlineData("application/octet-stream")]
+    public void AnotherContentTypeIsNotClaimed(string contentType) {
+        Assert.False(
+            Pipeline.Deserializer(Pipeline.Pool())
+                .CanProcessContext(Pipeline.Context(contentType: contentType)));
+    }
+
+    [Fact]
+    public void AMissingContentTypeIsNotClaimed() {
+        Assert.False(
+            Pipeline.Deserializer(Pipeline.Pool())
+                .CanProcessContext(Pipeline.Context(contentType: null)));
+    }
+
+    [Fact]
+    public void ItOffersItselfAsTheDefault() {
+        Assert.True(Pipeline.Deserializer(Pipeline.Pool()).IsDefaultSerializer);
+    }
+
+    #endregion
+
+    private class SnakePayload {
+        public string? FirstName { get; set; }
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/NewtonsoftSerializerConfigurationTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/NewtonsoftSerializerConfigurationTests.cs
@@ -1,0 +1,51 @@
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.Newtonsoft.Tests;
+
+/// <summary>
+/// The configuration model the package exposes.
+/// </summary>
+/// <remarks>
+/// Generated from <c>[ConfigurationModel]</c>, so what is being checked is that the generator gave
+/// the field a settable property and a working default — the shape a consumer writes against. The
+/// default has to produce a serializer without any configuration at all, because installing the
+/// package and configuring nothing is the common case.
+/// </remarks>
+public class NewtonsoftSerializerConfigurationTests {
+
+    [Fact]
+    public void TheDefaultProviderBuildsASerializer() {
+        var configuration = new NewtonsoftSerializerConfiguration();
+
+        Assert.NotNull(configuration.SerializerProvider(null!));
+    }
+
+    /// <summary>
+    /// A fresh serializer per call rather than a shared one. <c>SharedSerializer</c> is what makes
+    /// it a singleton, and it calls this exactly once.
+    /// </summary>
+    [Fact]
+    public void TheDefaultProviderBuildsAFreshSerializerEachCall() {
+        var configuration = new NewtonsoftSerializerConfiguration();
+
+        Assert.NotSame(
+            configuration.SerializerProvider(null!), configuration.SerializerProvider(null!));
+    }
+
+    [Fact]
+    public void TheProviderCanBeReplaced() {
+        var expected = JsonSerializer.CreateDefault();
+        var configuration = new NewtonsoftSerializerConfiguration {
+            SerializerProvider = _ => expected
+        };
+
+        Assert.Same(expected, configuration.SerializerProvider(null!));
+    }
+
+    [Fact]
+    public void TheConfigurationImplementsItsGeneratedInterface() {
+        Assert.IsAssignableFrom<INewtonsoftSerializerConfiguration>(
+            new NewtonsoftSerializerConfiguration());
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/NewtonsoftSerializerTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/NewtonsoftSerializerTests.cs
@@ -1,0 +1,150 @@
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Serializers.Newtonsoft.Tests.Support;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.Newtonsoft.Tests;
+
+/// <summary>
+/// Writing a response body with Newtonsoft.
+/// </summary>
+/// <remarks>
+/// The write path was never broken the way the read path was, but it was equally unrun — the
+/// assembly had no test project and sat at 0%. What is worth pinning is the buffering: the
+/// serializer writes into a pooled stream and copies to the response only once the whole value has
+/// been written, so a serializer that throws part-way leaves nothing half-written on the wire.
+/// </remarks>
+public class NewtonsoftSerializerTests {
+
+    [Fact]
+    public async Task AValueIsWrittenAsJson() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Pipeline.Payload("first", 2);
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context);
+
+        Assert.Equal("""{"Name":"first","Count":2}""", Pipeline.BodyOf(context));
+    }
+
+    [Fact]
+    public async Task ANullValueIsWrittenAsJsonNull() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = null;
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context);
+
+        Assert.Equal("null", Pipeline.BodyOf(context));
+    }
+
+    [Fact]
+    public async Task TheConfiguredNamingStrategyIsHonoured() {
+        var serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings {
+            ContractResolver = new DefaultContractResolver {
+                NamingStrategy = new SnakeCaseNamingStrategy()
+            }
+        });
+
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Pipeline.Payload("first", 2);
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool(), serializer).SerializeResponse(context);
+
+        Assert.Equal("""{"name":"first","count":2}""", Pipeline.BodyOf(context));
+    }
+
+    /// <summary>
+    /// The setting that most often motivates reaching for this package at all.
+    /// </summary>
+    [Fact]
+    public async Task ConfiguredNullHandlingIsHonoured() {
+        var serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings {
+            NullValueHandling = NullValueHandling.Ignore
+        });
+
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Optional(null, 2);
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool(), serializer).SerializeResponse(context);
+
+        Assert.Equal("""{"Count":2}""", Pipeline.BodyOf(context));
+    }
+
+    [Fact]
+    public async Task ThePooledBufferIsReturnedAfterUse() {
+        var pool = Pipeline.Pool();
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Pipeline.Payload("first", 2);
+
+        await Pipeline.ResponseSerializer(pool).SerializeResponse(context);
+
+        using var reservation = pool.Get();
+
+        Assert.Equal(0, reservation.Item.Length);
+    }
+
+    /// <summary>
+    /// The response body belongs to the transport, which writes headers and closes it afterwards.
+    /// </summary>
+    [Fact]
+    public async Task TheResponseBodyIsLeftOpen() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Pipeline.Payload("first", 2);
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context);
+
+        Assert.True(context.Response.Body.CanWrite, "the serializer closed a body it was handed");
+    }
+
+    [Fact]
+    public async Task TwoResponsesOnOneInstanceDoNotBleedIntoEachOther() {
+        var serializer = Pipeline.ResponseSerializer(Pipeline.Pool());
+
+        var first = Pipeline.Context();
+        first.Response.ResponseValue = new Pipeline.Payload("first", 1);
+
+        var second = Pipeline.Context();
+        second.Response.ResponseValue = new Pipeline.Payload("second", 2);
+
+        await serializer.SerializeResponse(first);
+        await serializer.SerializeResponse(second);
+
+        Assert.Equal("""{"Name":"first","Count":1}""", Pipeline.BodyOf(first));
+        Assert.Equal("""{"Name":"second","Count":2}""", Pipeline.BodyOf(second));
+    }
+
+    #region media type
+
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData("*/*")]
+    [InlineData("application/*")]
+    public void JsonMediaTypesAreClaimed(string mediaType) {
+        Assert.True(
+            Pipeline.ResponseSerializer(Pipeline.Pool()).CanProduce(mediaType, Pipeline.Context()));
+    }
+
+    [Theory]
+    [InlineData("text/plain")]
+    [InlineData("text/html")]
+    [InlineData("application/xml")]
+    public void OtherMediaTypesAreNotClaimed(string mediaType) {
+        Assert.False(
+            Pipeline.ResponseSerializer(Pipeline.Pool()).CanProduce(mediaType, Pipeline.Context()));
+    }
+
+    [Fact]
+    public void ItOffersItselfAsTheDefault() {
+        Assert.True(Pipeline.ResponseSerializer(Pipeline.Pool()).IsDefaultSerializer);
+    }
+
+    #endregion
+
+    private record Optional(string? Name, int Count);
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SerializerPrecedenceTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SerializerPrecedenceTests.cs
@@ -1,0 +1,185 @@
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Configuration;
+using Hardened.Requests.Runtime.Serializer;
+using Hardened.Requests.Serializers.Newtonsoft.Impl;
+using Hardened.Requests.Serializers.Newtonsoft.Tests.Support;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.Newtonsoft.Tests;
+
+/// <summary>
+/// Installing the package is enough to be sure it is used.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It was not, until 2026-08-18. Neither Newtonsoft type stated an order, so
+/// <see cref="NewtonsoftSerializer"/> sat at <see cref="ResponseSerializerOrder.Normal"/> — exactly
+/// where <c>SystemTextJsonResponseSerializer</c> sits — and both return
+/// <c>IsDefaultSerializer</c>. Which one wrote a JSON response came down to which module registered
+/// last, and <c>SystemTextJsonResponseSerializer</c>'s own remarks say at length that registration
+/// order here is not something an application can steer. Displacing the built-in JSON serializer is
+/// the entire purpose of this package.
+/// </para>
+/// <para>
+/// The read half was worse: <see cref="IRequestDeserializer"/> had no <c>Order</c> at all, so
+/// nothing could be stated. It has one now.
+/// </para>
+/// <para>
+/// <b>Both registration orders are tested.</b> One order alone proves nothing here — the whole
+/// defect was that the answer depended on it.
+/// </para>
+/// </remarks>
+public class SerializerPrecedenceTests {
+
+    private static IOptions<IJsonSerializerConfiguration> JsonConfiguration() =>
+        Options.Create<IJsonSerializerConfiguration>(new JsonSerializerConfiguration());
+
+    private static IResponseSerializer Newtonsoft() =>
+        Pipeline.ResponseSerializer(Pipeline.Pool());
+
+    private static IResponseSerializer SystemTextJson() =>
+        new SystemTextJsonResponseSerializer(JsonConfiguration());
+
+    private static IRequestDeserializer NewtonsoftReader() =>
+        Pipeline.Deserializer(Pipeline.Pool());
+
+    private static IRequestDeserializer SystemTextJsonReader() =>
+        new SystemTextJsonRequestDeserializer(
+            JsonConfiguration(), NullLogger<SystemTextJsonRequestDeserializer>.Instance);
+
+    private static SerializationLocatorService Locator(
+        IEnumerable<IRequestDeserializer> deserializers,
+        IEnumerable<IResponseSerializer> serializers) =>
+        new(deserializers, serializers);
+
+    #region responses
+
+    [Fact]
+    public void NewtonsoftWritesTheResponseWhenItRegisteredLast() {
+        var locator = Locator([], [SystemTextJson(), Newtonsoft()]);
+
+        Assert.IsType<NewtonsoftSerializer>(
+            locator.FindResponseSerializer(Pipeline.Context()));
+    }
+
+    /// <summary>
+    /// The order that used to lose. Reverse-registration put System.Text.Json first, and nothing
+    /// outranked it.
+    /// </summary>
+    [Fact]
+    public void NewtonsoftWritesTheResponseWhenItRegisteredFirst() {
+        var locator = Locator([], [Newtonsoft(), SystemTextJson()]);
+
+        Assert.IsType<NewtonsoftSerializer>(
+            locator.FindResponseSerializer(Pipeline.Context()));
+    }
+
+    [Fact]
+    public void NewtonsoftIsTheDefaultResponseSerializerForAClientWithNoPreference() {
+        var context = Pipeline.Context();
+
+        context.Request.Headers["Accept"] = "*/*";
+
+        Assert.IsType<NewtonsoftSerializer>(
+            Locator([], [SystemTextJson(), Newtonsoft()]).FindResponseSerializer(context));
+    }
+
+    #endregion
+
+    #region requests
+
+    [Fact]
+    public void NewtonsoftReadsTheRequestWhenItRegisteredLast() {
+        var locator = Locator([SystemTextJsonReader(), NewtonsoftReader()], []);
+
+        Assert.IsType<NewtonsoftDeserializer>(
+            locator.FindRequestDeserializer(Pipeline.Context("{}")));
+    }
+
+    [Fact]
+    public void NewtonsoftReadsTheRequestWhenItRegisteredFirst() {
+        var locator = Locator([NewtonsoftReader(), SystemTextJsonReader()], []);
+
+        Assert.IsType<NewtonsoftDeserializer>(
+            locator.FindRequestDeserializer(Pipeline.Context("{}")));
+    }
+
+    /// <summary>
+    /// A body carrying no content type falls to the default, and that has to be the same
+    /// deserializer that would have claimed it — otherwise one request is read by Newtonsoft and
+    /// the next by System.Text.Json depending on a header.
+    /// </summary>
+    [Fact]
+    public void NewtonsoftIsAlsoTheDefaultForABodyWithNoContentType() {
+        var locator = Locator([SystemTextJsonReader(), NewtonsoftReader()], []);
+
+        Assert.IsType<NewtonsoftDeserializer>(
+            locator.FindRequestDeserializer(Pipeline.Context("{}", contentType: null)));
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Both directions agree. A package that wrote responses with Newtonsoft while System.Text.Json
+    /// read the requests would apply one naming strategy on the way out and another on the way in.
+    /// </summary>
+    [Fact]
+    public void BothDirectionsResolveToNewtonsoft() {
+        var locator = Locator(
+            [SystemTextJsonReader(), NewtonsoftReader()],
+            [SystemTextJson(), Newtonsoft()]);
+
+        Assert.IsType<NewtonsoftDeserializer>(
+            locator.FindRequestDeserializer(Pipeline.Context("{}")));
+        Assert.IsType<NewtonsoftSerializer>(
+            locator.FindResponseSerializer(Pipeline.Context()));
+    }
+
+    #region behind the AOT serializers
+
+    /// <summary>
+    /// An application importing <c>[AotSerializerModule]</c> keeps the source-generated serializers.
+    /// </summary>
+    /// <remarks>
+    /// The combination is contradictory — this package is reflection-based and the AOT module exists
+    /// because reflection is not there — but if anything resolves it, the generated one has to be
+    /// the answer. That is why Newtonsoft sits one step behind <c>Specialized</c> rather than at it.
+    /// </remarks>
+    [Fact]
+    public void TheAotResponseSerializerStillOutranksNewtonsoft() {
+        Assert.True(
+            new AotResponseSerializer(JsonConfiguration(), []).Order < Newtonsoft().Order,
+            "the AOT response serializer must stay ahead of Newtonsoft");
+    }
+
+    [Fact]
+    public void TheAotRequestDeserializerStillOutranksNewtonsoft() {
+        var aot = new AotRequestDeserializer(
+            JsonConfiguration(), NullLogger<AotRequestDeserializer>.Instance, []);
+
+        Assert.True(
+            aot.Order < NewtonsoftReader().Order,
+            "the AOT request deserializer must stay ahead of Newtonsoft");
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Newtonsoft outranks the built-in pair without being ahead of a serializer that claims one
+    /// specific media type.
+    /// </summary>
+    [Fact]
+    public void NewtonsoftSitsBetweenSpecializedAndNormal() {
+        Assert.InRange(
+            Newtonsoft().Order,
+            (int)ResponseSerializerOrder.Specialized + 1,
+            (int)ResponseSerializerOrder.Normal - 1);
+
+        Assert.InRange(
+            NewtonsoftReader().Order,
+            (int)RequestDeserializerOrder.Specialized + 1,
+            (int)RequestDeserializerOrder.Normal - 1);
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SharedSerializerTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SharedSerializerTests.cs
@@ -1,0 +1,106 @@
+using Hardened.Requests.Serializers.Newtonsoft.Impl;
+using Hardened.Requests.Serializers.Newtonsoft.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.Newtonsoft.Tests;
+
+/// <summary>
+/// The one <see cref="JsonSerializer"/> both directions share.
+/// </summary>
+/// <remarks>
+/// A single instance is the point: settings configured once must apply to reading and writing
+/// alike, or a model that round-trips under one naming strategy is written under another. It is
+/// registered as a singleton and built from the configured provider exactly once, which is also
+/// what makes an expensive <c>ContractResolver</c> affordable — Newtonsoft caches contracts on the
+/// resolver, and a per-request serializer would rebuild them.
+/// </remarks>
+public class SharedSerializerTests {
+
+    private static SharedSerializer Build(
+        Func<IServiceProvider, JsonSerializer>? provider = null,
+        Action<ServiceCollection>? configureServices = null) {
+        var services = new ServiceCollection();
+
+        configureServices?.Invoke(services);
+
+        return new SharedSerializer(services.BuildServiceProvider(), Pipeline.Configuration(provider));
+    }
+
+    [Fact]
+    public void TheDefaultConfigurationYieldsASerializer() {
+        Assert.NotNull(Build().Serializer);
+    }
+
+    [Fact]
+    public void TheConfiguredProviderIsWhatBuildsIt() {
+        var expected = JsonSerializer.CreateDefault();
+
+        Assert.Same(expected, Build(_ => expected).Serializer);
+    }
+
+    /// <summary>
+    /// Built once, in the constructor. A provider called per access would rebuild the contract
+    /// cache on every request.
+    /// </summary>
+    [Fact]
+    public void TheProviderRunsOnceRatherThanPerAccess() {
+        var calls = 0;
+
+        var shared = Build(_ => {
+            calls++;
+
+            return JsonSerializer.CreateDefault();
+        });
+
+        _ = shared.Serializer;
+        _ = shared.Serializer;
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void TheSerializerIsTheSameInstanceEveryTime() {
+        var shared = Build();
+
+        Assert.Same(shared.Serializer, shared.Serializer);
+    }
+
+    /// <summary>
+    /// The provider is handed the application's container, so a serializer can be built from
+    /// registered services — a converter that needs a clock or a tenant, for instance.
+    /// </summary>
+    [Fact]
+    public void TheProviderIsGivenTheServiceProvider() {
+        IServiceProvider? seen = null;
+
+        Build(
+            serviceProvider => {
+                seen = serviceProvider;
+
+                return JsonSerializer.CreateDefault();
+            },
+            services => services.AddSingleton("registered"));
+
+        Assert.NotNull(seen);
+        Assert.Equal("registered", seen.GetRequiredService<string>());
+    }
+
+    /// <summary>
+    /// Reading and writing share one instance, so settings configured once apply to both.
+    /// </summary>
+    [Fact]
+    public void BothDirectionsSeeTheSameSerializer() {
+        var shared = Build();
+        var pool = Pipeline.Pool();
+
+        var deserializer = new NewtonsoftDeserializer(
+            pool, shared, Microsoft.Extensions.Logging.Abstractions.NullLogger<NewtonsoftDeserializer>.Instance);
+        var serializer = new NewtonsoftSerializer(shared, pool);
+
+        Assert.NotNull(deserializer);
+        Assert.NotNull(serializer);
+        Assert.Same(shared.Serializer, shared.Serializer);
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/Support/Pipeline.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/Support/Pipeline.cs
@@ -1,0 +1,133 @@
+using System.Text;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Runtime.QueryString;
+using Hardened.Requests.Serializers.Newtonsoft.Impl;
+using Hardened.Requests.Testing;
+using Hardened.Shared.Runtime.Collections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using NSubstitute;
+
+namespace Hardened.Requests.Serializers.Newtonsoft.Tests.Support;
+
+/// <summary>
+/// Real request, real response, real pool.
+/// </summary>
+/// <remarks>
+/// The pool is the production <see cref="MemoryStreamPool"/> rather than a substitute, and
+/// deliberately. Both serializers borrow from it, and the defect this suite was written against was
+/// a reservation being taken three times and read once — which a substitute handing back a fresh
+/// stream every call would have hidden completely.
+/// </remarks>
+public static class Pipeline {
+
+    public static MemoryStreamPool Pool() => new();
+
+    /// <summary>
+    /// The production pool, counting how many reservations were taken and how many came back.
+    /// </summary>
+    /// <remarks>
+    /// A leaked reservation is invisible through <see cref="IItemPool{T}"/> alone — the pool simply
+    /// makes another stream, so the next borrower cannot tell. Counting is the only way to assert
+    /// it, and it needs asserting: the deserializer took three reservations per request and
+    /// returned one until 2026-08-18.
+    /// </remarks>
+    public sealed class CountingPool : IMemoryStreamPool {
+        private readonly MemoryStreamPool _inner = new();
+
+        public int Taken { get; private set; }
+
+        public int Returned { get; private set; }
+
+        public IPoolItemReservation<MemoryStream> Get() {
+            Taken++;
+
+            return new Reservation(this, _inner.Get());
+        }
+
+        private sealed class Reservation : IPoolItemReservation<MemoryStream> {
+            private readonly CountingPool _pool;
+            private readonly IPoolItemReservation<MemoryStream> _inner;
+
+            public Reservation(CountingPool pool, IPoolItemReservation<MemoryStream> inner) {
+                _pool = pool;
+                _inner = inner;
+            }
+
+            public MemoryStream Item => _inner.Item;
+
+            public void Dispose() {
+                _pool.Returned++;
+
+                _inner.Dispose();
+            }
+        }
+    }
+
+    public static ISharedSerializer Serializer(JsonSerializer? serializer = null) {
+        var shared = Substitute.For<ISharedSerializer>();
+
+        shared.Serializer.Returns(serializer ?? JsonSerializer.CreateDefault());
+
+        return shared;
+    }
+
+    public static NewtonsoftDeserializer Deserializer(
+        IMemoryStreamPool pool, JsonSerializer? serializer = null) =>
+        new(pool, Serializer(serializer), NullLogger<NewtonsoftDeserializer>.Instance);
+
+    public static NewtonsoftSerializer ResponseSerializer(
+        IMemoryStreamPool pool, JsonSerializer? serializer = null) =>
+        new(Serializer(serializer), pool);
+
+    /// <summary>A context whose request body is <paramref name="body"/>.</summary>
+    public static IExecutionContext Context(
+        string? body = null, string? contentType = KnownContentType.Json) {
+        var services = new ServiceCollection();
+        var provider = services.BuildServiceProvider();
+
+        var request = new TestExecutionRequest(
+            "POST", "/", KnownContentType.Json,
+            new SimpleQueryStringCollection(new Dictionary<string, string>())) {
+            Body = body is null ? Stream.Null : new MemoryStream(Encoding.UTF8.GetBytes(body))
+        };
+
+        if (contentType != null) {
+            request.Headers[KnownHeaders.ContentType] = contentType;
+        }
+
+        return new TestExecutionContext(
+            provider,
+            provider,
+            Substitute.For<IKnownServices>(),
+            request,
+            new TestExecutionResponse(new MemoryStream()),
+            CancellationToken.None,
+            null);
+    }
+
+    /// <summary>Everything written to the response body, as text.</summary>
+    public static string BodyOf(IExecutionContext context) {
+        context.Response.Body.Position = 0;
+
+        using var reader = new StreamReader(context.Response.Body, leaveOpen: true);
+
+        return reader.ReadToEnd();
+    }
+
+    public static IOptions<INewtonsoftSerializerConfiguration> Configuration(
+        Func<IServiceProvider, JsonSerializer>? provider = null) {
+        var configuration = new NewtonsoftSerializerConfiguration();
+
+        if (provider != null) {
+            configuration.SerializerProvider = provider;
+        }
+
+        return Options.Create<INewtonsoftSerializerConfiguration>(configuration);
+    }
+
+    public record Payload(string Name, int Count);
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Impl/NewtonsoftDeserializer.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Impl/NewtonsoftDeserializer.cs
@@ -26,32 +26,51 @@ public class NewtonsoftDeserializer : IRequestDeserializer {
         return context.Request.ContentType?.Contains("application/json") ?? false;
     }
 
-
+    /// <summary>
+    /// Reads the request body and deserializes it, leaving the body open for whoever owns it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method returned <c>default(T)</c> for every request until 2026-08-18, and had done since
+    /// the package shipped. It took one reservation from the pool, copied the body into a
+    /// <em>second</em> one, seeked a <em>third</em>, and then read the first — which was empty. Two
+    /// of the three were never disposed, so every request leaked a pooled stream. Even with the
+    /// right stream it could not have worked: <c>ReadToEndAsync</c> ran the <c>StreamReader</c> to
+    /// EOF before <c>Deserialize</c> was given the <c>JsonTextReader</c> over it, so the parser saw
+    /// no tokens.
+    /// </para>
+    /// <para>
+    /// Nothing caught it because nothing ran it. The assembly was at 0% line coverage with no test
+    /// project, and no integration fixture imports the package.
+    /// </para>
+    /// <para>
+    /// The three <c>LogInformation</c> calls went with it. They were debug leftovers, and one of
+    /// them wrote the entire request body to the log at Information — every credential, token and
+    /// personal detail any consumer ever posted.
+    /// </para>
+    /// <para>
+    /// <c>leaveOpen: true</c> on the reader is load-bearing rather than tidy: <c>MemoryStreamPool</c>
+    /// resets <c>Position</c> when a reservation is returned, which throws on a stream a reader
+    /// closed on its way out. That is the same defect <c>JsonSerializerImpl.DeserializeAsync</c>
+    /// carried until 2026-08-12.
+    /// </para>
+    /// </remarks>
     public async ValueTask<T?> DeserializeRequestBody<T>(IExecutionContext context) {
         try {
-            using var memoryStreamRes = _memoryStreamPool.Get();
+            using var buffer = _memoryStreamPool.Get();
 
-            _logger.LogInformation("Length: " + memoryStreamRes.Item.Length);
+            await context.Request.Body.CopyToAsync(buffer.Item);
 
-            await context.Request.Body.CopyToAsync(_memoryStreamPool.Get().Item);
+            buffer.Item.Position = 0;
 
-            _logger.LogInformation("Length: " + memoryStreamRes.Item.Length);
-
-            _memoryStreamPool.Get().Item.Seek(0, SeekOrigin.Begin);
-
-            using var textReader = new StreamReader(memoryStreamRes.Item, null, true, -1, true);
+            using var textReader = new StreamReader(buffer.Item, null, true, -1, true);
             using var jsonReader = new JsonTextReader(textReader);
-
-            var stringValue = await textReader.ReadToEndAsync();
-
-            _logger.LogInformation("Received: " + stringValue);
-
-            memoryStreamRes.Item.Position = 0;
 
             return _sharedSerializer.Serializer.Deserialize<T>(jsonReader);
         }
         catch (Exception exp) {
-            _logger.LogError(exp, "serializers threw exception " + exp.Message);
+            _logger.LogError(exp, "Newtonsoft deserializer threw {Message}", exp.Message);
+
             throw;
         }
     }

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Impl/NewtonsoftDeserializer.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Impl/NewtonsoftDeserializer.cs
@@ -22,6 +22,17 @@ public class NewtonsoftDeserializer : IRequestDeserializer {
 
     public bool IsDefaultSerializer => true;
 
+    /// <summary>
+    /// Ahead of <c>SystemTextJsonRequestDeserializer</c>, and behind the AOT deserializer.
+    /// </summary>
+    /// <remarks>
+    /// The read half of the same statement <c>NewtonsoftSerializer.Order</c> makes, and it has to
+    /// agree with it. A package that wrote responses with Newtonsoft while some other deserializer
+    /// read the requests would apply one naming strategy on the way out and another on the way in —
+    /// a model that round-trips through neither.
+    /// </remarks>
+    public int Order => (int)RequestDeserializerOrder.Specialized + 1;
+
     public bool CanProcessContext(IExecutionContext context) {
         return context.Request.ContentType?.Contains("application/json") ?? false;
     }

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Impl/NewtonsoftSerializer.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Impl/NewtonsoftSerializer.cs
@@ -18,6 +18,29 @@ public class NewtonsoftSerializer : IResponseSerializer {
 
     public bool IsDefaultSerializer => true;
 
+    /// <summary>
+    /// Ahead of <c>SystemTextJsonResponseSerializer</c>, and behind the AOT serializers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Displacing the built-in JSON serializer is the entire purpose of this package, and until
+    /// 2026-08-18 it did not state a precedence at all. It sat at
+    /// <see cref="ResponseSerializerOrder.Normal"/> — exactly where
+    /// <c>SystemTextJsonResponseSerializer</c> sits — and both return
+    /// <see cref="IsDefaultSerializer"/>, so which one wrote a JSON response came down to which
+    /// module registered last. Installing the package was not enough to be sure it was used.
+    /// </para>
+    /// <para>
+    /// <b>Behind <see cref="ResponseSerializerOrder.Specialized"/> rather than at it</b>, so
+    /// <c>AotResponseSerializer</c> still wins in an application that imports
+    /// <c>[AotSerializerModule]</c>. That combination is contradictory — this serializer is
+    /// reflection-based and the AOT module exists because reflection is not there — and if anything
+    /// resolves it, the source-generated one is the answer. Slotting between two named values is
+    /// what the enum's spacing is for.
+    /// </para>
+    /// </remarks>
+    public int Order => (int)ResponseSerializerOrder.Specialized + 1;
+
     public bool CanProduce(string mediaType, IExecutionContext context) =>
         MediaType.Matches(mediaType, KnownContentType.Json);
 

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Logging/HardenedLoggingBuilderTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Logging/HardenedLoggingBuilderTests.cs
@@ -1,0 +1,38 @@
+using Hardened.Shared.Runtime.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Logging;
+
+/// <summary>
+/// The <see cref="ILoggingBuilder"/> a Hardened application hands to the standard logging
+/// extension methods.
+/// </summary>
+/// <remarks>
+/// It carries nothing but the service collection, and that is the point: every
+/// <c>AddConsole</c>-shaped extension in the BCL is written against <see cref="ILoggingBuilder"/>
+/// and registers into <see cref="ILoggingBuilder.Services"/>. Handing back a different collection
+/// than the one the application is being built into would make those calls silently no-ops.
+/// </remarks>
+public class HardenedLoggingBuilderTests {
+
+    [Fact]
+    public void ServicesIsTheCollectionItWasGiven() {
+        var services = new ServiceCollection();
+
+        Assert.Same(services, new HardenedLoggingBuilder(services).Services);
+    }
+
+    /// <summary>
+    /// A standard logging extension registers into the application's own collection.
+    /// </summary>
+    [Fact]
+    public void AStandardLoggingExtensionRegistersIntoTheApplicationsCollection() {
+        var services = new ServiceCollection();
+
+        ((ILoggingBuilder)new HardenedLoggingBuilder(services)).AddFilter("Test", LogLevel.Warning);
+
+        Assert.NotEmpty(services);
+    }
+}

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Utilities/ArrayFromTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Utilities/ArrayFromTests.cs
@@ -1,0 +1,48 @@
+using Hardened.Shared.Runtime.Utilities;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Utilities;
+
+/// <summary>
+/// The helper generated code uses to build a metadata array without writing an array initializer.
+/// </summary>
+/// <remarks>
+/// Trivial, and it ships — every handler's emitted metadata goes through it. What is worth pinning
+/// is that <c>ObjectValues</c> hands back the params array itself rather than a copy, because the
+/// generated call site is <c>ArrayFrom.ObjectValues(a, b, c)</c> and an extra copy per handler
+/// construction is exactly the allocation the helper exists to avoid.
+/// </remarks>
+public class ArrayFromTests {
+
+    [Fact]
+    public void ObjectValuesReturnsTheValuesInOrder() {
+        var values = ArrayFrom.ObjectValues("first", 2, true);
+
+        Assert.Equal(["first", 2, true], values);
+    }
+
+    [Fact]
+    public void ObjectValuesOfNothingIsEmptyRatherThanNull() {
+        Assert.Empty(ArrayFrom.ObjectValues());
+    }
+
+    [Fact]
+    public void ObjectValuesHandsBackTheParamsArrayItself() {
+        var source = new object[] { "first", 2 };
+
+        Assert.Same(source, ArrayFrom.ObjectValues(source));
+    }
+
+    [Fact]
+    public void ValuesKeepsTheElementType() {
+        var values = ArrayFrom.Values("first", "second");
+
+        Assert.IsType<string[]>(values);
+        Assert.Equal(["first", "second"], values);
+    }
+
+    [Fact]
+    public void ValuesOfNothingIsEmptyRatherThanNull() {
+        Assert.Empty(ArrayFrom.Values<string>());
+    }
+}

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Utilities/DateTimeExtensionsTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Utilities/DateTimeExtensionsTests.cs
@@ -1,0 +1,92 @@
+using Hardened.Shared.Runtime.Utilities;
+using Xunit;
+
+namespace Hardened.Shared.Runtime.Tests.Utilities;
+
+/// <summary>
+/// Truncation and epoch conversion, neither of which had a test.
+/// </summary>
+/// <remarks>
+/// <c>Floor</c> is what a partition key or a metric bucket is built from, so the two properties that
+/// matter are that it truncates rather than rounds — a value one tick before the next second must
+/// not land in it — and that it preserves <see cref="DateTimeKind"/>. Losing the kind turns a UTC
+/// timestamp into an unspecified one, which the next conversion reads as local.
+/// </remarks>
+public class DateTimeExtensionsTests {
+
+    [Theory]
+    [InlineData(DateTimePrecision.Millisecond)]
+    [InlineData(DateTimePrecision.Second)]
+    [InlineData(DateTimePrecision.Minute)]
+    [InlineData(DateTimePrecision.Hour)]
+    [InlineData(DateTimePrecision.Day)]
+    public void FloorLeavesNoRemainderAtItsPrecision(DateTimePrecision precision) {
+        var value = new DateTime(2026, 8, 18, 13, 47, 29, 856, DateTimeKind.Utc).AddTicks(4321);
+
+        Assert.Equal(0, value.Floor(precision).Ticks % (long)precision);
+    }
+
+    [Fact]
+    public void FloorTruncatesRatherThanRounds() {
+        var value = new DateTime(2026, 8, 18, 13, 47, 29, DateTimeKind.Utc)
+            .AddTicks(TimeSpan.TicksPerSecond - 1);
+
+        Assert.Equal(
+            new DateTime(2026, 8, 18, 13, 47, 29, DateTimeKind.Utc),
+            value.Floor(DateTimePrecision.Second));
+    }
+
+    [Fact]
+    public void FloorOfAnAlreadyFlooredValueIsItself() {
+        var value = new DateTime(2026, 8, 18, 13, 0, 0, DateTimeKind.Utc);
+
+        Assert.Equal(value, value.Floor(DateTimePrecision.Hour));
+    }
+
+    /// <summary>
+    /// Dropping the kind is how a UTC timestamp becomes one the next conversion reads as local.
+    /// </summary>
+    [Theory]
+    [InlineData(DateTimeKind.Utc)]
+    [InlineData(DateTimeKind.Local)]
+    [InlineData(DateTimeKind.Unspecified)]
+    public void FloorPreservesTheKind(DateTimeKind kind) {
+        var value = new DateTime(2026, 8, 18, 13, 47, 29, 856, kind);
+
+        Assert.Equal(kind, value.Floor(DateTimePrecision.Minute).Kind);
+    }
+
+    [Fact]
+    public void ToEpochOfTheEpochIsZero() {
+        Assert.Equal(0, new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToEpoch());
+    }
+
+    [Fact]
+    public void ToEpochCountsWholeSeconds() {
+        Assert.Equal(
+            1_000_000_000, new DateTime(2001, 9, 9, 1, 46, 40, DateTimeKind.Utc).ToEpoch());
+    }
+
+    [Fact]
+    public void ToEpochIsNegativeBeforeTheEpoch() {
+        Assert.Equal(-86_400, new DateTime(1969, 12, 31, 0, 0, 0, DateTimeKind.Utc).ToEpoch());
+    }
+
+    [Fact]
+    public void ToEpochMillisecondsKeepsTheSubSecondPart() {
+        Assert.Equal(
+            1_000_000_000_250,
+            new DateTime(2001, 9, 9, 1, 46, 40, 250, DateTimeKind.Utc).ToEpochMilliseconds());
+    }
+
+    /// <summary>
+    /// The two conversions have to agree, or a record written with one and read with the other
+    /// lands a second apart.
+    /// </summary>
+    [Fact]
+    public void ToEpochAndToEpochMillisecondsAgree() {
+        var value = new DateTime(2026, 8, 18, 13, 47, 29, DateTimeKind.Utc);
+
+        Assert.Equal(value.ToEpoch() * 1000, value.ToEpochMilliseconds());
+    }
+}

--- a/src/Shared/Hardened.Shared.Testing.Tests/Impl/TestApplicationTests.cs
+++ b/src/Shared/Hardened.Shared.Testing.Tests/Impl/TestApplicationTests.cs
@@ -1,0 +1,308 @@
+using DependencyModules.Runtime.Interfaces;
+using Hardened.Shared.Runtime.Application;
+using Hardened.Shared.Testing.Impl;
+using Hardened.Shared.Testing.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Hardened.Shared.Testing.Tests.Impl;
+
+/// <summary>
+/// The application root every Hardened test host is built on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It was at <b>0% line coverage</b> — nineteen lines, in a package that ships, underneath every
+/// consumer's test suite. It ran constantly and nothing asserted anything about it.
+/// </para>
+/// <para>
+/// Two things here are worth pinning. <b>Overrides run after the module</b>, which is what makes
+/// <c>[Mock]</c> able to beat an application's own registration — reverse that and every mock in
+/// every consumer's suite silently stops taking effect while the tests still pass, because the real
+/// service usually works. And <b>the constructor runs startup services</b>, so a test host reaches
+/// a handler with the same wiring production would have.
+/// </para>
+/// <para>
+/// The two constructors have near-identical bodies, one per module shape.
+/// <see cref="BothModuleShapesProduceTheSameWiring"/> is what notices when only one is edited.
+/// </para>
+/// </remarks>
+public class TestApplicationTests {
+
+    private static IHardenedEnvironment Environment() => new EnvironmentImpl();
+
+    /// <summary>An <see cref="IApplicationModule"/> that registers whatever it is handed.</summary>
+    private sealed class ApplicationModule : IApplicationModule {
+        private readonly Action<IHardenedEnvironment, IServiceCollection> _configure;
+
+        public ApplicationModule(Action<IHardenedEnvironment, IServiceCollection> configure) {
+            _configure = configure;
+        }
+
+        public void ConfigureModule(IHardenedEnvironment environment, IServiceCollection services) =>
+            _configure(environment, services);
+    }
+
+    /// <summary>An <see cref="IDependencyModule"/> that registers whatever it is handed.</summary>
+    private sealed class DependencyModule : IDependencyModule {
+        private readonly Action<IServiceCollection> _configure;
+
+        public DependencyModule(Action<IServiceCollection> configure) {
+            _configure = configure;
+        }
+
+        public void PopulateServiceCollection(IServiceCollection services) => _configure(services);
+    }
+
+    private static TestApplication FromApplicationModule(
+        Action<IHardenedEnvironment, IServiceCollection>? configure = null,
+        Action<IHardenedEnvironment, IServiceCollection>? overrides = null) =>
+        new(new ApplicationModule(configure ?? ((_, _) => { })), "test", Environment(), overrides);
+
+    private static TestApplication FromDependencyModule(
+        Action<IServiceCollection>? configure = null,
+        Action<IHardenedEnvironment, IServiceCollection>? overrides = null) =>
+        new(new DependencyModule(configure ?? (_ => { })), "test", Environment(), overrides);
+
+    #region what the container ends up with
+
+    [Fact]
+    public async Task TheModulesRegistrationsReachTheProvider() {
+        await using var application = FromApplicationModule(
+            (_, services) => services.AddSingleton<IGreetingService, RealGreetingService>());
+
+        Assert.Equal(
+            "real hello world",
+            application.Provider.GetRequiredService<IGreetingService>().Greet("world"));
+    }
+
+    [Fact]
+    public async Task ADependencyModulesRegistrationsReachTheProviderToo() {
+        await using var application = FromDependencyModule(
+            services => services.AddSingleton<IGreetingService, RealGreetingService>());
+
+        Assert.Equal(
+            "real hello world",
+            application.Provider.GetRequiredService<IGreetingService>().Greet("world"));
+    }
+
+    /// <summary>
+    /// Logging is registered before the module, so a module resolving a logger does not have to
+    /// bring its own stack.
+    /// </summary>
+    [Fact]
+    public async Task LoggingIsAvailableWithoutTheModuleRegisteringIt() {
+        await using var application = FromApplicationModule();
+
+        Assert.NotNull(application.Provider.GetRequiredService<ILogger<TestApplicationTests>>());
+    }
+
+    [Fact]
+    public async Task TheEnvironmentIsResolvable() {
+        var environment = Environment();
+
+        await using var application = new TestApplication(
+            new ApplicationModule((_, _) => { }), "test", environment, null);
+
+        Assert.Same(environment, application.Provider.GetRequiredService<IHardenedEnvironment>());
+    }
+
+    /// <summary>
+    /// The module is handed the same environment the container gets, so a module that branches on
+    /// it and a service that reads it agree.
+    /// </summary>
+    [Fact]
+    public async Task TheModuleIsGivenTheSameEnvironment() {
+        var environment = Environment();
+        IHardenedEnvironment? seen = null;
+
+        await using var application = new TestApplication(
+            new ApplicationModule((given, _) => seen = given), "test", environment, null);
+
+        Assert.Same(environment, seen);
+    }
+
+    #endregion
+
+    #region overrides
+
+    /// <summary>
+    /// <b>Overrides run after the module.</b> This is what lets <c>[Mock]</c> beat an application's
+    /// own registration. Reversed, every mock in every consumer's suite would silently stop taking
+    /// effect — and the tests would mostly still pass, because the real service usually works.
+    /// </summary>
+    [Fact]
+    public async Task AnOverrideReplacesTheModulesRegistration() {
+        await using var application = FromApplicationModule(
+            (_, services) => services.AddSingleton<IGreetingService, RealGreetingService>(),
+            (_, services) => services.AddSingleton<IGreetingService>(new StubGreeting()));
+
+        Assert.Equal(
+            "stub hello world",
+            application.Provider.GetRequiredService<IGreetingService>().Greet("world"));
+    }
+
+    [Fact]
+    public async Task AnOverrideReplacesADependencyModulesRegistrationToo() {
+        await using var application = FromDependencyModule(
+            services => services.AddSingleton<IGreetingService, RealGreetingService>(),
+            (_, services) => services.AddSingleton<IGreetingService>(new StubGreeting()));
+
+        Assert.Equal(
+            "stub hello world",
+            application.Provider.GetRequiredService<IGreetingService>().Greet("world"));
+    }
+
+    [Fact]
+    public async Task AnOverrideMayAddAServiceTheModuleNeverRegistered() {
+        await using var application = FromApplicationModule(
+            overrides: (_, services) => services.AddSingleton<IGreetingService>(new StubGreeting()));
+
+        Assert.Equal(
+            "stub hello world",
+            application.Provider.GetRequiredService<IGreetingService>().Greet("world"));
+    }
+
+    [Fact]
+    public async Task NoOverrideIsFine() {
+        await using var application = FromApplicationModule();
+
+        Assert.NotNull(application.Provider);
+    }
+
+    [Fact]
+    public async Task TheOverrideIsGivenTheEnvironment() {
+        var environment = Environment();
+        IHardenedEnvironment? seen = null;
+
+        await using var application = new TestApplication(
+            new ApplicationModule((_, _) => { }), "test", environment,
+            (given, _) => seen = given);
+
+        Assert.Same(environment, seen);
+    }
+
+    #endregion
+
+    #region startup
+
+    /// <summary>
+    /// The constructor runs startup services, so a test host reaches a handler with the wiring
+    /// production would have rather than one that skipped every startup step.
+    /// </summary>
+    [Fact]
+    public async Task StartupServicesRunBeforeTheConstructorReturns() {
+        var startup = new RecordingStartupService();
+
+        await using var application = FromApplicationModule(
+            (_, services) => services.AddSingleton<IStartupService>(startup));
+
+        Assert.True(startup.Ran, "the startup service had not run when the constructor returned");
+    }
+
+    [Fact]
+    public async Task EveryStartupServiceRuns() {
+        var first = new RecordingStartupService();
+        var second = new RecordingStartupService();
+
+        await using var application = FromApplicationModule((_, services) => {
+            services.AddSingleton<IStartupService>(first);
+            services.AddSingleton<IStartupService>(second);
+        });
+
+        Assert.True(first.Ran);
+        Assert.True(second.Ran);
+    }
+
+    /// <summary>
+    /// A startup service registered by an override runs too — it is in the container by the time
+    /// startup happens.
+    /// </summary>
+    [Fact]
+    public async Task AStartupServiceAddedByAnOverrideAlsoRuns() {
+        var startup = new RecordingStartupService();
+
+        await using var application = FromApplicationModule(
+            overrides: (_, services) => services.AddSingleton<IStartupService>(startup));
+
+        Assert.True(startup.Ran);
+    }
+
+    #endregion
+
+    #region disposal
+
+    /// <summary>
+    /// Registered by type, not by instance: the container only disposes what it constructed, so an
+    /// <c>AddSingleton(new Thing())</c> would prove nothing about whether the provider was disposed.
+    /// </summary>
+    [Fact]
+    public async Task DisposingDisposesSingletonsTheContainerOwns() {
+        var application = FromApplicationModule(
+            (_, services) => services.AddSingleton<TrackedDisposable>());
+
+        var disposable = application.Provider.GetRequiredService<TrackedDisposable>();
+
+        Assert.False(disposable.Disposed);
+
+        await application.DisposeAsync();
+
+        Assert.True(disposable.Disposed);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Two constructors, near-identical bodies. This fails when one is edited and the other is not.
+    /// </summary>
+    [Fact]
+    public async Task BothModuleShapesProduceTheSameWiring() {
+        var startup = new RecordingStartupService();
+        var otherStartup = new RecordingStartupService();
+
+        await using var fromApplication = FromApplicationModule(
+            (_, services) => {
+                services.AddSingleton<IGreetingService, RealGreetingService>();
+                services.AddSingleton<IStartupService>(startup);
+            },
+            (_, services) => services.AddSingleton<IGreetingService>(new StubGreeting()));
+
+        await using var fromDependency = FromDependencyModule(
+            services => {
+                services.AddSingleton<IGreetingService, RealGreetingService>();
+                services.AddSingleton<IStartupService>(otherStartup);
+            },
+            (_, services) => services.AddSingleton<IGreetingService>(new StubGreeting()));
+
+        Assert.Equal(
+            fromApplication.Provider.GetRequiredService<IGreetingService>().Greet("world"),
+            fromDependency.Provider.GetRequiredService<IGreetingService>().Greet("world"));
+
+        Assert.Equal(startup.Ran, otherStartup.Ran);
+        Assert.True(startup.Ran);
+
+        Assert.NotNull(fromApplication.Provider.GetRequiredService<ILogger<TestApplicationTests>>());
+        Assert.NotNull(fromDependency.Provider.GetRequiredService<ILogger<TestApplicationTests>>());
+    }
+
+    private sealed class StubGreeting : IGreetingService {
+        public string Greet(string name) => $"stub hello {name}";
+    }
+
+    private sealed class RecordingStartupService : IStartupService {
+        public bool Ran { get; private set; }
+
+        public Task<bool> Startup(IServiceProvider provider) {
+            Ran = true;
+
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class TrackedDisposable : IDisposable {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/PatternRegistry.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/PatternRegistry.cs
@@ -26,6 +26,20 @@ namespace Hardened.Idl.Validation;
 internal sealed class PatternRegistry {
     private readonly Dictionary<string, string> _members = new(System.StringComparer.Ordinal);
     private readonly List<string> _rejected = new();
+
+    /// <summary>
+    /// Which patterns are already in <see cref="_rejected"/>.
+    /// </summary>
+    /// <remarks>
+    /// A set rather than a scan of <see cref="_rejected"/>, because the entries there are
+    /// <c>pattern + " - " + message</c> and the scan used to ask whether any entry <em>started
+    /// with</em> the pattern. A pattern that is a prefix of one already rejected therefore matched
+    /// an unrelated entry and was dropped: reject <c>\_x</c> and then <c>\_</c>, and only the first
+    /// was ever reported. Both are refused either way - this decides only what the build says it
+    /// refused, which is the whole point of keeping the list.
+    /// </remarks>
+    private readonly HashSet<string> _rejectedPatterns = new(System.StringComparer.Ordinal);
+
     private readonly string _namespace;
 
     public PatternRegistry(string patternNamespace, string specFileName) {
@@ -77,7 +91,7 @@ internal sealed class PatternRegistry {
             _ = new Regex(pattern);
             return true;
         } catch (System.ArgumentException exception) {
-            if (!_rejected.Exists(entry => entry.StartsWith(pattern, System.StringComparison.Ordinal))) {
+            if (_rejectedPatterns.Add(pattern)) {
                 _rejected.Add(pattern + " - " + exception.Message);
             }
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ConstraintAttributesTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ConstraintAttributesTests.cs
@@ -1,0 +1,349 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Idl.Models;
+using Hardened.Idl.Validation;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// OpenAPI's constraint keywords becoming ValidationModules attributes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// At <b>48% line coverage</b>, and what was dark is the half that matters: every guard here exists
+/// because a real published specification produced code that did not compile. The doc comments name
+/// them — Box puts <c>minimum</c> on a string, Vercel puts an <c>enum</c> on a member that fell back
+/// to <c>JsonElement</c>, OpenAI types parameters as generated enums. Each one is a CS0019 or CS0037
+/// in a generated file, from a spec that is not wrong.
+/// </para>
+/// <para>
+/// So these tests are mostly about what is <em>not</em> emitted. A guard that stops firing does not
+/// fail a test that only checks the happy path — it fails a consumer's build.
+/// </para>
+/// </remarks>
+public class ConstraintAttributesTests {
+
+    private static PatternRegistry Patterns() =>
+        new(EmitterHarness.RootNamespace + ".Validation", "petstore");
+
+    private static PropertyModel Property(
+        int? minLength = null, int? maxLength = null,
+        decimal? minimum = null, decimal? maximum = null,
+        bool exclusiveMinimum = false, bool exclusiveMaximum = false,
+        string? pattern = null,
+        int? minItems = null, int? maxItems = null,
+        List<string>? enumValues = null) =>
+        new() {
+            Name = "value",
+            MinLength = minLength,
+            MaxLength = maxLength,
+            Minimum = minimum,
+            Maximum = maximum,
+            ExclusiveMinimum = exclusiveMinimum,
+            ExclusiveMaximum = exclusiveMaximum,
+            Pattern = pattern,
+            MinItems = minItems,
+            MaxItems = maxItems,
+            EnumValues = enumValues
+        };
+
+    private static IReadOnlyList<ConstraintAttributes.Model> For(
+        PropertyModel property, string csType, bool required = false) =>
+        ConstraintAttributes.ForProperty(property, required, Patterns(), csType);
+
+    private static IReadOnlyList<string> Names(IReadOnlyList<ConstraintAttributes.Model> attributes) =>
+        attributes.Select(attribute => attribute.Type.Name).ToList();
+
+    private static ConstraintAttributes.Model Single(
+        IReadOnlyList<ConstraintAttributes.Model> attributes, string name) =>
+        Assert.Single(attributes, attribute => attribute.Type.Name == name);
+
+    #region required
+
+    [Fact]
+    public void RequiredIsEmittedWhenTheCallerSaysSo() {
+        Assert.Contains("RequiredAttribute", Names(For(Property(), "string", required: true)));
+    }
+
+    [Fact]
+    public void RequiredIsNotEmittedOtherwise() {
+        Assert.DoesNotContain("RequiredAttribute", Names(For(Property(), "string")));
+    }
+
+    [Fact]
+    public void RequiredTakesNoArguments() {
+        Assert.Empty(Single(For(Property(), "string", required: true), "RequiredAttribute").Arguments);
+    }
+
+    /// <summary>
+    /// Requiredness comes from the caller, not the facets — the caller is the one that knows the
+    /// C# type. A non-nullable value type can never be absent, and the validation generator answers
+    /// <c>[Required]</c> on one with <c>value.petId is null</c> against a <c>long</c>: CS0037.
+    /// </summary>
+    [Fact]
+    public void TheFacetsDoNotDecideRequiredness() {
+        Assert.DoesNotContain("RequiredAttribute", Names(For(Property(minLength: 1), "long")));
+    }
+
+    #endregion
+
+    #region string length
+
+    [Fact]
+    public void AStringWithBothLengthBoundsGetsStringLength() {
+        Assert.Equal(
+            ["Min = 1", "Max = 64"],
+            Single(For(Property(minLength: 1, maxLength: 64), "string"), "StringLengthAttribute").Arguments);
+    }
+
+    /// <summary>
+    /// Named arguments, because a spec may set one bound and not the other while the positional
+    /// constructor takes both.
+    /// </summary>
+    [Fact]
+    public void OnlyTheDeclaredBoundIsWritten() {
+        Assert.Equal(
+            ["Max = 64"],
+            Single(For(Property(maxLength: 64), "string"), "StringLengthAttribute").Arguments);
+
+        Assert.Equal(
+            ["Min = 1"],
+            Single(For(Property(minLength: 1), "string"), "StringLengthAttribute").Arguments);
+    }
+
+    [Fact]
+    public void NoLengthBoundEmitsNoStringLength() {
+        Assert.DoesNotContain("StringLengthAttribute", Names(For(Property(), "string")));
+    }
+
+    /// <summary>
+    /// A length cannot be read off a type that has none.
+    /// </summary>
+    [Theory]
+    [InlineData("int")]
+    [InlineData("long")]
+    [InlineData("JsonElement")]
+    [InlineData("List<string>")]
+    public void ALengthBoundOnANonStringTypeIsDropped(string csType) {
+        Assert.DoesNotContain(
+            "StringLengthAttribute", Names(For(Property(minLength: 1, maxLength: 64), csType)));
+    }
+
+    #endregion
+
+    #region numeric range
+
+    [Theory]
+    [InlineData("int")]
+    [InlineData("long")]
+    [InlineData("double")]
+    [InlineData("decimal")]
+    [InlineData("float")]
+    [InlineData("short")]
+    [InlineData("byte")]
+    public void ANumericTypeWithBoundsGetsRange(string csType) {
+        Assert.Contains("RangeAttribute", Names(For(Property(minimum: 1, maximum: 10), csType)));
+    }
+
+    /// <summary>
+    /// Box declares <c>minimum</c> on a string. Emitted, the generated comparison is CS0019.
+    /// </summary>
+    [Theory]
+    [InlineData("string")]
+    [InlineData("JsonElement")]
+    [InlineData("List<int>")]
+    public void ANumericBoundOnANonNumericTypeIsDropped(string csType) {
+        Assert.DoesNotContain("RangeAttribute", Names(For(Property(minimum: 1, maximum: 10), csType)));
+    }
+
+    /// <summary>
+    /// <c>Range</c> has no partially-bounded constructor, so an absent bound becomes the extreme
+    /// rather than being omitted.
+    /// </summary>
+    [Fact]
+    public void AnAbsentBoundBecomesTheExtreme() {
+        var arguments = Single(For(Property(minimum: 5), "int"), "RangeAttribute").Arguments;
+
+        Assert.Equal(2, arguments.Count);
+        Assert.Equal("5", arguments[0]);
+        Assert.Equal(((double)decimal.MaxValue).ToString("R", System.Globalization.CultureInfo.InvariantCulture),
+            arguments[1]);
+    }
+
+    [Fact]
+    public void ExclusiveBoundsAreNamedArgumentsAfterThePositionalOnes() {
+        var arguments =
+            Single(For(Property(minimum: 1, maximum: 10, exclusiveMinimum: true, exclusiveMaximum: true), "int"),
+                "RangeAttribute").Arguments;
+
+        Assert.Equal(4, arguments.Count);
+        Assert.Equal("ExclusiveMin = true", arguments[2]);
+        Assert.Equal("ExclusiveMax = true", arguments[3]);
+    }
+
+    [Fact]
+    public void AnInclusiveBoundWritesNoExclusiveFlag() {
+        var arguments = Single(For(Property(minimum: 1, maximum: 10), "int"), "RangeAttribute").Arguments;
+
+        Assert.Equal(2, arguments.Count);
+    }
+
+    /// <summary>
+    /// Invariant culture, or a machine with a comma decimal separator emits <c>1,5</c> and the
+    /// generated file does not parse.
+    /// </summary>
+    [Fact]
+    public void AFractionalBoundIsWrittenInvariant() {
+        Assert.Equal(
+            "1.5",
+            Single(For(Property(minimum: 1.5m, maximum: 10), "double"), "RangeAttribute").Arguments[0]);
+    }
+
+    #endregion
+
+    #region pattern
+
+    [Fact]
+    public void AStringWithAPatternGetsPatternInItsReferenceForm() {
+        var arguments = Single(For(Property(pattern: "^[a-z]+$"), "string"), "PatternAttribute").Arguments;
+
+        Assert.Equal(2, arguments.Count);
+        Assert.StartsWith("typeof(global::", arguments[0]);
+        Assert.StartsWith("nameof(global::", arguments[1]);
+    }
+
+    /// <summary>
+    /// A pattern .NET's engine will not take is reported against the spec rather than emitted into
+    /// a member that cannot be generated.
+    /// </summary>
+    [Fact]
+    public void APatternTheRuntimeRefusesEmitsNoAttribute() {
+        Assert.DoesNotContain(
+            "PatternAttribute", Names(For(Property(pattern: @"^[a-zA-Z0-9\-\_]+$"), "string")));
+    }
+
+    [Theory]
+    [InlineData("int")]
+    [InlineData("JsonElement")]
+    public void APatternOnANonStringTypeIsDropped(string csType) {
+        Assert.DoesNotContain("PatternAttribute", Names(For(Property(pattern: "^[a-z]+$"), csType)));
+    }
+
+    [Fact]
+    public void AnEmptyPatternEmitsNothing() {
+        Assert.DoesNotContain("PatternAttribute", Names(For(Property(pattern: ""), "string")));
+    }
+
+    #endregion
+
+    #region item count
+
+    [Theory]
+    [InlineData("List<string>")]
+    [InlineData("Dictionary<string, int>")]
+    [InlineData("string[]")]
+    public void ACountedTypeWithBoundsGetsItemCount(string csType) {
+        Assert.Equal(
+            ["Min = 1", "Max = 5"],
+            Single(For(Property(minItems: 1, maxItems: 5), csType), "ItemCountAttribute").Arguments);
+    }
+
+    /// <summary>
+    /// An array whose element type cannot be named degrades to <c>JsonElement</c>, and
+    /// <c>[ItemCount]</c> then draws <c>value.X.Count</c> against a struct with no such member.
+    /// </summary>
+    [Theory]
+    [InlineData("JsonElement")]
+    [InlineData("string")]
+    [InlineData("int")]
+    public void AnItemBoundOnATypeWithNoCountIsDropped(string csType) {
+        Assert.DoesNotContain("ItemCountAttribute", Names(For(Property(minItems: 1, maxItems: 5), csType)));
+    }
+
+    #endregion
+
+    #region allowed values
+
+    [Fact]
+    public void AStringEnumBecomesAllowedValues() {
+        Assert.Equal(
+            ["\"available\"", "\"pending\""],
+            Single(For(Property(enumValues: ["available", "pending"]), "string"), "AllowedValuesAttribute")
+                .Arguments);
+    }
+
+    /// <summary>
+    /// A parameter whose schema is a <c>$ref</c> to an enum is typed as the generated enum, and
+    /// <c>[AllowedValues]</c> then compares that enum against string literals — CS0019, once per
+    /// member. OpenAI's specification does this.
+    /// </summary>
+    [Theory]
+    [InlineData("PetStatus")]
+    [InlineData("JsonElement")]
+    [InlineData("int")]
+    public void AnEnumOnANonStringTypeIsDropped(string csType) {
+        Assert.DoesNotContain(
+            "AllowedValuesAttribute", Names(For(Property(enumValues: ["available"]), csType)));
+    }
+
+    [Fact]
+    public void AnEmptyEnumEmitsNothing() {
+        Assert.DoesNotContain("AllowedValuesAttribute", Names(For(Property(enumValues: []), "string")));
+    }
+
+    [Fact]
+    public void AnAllowedValueContainingAQuoteIsEscaped() {
+        Assert.Equal(
+            ["\"say \\\"hi\\\"\"", "\"back\\\\slash\""],
+            Single(For(Property(enumValues: ["say \"hi\"", "back\\slash"]), "string"),
+                "AllowedValuesAttribute").Arguments);
+    }
+
+    #endregion
+
+    [Fact]
+    public void APropertyWithNoConstraintsGetsNoAttributes() {
+        Assert.Empty(For(Property(), "string"));
+    }
+
+    [Fact]
+    public void EveryAttributeComesFromTheConstraintsNamespace() {
+        var attributes = For(
+            Property(minLength: 1, maxLength: 5, pattern: "^[a-z]+$", enumValues: ["a"]),
+            "string", required: true);
+
+        Assert.NotEmpty(attributes);
+        Assert.All(attributes,
+            attribute => Assert.Equal("ValidationModules.Constraints", attribute.Type.Namespace));
+    }
+
+    [Fact]
+    public void ValidateNestedNamesTheNestedAttribute() {
+        Assert.Equal("ValidateNestedAttribute", ConstraintAttributes.ValidateNested().Name);
+        Assert.Equal("ValidationModules.Constraints", ConstraintAttributes.ValidateNested().Namespace);
+    }
+
+    /// <summary>
+    /// A parameter goes through the same builder as a property, so the guards cannot be enforced on
+    /// request bodies and skipped on query strings — the failure the shared facets interface was
+    /// introduced to prevent.
+    /// </summary>
+    [Fact]
+    public void AParameterIsBuiltByTheSameRules() {
+        var parameter = new ParameterModel { Name = "status", MinLength = 1, MaxLength = 8 };
+
+        Assert.Equal(
+            ["Min = 1", "Max = 8"],
+            Single(
+                ConstraintAttributes.ForParameter(parameter, false, "string", Patterns()),
+                "StringLengthAttribute").Arguments);
+    }
+
+    [Fact]
+    public void AParameterBoundOnANonStringTypeIsDroppedToo() {
+        var parameter = new ParameterModel { Name = "limit", MinLength = 1, MaxLength = 8 };
+
+        Assert.Empty(ConstraintAttributes.ForParameter(parameter, false, "int", Patterns()));
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DeprecationTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DeprecationTests.cs
@@ -1,0 +1,87 @@
+using CSharpAuthor;
+using Hardened.Idl.Emitters;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// A schema or operation marked <c>deprecated</c>, as <c>[Obsolete]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// At <b>0% line coverage</b>. Twelve lines, and the whole of the reasoning is in whether the
+/// second constructor argument is <c>false</c> and whether the pragma is there.
+/// </para>
+/// <para>
+/// <b>Both are load-bearing.</b> A generated interface member carrying <c>[Obsolete]</c> produces
+/// CS0618 wherever it is implemented — which for a spec-first project is the consumer's own handler,
+/// code they did not write and cannot annotate away. This repository escalates warnings to errors
+/// under <c>ContinuousIntegrationBuild</c> and consumers commonly do the same, so one deprecated
+/// operation in a specification would break the build of every project implementing it. The pragma
+/// is what stops that; <c>false</c> is what keeps it a warning rather than an error.
+/// </para>
+/// </remarks>
+public class DeprecationTests {
+
+    private static string Emit() =>
+        EmitterHarness.Write(ns => {
+            var definition = ns.AddClass("Pet");
+
+            definition.Modifiers |= ComponentModifier.Public;
+
+            Deprecation.Apply(definition);
+        });
+
+    [Fact]
+    public void TheTypeIsMarkedObsolete() {
+        Assert.Contains("Obsolete", Emit());
+    }
+
+    [Fact]
+    public void TheMessageSaysWhereTheDeprecationCameFrom() {
+        Assert.Contains("Declared deprecated by the specification.", Emit());
+    }
+
+    /// <summary>
+    /// A warning, not an error. Deprecation is notice that something will go, not that it has gone.
+    /// </summary>
+    [Fact]
+    public void TheObsoleteAttributeIsAWarningRatherThanAnError() {
+        Assert.Contains("false", Emit());
+        Assert.DoesNotContain("true", Emit());
+    }
+
+    /// <summary>
+    /// Without this, one deprecated operation breaks the build of every project implementing it.
+    /// </summary>
+    [Fact]
+    public void TheDeclarationIsWrappedInAPragmaSuppressing618() {
+        var output = Emit();
+
+        Assert.Contains("#pragma warning disable 618", output);
+        Assert.Contains("#pragma warning restore 618", output);
+    }
+
+    [Fact]
+    public void ThePragmaSurroundsTheDeclaration() {
+        var output = Emit();
+
+        var disable = output.IndexOf("#pragma warning disable 618", System.StringComparison.Ordinal);
+        var declaration = output.IndexOf("class Pet", System.StringComparison.Ordinal);
+        var restore = output.IndexOf("#pragma warning restore 618", System.StringComparison.Ordinal);
+
+        Assert.InRange(declaration, disable, restore);
+    }
+
+    [Fact]
+    public void AnUndeprecatedTypeCarriesNeither() {
+        var output = EmitterHarness.Write(ns => {
+            var definition = ns.AddClass("Pet");
+
+            definition.Modifiers |= ComponentModifier.Public;
+        });
+
+        Assert.DoesNotContain("Obsolete", output);
+        Assert.DoesNotContain("618", output);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ErrorResponseEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ErrorResponseEmitterTests.cs
@@ -1,0 +1,249 @@
+using System.Collections.Generic;
+using Hardened.Idl.Emitters;
+using Hardened.Idl.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The exception type a handler throws to produce a response the specification declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The emitter was at <b>7% line coverage</b> — the eight lines that ran were the empty-loop case
+/// reached incidentally while emitting whole files. Every declared error response in every fixture
+/// produced code nothing had ever looked at.
+/// </para>
+/// <para>
+/// What matters here is the two shapes. A response with no declared body is a status and nothing
+/// else; a response naming a schema also gets a constructor parameter and a typed <c>Body</c>. The
+/// second is where the sharp edges are — the payload cast is written as raw code, so it bypasses
+/// the output context that qualifies every other type in the file.
+/// </para>
+/// </remarks>
+public class ErrorResponseEmitterTests {
+
+    private static OperationModel Operation(
+        string methodName = "GetPet",
+        string path = "/pets/{petId}",
+        string httpMethod = "GET",
+        params ErrorResponseModel[] errors) =>
+        new() {
+            OperationId = methodName,
+            MethodName = methodName,
+            Path = path,
+            HttpMethod = httpMethod,
+            ErrorResponses = new List<ErrorResponseModel>(errors)
+        };
+
+    private static string Emit(params OperationModel[] operations) =>
+        EmitterHarness.Write(ns => ErrorResponseEmitter.Emit(
+            ns,
+            new ServiceModel { Tag = "pets", Operations = new List<OperationModel>(operations) },
+            EmitterHarness.ModelsNamespace));
+
+    private static IReadOnlyList<string> Names(params OperationModel[] operations) {
+        var emitted = new List<string>();
+
+        EmitterHarness.Write(ns => {
+            foreach (var definition in ErrorResponseEmitter.Emit(
+                         ns,
+                         new ServiceModel { Tag = "pets", Operations = new List<OperationModel>(operations) },
+                         EmitterHarness.ModelsNamespace)) {
+                emitted.Add(definition.Name);
+            }
+        });
+
+        return emitted;
+    }
+
+    #region naming
+
+    /// <summary>
+    /// Named for the operation as well as the status, so what a handler may throw is discoverable
+    /// from the handler — and so it cannot collide with the framework's own
+    /// <c>BadRequestException</c>, which a status-only name would.
+    /// </summary>
+    [Fact]
+    public void AnExceptionIsNamedForItsOperationAndStatus() {
+        Assert.Equal(
+            ["GetPetNotFoundException"],
+            Names(Operation(errors: new ErrorResponseModel { StatusCode = 404 })));
+    }
+
+    [Theory]
+    [InlineData(400, "GetPetBadRequestException")]
+    [InlineData(401, "GetPetUnauthorizedException")]
+    [InlineData(402, "GetPetPaymentRequiredException")]
+    [InlineData(403, "GetPetForbiddenException")]
+    [InlineData(404, "GetPetNotFoundException")]
+    [InlineData(405, "GetPetMethodNotAllowedException")]
+    [InlineData(406, "GetPetNotAcceptableException")]
+    [InlineData(408, "GetPetRequestTimeoutException")]
+    [InlineData(409, "GetPetConflictException")]
+    [InlineData(410, "GetPetGoneException")]
+    [InlineData(412, "GetPetPreconditionFailedException")]
+    [InlineData(413, "GetPetPayloadTooLargeException")]
+    [InlineData(415, "GetPetUnsupportedMediaTypeException")]
+    [InlineData(422, "GetPetUnprocessableEntityException")]
+    [InlineData(423, "GetPetLockedException")]
+    [InlineData(429, "GetPetTooManyRequestsException")]
+    [InlineData(500, "GetPetInternalServerErrorException")]
+    [InlineData(501, "GetPetNotImplementedException")]
+    [InlineData(502, "GetPetBadGatewayException")]
+    [InlineData(503, "GetPetServiceUnavailableException")]
+    [InlineData(504, "GetPetGatewayTimeoutException")]
+    public void EveryWellKnownStatusHasAName(int statusCode, string expected) {
+        Assert.Equal(
+            [expected], Names(Operation(errors: new ErrorResponseModel { StatusCode = statusCode })));
+    }
+
+    /// <summary>
+    /// A status with no well-known name keeps its number. Reads badly, but a specification using
+    /// 418 deserves a type as much as one using 404.
+    /// </summary>
+    [Theory]
+    [InlineData(418, "GetPetStatus418Exception")]
+    [InlineData(451, "GetPetStatus451Exception")]
+    [InlineData(599, "GetPetStatus599Exception")]
+    public void AnUnrecognisedStatusKeepsItsNumber(int statusCode, string expected) {
+        Assert.Equal(
+            [expected], Names(Operation(errors: new ErrorResponseModel { StatusCode = statusCode })));
+    }
+
+    [Fact]
+    public void EveryDeclaredErrorOnAnOperationGetsAType() {
+        Assert.Equal(
+            ["GetPetNotFoundException", "GetPetConflictException"],
+            Names(Operation(errors:
+                [new ErrorResponseModel { StatusCode = 404 }, new ErrorResponseModel { StatusCode = 409 }])));
+    }
+
+    [Fact]
+    public void EveryOperationInTheServiceContributes() {
+        Assert.Equal(
+            ["GetPetNotFoundException", "DeletePetConflictException"],
+            Names(
+                Operation("GetPet", errors: new ErrorResponseModel { StatusCode = 404 }),
+                Operation("DeletePet", errors: new ErrorResponseModel { StatusCode = 409 })));
+    }
+
+    [Fact]
+    public void AnOperationDeclaringNoErrorsEmitsNothing() {
+        Assert.Empty(Names(Operation()));
+    }
+
+    [Fact]
+    public void AServiceWithNoOperationsEmitsNothing() {
+        EmitterHarness.Write(ns => Assert.Empty(
+            ErrorResponseEmitter.Emit(
+                ns, new ServiceModel { Tag = "pets" }, EmitterHarness.ModelsNamespace)));
+    }
+
+    #endregion
+
+    #region shape
+
+    /// <summary>
+    /// Partial, so a consumer can add to it, and derived from the framework's status exception so
+    /// the pipeline turns it into a response rather than a 500.
+    /// </summary>
+    [Fact]
+    public void TheExceptionIsAPublicPartialStatusCodeException() {
+        var output = Emit(Operation(errors: new ErrorResponseModel { StatusCode = 404 }));
+
+        Assert.Contains("public partial class GetPetNotFoundException", output);
+        Assert.Contains("StatusCodeException", output);
+    }
+
+    /// <summary>
+    /// No declared body means a status and nothing else — no constructor parameter, no
+    /// <c>Body</c>.
+    /// </summary>
+    [Fact]
+    public void AResponseWithNoBodyTakesNoConstructorArgument() {
+        var output = Emit(Operation(errors: new ErrorResponseModel { StatusCode = 404 }));
+
+        Assert.Contains("base(404)", output);
+        Assert.DoesNotContain("Body", output);
+    }
+
+    [Fact]
+    public void AResponseWithABodyPassesItToTheBase() {
+        var output = Emit(Operation(errors:
+            new ErrorResponseModel { StatusCode = 404, Ref = "#/components/schemas/Error" }));
+
+        Assert.Contains("base(404, value)", output);
+    }
+
+    /// <summary>
+    /// Typed access to the body, which the base can only offer as <c>object</c>.
+    /// </summary>
+    [Fact]
+    public void AResponseWithABodyExposesItTyped() {
+        var output = Emit(Operation(errors:
+            new ErrorResponseModel { StatusCode = 404, Ref = "#/components/schemas/Error" }));
+
+        Assert.Contains("Error Body", output);
+    }
+
+    /// <summary>
+    /// <b>Named <c>Body</c> rather than hiding the base's <c>Value</c>.</b> A reader seeing
+    /// <c>Value</c> on the derived type would have no way to tell it was not the one they knew
+    /// about.
+    /// </summary>
+    [Fact]
+    public void TheTypedAccessorDoesNotHideTheBasesValue() {
+        var output = Emit(Operation(errors:
+            new ErrorResponseModel { StatusCode = 404, Ref = "#/components/schemas/Error" }));
+
+        Assert.DoesNotContain("new ", output);
+        Assert.Contains("Value!", output);
+    }
+
+    /// <summary>
+    /// The cast is written as raw code, so it bypasses the output context that qualifies every
+    /// other type in the file. It has to carry the global-qualified name itself, or it binds to a
+    /// consumer type of the same name.
+    /// </summary>
+    [Fact]
+    public void TheBodyCastIsGlobalQualified() {
+        var output = Emit(Operation(errors:
+            new ErrorResponseModel { StatusCode = 404, Ref = "#/components/schemas/Error" }));
+
+        Assert.Contains($"(global::{EmitterHarness.ModelsNamespace}.Error)Value!", output);
+    }
+
+    [Fact]
+    public void ARefIsPascalCasedIntoATypeName() {
+        var output = Emit(Operation(errors:
+            new ErrorResponseModel { StatusCode = 409, Ref = "#/components/schemas/conflict_detail" }));
+
+        Assert.Contains("ConflictDetail Body", output);
+    }
+
+    #endregion
+
+    #region documentation
+
+    [Fact]
+    public void TheDeclaredDescriptionBecomesTheDocComment() {
+        var output = Emit(Operation(errors: new ErrorResponseModel {
+            StatusCode = 404, Description = "No pet with that identifier."
+        }));
+
+        Assert.Contains("No pet with that identifier.", output);
+    }
+
+    /// <summary>
+    /// A response the document did not describe still gets a comment, built from what is known.
+    /// </summary>
+    [Fact]
+    public void AResponseWithNoDescriptionGetsAGeneratedOne() {
+        var output = Emit(Operation(errors: new ErrorResponseModel { StatusCode = 404 }));
+
+        Assert.Contains("The 404 response declared for GET /pets/{petId}.", output);
+    }
+
+    #endregion
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/FilterTypeEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/FilterTypeEmitterTests.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using Hardened.Idl.Emitters;
+using Hardened.Idl.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The partial attribute class an <c>x-filter-types</c> entry becomes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The emitter was at <b>0% line coverage</b> — not one line had ever run. It emits a public
+/// attribute that a consumer completes with the other half of the partial, so what it gets wrong is
+/// wrong in code somebody else has to compile against.
+/// </para>
+/// <para>
+/// Default values are the sharp part: <c>FormatDefault</c> switches on the declared C# type and
+/// writes a literal, so a string default has to be quoted and escaped, a <c>bool</c> has to be
+/// lower-cased for C#, and an enum default has to be qualified by its type rather than quoted.
+/// </para>
+/// </remarks>
+public class FilterTypeEmitterTests {
+
+    private const string FilterNamespace = EmitterHarness.RootNamespace + ".Filters";
+
+    private static FilterTypeModel Model(string name = "throttle", params FilterTypePropertyModel[] properties) =>
+        new() {
+            Name = name,
+            Namespace = FilterNamespace,
+            Properties = new List<FilterTypePropertyModel>(properties)
+        };
+
+    private static string Emit(FilterTypeModel model) =>
+        EmitterHarness.Write(ns => FilterTypeEmitter.Emit(ns, model), FilterNamespace);
+
+    #region the type itself
+
+    /// <summary>
+    /// Public and partial, because the consumer writes the other half — the interface
+    /// implementation that makes it an actual filter.
+    /// </summary>
+    [Fact]
+    public void TheAttributeIsPublicAndPartial() {
+        Assert.Contains("public partial class ThrottleAttribute", Emit(Model()));
+    }
+
+    [Fact]
+    public void TheAttributeDerivesFromAttribute() {
+        Assert.Contains("Attribute", Emit(Model()));
+    }
+
+    /// <summary>
+    /// Applicable to a class and a method, which is what lets one filter be declared for a whole
+    /// controller or for a single operation.
+    /// </summary>
+    [Fact]
+    public void TheAttributeIsUsableOnAClassAndAMethod() {
+        var output = Emit(Model());
+
+        Assert.Contains("AttributeTargets.Class", output);
+        Assert.Contains("AttributeTargets.Method", output);
+    }
+
+    /// <summary>
+    /// The class name comes from the model, which appends the suffix — so a spec naming a filter
+    /// <c>throttle</c> produces <c>[Throttle]</c> at the use site.
+    /// </summary>
+    [Theory]
+    [InlineData("throttle", "ThrottleAttribute")]
+    [InlineData("rate_limit", "RateLimitAttribute")]
+    [InlineData("require-scope", "RequireScopeAttribute")]
+    public void TheClassNameIsPascalCasedWithTheSuffix(string declared, string expected) {
+        Assert.Contains($"public partial class {expected}", Emit(Model(declared)));
+    }
+
+    [Fact]
+    public void AFilterWithNoPropertiesStillEmitsTheType() {
+        Assert.Contains("public partial class ThrottleAttribute", Emit(Model()));
+    }
+
+    #endregion
+
+    #region properties
+
+    [Fact]
+    public void ADeclaredPropertyIsEmittedPublic() {
+        var output = Emit(Model("throttle",
+            new FilterTypePropertyModel { Name = "Limit", CSharpType = "int" }));
+
+        Assert.Contains("public int Limit", output);
+    }
+
+    [Fact]
+    public void EveryDeclaredPropertyIsEmitted() {
+        var output = Emit(Model("throttle",
+            new FilterTypePropertyModel { Name = "Limit", CSharpType = "int" },
+            new FilterTypePropertyModel { Name = "Window", CSharpType = "string" }));
+
+        Assert.Contains("public int Limit", output);
+        Assert.Contains("public string Window", output);
+    }
+
+    [Fact]
+    public void APropertyWithNoDefaultGetsNoInitializer() {
+        var output = Emit(Model("throttle",
+            new FilterTypePropertyModel { Name = "Limit", CSharpType = "int" }));
+
+        Assert.DoesNotContain("Limit { get; set; } =", output);
+    }
+
+    #endregion
+
+    #region default values
+
+    [Fact]
+    public void AnIntegerDefaultIsWrittenBare() {
+        Assert.Contains(
+            "= 100",
+            Emit(Model("throttle",
+                new FilterTypePropertyModel { Name = "Limit", CSharpType = "int", Default = "100" })));
+    }
+
+    [Theory]
+    [InlineData("long", "9000")]
+    [InlineData("float", "1.5")]
+    [InlineData("double", "2.25")]
+    public void EveryNumericDefaultIsWrittenBare(string csharpType, string value) {
+        Assert.Contains(
+            $"= {value}",
+            Emit(Model("throttle",
+                new FilterTypePropertyModel { Name = "Value", CSharpType = csharpType, Default = value })));
+    }
+
+    [Fact]
+    public void AStringDefaultIsQuoted() {
+        Assert.Contains(
+            "= \"minute\"",
+            Emit(Model("throttle",
+                new FilterTypePropertyModel { Name = "Window", CSharpType = "string", Default = "minute" })));
+    }
+
+    /// <summary>
+    /// A default containing a quote or a backslash has to survive being written into a C# literal.
+    /// </summary>
+    [Theory]
+    [InlineData("say \"hi\"", "\"say \\\"hi\\\"\"")]
+    [InlineData("back\\slash", "\"back\\\\slash\"")]
+    public void AStringDefaultIsEscaped(string declared, string expected) {
+        Assert.Contains(
+            "= " + expected,
+            Emit(Model("throttle",
+                new FilterTypePropertyModel { Name = "Window", CSharpType = "string", Default = declared })));
+    }
+
+    /// <summary>
+    /// YAML writes <c>True</c>; C# will not compile it.
+    /// </summary>
+    [Theory]
+    [InlineData("True", "true")]
+    [InlineData("true", "true")]
+    [InlineData("False", "false")]
+    [InlineData("FALSE", "false")]
+    public void ABooleanDefaultIsLowerCasedForCSharp(string declared, string expected) {
+        var output = Emit(Model("throttle",
+            new FilterTypePropertyModel { Name = "Enabled", CSharpType = "bool", Default = declared }));
+
+        Assert.Contains("= " + expected, output);
+    }
+
+    /// <summary>
+    /// An enum default is qualified by its type rather than quoted — the property's type is the
+    /// enum, so a string literal would not compile.
+    /// </summary>
+    [Fact]
+    public void AnEnumDefaultIsQualifiedByItsType() {
+        var output = Emit(Model("throttle",
+            new FilterTypePropertyModel {
+                Name = "Mode",
+                CSharpType = "string",
+                EnumType = "Test.Api.Filters.ThrottleMode",
+                Default = "Sliding"
+            }));
+
+        Assert.Contains("= Test.Api.Filters.ThrottleMode.Sliding", output);
+    }
+
+    /// <summary>
+    /// The enum type also becomes the property's type, not the declared <c>CSharpType</c>.
+    /// </summary>
+    [Fact]
+    public void AnEnumPropertyUsesTheEnumTypeRatherThanTheDeclaredOne() {
+        var output = Emit(Model("throttle",
+            new FilterTypePropertyModel {
+                Name = "Mode",
+                CSharpType = "string",
+                EnumType = "Test.Api.Filters.ThrottleMode"
+            }));
+
+        Assert.Contains("ThrottleMode Mode", output);
+        Assert.DoesNotContain("string Mode", output);
+    }
+
+    /// <summary>
+    /// An unrecognised C# type falls back to a quoted literal rather than emitting the value bare,
+    /// which would produce something that does not compile.
+    /// </summary>
+    [Fact]
+    public void AnUnrecognisedTypeFallsBackToAQuotedLiteral() {
+        Assert.Contains(
+            "= \"PT1M\"",
+            Emit(Model("throttle",
+                new FilterTypePropertyModel {
+                    Name = "Window", CSharpType = "TimeSpan", Default = "PT1M"
+                })));
+    }
+
+    #endregion
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OperationParametersTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OperationParametersTests.cs
@@ -1,0 +1,321 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Idl.Models;
+using Hardened.Idl.Validation;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The parameter interface one operation gets, when anything about it is constrained.
+/// </summary>
+/// <remarks>
+/// <para>
+/// At <b>35% line coverage</b>. This is the seam between the build task and the source generator:
+/// the task cannot name the handler's nested <c>Parameters</c> class, so it names an interface, puts
+/// the constraints on it, and lets the generator make <c>Parameters</c> implement it.
+/// </para>
+/// <para>
+/// The decision worth guarding is <b>returning null</b>. An interface is emitted only when something
+/// is actually constrained, and the same question decides whether <c>[ValidateNested]</c> goes on the
+/// body — a <c>[ValidateNested]</c> naming a validator the generator declined to emit is CS0234 in a
+/// generated file. Both answers have to come from one place to stay in step, and this is it.
+/// </para>
+/// </remarks>
+public class OperationParametersTests {
+
+    private static PatternRegistry Patterns() =>
+        new(EmitterHarness.RootNamespace + ".Validation", "petstore");
+
+    private static ParameterModel Parameter(
+        string name = "petId",
+        string type = "string",
+        bool required = false,
+        int? minLength = null,
+        int? maxLength = null,
+        string? refName = null) =>
+        new() {
+            Name = name,
+            In = "path",
+            Type = type,
+            IsRequired = required,
+            MinLength = minLength,
+            MaxLength = maxLength,
+            Ref = refName
+        };
+
+    private static OperationModel Operation(params ParameterModel[] parameters) =>
+        new() {
+            OperationId = "getPet",
+            MethodName = "GetPet",
+            Path = "/pets/{petId}",
+            HttpMethod = "GET",
+            Parameters = new List<ParameterModel>(parameters)
+        };
+
+    private static ServiceSpecModel Spec(OperationModel operation, params SchemaModel[] schemas) =>
+        new() {
+            Services = [new ServiceModel { Tag = "pets", Operations = [operation] }],
+            Schemas = new List<SchemaModel>(schemas)
+        };
+
+    private static OperationParameters.Model? Build(
+        OperationModel operation, params SchemaModel[] schemas) =>
+        OperationParameters.Build(
+            operation, Spec(operation, schemas), EmitterHarness.ModelsNamespace, Patterns());
+
+    #region whether an interface is emitted at all
+
+    /// <summary>
+    /// Nothing constrained means no interface. Emitting an empty one would make the generator
+    /// produce a validator with nothing to check.
+    /// </summary>
+    [Fact]
+    public void AnOperationWithNoConstraintsGetsNoInterface() {
+        Assert.Null(Build(Operation(Parameter())));
+    }
+
+    [Fact]
+    public void AnOperationWithNoParametersAtAllGetsNoInterface() {
+        Assert.Null(Build(Operation()));
+    }
+
+    [Fact]
+    public void OneConstrainedParameterIsEnough() {
+        Assert.NotNull(Build(Operation(Parameter(minLength: 1))));
+    }
+
+    #endregion
+
+    #region shape
+
+    [Fact]
+    public void TheInterfaceIsNamedForTheOperationsMethodName() {
+        Assert.Equal("IGetPetParameters", Build(Operation(Parameter(minLength: 1)))!.InterfaceName);
+    }
+
+    /// <summary>
+    /// The document's own operation id is carried through unchanged — it is what a reader matches
+    /// against, and it is not always a legal C# name.
+    /// </summary>
+    [Fact]
+    public void TheDocumentsOperationIdIsCarried() {
+        Assert.Equal("getPet", Build(Operation(Parameter(minLength: 1)))!.OperationId);
+    }
+
+    /// <summary>
+    /// Every parameter becomes a member, not only the constrained ones — the interface has to match
+    /// what the handler's <c>Parameters</c> class declares.
+    /// </summary>
+    [Fact]
+    public void EveryParameterBecomesAMember() {
+        var model = Build(Operation(
+            Parameter("petId", minLength: 1),
+            Parameter("name")));
+
+        Assert.Equal(["petId", "name"], model!.Members.Select(member => member.Name));
+    }
+
+    [Fact]
+    public void OnlyTheConstrainedParameterCarriesAttributes() {
+        var model = Build(Operation(
+            Parameter("petId", minLength: 1),
+            Parameter("name")));
+
+        Assert.NotEmpty(model!.Members[0].Attributes);
+        Assert.Empty(model.Members[1].Attributes);
+    }
+
+    #endregion
+
+    #region requiredness
+
+    [Fact]
+    public void ARequiredStringParameterCarriesRequired() {
+        var model = Build(Operation(Parameter(required: true, minLength: 1)));
+
+        Assert.Contains(
+            model!.Members[0].Attributes, attribute => attribute.Type.Name == "RequiredAttribute");
+    }
+
+    /// <summary>
+    /// Suppressed where the C# type already guarantees presence. A required integer path parameter
+    /// is the common case, and <c>[Required]</c> on one makes the validation generator emit
+    /// <c>value.petId is null</c> against a <c>long</c> — CS0037.
+    /// </summary>
+    [Fact]
+    public void ARequiredNonNullableValueTypeDoesNotCarryRequired() {
+        // A second, constrained parameter so an interface is produced at all — the integer's own
+        // constraints are exactly what is expected to come back empty.
+        var model = Build(Operation(
+            Parameter("petId", type: "integer", required: true),
+            Parameter("name", minLength: 1)));
+
+        Assert.Equal("petId", model!.Members[0].Name);
+        Assert.Empty(model.Members[0].Attributes);
+    }
+
+    /// <summary>
+    /// A generated enum is a value type too, and the spec's own schemas are what say so.
+    /// </summary>
+    [Fact]
+    public void ARequiredParameterTypedAsAGeneratedEnumDoesNotCarryRequired() {
+        var operation = Operation(
+            Parameter("status", required: true, refName: "#/components/schemas/PetStatus"),
+            Parameter("name", minLength: 1));
+
+        var model = OperationParameters.Build(
+            operation,
+            Spec(operation, new SchemaModel {
+                Name = "PetStatus", Kind = SchemaKind.Enum, EnumValues = ["available", "sold"]
+            }),
+            EmitterHarness.ModelsNamespace,
+            Patterns());
+
+        Assert.NotNull(model);
+        Assert.Equal("status", model!.Members[0].Name);
+        Assert.Empty(model.Members[0].Attributes);
+    }
+
+    /// <summary>
+    /// The suppression is about the type, not the name. The same parameter typed as a string does
+    /// carry <c>[Required]</c>.
+    /// </summary>
+    [Fact]
+    public void ARequiredStringParameterStillCarriesRequiredAlongsideAValueType() {
+        var model = Build(Operation(
+            Parameter("petId", type: "integer", required: true),
+            Parameter("name", required: true, minLength: 1)));
+
+        Assert.Empty(model!.Members[0].Attributes);
+        Assert.Contains(
+            model.Members[1].Attributes, attribute => attribute.Type.Name == "RequiredAttribute");
+    }
+
+    #endregion
+
+    #region the request body
+
+    private static SchemaModel Body(params PropertyModel[] properties) =>
+        new() {
+            Name = "Pet",
+            Kind = SchemaKind.Object,
+            Properties = new List<PropertyModel>(properties)
+        };
+
+    private static PropertyModel BodyProperty(
+        string name = "name", string type = "string", int? minLength = null, bool readOnly = false) =>
+        new() { Name = name, Type = type, MinLength = minLength, IsReadOnly = readOnly };
+
+    private static OperationModel PostWithBody() =>
+        new() {
+            OperationId = "addPet",
+            MethodName = "AddPet",
+            Path = "/pets",
+            HttpMethod = "POST",
+            RequestBodyRef = "#/components/schemas/Pet"
+        };
+
+    [Fact]
+    public void AConstrainedBodyAddsABodyMember() {
+        var operation = PostWithBody();
+
+        var model = OperationParameters.Build(
+            operation,
+            Spec(operation, Body(BodyProperty(minLength: 1))),
+            EmitterHarness.ModelsNamespace,
+            Patterns());
+
+        Assert.NotNull(model);
+        Assert.Equal("body", Assert.Single(model!.Members).Name);
+    }
+
+    /// <summary>
+    /// <c>[ValidateNested]</c> is what makes the generated validator descend, which is what gives
+    /// body errors their <c>body.</c> prefix and distinguishes them from a path parameter of the
+    /// same name.
+    /// </summary>
+    [Fact]
+    public void AConstrainedBodyCarriesValidateNested() {
+        var operation = PostWithBody();
+
+        var model = OperationParameters.Build(
+            operation,
+            Spec(operation, Body(BodyProperty(minLength: 1))),
+            EmitterHarness.ModelsNamespace,
+            Patterns());
+
+        Assert.Equal(
+            "ValidateNestedAttribute",
+            Assert.Single(Assert.Single(model!.Members).Attributes).Type.Name);
+    }
+
+    /// <summary>
+    /// A body with nothing to check gets no <c>[ValidateNested]</c>, and with no other constraint
+    /// the operation gets no interface at all. Naming a validator the generator declined to emit is
+    /// CS0234 in a generated file.
+    /// </summary>
+    [Fact]
+    public void AnUnconstrainedBodyProducesNoInterface() {
+        var operation = PostWithBody();
+
+        Assert.Null(OperationParameters.Build(
+            operation,
+            Spec(operation, Body(BodyProperty())),
+            EmitterHarness.ModelsNamespace,
+            Patterns()));
+    }
+
+    /// <summary>
+    /// A read-only property's constraints are never emitted, so a body whose only constrained
+    /// property is read-only has nothing to descend into.
+    /// </summary>
+    [Fact]
+    public void ABodyConstrainedOnlyOnAReadOnlyPropertyDoesNotValidateNested() {
+        var operation = PostWithBody();
+
+        Assert.Null(OperationParameters.Build(
+            operation,
+            Spec(operation, Body(BodyProperty(minLength: 1, readOnly: true))),
+            EmitterHarness.ModelsNamespace,
+            Patterns()));
+    }
+
+    [Fact]
+    public void ABodyRefThatMatchesNoObjectSchemaAddsNoMember() {
+        var operation = PostWithBody();
+
+        Assert.Null(OperationParameters.Build(
+            operation, Spec(operation), EmitterHarness.ModelsNamespace, Patterns()));
+    }
+
+    [Fact]
+    public void AnOperationWithNoBodyRefAddsNoBodyMember() {
+        var model = Build(Operation(Parameter(minLength: 1)));
+
+        Assert.DoesNotContain(model!.Members, member => member.Name == "body");
+    }
+
+    /// <summary>
+    /// A constrained parameter still produces an interface even when the body has nothing to check,
+    /// and the body member comes along so the interface matches the Parameters class.
+    /// </summary>
+    [Fact]
+    public void AConstrainedParameterCarriesAnUnconstrainedBodyAlong() {
+        var operation = PostWithBody();
+
+        operation.Parameters = [Parameter("petId", minLength: 1)];
+
+        var model = OperationParameters.Build(
+            operation,
+            Spec(operation, Body(BodyProperty())),
+            EmitterHarness.ModelsNamespace,
+            Patterns());
+
+        Assert.NotNull(model);
+        Assert.Equal(["petId", "body"], model!.Members.Select(member => member.Name));
+        Assert.Empty(model.Members[1].Attributes);
+    }
+
+    #endregion
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/PatternRegistryTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/PatternRegistryTests.cs
@@ -1,0 +1,298 @@
+using Hardened.Idl.Validation;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The regular expressions a spec declares, and the <c>[GeneratedRegex]</c> member each becomes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The registry was at <b>21% line coverage</b>. It was constructed by the schema tests and asked
+/// nothing, so neither the rejection path nor the deduplication had ever run.
+/// </para>
+/// <para>
+/// Two properties carry real weight. <b>The member name has to be identical on every build</b> —
+/// it is written into emitted source, so a name that moved would churn the file and recompile every
+/// consumer; that is why the hash is FNV-1a rather than <c>string.GetHashCode</c>, which .NET Core
+/// randomises per process. And <b>a pattern .NET cannot compile has to be refused here</b>, because
+/// emitted anyway it reaches <c>[GeneratedRegex]</c>, fails to generate, and leaves its partial
+/// method unimplemented — CS8795 in a generated file, for a pattern the document was entitled to
+/// write.
+/// </para>
+/// </remarks>
+public class PatternRegistryTests {
+
+    private const string PatternNamespace = EmitterHarness.RootNamespace + ".Validation";
+
+    private static PatternRegistry Registry(string specFileName = "petstore") =>
+        new(PatternNamespace, specFileName);
+
+    #region the class the members live on
+
+    [Theory]
+    [InlineData("petstore", "PetstorePatterns")]
+    [InlineData("pet_store", "PetStorePatterns")]
+    [InlineData("pet-store", "PetStorePatterns")]
+    public void TheClassIsNamedForTheSpecFile(string specFileName, string expected) {
+        Assert.Equal(expected, Registry(specFileName).ClassName);
+    }
+
+    [Fact]
+    public void AFreshRegistryIsEmpty() {
+        var registry = Registry();
+
+        Assert.True(registry.IsEmpty);
+        Assert.Empty(registry.Members);
+        Assert.Empty(registry.Rejected);
+    }
+
+    [Fact]
+    public void RegisteringAPatternMakesItNonEmpty() {
+        var registry = Registry();
+
+        registry.AttributeArguments("^[a-z]+$");
+
+        Assert.False(registry.IsEmpty);
+    }
+
+    #endregion
+
+    #region the reference form
+
+    /// <summary>
+    /// <c>[Pattern(typeof(X), nameof(X.Y))]</c> rather than <c>[Pattern("...")]</c>. The inline form
+    /// makes the validation generator declare a <c>Regex</c> itself, which roots the parser and the
+    /// interpreter — 448 KB on an AOT publish against 33 KB — and is what VM0017 rejects.
+    /// </summary>
+    [Fact]
+    public void TheArgumentsAreATypeAndAMemberName() {
+        var arguments = Registry().AttributeArguments("^[a-z]+$");
+
+        Assert.NotNull(arguments);
+        Assert.Equal(2, arguments!.Count);
+        Assert.Equal($"typeof(global::{PatternNamespace}.PetstorePatterns)", arguments[0]);
+        Assert.Equal($"nameof(global::{PatternNamespace}.PetstorePatterns.P_c37a8736)", arguments[1]);
+    }
+
+    /// <summary>
+    /// Global-qualified, so the reference cannot bind to a consumer type of the same name.
+    /// </summary>
+    [Fact]
+    public void TheTypeReferenceIsGlobalQualified() {
+        var arguments = Registry().AttributeArguments("^[a-z]+$");
+
+        Assert.All(arguments!, argument => Assert.Contains("global::", argument));
+    }
+
+    #endregion
+
+    #region member naming
+
+    /// <summary>
+    /// Pinned literals, on purpose. Asserting only that two calls agree would pass for
+    /// <c>string.GetHashCode</c>, which is stable within a process and different between them — and
+    /// a name that changes between builds churns the emitted file and recompiles every consumer.
+    /// These values are FNV-1a and must not move.
+    /// </summary>
+    [Theory]
+    [InlineData("^[a-z]+$", "P_c37a8736")]
+    [InlineData(@"^\d{3}-\d{4}$", "P_07d7974f")]
+    [InlineData("abc", "P_1a47e90b")]
+    public void MemberNamesAreAStableHashOfThePattern(string pattern, string expected) {
+        var registry = Registry();
+
+        registry.AttributeArguments(pattern);
+
+        Assert.Equal(expected, Assert.Single(registry.Members).Value);
+    }
+
+    /// <summary>
+    /// Two registries agree, which is the same property one build after another relies on.
+    /// </summary>
+    [Fact]
+    public void TwoRegistriesNameThePatternIdentically() {
+        Assert.Equal(
+            Registry().AttributeArguments("^[a-z]+$"),
+            Registry().AttributeArguments("^[a-z]+$"));
+    }
+
+    /// <summary>
+    /// The member name does not depend on the spec file, only the class it hangs off does.
+    /// </summary>
+    [Fact]
+    public void TheMemberNameIsIndependentOfTheSpecFile() {
+        var first = Registry("petstore");
+        var second = Registry("bank");
+
+        first.AttributeArguments("^[a-z]+$");
+        second.AttributeArguments("^[a-z]+$");
+
+        Assert.Equal(
+            Assert.Single(first.Members).Value, Assert.Single(second.Members).Value);
+    }
+
+    [Fact]
+    public void EveryMemberNameIsAValidCSharpIdentifier() {
+        var registry = Registry();
+
+        foreach (var pattern in new[] { "^[a-z]+$", @"^\d+$", "[!@#$%^&*()]", "a|b" }) {
+            registry.AttributeArguments(pattern);
+        }
+
+        Assert.All(registry.Members.Values, member => {
+            Assert.StartsWith("P_", member);
+            Assert.Equal(10, member.Length);
+            Assert.All(member.Substring(2), character => Assert.True(Uri.IsHexDigit(character)));
+        });
+    }
+
+    #endregion
+
+    #region deduplication
+
+    /// <summary>
+    /// Identical patterns collapse onto one member, which is the reason names come from the pattern
+    /// rather than from the property that declared it.
+    /// </summary>
+    [Fact]
+    public void ThePatternDeclaredTwiceGetsOneMember() {
+        var registry = Registry();
+
+        var first = registry.AttributeArguments("^[a-z]+$");
+        var second = registry.AttributeArguments("^[a-z]+$");
+
+        Assert.Single(registry.Members);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void DifferentPatternsGetDifferentMembers() {
+        var registry = Registry();
+
+        registry.AttributeArguments("^[a-z]+$");
+        registry.AttributeArguments(@"^\d+$");
+
+        Assert.Equal(2, registry.Members.Count);
+    }
+
+    [Fact]
+    public void MembersAreKeyedByPattern() {
+        var registry = Registry();
+
+        registry.AttributeArguments("^[a-z]+$");
+
+        Assert.Equal("^[a-z]+$", Assert.Single(registry.Members).Key);
+    }
+
+    #endregion
+
+    #region patterns .NET will not compile
+
+    /// <summary>
+    /// The case this exists for. OpenAPI specifies ECMA-262, and .NET's engine is not a superset:
+    /// <c>\_</c> is an ordinary escaped underscore in ECMA-262 and an unrecognised escape here.
+    /// Grafana's published spec declares one.
+    /// </summary>
+    [Fact]
+    public void APatternDotNetCannotCompileIsRefused() {
+        Assert.Null(Registry().AttributeArguments(@"^[a-zA-Z0-9\-\_]+$"));
+    }
+
+    [Fact]
+    public void ARefusedPatternDeclaresNoMember() {
+        var registry = Registry();
+
+        registry.AttributeArguments(@"^[a-zA-Z0-9\-\_]+$");
+
+        Assert.Empty(registry.Members);
+        Assert.True(registry.IsEmpty);
+    }
+
+    /// <summary>
+    /// Recorded with the reason, so the build can say what it dropped rather than silently
+    /// generating a weaker model.
+    /// </summary>
+    [Fact]
+    public void ARefusedPatternIsRecordedWithItsReason() {
+        var registry = Registry();
+
+        registry.AttributeArguments(@"^[a-zA-Z0-9\-\_]+$");
+
+        var rejected = Assert.Single(registry.Rejected);
+
+        Assert.StartsWith(@"^[a-zA-Z0-9\-\_]+$", rejected);
+        Assert.Contains(" - ", rejected);
+    }
+
+    [Theory]
+    [InlineData("(unclosed")]
+    [InlineData("[unclosed")]
+    [InlineData("a{2,1}")]
+    [InlineData(@"\_")]
+    public void EveryUncompilablePatternIsRefused(string pattern) {
+        var registry = Registry();
+
+        Assert.Null(registry.AttributeArguments(pattern));
+        Assert.Single(registry.Rejected);
+    }
+
+    [Fact]
+    public void TheSamePatternRefusedTwiceIsRecordedOnce() {
+        var registry = Registry();
+
+        registry.AttributeArguments(@"\_");
+        registry.AttributeArguments(@"\_");
+
+        Assert.Single(registry.Rejected);
+    }
+
+    /// <summary>
+    /// A refused pattern that is a prefix of one already refused is still reported.
+    /// </summary>
+    /// <remarks>
+    /// It was not, until 2026-08-18. Entries are <c>pattern + " - " + message</c> and the
+    /// deduplication asked whether any entry <em>started with</em> the pattern, so refusing
+    /// <c>\_x</c> and then <c>\_</c> matched an unrelated entry and dropped the second. Both were
+    /// refused either way; the build simply understated what it had dropped, which is the one job
+    /// this list has.
+    /// </remarks>
+    [Fact]
+    public void APatternThatIsAPrefixOfAnAlreadyRefusedOneIsStillReported() {
+        var registry = Registry();
+
+        Assert.Null(registry.AttributeArguments(@"\_x"));
+        Assert.Null(registry.AttributeArguments(@"\_"));
+
+        Assert.Equal(2, registry.Rejected.Count);
+    }
+
+    [Fact]
+    public void RefusalsAreReportedInTheOrderTheyWereSeen() {
+        var registry = Registry();
+
+        registry.AttributeArguments(@"\_");
+        registry.AttributeArguments("(unclosed");
+
+        Assert.Equal(2, registry.Rejected.Count);
+        Assert.StartsWith(@"\_", registry.Rejected[0]);
+        Assert.StartsWith("(unclosed", registry.Rejected[1]);
+    }
+
+    /// <summary>
+    /// A refusal does not disturb the patterns that did compile.
+    /// </summary>
+    [Fact]
+    public void AGoodPatternStillRegistersAlongsideARefusedOne() {
+        var registry = Registry();
+
+        registry.AttributeArguments("^[a-z]+$");
+        registry.AttributeArguments(@"\_");
+        registry.AttributeArguments(@"^\d+$");
+
+        Assert.Equal(2, registry.Members.Count);
+        Assert.Single(registry.Rejected);
+    }
+
+    #endregion
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ValidationEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ValidationEmitterTests.cs
@@ -1,0 +1,258 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Idl.Models;
+using Hardened.Idl.Validation;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The parameter interfaces and <c>[GeneratedRegex]</c> members a spec's constraints become.
+/// </summary>
+/// <remarks>
+/// <para>
+/// At <b>35% line coverage</b>. <c>OperationParametersTests</c> covers what goes into the model;
+/// this covers what reaches the file.
+/// </para>
+/// <para>
+/// <b><see cref="EmitPatterns"/> is why the build task exists at all.</b> A source generator cannot
+/// emit <c>[GeneratedRegex]</c> — its output is not in the compilation the regex generator reads, so
+/// the partial method is never implemented and the consumer's build fails with CS8795. And it is
+/// written as raw text rather than through <c>MethodDefinition</c>, which always writes a body: a
+/// partial method with <c>{ }</c> is SYSLIB1043. Both mistakes produce a generated file that does
+/// not compile, in somebody else's project.
+/// </para>
+/// </remarks>
+public class ValidationEmitterTests {
+
+    private const string ValidationNamespace = EmitterHarness.RootNamespace + ".Validation";
+
+    private static PatternRegistry Patterns() => new(ValidationNamespace, "petstore");
+
+    private static ParameterModel Parameter(
+        string name = "petId", int? minLength = null, string? pattern = null) =>
+        new() { Name = name, In = "path", Type = "string", MinLength = minLength, Pattern = pattern };
+
+    private static ServiceSpecModel Spec(params OperationModel[] operations) =>
+        new() {
+            Services = [new ServiceModel { Tag = "pets", Operations = new List<OperationModel>(operations) }],
+            Schemas = []
+        };
+
+    private static OperationModel Operation(string methodName, params ParameterModel[] parameters) =>
+        new() {
+            OperationId = methodName,
+            MethodName = methodName,
+            Path = "/pets",
+            HttpMethod = "GET",
+            Parameters = new List<ParameterModel>(parameters)
+        };
+
+    private static string EmitInterfaces(ServiceSpecModel spec, PatternRegistry? patterns = null) =>
+        EmitterHarness.Write(
+            ns => ValidationEmitter.Emit(
+                ns, spec, EmitterHarness.ModelsNamespace, patterns ?? Patterns()),
+            ValidationNamespace);
+
+    private static IReadOnlyList<OperationParameters.Model> Models(
+        ServiceSpecModel spec, PatternRegistry? patterns = null) {
+        IReadOnlyList<OperationParameters.Model> result = [];
+
+        EmitterHarness.Write(
+            ns => result = ValidationEmitter.Emit(
+                ns, spec, EmitterHarness.ModelsNamespace, patterns ?? Patterns()),
+            ValidationNamespace);
+
+        return result;
+    }
+
+    #region interfaces
+
+    [Fact]
+    public void AConstrainedOperationGetsAPublicPartialInterface() {
+        Assert.Contains(
+            "public partial interface IGetPetParameters",
+            EmitInterfaces(Spec(Operation("GetPet", Parameter(minLength: 1)))));
+    }
+
+    [Fact]
+    public void AnUnconstrainedOperationGetsNothing() {
+        Assert.DoesNotContain(
+            "interface", EmitInterfaces(Spec(Operation("GetPet", Parameter()))));
+    }
+
+    [Fact]
+    public void EveryConstrainedOperationInTheSpecGetsOne() {
+        var output = EmitInterfaces(Spec(
+            Operation("GetPet", Parameter(minLength: 1)),
+            Operation("ListPets", Parameter("limit", minLength: 2))));
+
+        Assert.Contains("IGetPetParameters", output);
+        Assert.Contains("IListPetsParameters", output);
+    }
+
+    [Fact]
+    public void OnlyTheConstrainedOperationsAreEmitted() {
+        var models = Models(Spec(
+            Operation("GetPet", Parameter(minLength: 1)),
+            Operation("ListPets", Parameter("limit"))));
+
+        Assert.Equal(["IGetPetParameters"], models.Select(model => model.InterfaceName));
+    }
+
+    [Fact]
+    public void EveryServiceInTheSpecContributes() {
+        var spec = new ServiceSpecModel {
+            Services = [
+                new ServiceModel { Tag = "pets", Operations = [Operation("GetPet", Parameter(minLength: 1))] },
+                new ServiceModel { Tag = "store", Operations = [Operation("GetOrder", Parameter("orderId", minLength: 1))] }
+            ],
+            Schemas = []
+        };
+
+        Assert.Equal(
+            ["IGetPetParameters", "IGetOrderParameters"],
+            Models(spec).Select(model => model.InterfaceName));
+    }
+
+    /// <summary>
+    /// Get-only. The interface describes what the handler's <c>Parameters</c> class already has;
+    /// declaring a setter would make the generated class have to provide one.
+    /// </summary>
+    [Fact]
+    public void ThePropertiesAreGetOnly() {
+        var output = EmitInterfaces(Spec(Operation("GetPet", Parameter(minLength: 1))));
+
+        Assert.Contains("get;", output);
+        Assert.DoesNotContain("set;", output);
+    }
+
+    [Fact]
+    public void TheConstraintsReachTheProperty() {
+        Assert.Contains(
+            "StringLength",
+            EmitInterfaces(Spec(Operation("GetPet", Parameter(minLength: 1)))));
+    }
+
+    [Fact]
+    public void EveryParameterBecomesAProperty() {
+        var output = EmitInterfaces(Spec(
+            Operation("GetPet", Parameter("petId", minLength: 1), Parameter("name"))));
+
+        Assert.Contains("petId", output);
+        Assert.Contains("name", output);
+    }
+
+    #endregion
+
+    #region the GeneratedRegex members
+
+    private static string EmitPatterns(PatternRegistry patterns) =>
+        EmitterHarness.Write(
+            ns => ValidationEmitter.EmitPatterns(ns, patterns), ValidationNamespace);
+
+    [Fact]
+    public void NoPatternsEmitsNoClass() {
+        Assert.DoesNotContain("PetstorePatterns", EmitPatterns(Patterns()));
+    }
+
+    [Fact]
+    public void APatternBecomesAPartialClassNamedForTheSpec() {
+        var patterns = Patterns();
+
+        patterns.AttributeArguments("^[a-z]+$");
+
+        Assert.Contains("internal static partial class PetstorePatterns", EmitPatterns(patterns));
+    }
+
+    /// <summary>
+    /// A partial method with no body. <c>MethodDefinition</c> always writes one, so
+    /// <c>ComponentModifier.Partial</c> on a method produces <c>static Regex P_x() { }</c> and
+    /// SYSLIB1043 — which is why this half is raw text.
+    /// </summary>
+    [Fact]
+    public void TheMemberIsABodylessPartialMethod() {
+        var patterns = Patterns();
+
+        patterns.AttributeArguments("^[a-z]+$");
+
+        var output = EmitPatterns(patterns);
+
+        Assert.Contains("public static partial global::System.Text.RegularExpressions.Regex P_c37a8736();", output);
+        Assert.DoesNotContain("P_c37a8736() {", output);
+    }
+
+    [Fact]
+    public void TheMemberCarriesGeneratedRegexWithThePattern() {
+        var patterns = Patterns();
+
+        patterns.AttributeArguments("^[a-z]+$");
+
+        Assert.Contains(
+            "[global::System.Text.RegularExpressions.GeneratedRegex(\"^[a-z]+$\")]",
+            EmitPatterns(patterns));
+    }
+
+    /// <summary>
+    /// A pattern is full of backslashes by nature, and it has to survive being written into a C#
+    /// string literal.
+    /// </summary>
+    [Fact]
+    public void ABackslashInThePatternIsEscaped() {
+        var patterns = Patterns();
+
+        patterns.AttributeArguments(@"^\d{3}$");
+
+        Assert.Contains(@"GeneratedRegex(""^\\d{3}$"")", EmitPatterns(patterns));
+    }
+
+    [Fact]
+    public void AQuoteInThePatternIsEscaped() {
+        var patterns = Patterns();
+
+        patterns.AttributeArguments("^\"[a-z]+\"$");
+
+        Assert.Contains(@"GeneratedRegex(""^\""[a-z]+\""$"")", EmitPatterns(patterns));
+    }
+
+    [Fact]
+    public void EveryDistinctPatternGetsItsOwnMember() {
+        var patterns = Patterns();
+
+        patterns.AttributeArguments("^[a-z]+$");
+        patterns.AttributeArguments(@"^\d+$");
+
+        var output = EmitPatterns(patterns);
+
+        Assert.Equal(2, output.Split("GeneratedRegex").Length - 1);
+    }
+
+    /// <summary>
+    /// A pattern the runtime refuses never reaches the file — emitted, it would fail to generate
+    /// and leave its partial method unimplemented.
+    /// </summary>
+    [Fact]
+    public void ARefusedPatternIsNotEmitted() {
+        var patterns = Patterns();
+
+        patterns.AttributeArguments(@"^[a-zA-Z0-9\-\_]+$");
+
+        Assert.DoesNotContain("GeneratedRegex", EmitPatterns(patterns));
+    }
+
+    /// <summary>
+    /// The class the constraint attributes point at and the class emitted here are the same name,
+    /// or every <c>[Pattern]</c> reference is CS0234.
+    /// </summary>
+    [Fact]
+    public void TheEmittedClassIsTheOneTheAttributesReference() {
+        var patterns = Patterns();
+
+        var arguments = patterns.AttributeArguments("^[a-z]+$");
+
+        Assert.Contains($"class {patterns.ClassName}", EmitPatterns(patterns));
+        Assert.Contains(patterns.ClassName, arguments![0]);
+    }
+
+    #endregion
+}

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/Hardened.Validation.SourceGenerator.Tests.csproj
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/Hardened.Validation.SourceGenerator.Tests.csproj
@@ -1,0 +1,63 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!--
+            Referenced as a normal assembly rather than an analyzer so a GeneratorDriver can drive
+            it directly.
+
+            Hardened.SourceGenerator is deliberately NOT referenced alongside it, and neither is any
+            other generator assembly. This one compiles Hardened.SourceGenerator/Shared, CSharpAuthor
+            and ValidationModules.SourceGenerator.Impl in via linked Compile items, so a second
+            generator reference would put two copies of every one of those types in scope and every
+            use would be ambiguous - the CS0433 that Hardened.OpenApi.SourceGenerator.Tests
+            documents at length.
+        -->
+        <ProjectReference Include="..\Hardened.Validation.SourceGenerator\Hardened.Validation.SourceGenerator.csproj"/>
+
+        <ProjectReference Include="..\Hardened.SourceGeneration.Testing\Hardened.SourceGeneration.Testing.csproj"/>
+
+        <!-- [HardenedModule], which is what the entry point selector looks for. -->
+        <ProjectReference Include="..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
+
+    </ItemGroup>
+
+    <!--
+        ValidationModules.Runtime carries IValidatorFor<T> and the constraint attributes the test
+        source is written against. Referenced directly rather than pulled in through
+        Hardened.Requests.Runtime, which would work and would also drag that whole assembly into
+        this project's coverage run at zero - every class in it reading as untested because this
+        suite happens not to touch it.
+
+        Resolved the same way the rest of the repository resolves it: a sibling checkout when one is
+        there, the published package otherwise, so a CI runner without the checkout builds against
+        what shipped rather than failing on a path that does not exist.
+    -->
+    <PropertyGroup>
+        <ValidationModulesRoot Condition="'$(ValidationModulesRoot)' == ''">$(MSBuildThisFileDirectory)..\..\..\..\ValidationModules</ValidationModulesRoot>
+        <ValidationModulesRuntimeProject>$(ValidationModulesRoot)\src\ValidationModules.Runtime\ValidationModules.Runtime.csproj</ValidationModulesRuntimeProject>
+        <UseLocalValidationModules Condition="'$(UseLocalValidationModules)' == '' And Exists('$(ValidationModulesRuntimeProject)')">true</UseLocalValidationModules>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Condition="'$(UseLocalValidationModules)' == 'true'" Include="$(ValidationModulesRuntimeProject)"/>
+        <PackageReference Condition="'$(UseLocalValidationModules)' != 'true'" Include="ValidationModules.Runtime" Version="$(ValidationModulesVersion)"/>
+    </ItemGroup>
+
+</Project>

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
@@ -1,0 +1,333 @@
+using Hardened.Shared.Runtime.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Validation.SourceGenerator;
+using Microsoft.CodeAnalysis;
+using ValidationModules;
+using Xunit;
+
+namespace Hardened.Validation.SourceGenerator.Tests;
+
+/// <summary>
+/// The generator that turns constraint attributes into validators and registers them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It was at <b>12% line coverage / 3% branch</b>, and the only thing driving it was
+/// <c>ValidationAttachmentTests</c> over in the web generator's suite — which runs it as the
+/// <em>other half</em> of a pair, to prove the web generator's output compiles beside it. Nothing
+/// ran it on its own terms, so its own decisions had never been asserted.
+/// </para>
+/// <para>
+/// Every case ends at <see cref="GeneratorResult.AssertNoErrors"/>, which compiles the generated
+/// trees together with the source. Asserting on emitted text alone proves the characters are what
+/// was expected, not that a consumer can build — the rule <c>testing-conventions.md</c> §1 exists
+/// for.
+/// </para>
+/// </remarks>
+public class ValidationGeneratorTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(HardenedModuleAttribute),   // Hardened.Shared.Runtime
+        typeof(IValidatorFor<object>)      // ValidationModules.Runtime
+    ];
+
+    private static GeneratorResult Run(params (string Name, string Source)[] sources) =>
+        GeneratorTestHarness.Run(
+            sources.ToDictionary(pair => pair.Name, pair => pair.Source),
+            [new HardenedValidationGenerator()],
+            Anchors);
+
+    private const string EntryPoint = """
+        using Hardened.Shared.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        public partial class Application { }
+        """;
+
+    private static string Model(string ns = "TestApp.Models", string name = "Customer") => $$"""
+        using ValidationModules.Constraints;
+
+        namespace {{ns}};
+
+        public class {{name}} {
+            [Required]
+            [StringLength(Min = 1, Max = 64)]
+            public string Name { get; set; } = "";
+        }
+        """;
+
+    private static string RegistrationFile(GeneratorResult result) =>
+        result.GeneratedSources
+            .Single(pair => pair.Key.Contains("ValidationModule", StringComparison.Ordinal))
+            .Value;
+
+    private static bool HasRegistrationFile(GeneratorResult result) =>
+        result.GeneratedSources.Any(pair => pair.Key.Contains("ValidationModule", StringComparison.Ordinal));
+
+    #region the marker
+
+    /// <summary>
+    /// Says "this generator is running" to the handler generators, which emit calls to validators
+    /// this one produces and would otherwise name types nobody declares.
+    /// </summary>
+    [Fact]
+    public void TheMarkerIsEmittedEvenForAnEmptyCompilation() {
+        var result = Run(("Empty.cs", "namespace TestApp; public class Nothing { }"));
+
+        Assert.Contains(
+            result.GeneratedSources,
+            pair => pair.Key.Contains("Marker", StringComparison.Ordinal));
+
+        result.AssertNoErrors();
+    }
+
+    [Fact]
+    public void TheMarkerDeclaresTheTypeOtherGeneratorsLookFor() {
+        var marker = Run(("Empty.cs", "namespace TestApp; public class Nothing { }")).GeneratedSources
+            .Single(pair => pair.Key.Contains("Marker", StringComparison.Ordinal)).Value;
+
+        Assert.Contains("namespace Hardened.Validation.Generated", marker);
+        Assert.Contains("class ValidationGeneratorMarker", marker);
+    }
+
+    /// <summary>
+    /// Deliberately plain C#. It lands in whatever project references the generator, and a marker
+    /// needing a language version or a nullable context to compile would fail the builds it exists
+    /// to keep working.
+    /// </summary>
+    [Fact]
+    public void TheMarkerNeedsNoLanguageFeatures() {
+        var marker = Run(("Empty.cs", "namespace TestApp; public class Nothing { }")).GeneratedSources
+            .Single(pair => pair.Key.Contains("Marker", StringComparison.Ordinal)).Value;
+
+        Assert.DoesNotContain("#nullable", marker);
+        Assert.DoesNotContain("namespace Hardened.Validation.Generated;", marker);
+        Assert.Contains("{", marker);
+    }
+
+    #endregion
+
+    #region validators
+
+    [Fact]
+    public void AConstrainedModelGetsAValidator() {
+        var result = Run(("Entry.cs", EntryPoint), ("Customer.cs", Model()));
+
+        Assert.Contains(
+            result.GeneratedSources,
+            pair => pair.Key.Contains("Customer", StringComparison.Ordinal));
+
+        result.AssertNoErrors();
+    }
+
+    [Fact]
+    public void AnUnconstrainedModelGetsNoValidator() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Plain.cs", "namespace TestApp.Models; public class Plain { public string Name { get; set; } = \"\"; }"));
+
+        Assert.DoesNotContain(
+            result.GeneratedSources,
+            pair => pair.Key.Contains("Plain", StringComparison.Ordinal));
+
+        result.AssertNoErrors();
+    }
+
+    /// <summary>
+    /// <c>System.ComponentModel.DataAnnotations</c> reaches the same IR through the same front-end,
+    /// so a model annotated either way produces a validator.
+    /// </summary>
+    [Fact]
+    public void DataAnnotationsProduceAValidatorToo() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Annotated.cs", """
+                using System.ComponentModel.DataAnnotations;
+
+                namespace TestApp.Models;
+
+                public class Annotated {
+                    [Required]
+                    [StringLength(64, MinimumLength = 1)]
+                    public string Name { get; set; } = "";
+                }
+                """));
+
+        Assert.Contains(
+            result.GeneratedSources,
+            pair => pair.Key.Contains("Annotated", StringComparison.Ordinal));
+
+        result.AssertNoErrors();
+    }
+
+    /// <summary>
+    /// The hint name is namespace-qualified. <c>AddSource</c> throws on a duplicate, and that
+    /// failure takes the whole generator down rather than the second type — so two namespaces each
+    /// declaring a <c>Customer</c> is the case that has to work.
+    /// </summary>
+    [Fact]
+    public void TwoModelsOfTheSameNameInDifferentNamespacesBothGetValidators() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("First.cs", Model("TestApp.First")),
+            ("Second.cs", Model("TestApp.Second")));
+
+        Assert.Equal(
+            2,
+            result.GeneratedSources.Count(pair => pair.Key.Contains("Customer", StringComparison.Ordinal)));
+
+        result.AssertNoErrors();
+    }
+
+    [Fact]
+    public void EveryConstrainedModelGetsItsOwnValidator() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Customer.cs", Model(name: "Customer")),
+            ("Order.cs", Model(name: "Order")));
+
+        Assert.Contains(result.GeneratedSources, pair => pair.Key.Contains("Customer", StringComparison.Ordinal));
+        Assert.Contains(result.GeneratedSources, pair => pair.Key.Contains("Order", StringComparison.Ordinal));
+
+        result.AssertNoErrors();
+    }
+
+    #endregion
+
+    #region registration into the entry point
+
+    /// <summary>
+    /// A partial of the entry point class, adding to <c>DependencyRegistry&lt;TEntryPoint&gt;</c> —
+    /// the same mechanism the routing table uses, and the reason a consumer calls nothing.
+    /// DependencyModules composes sibling modules only through attributes someone writes, so a
+    /// module emitted next to the entry point would sit there unreferenced.
+    /// </summary>
+    [Fact]
+    public void ValidatorsAreRegisteredIntoTheEntryPoint() {
+        var result = Run(("Entry.cs", EntryPoint), ("Customer.cs", Model()));
+
+        var registration = RegistrationFile(result);
+
+        Assert.Contains("partial class Application", registration);
+        Assert.Contains("DependencyRegistry<Application>.Add(ValidationModuleDI)", registration);
+
+        result.AssertNoErrors();
+    }
+
+    /// <summary>
+    /// Without this the field initializer is trimmed and nothing is ever registered — the same
+    /// guard the routing table carries.
+    /// </summary>
+    [Fact]
+    public void TheRegistrationFieldIsHeldAgainstTrimming() {
+        Assert.Contains(
+            "DynamicDependency",
+            RegistrationFile(Run(("Entry.cs", EntryPoint), ("Customer.cs", Model()))));
+    }
+
+    /// <summary>
+    /// Registered as a type rather than an instance: a generated validator takes the validators for
+    /// its nested types as constructor parameters, so the container has to build it.
+    /// </summary>
+    [Fact]
+    public void AValidatorIsRegisteredAsASingletonClosedGeneric() {
+        var registration = RegistrationFile(Run(("Entry.cs", EntryPoint), ("Customer.cs", Model())));
+
+        Assert.Contains("AddSingleton<global::ValidationModules.IValidatorFor<", registration);
+        Assert.Contains("TestApp.Models.Customer>", registration);
+    }
+
+    /// <summary>
+    /// Ordered, so the emitted table does not reshuffle between builds — which would turn every
+    /// incremental compile into a diff.
+    /// </summary>
+    [Fact]
+    public void RegistrationsAreOrderedDeterministically() {
+        var first = RegistrationFile(Run(
+            ("Entry.cs", EntryPoint),
+            ("B.cs", Model("TestApp.Bravo")),
+            ("A.cs", Model("TestApp.Alpha"))));
+
+        var second = RegistrationFile(Run(
+            ("Entry.cs", EntryPoint),
+            ("A.cs", Model("TestApp.Alpha")),
+            ("B.cs", Model("TestApp.Bravo"))));
+
+        Assert.Equal(first, second);
+        Assert.True(
+            first.IndexOf("Alpha", StringComparison.Ordinal) <
+            first.IndexOf("Bravo", StringComparison.Ordinal),
+            "registrations are not ordered by namespace");
+    }
+
+    /// <summary>
+    /// Nothing to register means no file. An empty partial adding an empty method would still be
+    /// emitted on every build of every project that has none.
+    /// </summary>
+    [Fact]
+    public void NoValidatorsMeansNoRegistrationFile() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Plain.cs", "namespace TestApp.Models; public class Plain { public string Name { get; set; } = \"\"; }"));
+
+        Assert.False(HasRegistrationFile(result));
+
+        result.AssertNoErrors();
+    }
+
+    /// <summary>
+    /// A validator is still emitted for a compilation with no entry point — the model is the
+    /// developer's either way. Only the registration needs somewhere to land.
+    /// </summary>
+    [Fact]
+    public void AValidatorIsEmittedEvenWithNoEntryPoint() {
+        var result = Run(("Customer.cs", Model()));
+
+        Assert.Contains(
+            result.GeneratedSources,
+            pair => pair.Key.Contains("Customer", StringComparison.Ordinal));
+
+        Assert.False(HasRegistrationFile(result));
+
+        result.AssertNoErrors();
+    }
+
+    [Fact]
+    public void TheRegistrationFileIsNamedForTheEntryPoint() {
+        var result = Run(("Entry.cs", EntryPoint), ("Customer.cs", Model()));
+
+        Assert.Contains(
+            result.GeneratedSources,
+            pair => pair.Key.Contains("Application.ValidationModule", StringComparison.Ordinal));
+    }
+
+    #endregion
+
+    /// <summary>
+    /// The whole arrangement, compiled: entry point, several constrained models, both attribute
+    /// vocabularies, and the registration that wires them together.
+    /// </summary>
+    [Fact]
+    public void TheWholeArrangementCompiles() {
+        Run(
+            ("Entry.cs", EntryPoint),
+            ("Customer.cs", Model("TestApp.Models", "Customer")),
+            ("Order.cs", Model("TestApp.Orders", "Order")),
+            ("Annotated.cs", """
+                using System.ComponentModel.DataAnnotations;
+
+                namespace TestApp.Annotated;
+
+                public class Person {
+                    [Required]
+                    public string Name { get; set; } = "";
+
+                    [Range(0, 150)]
+                    public int Age { get; set; }
+                }
+                """))
+            .AssertNoErrors();
+    }
+}


### PR DESCRIPTION
Unit tests for the assemblies the coverage report had at or near zero, plus the three defects that writing them turned up.

**3,475 → 3,842 tests. 0 failures, 0 skipped, CI-mode build clean, no new warnings.**

The premise: enumeration points at where to look, running code finds what is wrong. Every defect below was found by writing a test for something measured at 0%, not by reading it.

## Defects found and fixed

**`NewtonsoftDeserializer` returned `default(T)` for every request, and had since the package shipped.** It took one reservation from the memory stream pool, copied the body into a second, seeked a third, and read the first — which was empty. Two of the three were never disposed, so every request leaked a pooled `MemoryStream`. Even with the right stream it could not have parsed: `ReadToEndAsync` ran the reader to EOF before `Deserialize` was handed the `JsonTextReader` over it. Five of the fifteen new deserializer tests fail against the original.

Three `LogInformation` calls went with it. One wrote the entire request body to the log at Information level.

**Newtonsoft could not displace System.Text.Json**, which is the only thing the package exists to do. `NewtonsoftSerializer` stated no `Order`, so it sat at `Normal` — exactly where `SystemTextJsonResponseSerializer` sits — and both claim `IsDefaultSerializer`. The read half was worse: `IRequestDeserializer` had no `Order` at all, so nothing could be stated. Fixed by mirroring the response side, and both Newtonsoft types now sit at `Specialized + 1` — ahead of System.Text.Json, behind the AOT serializers.

**`PatternRegistry` understated which patterns it dropped.** A regex OpenAPI is entitled to write but .NET will not compile is refused and recorded so the build can report it. The dedup asked whether any existing entry *started with* the pattern — but entries are `pattern + " - " + message`, so a pattern that is a prefix of one already rejected matched an unrelated entry and was never recorded. No generated code changes; what was lost is the diagnostic.

## Coverage moved

| | Before | After |
|---|---:|---:|
| `Hardened.Requests.Serializers.Newtonsoft` | 0% | tested, 52 cases |
| `FilterTypeEmitter`, `Deprecation` | 0% | 100% |
| `ErrorResponseEmitter` | 7% | 100% |
| `PatternRegistry` | 21% | 100% |
| `OperationParameters`, `ValidationEmitter` | ~35% | 100% |
| `ConstraintAttributes` | 48% | 100% |
| `Hardened.Validation.SourceGenerator` (own classes) | 12% | 100% |
| `TestApplication` | 0% | covered |

`Idl.Emit`/`Idl.Shared` code in the OpenApi build task: 1,380 uncovered lines → 990.

## Notes for review

**Most of the emitter tests assert what is *not* emitted.** Every guard in `ConstraintAttributes` exists because a published spec produced code that did not compile — Box putting `minimum` on a string, Vercel putting an `enum` on a `JsonElement` fallback, OpenAI typing parameters as generated enums. A guard that stops firing does not fail a happy-path test; it fails a consumer's build with CS0019 in a generated file.

**`PatternRegistry`'s member names are pinned to FNV-1a literals**, not compared between two calls. Comparing calls would pass for `string.GetHashCode`, which is stable within a process and differs between them — and a name that moved between builds would churn the emitted file and recompile every consumer.

**Public API is additive** and re-approved after reading the diff: `RequestDeserializerOrder`, `Order` on `IRequestDeserializer` (a default interface member, so existing implementors keep compiling), and `Order` on three implementations.

**`coverage-baseline.json` is deliberately not touched.** It has to be written from a CI `Summary.json` rather than a local run — see `scripts/coverage-gate.py` and commit `1aa5318`. Worth doing on top of this once CI has run, and separately: `Hardened.Smithy.BuildTask` still has no baseline entry at all, so ~8,600 lines are ungated.

## Reported, not fixed

`HardenedRequestModule` still registers `IRequestDeserializer` with `TryAddSingleton` while the `IResponseSerializer` line beside it was deliberately changed to `Add`. That is the same defect the response line's remark describes: `Try` keys on the service type, so any application registering an `IRequestDeserializer` first silently removes JSON request deserialization entirely.

Not fixed here because it is not a pure correction. With `Order` now in place the one-word change is possible, but it changes behaviour for an application registering its own JSON deserializer today: currently theirs is the only one and always wins, afterwards it ties with System.Text.Json at `Normal`. That is a call rather than a bug fix, and Newtonsoft ordering works either way.

## Out of scope

Static content — separate spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFy7Z6gdXU6tr65TndEUS8