### PR TITLE
Pack the static content targets file, which .gitignore was eating

### DIFF
--- a/src/Web/Hardened.Web.StaticContent/Hardened.Web.StaticContent.csproj
+++ b/src/Web/Hardened.Web.StaticContent/Hardened.Web.StaticContent.csproj
@@ -21,15 +21,42 @@
     </ItemGroup>
 
     <!--
-      The targets file and the task travel with the package: build/ is imported automatically by a
-      consuming project, and tasks/ is where the targets file looks for the assembly.
+      Package\ rather than build\, because .gitignore ignores build/ - so the targets file was
+      never committed and the Pack step failed on a path that exists only on the machine that wrote
+      it. Hardened.Smithy.SourceGenerator already sits in Package\ for this reason.
+
+      PackagePath must use a forward slash. A trailing backslash packs to "build//" on Linux and
+      macOS, where NuGet never imports it - the failure that shipped once already on the OpenAPI
+      package and is silent until a consumer finds no generated types.
     -->
     <ItemGroup>
-        <None Include="build\Hardened.Web.StaticContent.targets" Pack="true" PackagePath="build\"/>
-        <None Include="..\Hardened.Web.StaticContent.BuildTask\bin\$(Configuration)\net8.0\Hardened.Web.StaticContent.BuildTask.dll"
-              Pack="true" PackagePath="tasks\net8.0\" Condition="Exists('..\Hardened.Web.StaticContent.BuildTask\bin\$(Configuration)\net8.0\Hardened.Web.StaticContent.BuildTask.dll')"/>
-        <None Include="..\Hardened.Web.StaticContent.BuildTask\bin\$(Configuration)\net472\Hardened.Web.StaticContent.BuildTask.dll"
-              Pack="true" PackagePath="tasks\net472\" Condition="Exists('..\Hardened.Web.StaticContent.BuildTask\bin\$(Configuration)\net472\Hardened.Web.StaticContent.BuildTask.dll')"/>
+        <Content Include="Package\Hardened.Web.StaticContent.*">
+            <Pack>true</Pack>
+            <PackagePath>build/</PackagePath>
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
+    </ItemGroup>
+
+    <!--
+      Both task flavours. The targets file selects between them on $(MSBuildRuntimeType), so one
+      package serves Visual Studio's .NET Framework MSBuild and the CLI's .NET one.
+    -->
+    <ItemGroup>
+        <None Include="..\Hardened.Web.StaticContent.BuildTask\bin\$(Configuration)\net472\**\*.dll"
+              Pack="true" PackagePath="tasks/net472" Visible="false"/>
+        <None Include="..\Hardened.Web.StaticContent.BuildTask\bin\$(Configuration)\net8.0\**\*.dll"
+              Pack="true" PackagePath="tasks/net8.0" Visible="false"/>
+    </ItemGroup>
+
+    <!--
+      Built before this can be packed, and not bound against: the task runs in MSBuild and the
+      runtime runs in the application.
+    -->
+    <ItemGroup>
+        <ProjectReference Include="..\Hardened.Web.StaticContent.BuildTask\Hardened.Web.StaticContent.BuildTask.csproj"
+                          ReferenceOutputAssembly="false"
+                          SkipGetTargetFrameworkProperties="true"
+                          PrivateAssets="all"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Web/Hardened.Web.StaticContent/Package/Hardened.Web.StaticContent.targets
+++ b/src/Web/Hardened.Web.StaticContent/Package/Hardened.Web.StaticContent.targets
@@ -1,0 +1,120 @@
+<Project>
+    <!--
+      Declare a content directory and the build works out everything the runtime would otherwise
+      discover per request:
+
+        <ItemGroup>
+          <HardenedStaticContent Include="wwwroot" RoutePrefix="/" FallBackFile="index.html" />
+        </ItemGroup>
+
+      Without one the application reads the directory at run time instead, so this whole file is an
+      optimisation and a verification layer rather than a requirement.
+    -->
+
+    <PropertyGroup>
+        <ExcludeGeneratedCodeFromCoverage Condition="'$(ExcludeGeneratedCodeFromCoverage)' == ''">true</ExcludeGeneratedCodeFromCoverage>
+        <HardenedStaticContentNamespace Condition="'$(HardenedStaticContentNamespace)' == ''">$(RootNamespace)</HardenedStaticContentNamespace>
+        <HardenedStaticContentNamespace Condition="'$(HardenedStaticContentNamespace)' == ''">Generated</HardenedStaticContentNamespace>
+        <HardenedStaticContentEmbedThresholdBytes Condition="'$(HardenedStaticContentEmbedThresholdBytes)' == ''">1048576</HardenedStaticContentEmbedThresholdBytes>
+
+        <_HardenedStaticContentTasksDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../tasks/net8.0/</_HardenedStaticContentTasksDir>
+        <_HardenedStaticContentTasksDir Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../tasks/net472/</_HardenedStaticContentTasksDir>
+        <HardenedStaticContentTaskAssembly Condition="'$(HardenedStaticContentTaskAssembly)' == ''">$(_HardenedStaticContentTasksDir)Hardened.Web.StaticContent.BuildTask.dll</HardenedStaticContentTaskAssembly>
+    </PropertyGroup>
+
+    <!--
+      Out of process. The usual objection - a process per invocation - does not apply: this runs
+      once per project. In process, the task assembly is held open afterwards, so in this repository,
+      where the same build produces the task and consumes it, an edited task would be silently
+      ignored until the MSBuild nodes died.
+    -->
+    <UsingTask TaskName="Hardened.Web.StaticContent.BuildTask.BuildStaticContentManifest"
+               Condition="'$(HardenedStaticContentInProcessTask)' != 'true'"
+               TaskFactory="TaskHostFactory"
+               AssemblyFile="$(HardenedStaticContentTaskAssembly)"/>
+
+    <UsingTask TaskName="Hardened.Web.StaticContent.BuildTask.BuildStaticContentManifest"
+               Condition="'$(HardenedStaticContentInProcessTask)' == 'true'"
+               AssemblyFile="$(HardenedStaticContentTaskAssembly)"/>
+
+    <!--
+      The file the task will write is declared HERE, at the top level, and not inside the target
+      that writes it.
+
+      An IDE builds its project model out of MSBuild *evaluation*, not out of a build. Rider has no
+      CompileDesignTime target at all, so a file that only becomes a @(Compile) item while a target
+      is running is a file the editor never hears about: the manifest resolves on the compiler
+      command line and nowhere else, and every reference to it reddens in a project that builds
+      clean.
+
+      Top level is also what makes the path resolvable. MSBuild evaluates every top-level ItemGroup
+      after every property and every import, so $(IntermediateOutputPath) is final here even though
+      it is still empty when a csproj body imports this file.
+
+      A transform of @(HardenedStaticContent) rather than a glob of the output directory: on a clean
+      tree the file does not exist yet, and a glob would come back empty on exactly the build that
+      has to declare it.
+    -->
+    <ItemGroup Condition="'@(HardenedStaticContent)' != ''">
+        <_HardenedStaticContentSource Include="@(HardenedStaticContent->'$(IntermediateOutputPath)staticcontent/%(Filename).staticcontent.g.cs')"/>
+        <Compile Include="@(_HardenedStaticContentSource)" Visible="false"/>
+    </ItemGroup>
+
+    <!--
+      Every metadata value the task reads, none of which touches the content directory when it
+      changes - so without this the up-to-date check below would skip the target and leave the
+      previous manifest in place after someone changed the route prefix.
+    -->
+    <Target Name="HardenedStaticContentStamp" Condition="'@(HardenedStaticContent)' != ''">
+        <MakeDir Directories="$(IntermediateOutputPath)staticcontent"/>
+
+        <WriteLinesToFile
+            File="$(IntermediateOutputPath)staticcontent/options.stamp"
+            Lines="@(HardenedStaticContent->'%(Identity)|%(RoutePrefix)|%(FallBackFile)');$(HardenedStaticContentNamespace)|$(HardenedStaticContentEmbedThresholdBytes)"
+            Overwrite="true"
+            WriteOnlyWhenDifferent="true"/>
+    </Target>
+
+    <!--
+      Inputs are the content itself, so adding, removing or editing a file rebuilds the manifest.
+      A directory glob rather than the item, because the item names a directory and MSBuild would
+      otherwise compare against the directory's own timestamp - which does not move when a file
+      two levels down inside it changes.
+    -->
+    <Target Name="HardenedStaticContentManifest"
+            DependsOnTargets="HardenedStaticContentStamp"
+            BeforeTargets="CoreCompile"
+            Condition="'@(HardenedStaticContent)' != ''"
+            Inputs="@(HardenedStaticContent->'%(Identity)/**/*');$(IntermediateOutputPath)staticcontent/options.stamp"
+            Outputs="@(_HardenedStaticContentSource)">
+
+        <BuildStaticContentManifest
+            ContentDirectory="%(HardenedStaticContent.Identity)"
+            RoutePrefix="%(HardenedStaticContent.RoutePrefix)"
+            FallBackFile="%(HardenedStaticContent.FallBackFile)"
+            OutputFile="$(IntermediateOutputPath)staticcontent/%(HardenedStaticContent.Filename).staticcontent.g.cs"
+            Namespace="$(HardenedStaticContentNamespace)"
+            EmbedThresholdBytes="$(HardenedStaticContentEmbedThresholdBytes)"
+            ExcludeFromCoverage="$(ExcludeGeneratedCodeFromCoverage)"/>
+    </Target>
+
+    <!--
+      Runs even when the target above is skipped as up to date, because that is the case worth
+      catching: a manifest that is not on disk means the up-to-date check was made against a file
+      that is not there, and the compiler is about to open it. Silence would surface as a missing
+      type in a project that builds clean everywhere else.
+    -->
+    <Target Name="HardenedStaticContentVerify"
+            DependsOnTargets="HardenedStaticContentManifest"
+            BeforeTargets="CoreCompile"
+            Condition="'@(HardenedStaticContent)' != ''">
+
+        <Error Condition="'@(_HardenedStaticContentSource)' == ''"
+               Code="HSTATIC006"
+               Text="Hardened.Web.StaticContent.targets was imported before these items were declared: @(HardenedStaticContent). No manifest reached the compilation. Move the &lt;Import&gt; below the &lt;HardenedStaticContent&gt; item group."/>
+
+        <Error Condition="!Exists('%(_HardenedStaticContentSource.FullPath)')"
+               Code="HSTATIC007"
+               Text="The static content manifest '%(_HardenedStaticContentSource.Identity)' was not written. Delete $(IntermediateOutputPath)staticcontent and rebuild."/>
+    </Target>
+</Project>


### PR DESCRIPTION
Fixes `main`, red since #146.

`Hardened.Web.StaticContent` kept its MSBuild targets in `build/`, which `.gitignore` ignores — so the file was never committed and Pack failed:

```
error : Could not find a part of the path
'.../src/Web/Hardened.Web.StaticContent/build'.
```

**The PR was green because packing only runs on `main`.** The workflow's `on:` filters publishing to the default branch, so nothing on a pull request exercises Pack.

## The fix

`Hardened.Smithy.SourceGenerator` already keeps its targets in `Package/` for exactly this reason. Same layout here, and the same `PackagePath` rule its comment records — a forward slash, because a trailing backslash packs to `build//` on Linux and macOS where NuGet never imports it, silent until a consumer finds the targets never ran. **The version that just shipped had the backslash too**, so this would have failed a second time even with the path fixed.

Task assemblies move to the same shape while they're being touched: a recursive glob per framework, and a `ProjectReference` with `ReferenceOutputAssembly="false"` so the task is built before this is packed without being bound against.

## Verified

Packed locally and read the result — the step CI cannot run on a pull request:

```
build/Hardened.Web.StaticContent.targets
lib/net8.0/Hardened.Web.StaticContent.dll
tasks/net472/Hardened.Web.StaticContent.BuildTask.dll
tasks/net8.0/Hardened.Web.StaticContent.BuildTask.dll
```

`build/<PackageId>.targets` is the name NuGet auto-imports, and `../tasks/` is what the targets file resolves against.

## Unrelated, noticed while verifying

`AspNetExecutionContextTests.AForkKeepsTheStartTime`, from #144, is timing-flaky. It compares two `GetElapsedMilliseconds()` readings to 0 decimal places; on a busy machine they differ by more than a millisecond:

```
Expected: 0 (rounded from 0.0789…)
Actual:   1 (rounded from 1.4439…)
```

Green on an idle CI runner, fails consistently on a loaded one. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBQQKxCiZSJNBV1wCsCKdP