### PR TITLE
Cover the branches CI said were untaken

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/ResolvedPrincipalTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/ResolvedPrincipalTests.cs
@@ -1,0 +1,282 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Authorization;
+
+/// <summary>
+/// The caller a requirement sees on its second walk, after a contributor resolved grants.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>AuthorizationFilterTests</c> covers what the filter <em>decides</em>, and covers it well. What
+/// it never looks at is the principal handed to the requirement for the re-walk — a private
+/// <c>ResolvedPrincipal</c> wrapping a private <c>UnionSet</c>. CI measured those fourteen lines at
+/// zero while the filter as a whole read 58.8%: every member but <c>Contains</c> and the
+/// constructor.
+/// </para>
+/// <para>
+/// They are reachable, and they matter. A requirement is an abstract class a consumer may implement,
+/// so anything it reads off the principal or asks of the grant set is a supported call — and
+/// <c>UnionSet</c> is hand-written set algebra over two sets that may overlap. If <c>Subject</c>
+/// came back null on the second walk, a requirement that reads it would see a different caller than
+/// it saw on the first.
+/// </para>
+/// </remarks>
+public class ResolvedPrincipalTests {
+
+    /// <summary>Resolves the grants it was built with, so the re-walk has something to see.</summary>
+    private sealed class ResolvingHandler : IActivityAuthorizationHandler {
+        private readonly HashSet<string> _resolvable;
+
+        public ResolvingHandler(params string[] resolvable) {
+            _resolvable = new HashSet<string>(resolvable, StringComparer.Ordinal);
+        }
+
+        public ValueTask<GrantResolution> Resolve(
+            IExecutionContext context, IReadOnlyList<string> grants) =>
+            new(new GrantResolution(
+                grants.Where(_resolvable.Contains).ToHashSet(StringComparer.Ordinal),
+                AuthorizationDecision.Abstain));
+    }
+
+    /// <summary>
+    /// Records the principal it is walked with, so a test can ask the resolved one questions.
+    /// </summary>
+    private sealed class CapturingRequirement : Requirement {
+        private readonly string[] _grants;
+
+        public CapturingRequirement(params string[] grants) {
+            _grants = grants;
+        }
+
+        public ICallerPrincipal? LastWalkedWith { get; private set; }
+
+        public int Walks { get; private set; }
+
+        public override bool RequiresContext => false;
+
+        public override IEnumerable<string> RequiredGrants => _grants;
+
+        public override bool IsSatisfiedBy(ICallerPrincipal principal, IExecutionContext context) {
+            Walks++;
+            LastWalkedWith = principal;
+
+            return _grants.All(principal.Grants.Contains);
+        }
+    }
+
+    /// <summary>
+    /// Runs the filter to the point where the requirement has been walked a second time, and hands
+    /// back the principal it was walked with.
+    /// </summary>
+    private static async Task<ICallerPrincipal> Resolved(
+        ICallerPrincipal caller, string[] required, params string[] resolvable) {
+        var requirement = new CapturingRequirement(required);
+
+        var context = Pipeline.Context(configureServices: services => {
+            services.AddSingleton<IActivityAuthorizationService, ActivityAuthorizationService>();
+            services.AddSingleton<IActivityAuthorizationHandler>(new ResolvingHandler(resolvable));
+        });
+
+        context.CallerPrincipal = caller;
+
+        await Pipeline.Chain(
+            context, new AuthorizationFilter(requirement, beforeSerialization: true)).Next();
+
+        Assert.Equal(2, requirement.Walks);
+        Assert.NotNull(requirement.LastWalkedWith);
+        Assert.NotSame(caller, requirement.LastWalkedWith);
+
+        return requirement.LastWalkedWith!;
+    }
+
+    private static ICallerPrincipal Holding(params string[] grants) =>
+        new CallerPrincipal("bearer", grants, subject: "user-1", issuer: "https://issuer.test");
+
+    private static Task<ICallerPrincipal> Standard() =>
+        Resolved(Holding("pets:read"), ["pets:read", "pets:write"], "pets:write");
+
+    #region the caller travels with the resolved grants
+
+    /// <summary>
+    /// The wrapper is the same caller. A requirement reading the subject on its second walk must
+    /// not see a different one than it saw on its first.
+    /// </summary>
+    [Fact]
+    public async Task TheResolvedPrincipalKeepsTheSubject() {
+        Assert.Equal("user-1", (await Standard()).Subject);
+    }
+
+    [Fact]
+    public async Task TheResolvedPrincipalKeepsTheIssuer() {
+        Assert.Equal("https://issuer.test", (await Standard()).Issuer);
+    }
+
+    [Fact]
+    public async Task TheResolvedPrincipalKeepsTheAuthenticationScheme() {
+        Assert.Equal("bearer", (await Standard()).AuthenticationScheme);
+    }
+
+    [Fact]
+    public async Task TheResolvedPrincipalIsStillAuthenticated() {
+        Assert.True((await Standard()).IsAuthenticated);
+    }
+
+    [Fact]
+    public async Task ClaimsStillResolveThroughTheWrapper() {
+        var caller = new CallerPrincipal(
+            "bearer", ["pets:read"], claims: new Dictionary<string, string> { ["tenant"] = "acme" });
+
+        var resolved = await Resolved(caller, ["pets:read", "pets:write"], "pets:write");
+
+        Assert.True(resolved.TryGetClaim("tenant", out var tenant));
+        Assert.Equal("acme", tenant);
+    }
+
+    [Fact]
+    public async Task AClaimTheCallerDoesNotHaveIsStillAbsent() {
+        Assert.False((await Standard()).TryGetClaim("nope", out _));
+    }
+
+    #endregion
+
+    #region the union of held and resolved grants
+
+    [Fact]
+    public async Task TheUnionContainsTheGrantTheCredentialCarried() {
+        Assert.Contains("pets:read", (await Standard()).Grants);
+    }
+
+    [Fact]
+    public async Task TheUnionContainsTheResolvedGrant() {
+        Assert.Contains("pets:write", (await Standard()).Grants);
+    }
+
+    [Fact]
+    public async Task TheUnionHoldsNothingElse() {
+        Assert.DoesNotContain("pets:delete", (await Standard()).Grants);
+    }
+
+    /// <summary>
+    /// Enumeration is what a requirement rendering a description walks, and the two sets may
+    /// overlap — the same grant held and resolved must appear once.
+    /// </summary>
+    [Fact]
+    public async Task EnumeratingTheUnionYieldsEachGrantOnce() {
+        var resolved = await Resolved(
+            Holding("pets:read"), ["pets:read", "pets:write"], "pets:read", "pets:write");
+
+        Assert.Equal(
+            ["pets:read", "pets:write"], resolved.Grants.OrderBy(grant => grant, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheCountDoesNotDoubleCountAnOverlap() {
+        var resolved = await Resolved(
+            Holding("pets:read"), ["pets:read", "pets:write"], "pets:read", "pets:write");
+
+        Assert.Equal(2, resolved.Grants.Count);
+    }
+
+    [Fact]
+    public async Task TheCountIsTheSizeOfTheUnion() {
+        Assert.Equal(2, (await Standard()).Grants.Count);
+    }
+
+    #endregion
+
+    #region set algebra
+
+    [Fact]
+    public async Task SetEqualsMatchesTheUnion() {
+        var grants = (await Standard()).Grants;
+
+        Assert.True(grants.SetEquals(["pets:read", "pets:write"]));
+        Assert.False(grants.SetEquals(["pets:read"]));
+    }
+
+    [Fact]
+    public async Task OverlapsFindsASharedGrant() {
+        var grants = (await Standard()).Grants;
+
+        Assert.True(grants.Overlaps(["pets:write", "pets:delete"]));
+        Assert.False(grants.Overlaps(["pets:delete"]));
+    }
+
+    [Fact]
+    public async Task IsSubsetOfComparesAgainstAWiderSet() {
+        var grants = (await Standard()).Grants;
+
+        Assert.True(grants.IsSubsetOf(["pets:read", "pets:write", "pets:delete"]));
+        Assert.True(grants.IsSubsetOf(["pets:read", "pets:write"]));
+        Assert.False(grants.IsSubsetOf(["pets:read"]));
+    }
+
+    [Fact]
+    public async Task IsProperSubsetOfExcludesTheEqualCase() {
+        var grants = (await Standard()).Grants;
+
+        Assert.True(grants.IsProperSubsetOf(["pets:read", "pets:write", "pets:delete"]));
+        Assert.False(grants.IsProperSubsetOf(["pets:read", "pets:write"]));
+    }
+
+    [Fact]
+    public async Task IsSupersetOfComparesAgainstANarrowerSet() {
+        var grants = (await Standard()).Grants;
+
+        Assert.True(grants.IsSupersetOf(["pets:read"]));
+        Assert.True(grants.IsSupersetOf(["pets:read", "pets:write"]));
+        Assert.False(grants.IsSupersetOf(["pets:read", "pets:delete"]));
+    }
+
+    [Fact]
+    public async Task IsProperSupersetOfExcludesTheEqualCase() {
+        var grants = (await Standard()).Grants;
+
+        Assert.True(grants.IsProperSupersetOf(["pets:read"]));
+        Assert.False(grants.IsProperSupersetOf(["pets:read", "pets:write"]));
+    }
+
+    /// <summary>
+    /// Grants are compared ordinally everywhere else, and the union has to agree — a set that
+    /// matched case-insensitively would admit a caller holding <c>PETS:READ</c>.
+    /// </summary>
+    [Fact]
+    public async Task TheUnionComparesGrantsOrdinally() {
+        var grants = (await Standard()).Grants;
+
+        Assert.False(grants.Contains("PETS:READ"));
+        Assert.False(grants.Contains("Pets:Write"));
+    }
+
+    #endregion
+
+    /// <summary>
+    /// The resolved grants exist to answer one requirement. Leaving them on the context would
+    /// silently widen every later check in the request — already asserted by
+    /// <c>AuthorizationFilterTests.ResolvedGrantsDoNotStayOnThePrincipal</c>; this is the other
+    /// half, that the wrapper handed to the re-walk is not the context's principal.
+    /// </summary>
+    [Fact]
+    public async Task TheWrapperIsNotInstalledOnTheContext() {
+        var caller = Holding("pets:read");
+        var requirement = new CapturingRequirement("pets:read", "pets:write");
+
+        var context = Pipeline.Context(configureServices: services => {
+            services.AddSingleton<IActivityAuthorizationService, ActivityAuthorizationService>();
+            services.AddSingleton<IActivityAuthorizationHandler>(new ResolvingHandler("pets:write"));
+        });
+
+        context.CallerPrincipal = caller;
+
+        await Pipeline.Chain(
+            context, new AuthorizationFilter(requirement, beforeSerialization: true)).Next();
+
+        Assert.Same(caller, context.CallerPrincipal);
+        Assert.NotSame(caller, requirement.LastWalkedWith);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/AotJsonSerializerTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/AotJsonSerializerTests.cs
@@ -1,0 +1,248 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Requests.Runtime.Serializer;
+using Hardened.Shared.Runtime.Json;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Serializer;
+
+/// <summary>
+/// The <see cref="IJsonSerializer"/> an AOT-published application resolves.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CI measured it at <b>0%</b> — the last class in <c>Hardened.Requests.Runtime</c> with nothing at
+/// all. <c>AotSerializerModuleTests</c> asserts it is the registration the module makes; nothing
+/// ever constructed one.
+/// </para>
+/// <para>
+/// <b>The resolver chain is what is actually under test.</b> Registered contexts go on first and
+/// <see cref="PrimitiveJsonTypeInfoResolver"/> goes on last, and the order is load-bearing in both
+/// directions: a context has to answer first for the types it knows, and the primitive table has to
+/// answer at all — <c>JsonMetadataServices.CreatePropertyInfo&lt;T&gt;</c> resolves its converter by
+/// asking the options, so serializing a record with one string property asks the chain for
+/// <c>string</c> too. Without that entry every string property throws <c>NotSupportedException</c>.
+/// </para>
+/// </remarks>
+public class AotJsonSerializerTests {
+
+    // Payload and PayloadContext are declared once for this namespace in
+    // ResponseSerializerCompressionTests.cs, at namespace scope because System.Text.Json's
+    // generator does not emit for a context nested inside a type that is not itself partial.
+
+    /// <summary>Answers for nothing, but records that it was asked.</summary>
+    private sealed class RecordingResolver : IJsonTypeInfoResolver {
+        public List<Type> Asked { get; } = [];
+
+        public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options) {
+            Asked.Add(type);
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Typed as the interface, which is what an application resolves and what carries the optional
+    /// <c>pretty</c> and cancellation arguments — the concrete class declares neither.
+    /// </summary>
+    private static IJsonSerializer Serializer(params IJsonTypeInfoResolver[] resolvers) {
+        var configuration = new JsonSerializerConfiguration {
+            Options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        };
+
+        return new AotJsonSerializer(
+            Options.Create<IJsonSerializerConfiguration>(configuration), resolvers);
+    }
+
+    private static IJsonSerializer WithPayloadContext() => Serializer(PayloadContext.Default);
+
+    private static MemoryStream Json(string json) => new(Encoding.UTF8.GetBytes(json));
+
+    #region round trips through a generated context
+
+    [Fact]
+    public void SerializeWritesAModelTheContextKnows() {
+        Assert.Equal(
+            """{"name":"first","value":2}""",
+            WithPayloadContext().Serialize(new Payload("first", 2)));
+    }
+
+    [Fact]
+    public void DeserializeReadsAModelTheContextKnows() {
+        var payload = WithPayloadContext().Deserialize<Payload>("""{"name":"first","value":2}""");
+
+        Assert.Equal("first", payload.Name);
+        Assert.Equal(2, payload.Value);
+    }
+
+    [Fact]
+    public async Task DeserializeAsyncReadsFromAStream() {
+        var payload = await WithPayloadContext()
+            .DeserializeAsync<Payload>(Json("""{"name":"first","value":2}"""), TestContext.Current.CancellationToken);
+
+        Assert.Equal("first", payload.Name);
+        Assert.Equal(2, payload.Value);
+    }
+
+    [Fact]
+    public async Task SerializeAsyncWritesToAStream() {
+        var stream = new MemoryStream();
+
+        await WithPayloadContext().SerializeAsync(
+            stream, new Payload("first", 2), false, TestContext.Current.CancellationToken);
+
+        Assert.Equal("""{"name":"first","value":2}""", Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    [Fact]
+    public async Task AModelRoundTripsThroughTheStreamApi() {
+        var serializer = WithPayloadContext();
+        var stream = new MemoryStream();
+
+        await serializer.SerializeAsync(
+            stream, new Payload("first", 2), false, TestContext.Current.CancellationToken);
+
+        stream.Position = 0;
+
+        Assert.Equal(
+            new Payload("first", 2),
+            await serializer.DeserializeAsync<Payload>(stream, TestContext.Current.CancellationToken));
+    }
+
+    #endregion
+
+    #region the primitive table underneath
+
+    /// <summary>
+    /// The chain has to answer for <c>string</c> as well as for the record. Without the primitive
+    /// resolver every string property on every generated model throws.
+    /// </summary>
+    [Fact]
+    public void AStringSerializesWithoutAContextDeclaringIt() {
+        Assert.Equal("\"hello\"", WithPayloadContext().Serialize("hello"));
+    }
+
+    [Theory]
+    [InlineData(42, "42")]
+    [InlineData(true, "true")]
+    [InlineData(1.5, "1.5")]
+    public void ThePrimitiveLeafTypesSerialize(object value, string expected) {
+        Assert.Equal(expected, WithPayloadContext().Serialize(value));
+    }
+
+    [Fact]
+    public void AStringDeserializes() {
+        Assert.Equal("hello", WithPayloadContext().Deserialize<string>("\"hello\""));
+    }
+
+    /// <summary>
+    /// With no registered context at all the primitive table is the whole chain, and still answers
+    /// for the leaf types.
+    /// </summary>
+    [Fact]
+    public void ThePrimitiveTableAnswersWithNoRegisteredResolvers() {
+        Assert.Equal("\"hello\"", Serializer().Serialize("hello"));
+    }
+
+    #endregion
+
+    #region resolver ordering
+
+    /// <summary>
+    /// A registered resolver is asked before the primitive table, which is what lets an application
+    /// override how a leaf type is written.
+    /// </summary>
+    [Fact]
+    public void ARegisteredResolverIsAskedFirst() {
+        var recording = new RecordingResolver();
+
+        Serializer(recording).Serialize("hello");
+
+        Assert.Contains(typeof(string), recording.Asked);
+    }
+
+    /// <summary>
+    /// A resolver that answers nothing does not break the chain — the next one is asked.
+    /// </summary>
+    [Fact]
+    public void AResolverThatAnswersNothingFallsThroughToTheNext() {
+        Assert.Equal("\"hello\"", Serializer(new RecordingResolver()).Serialize("hello"));
+    }
+
+    [Fact]
+    public void EveryRegisteredResolverIsInTheChain() {
+        var first = new RecordingResolver();
+        var second = new RecordingResolver();
+
+        Serializer(first, second).Serialize("hello");
+
+        Assert.Contains(typeof(string), first.Asked);
+        Assert.Contains(typeof(string), second.Asked);
+    }
+
+    /// <summary>
+    /// A type nothing in the chain answers for is a clear failure rather than a silent reflection
+    /// fallback — which is the whole difference between this serializer and the reflection-based
+    /// one, and what makes a missing context a startup-shaped problem instead of a request that
+    /// behaves differently once published.
+    /// </summary>
+    [Fact]
+    public void ATypeNoResolverKnowsThrows() {
+        Assert.ThrowsAny<Exception>(() => Serializer().Serialize(new Payload("first", 2)));
+    }
+
+    #endregion
+
+    #region pretty printing
+
+    [Fact]
+    public void PrettyPrintingIndents() {
+        var pretty = WithPayloadContext().Serialize(new Payload("first", 2), pretty: true);
+
+        Assert.Contains("\n", pretty);
+        Assert.Contains("  ", pretty);
+    }
+
+    [Fact]
+    public void TheCompactFormIsTheDefault() {
+        Assert.DoesNotContain("\n", WithPayloadContext().Serialize(new Payload("first", 2)));
+    }
+
+    [Fact]
+    public async Task SerializeAsyncCanBePretty() {
+        var stream = new MemoryStream();
+
+        await WithPayloadContext().SerializeAsync(
+            stream, new Payload("first", 2), true, TestContext.Current.CancellationToken);
+
+        Assert.Contains("\n", Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    /// <summary>
+    /// The pretty options carry the same resolver chain as the compact ones. Built separately, so a
+    /// resolver added to one and not the other would make pretty printing fail on exactly the types
+    /// the application declared.
+    /// </summary>
+    [Fact]
+    public void PrettyPrintingUsesTheSameResolverChain() {
+        Assert.Contains("first", WithPayloadContext().Serialize(new Payload("first", 2), pretty: true));
+        Assert.Equal("\"hello\"", WithPayloadContext().Serialize("hello", pretty: true));
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task DeserializingNullThrowsRatherThanReturningIt() {
+        await Assert.ThrowsAsync<Exception>(
+            () => WithPayloadContext().DeserializeAsync<Payload>(
+                Json("null"), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void DeserializingNullFromAStringThrowsToo() {
+        Assert.Throws<Exception>(() => WithPayloadContext().Deserialize<Payload>("null"));
+    }
+}

--- a/src/Shared/Hardened.Shared.Testing.Tests/Impl/AttributeUtilityTests.cs
+++ b/src/Shared/Hardened.Shared.Testing.Tests/Impl/AttributeUtilityTests.cs
@@ -1,0 +1,227 @@
+using System.Reflection;
+using Hardened.Shared.Testing.Impl;
+using Xunit;
+
+[assembly: Hardened.Shared.Testing.Tests.Impl.AttributeUtilityTests.Scoped("assembly")]
+
+namespace Hardened.Shared.Testing.Tests.Impl;
+
+/// <summary>
+/// The reflection walk that feeds the attribute stack behind <c>[HardenedTest]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CI measured it at <b>40% line / 38.8% branch</b>, the worst branch coverage of anything in
+/// <c>Hardened.Shared.Testing</c>. <c>AttributeCollectionTests</c> covers the collection this feeds,
+/// built from arrays a test hands it; nothing drove the reflection that fills those arrays from a
+/// real method, class and assembly.
+/// </para>
+/// <para>
+/// <b>The two families search in opposite directions, and that is the point of this file.</b>
+/// <c>GetTestAttribute</c> returns the narrowest declaration — parameter, then method, then class,
+/// then assembly, first match wins. <c>GetTestAttributes</c> accumulates the other way round —
+/// assembly, class, method, parameter. Both are defensible and they are not the same rule, so a
+/// caller that assumes one order and gets the other reads the wrong attribute with no error
+/// anywhere.
+/// </para>
+/// </remarks>
+public class AttributeUtilityTests {
+
+    [AttributeUsage(
+        AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method |
+        AttributeTargets.Parameter,
+        AllowMultiple = true)]
+    public sealed class ScopedAttribute : Attribute {
+        public ScopedAttribute(string scope) {
+            Scope = scope;
+        }
+
+        public string Scope { get; }
+    }
+
+    private sealed class UnrelatedAttribute : Attribute { }
+
+    private static MethodInfo MethodOf(Type type, string name) =>
+        type.GetMethod(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static ParameterInfo ParameterOf(Type type, string name) =>
+        MethodOf(type, name).GetParameters()[0];
+
+    #region fixtures
+
+    [Scoped("class")]
+    private class DecoratedClass {
+        [Scoped("method")]
+        public void MethodDeclares([Scoped("parameter")] string value) { }
+
+        [Scoped("method")]
+        public void MethodOnly(string value) { }
+
+        public void ClassOnly(string value) { }
+    }
+
+    private class PlainClass {
+        public void AssemblyOnly(string value) { }
+
+        public void NoneAnywhere(string value) { }
+    }
+
+    #endregion
+
+    #region GetTestAttribute — narrowest wins
+
+    [Fact]
+    public void AMethodPrefersItsOwnDeclaration() {
+        Assert.Equal(
+            "method",
+            MethodOf(typeof(DecoratedClass), nameof(DecoratedClass.MethodOnly))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AMethodFallsBackToItsClass() {
+        Assert.Equal(
+            "class",
+            MethodOf(typeof(DecoratedClass), nameof(DecoratedClass.ClassOnly))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AMethodFallsBackToTheAssembly() {
+        Assert.Equal(
+            "assembly",
+            MethodOf(typeof(PlainClass), nameof(PlainClass.AssemblyOnly))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AnAttributeDeclaredNowhereIsNull() {
+        Assert.Null(
+            MethodOf(typeof(PlainClass), nameof(PlainClass.NoneAnywhere))
+                .GetTestAttribute<UnrelatedAttribute>());
+    }
+
+    /// <summary>
+    /// The parameter is narrower than the method it is on.
+    /// </summary>
+    [Fact]
+    public void AParameterPrefersItsOwnDeclaration() {
+        Assert.Equal(
+            "parameter",
+            ParameterOf(typeof(DecoratedClass), nameof(DecoratedClass.MethodDeclares))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AParameterFallsBackToItsMethod() {
+        Assert.Equal(
+            "method",
+            ParameterOf(typeof(DecoratedClass), nameof(DecoratedClass.MethodOnly))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AParameterFallsBackToItsClass() {
+        Assert.Equal(
+            "class",
+            ParameterOf(typeof(DecoratedClass), nameof(DecoratedClass.ClassOnly))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AParameterFallsBackToTheAssembly() {
+        Assert.Equal(
+            "assembly",
+            ParameterOf(typeof(PlainClass), nameof(PlainClass.AssemblyOnly))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AParameterAttributeDeclaredNowhereIsNull() {
+        Assert.Null(
+            ParameterOf(typeof(PlainClass), nameof(PlainClass.NoneAnywhere))
+                .GetTestAttribute<UnrelatedAttribute>());
+    }
+
+    #endregion
+
+    #region GetTestAttributes — every scope, widest first
+
+    /// <summary>
+    /// Every scope, not the first that matches. A method-level attribute does not suppress the
+    /// class's — that is what lets a class declare a shared mock and a method add one.
+    /// </summary>
+    [Fact]
+    public void EveryScopeContributesToAMethodsAttributes() {
+        var scopes = MethodOf(typeof(DecoratedClass), nameof(DecoratedClass.MethodOnly))
+            .GetTestAttributes<ScopedAttribute>()
+            .Select(attribute => attribute.Scope)
+            .ToArray();
+
+        Assert.Equal(["assembly", "class", "method"], scopes);
+    }
+
+    /// <summary>
+    /// <b>The opposite order to <c>GetTestAttribute</c>.</b> That method returns the narrowest
+    /// declaration; this one lists the widest first. Whatever consumes the list decides which end
+    /// wins, and it has to know which end it is being handed.
+    /// </summary>
+    [Fact]
+    public void TheAccumulatedOrderIsWidestFirst() {
+        var scopes = ParameterOf(typeof(DecoratedClass), nameof(DecoratedClass.MethodDeclares))
+            .GetTestAttributes<ScopedAttribute>()
+            .Select(attribute => attribute.Scope)
+            .ToArray();
+
+        Assert.Equal(["assembly", "class", "method", "parameter"], scopes);
+
+        // The single-attribute lookup answers with the last of these, not the first.
+        Assert.Equal(
+            scopes[^1],
+            ParameterOf(typeof(DecoratedClass), nameof(DecoratedClass.MethodDeclares))
+                .GetTestAttribute<ScopedAttribute>()!.Scope);
+    }
+
+    [Fact]
+    public void AParameterWithNoDeclarationStillCollectsTheWiderScopes() {
+        var scopes = ParameterOf(typeof(DecoratedClass), nameof(DecoratedClass.ClassOnly))
+            .GetTestAttributes<ScopedAttribute>()
+            .Select(attribute => attribute.Scope)
+            .ToArray();
+
+        Assert.Equal(["assembly", "class"], scopes);
+    }
+
+    [Fact]
+    public void AMethodOnAnUndecoratedClassStillCollectsTheAssembly() {
+        Assert.Equal(
+            ["assembly"],
+            MethodOf(typeof(PlainClass), nameof(PlainClass.AssemblyOnly))
+                .GetTestAttributes<ScopedAttribute>()
+                .Select(attribute => attribute.Scope));
+    }
+
+    [Fact]
+    public void AnAttributeDeclaredNowhereCollectsNothing() {
+        Assert.Empty(
+            MethodOf(typeof(PlainClass), nameof(PlainClass.NoneAnywhere))
+                .GetTestAttributes<UnrelatedAttribute>());
+
+        Assert.Empty(
+            ParameterOf(typeof(PlainClass), nameof(PlainClass.NoneAnywhere))
+                .GetTestAttributes<UnrelatedAttribute>());
+    }
+
+    /// <summary>
+    /// Only the requested type. An unrelated attribute in the same scope must not be returned as
+    /// one — <c>OfType</c> and the <c>is T</c> filter are what keep the two families honest.
+    /// </summary>
+    [Fact]
+    public void AnUnrelatedAttributeInTheSameScopeIsIgnored() {
+        Assert.Empty(
+            MethodOf(typeof(DecoratedClass), nameof(DecoratedClass.MethodOnly))
+                .GetTestAttributes<UnrelatedAttribute>());
+    }
+
+    #endregion
+}

--- a/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/AspNetCoreExtensionsTests.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/AspNetCoreExtensionsTests.cs
@@ -1,0 +1,175 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Web.AspNetCore.Runtime;
+using Hardened.Web.AspNetCore.Runtime.Impl;
+using Hardened.Web.Runtime.Handlers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Web.AspNetCore.Runtime.Tests;
+
+/// <summary>
+/// <c>UseHardened</c>, which is the one line an ASP.NET-hosted application writes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CI measured it at <b>0%</b>. Eight lines, in the public entry point of the package, and every
+/// ASP.NET consumer runs them — the suite reached the handler underneath but never the call that
+/// installs it.
+/// </para>
+/// <para>
+/// It does two separate things that both have to happen: it inserts the middleware that hands a
+/// request to Hardened, and it registers the web handler into the middleware chain Hardened runs
+/// internally. Doing only the first produces an application that accepts requests and routes none
+/// of them.
+/// </para>
+/// </remarks>
+public class AspNetCoreExtensionsTests {
+
+    private static IApplicationBuilder Builder(
+        IMiddlewareService? middleware = null,
+        IWebExecutionHandlerService? handler = null) {
+        var services = new ServiceCollection();
+
+        if (middleware != null) {
+            services.AddSingleton(middleware);
+        }
+
+        if (handler != null) {
+            services.AddSingleton(handler);
+        }
+
+        return new ApplicationBuilder(services.BuildServiceProvider());
+    }
+
+    [Fact]
+    public void UseHardenedRegistersTheWebHandlerWithTheMiddlewareService() {
+        var middleware = Substitute.For<IMiddlewareService>();
+        var handler = Substitute.For<IWebExecutionHandlerService>();
+
+        Builder(middleware, handler).UseHardened();
+
+        middleware.Received(1).Use(Arg.Any<Func<IExecutionContext, IExecutionFilter>>());
+    }
+
+    /// <summary>
+    /// The handler it registers is the one resolved from the container, not a fresh one — the
+    /// service holds the routing table.
+    /// </summary>
+    [Fact]
+    public void TheRegisteredFilterIsTheResolvedWebHandler() {
+        var middleware = Substitute.For<IMiddlewareService>();
+        var handler = Substitute.For<IWebExecutionHandlerService>();
+
+        Func<IExecutionContext, IExecutionFilter>? registered = null;
+
+        middleware.Use(Arg.Do<Func<IExecutionContext, IExecutionFilter>>(value => registered = value));
+
+        Builder(middleware, handler).UseHardened();
+
+        Assert.NotNull(registered);
+        Assert.Same(handler, registered!(Substitute.For<IExecutionContext>()));
+    }
+
+    /// <summary>
+    /// Returned so it chains, which is how every ASP.NET pipeline is written.
+    /// </summary>
+    [Fact]
+    public void UseHardenedReturnsTheBuilder() {
+        var builder = Builder(Substitute.For<IMiddlewareService>(), Substitute.For<IWebExecutionHandlerService>());
+
+        Assert.Same(builder, builder.UseHardened());
+    }
+
+    /// <summary>
+    /// A missing registration fails at startup rather than on the first request. An application
+    /// that called <c>UseHardened</c> without the module registered would otherwise accept traffic
+    /// and refuse all of it.
+    /// </summary>
+    [Fact]
+    public void UseHardenedThrowsWhenTheMiddlewareServiceIsMissing() {
+        Assert.Throws<InvalidOperationException>(
+            () => Builder(handler: Substitute.For<IWebExecutionHandlerService>()).UseHardened());
+    }
+
+    [Fact]
+    public void UseHardenedThrowsWhenTheWebHandlerServiceIsMissing() {
+        Assert.Throws<InvalidOperationException>(
+            () => Builder(Substitute.For<IMiddlewareService>()).UseHardened());
+    }
+
+    #region the middleware itself
+
+    [Fact]
+    public async Task TheMiddlewareHandsTheRequestToTheResolvedHandler() {
+        var handler = Substitute.For<IAspNetCoreRequestHandler>();
+
+        handler.HandleRequest(Arg.Any<HttpContext>(), Arg.Any<RequestDelegate>())
+            .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+
+        services.AddSingleton(handler);
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+
+        await AspNetCoreExtensions.HardenedMiddleware(httpContext, _ => Task.CompletedTask);
+
+        await handler.Received(1).HandleRequest(httpContext, Arg.Any<RequestDelegate>());
+    }
+
+    /// <summary>
+    /// Resolved from <c>RequestServices</c> rather than captured at startup, so a handler
+    /// registered scoped gets the request's scope.
+    /// </summary>
+    [Fact]
+    public async Task TheHandlerIsResolvedPerRequest() {
+        var services = new ServiceCollection();
+
+        services.AddScoped<IAspNetCoreRequestHandler>(_ => {
+            var handler = Substitute.For<IAspNetCoreRequestHandler>();
+
+            handler.HandleRequest(Arg.Any<HttpContext>(), Arg.Any<RequestDelegate>())
+                .Returns(Task.CompletedTask);
+
+            return handler;
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        Assert.NotSame(
+            first.ServiceProvider.GetRequiredService<IAspNetCoreRequestHandler>(),
+            second.ServiceProvider.GetRequiredService<IAspNetCoreRequestHandler>());
+
+        await AspNetCoreExtensions.HardenedMiddleware(
+            new DefaultHttpContext { RequestServices = first.ServiceProvider }, _ => Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task TheNextDelegateIsPassedThroughSoTheHandlerCanFallThrough() {
+        var handler = Substitute.For<IAspNetCoreRequestHandler>();
+        RequestDelegate? seen = null;
+
+        handler.HandleRequest(Arg.Any<HttpContext>(), Arg.Do<RequestDelegate>(value => seen = value))
+            .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+
+        services.AddSingleton(handler);
+
+        RequestDelegate next = _ => Task.CompletedTask;
+
+        await AspNetCoreExtensions.HardenedMiddleware(
+            new DefaultHttpContext { RequestServices = services.BuildServiceProvider() }, next);
+
+        Assert.Same(next, seen);
+    }
+
+    #endregion
+}

--- a/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Impl/AspNetExecutionContextTests.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime.Tests/Impl/AspNetExecutionContextTests.cs
@@ -1,0 +1,256 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Shared.Runtime.Metrics;
+using Hardened.Web.AspNetCore.Runtime.Impl;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Web.AspNetCore.Runtime.Tests.Impl;
+
+/// <summary>
+/// The context an ASP.NET-hosted request runs on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CI measured this at <b>23% line / 25% branch</b> — the lowest of anything in a shipped runtime
+/// assembly, in the type every ASP.NET-hosted application builds per request. The conformance suites
+/// cover the request and response adapters beside it; the context itself was reached only far enough
+/// to construct it.
+/// </para>
+/// <para>
+/// <b><see cref="AForkIsTheSameCaller"/> and <see cref="AForkReportsOneCorrelationId"/> are why this
+/// file exists.</b> <c>Clone</c> is what <c>RetryFilter</c> calls for every attempt after the first,
+/// and its two comments — "the reference, not a copy: a fork is the same caller" and "the same
+/// request, so it reports one id rather than two" — are claims about what a retried request looks
+/// like in an audit log. Neither had been executed on this host.
+/// </para>
+/// </remarks>
+public class AspNetExecutionContextTests {
+
+    private static AspNetExecutionContext Context(out DefaultHttpContext httpContext) {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(Substitute.For<IKnownServices>());
+
+        httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        httpContext.Request.Method = "GET";
+        httpContext.Request.Path = "/pets";
+
+        return new AspNetExecutionContext(httpContext, Substitute.For<IMetricLogger>());
+    }
+
+    private static AspNetExecutionContext Context() => Context(out _);
+
+    #region pass-throughs to the HttpContext
+
+    /// <summary>
+    /// Both providers are the request's scope. A root provider that outlived the request would let
+    /// a singleton capture a scoped service.
+    /// </summary>
+    [Fact]
+    public void BothServiceProvidersAreTheRequestScope() {
+        var context = Context(out var httpContext);
+
+        Assert.Same(httpContext.RequestServices, context.RequestServices);
+        Assert.Same(httpContext.RequestServices, context.RootServiceProvider);
+    }
+
+    /// <summary>
+    /// The token is the connection's, so a handler that honours cancellation stops when the client
+    /// hangs up rather than running to completion writing to a closed socket.
+    /// </summary>
+    [Fact]
+    public void TheCancellationTokenTracksRequestAborted() {
+        using var aborted = new CancellationTokenSource();
+
+        var context = Context(out var httpContext);
+
+        httpContext.RequestAborted = aborted.Token;
+
+        Assert.Equal(aborted.Token, context.CancellationToken);
+
+        aborted.Cancel();
+
+        Assert.True(context.CancellationToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void TheRequestAndResponseWrapTheHttpContexts() {
+        var context = Context(out var httpContext);
+
+        Assert.Equal(httpContext.Request.Method, context.Request.Method);
+        Assert.Equal(httpContext.Request.Path.Value, context.Request.Path);
+    }
+
+    [Fact]
+    public void KnownServicesComesFromTheContainer() {
+        Assert.NotNull(Context().KnownServices);
+    }
+
+    [Fact]
+    public void TheStartTimeIsTaken() {
+        Assert.True(Context().StartTime.GetElapsedMilliseconds() >= 0);
+    }
+
+    /// <summary>
+    /// Hardened's own principal, not <c>HttpContext.User</c> — bridging the two is an opt-in
+    /// adapter, so moving a handler between hosts does not change how it authenticates.
+    /// </summary>
+    [Fact]
+    public void ThePrincipalStartsAnonymous() {
+        Assert.Same(AnonymousCallerPrincipal.Instance, Context().CallerPrincipal);
+        Assert.False(Context().CallerPrincipal.IsAuthenticated);
+    }
+
+    [Fact]
+    public void ACorrelationIdIsProducedWhenNoneWasSet() {
+        Assert.False(string.IsNullOrEmpty(Context().CorrelationId));
+    }
+
+    [Fact]
+    public void TheCorrelationIdIsStableWithinOneContext() {
+        var context = Context();
+
+        Assert.Equal(context.CorrelationId, context.CorrelationId);
+    }
+
+    #endregion
+
+    #region forking
+
+    private static IExecutionContext Fork(IExecutionContext context) =>
+        context.Clone(null, null, null, null);
+
+    [Fact]
+    public void AForkIsADifferentContext() {
+        var context = Context();
+
+        Assert.NotSame(context, Fork(context));
+    }
+
+    /// <summary>
+    /// A null argument keeps the current value — which is the whole shape <c>RetryFilter</c> relies
+    /// on, since it forks without replacing anything.
+    /// </summary>
+    [Fact]
+    public void AForkKeepsTheRequestAndResponseWhenNoneAreSupplied() {
+        var context = Context();
+        var fork = Fork(context);
+
+        Assert.Same(context.Request, fork.Request);
+        Assert.Same(context.Response, fork.Response);
+    }
+
+    [Fact]
+    public void AForkTakesASuppliedRequestAndResponse() {
+        var context = Context();
+        var request = Substitute.For<IExecutionRequest>();
+        var response = Substitute.For<IExecutionResponse>();
+
+        var fork = context.Clone(request, response, null, null);
+
+        Assert.Same(request, fork.Request);
+        Assert.Same(response, fork.Response);
+    }
+
+    [Fact]
+    public void AForkTakesASuppliedMetricLogger() {
+        var context = Context();
+        var metrics = Substitute.For<IMetricLogger>();
+
+        Assert.Same(metrics, context.Clone(null, null, null, metrics).RequestMetrics);
+    }
+
+    [Fact]
+    public void AForkKeepsTheMetricLoggerWhenNoneIsSupplied() {
+        var context = Context();
+
+        Assert.Same(context.RequestMetrics, Fork(context).RequestMetrics);
+    }
+
+    /// <summary>
+    /// The reference, not a copy. A retried attempt is the same caller, and an authorization filter
+    /// re-running on the fork has to reach the same answer.
+    /// </summary>
+    [Fact]
+    public void AForkIsTheSameCaller() {
+        var context = Context();
+        var caller = new CallerPrincipal("bearer", ["pets:read"]);
+
+        context.CallerPrincipal = caller;
+
+        Assert.Same(caller, Fork(context).CallerPrincipal);
+    }
+
+    /// <summary>
+    /// One id rather than two. A retried request that reported a fresh correlation id per attempt
+    /// would look like several requests in a log, which is exactly the thing a correlation id is
+    /// for.
+    /// </summary>
+    [Fact]
+    public void AForkReportsOneCorrelationId() {
+        var context = Context();
+
+        Assert.Equal(context.CorrelationId, Fork(context).CorrelationId);
+    }
+
+    [Fact]
+    public void AForkKeepsTheHandlerInstanceAndInfo() {
+        var context = Context();
+        var handler = new object();
+        var info = Substitute.For<IExecutionRequestHandlerInfo>();
+
+        context.HandlerInstance = handler;
+        context.HandlerInfo = info;
+
+        var fork = Fork(context);
+
+        Assert.Same(handler, fork.HandlerInstance);
+        Assert.Same(info, fork.HandlerInfo);
+    }
+
+    [Fact]
+    public void AForkKeepsTheStartTime() {
+        var context = Context();
+
+        Assert.Equal(context.StartTime.GetElapsedMilliseconds(), Fork(context).StartTime.GetElapsedMilliseconds(), 0);
+    }
+
+    /// <summary>
+    /// The fork still reaches the same connection — its services and cancellation come from the
+    /// same <c>HttpContext</c>, so a handler on the fork sees the client hang up.
+    /// </summary>
+    [Fact]
+    public void AForkStillSeesTheSameConnection() {
+        using var aborted = new CancellationTokenSource();
+
+        var context = Context(out var httpContext);
+
+        httpContext.RequestAborted = aborted.Token;
+
+        var fork = Fork(context);
+
+        Assert.Same(httpContext.RequestServices, fork.RequestServices);
+        Assert.Equal(aborted.Token, fork.CancellationToken);
+    }
+
+    /// <summary>
+    /// Forking a fork keeps the caller and the id, which is what three retry attempts actually do.
+    /// </summary>
+    [Fact]
+    public void ForkingAForkStillCarriesTheCallerAndId() {
+        var context = Context();
+        var caller = new CallerPrincipal("bearer", ["pets:read"]);
+
+        context.CallerPrincipal = caller;
+
+        var second = Fork(Fork(context));
+
+        Assert.Same(caller, second.CallerPrincipal);
+        Assert.Equal(context.CorrelationId, second.CorrelationId);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Follow-up to #143, aimed at what CI's own merged coverage report named rather than at a local run. The `coverage-report` artifact carries per-line HTML, so every class here was picked by reading which lines were dark and why.

**3,842 → 3,925 tests. 0 failures, 0 skipped, CI-mode build clean, no new warnings.** Tests only — no product changes.

## What was dark, and why it mattered

**`AuthorizationFilter` — 58.8%.** All fourteen uncovered lines were one thing: the private `ResolvedPrincipal` handed to a requirement for its *second* walk, and the `UnionSet` behind it. Every member but `Contains` and the constructor.

They're reachable and they matter. `Requirement` is an abstract class a consumer may implement, so anything it reads off the principal or asks of the grant set is a supported call — and `UnionSet` is hand-written set algebra over two sets that may overlap. If `Subject` came back null on the second walk, a requirement reading it would see a different caller than it saw on the first. The union is also asserted to compare ordinally, since a set matching case-insensitively would admit a caller holding `PETS:READ`.

**`AspNetExecutionContext` — 23% line / 25% branch**, the lowest of anything in a shipped runtime assembly, in the type every ASP.NET-hosted request is built on. `Clone` is what `RetryFilter` calls for every attempt after the first, and its two comments — *"the reference, not a copy: a fork is the same caller"* and *"the same request, so it reports one id rather than two"* — are claims about what a retried request looks like in an audit log. Neither had been executed on this host. A retry reporting a fresh correlation id per attempt would look like several requests in a log, which is the one thing a correlation id exists to prevent.

**`AspNetCoreExtensions` — 0%.** Eight lines, the public entry point of the package, and every ASP.NET consumer runs them. It does two separate things that both have to happen — insert the middleware, and register the web handler into Hardened's own chain — and doing only the first produces an application that accepts requests and routes none of them.

**`AttributeUtility` — 38.8% branch**, the worst in `Hardened.Shared.Testing`. `AttributeCollectionTests` covers the collection this feeds, built from arrays a test hands it; nothing drove the reflection that fills those arrays from a real method, class and assembly.

The two families search in **opposite directions**, which is the point of that file. `GetTestAttribute` returns the narrowest declaration — parameter, method, class, assembly, first match wins. `GetTestAttributes` accumulates the other way round — assembly, class, method, parameter. Both are defensible and they are not the same rule, so a caller assuming one and getting the other reads the wrong attribute with no error anywhere.

**`AotJsonSerializer` — 0%**, the last class in `Hardened.Requests.Runtime` with nothing at all. What's actually under test is the resolver chain: registered contexts first, `PrimitiveJsonTypeInfoResolver` last, and the order is load-bearing both ways — a context must answer first for what it knows, and the primitive table must answer at all, because `CreatePropertyInfo<T>` resolves its converter by asking the options. Serializing a record with one string property asks the chain for `string` too, and without that entry every string property throws.

## Notes for review

Its helper returns `IJsonSerializer` rather than the concrete type. The interface is what an application resolves and what carries the optional `pretty` and cancellation arguments; the class declares neither, so a test against the concrete type would not be testing the call a consumer makes.

`Payload` and `PayloadContext` are reused from `ResponseSerializerCompressionTests` rather than declared again — System.Text.Json's generator needs a context at namespace scope, so a second one in the same namespace is a collision rather than a local fixture.

`coverage-baseline.json` is still deliberately untouched; it needs a CI `Summary.json`. Worth doing on its own now that #143 has produced one — and `Hardened.Smithy.BuildTask` still has no baseline entry at all, so ~8,600 lines remain ungated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFy7Z6gdXU6tr65TndEUS8