### PR TITLE
Raise every coverage floor to what CI measures

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,86 +1,86 @@
 {
   "Hardened.DependencyModules.SourceGenerator": {
-    "line": 20.1,
-    "branch": 9.9
+    "line": 20.5,
+    "branch": 10.0
   },
   "Hardened.Idl.SourceGenerator": {
-    "line": 57.0,
-    "branch": 48.7
+    "line": 57.1,
+    "branch": 49.0
   },
   "Hardened.Library.SourceGenerator": {
-    "line": 39.4,
-    "branch": 19.1
+    "line": 39.2,
+    "branch": 18.8
   },
   "Hardened.OpenApi.BuildTask": {
-    "line": 10.7,
-    "branch": 10.7
+    "line": 13.8,
+    "branch": 11.9
   },
   "Hardened.Requests.Abstract": {
-    "line": 93.7,
-    "branch": 94.6
+    "line": 94.7,
+    "branch": 95.5
   },
   "Hardened.Requests.Runtime": {
-    "line": 82.7,
-    "branch": 83.9
+    "line": 96.9,
+    "branch": 92.9
   },
   "Hardened.Requests.Serializers.Newtonsoft": {
-    "line": 0.0,
-    "branch": 0.0
+    "line": 100.0,
+    "branch": 100.0
   },
   "Hardened.Requests.Testing": {
-    "line": 93.8,
-    "branch": 91.6
+    "line": 99.5,
+    "branch": 95.0
   },
   "Hardened.Shared.Runtime": {
-    "line": 90.4,
-    "branch": 85.2
+    "line": 95.6,
+    "branch": 91.7
   },
   "Hardened.Shared.Testing": {
-    "line": 75.9,
-    "branch": 56.5
+    "line": 96.2,
+    "branch": 81.5
   },
   "Hardened.SourceGeneration.Testing": {
-    "line": 80.9,
-    "branch": 74.1
+    "line": 83.4,
+    "branch": 78.1
   },
   "Hardened.SourceGenerator": {
-    "line": 71.4,
-    "branch": 57.0
+    "line": 74.0,
+    "branch": 65.3
   },
   "Hardened.Templates.RazorBlade": {
     "line": 100.0,
     "branch": 100.0
   },
   "Hardened.Validation.SourceGenerator": {
-    "line": 12.4,
-    "branch": 3.2
+    "line": 21.1,
+    "branch": 13.4
   },
   "Hardened.Web.AspNetCore.Runtime": {
-    "line": 66.2,
-    "branch": 80.9
+    "line": 96.5,
+    "branch": 97.1
   },
   "Hardened.Web.Kestrel.Runtime": {
-    "line": 96.6,
-    "branch": 84.6
+    "line": 97.3,
+    "branch": 88.1
   },
   "Hardened.Web.Runtime": {
-    "line": 98.5,
-    "branch": 98.5
+    "line": 98.7,
+    "branch": 99.0
   },
   "Hardened.Web.SourceGenerator": {
-    "line": 71.7,
-    "branch": 64.7
+    "line": 75.2,
+    "branch": 68.9
   },
   "Hardened.Web.StaticContent": {
-    "line": 94.9,
-    "branch": 85.1
+    "line": 95.8,
+    "branch": 86.0
   },
   "Hardened.Web.StaticContent.BuildTask": {
-    "line": 93.7,
-    "branch": 95.6
+    "line": 94.6,
+    "branch": 96.5
   },
   "Hardened.Web.Testing": {
-    "line": 98.0,
-    "branch": 88.8
+    "line": 98.1,
+    "branch": 94.4
   }
 }

--- a/scripts/coverage-gate.py
+++ b/scripts/coverage-gate.py
@@ -21,10 +21,40 @@ so a developer with ~/CSharpAuthor or ~/ValidationModules builds assemblies whos
 from the ones CI builds. A baseline written from that machine records percentages CI cannot
 reproduce, and an assembly - ValidationModules.Runtime - that only exists as a project locally.
 
-The coverage-report artifact is uploaded on every run, including a failed one:
+The coverage-report artifact is uploaded on every run, including a failed one - which is what
+makes a run that died in a later step, such as Pack, still usable for re-baselining:
 
     gh run download <run-id> -n coverage-report -D /tmp/cicov
     python3 scripts/coverage-gate.py --summary /tmp/cicov/Summary.json --update
+
+An assembly missing from the baseline is not necessarily an oversight
+-------------------------------------------------------------------
+
+This gate errors on a baseline entry no run reported, and only prints an assembly the run
+reported and the baseline does not. So an assembly that never reaches the report is never gated,
+and nothing says so.
+
+Hardened.Smithy.BuildTask is in that state, and adding a baseline entry for it would make every
+run fail rather than fix it. Measured 2026-08-18:
+
+    dotnet build src/Hardened.Framework.sln -c Release
+    dotnet test  src/Hardened.Framework.sln --no-build -c Release \
+        --settings coverlet.runsettings --collect:"XPlat Code Coverage"
+        -> 20 assemblies, Hardened.Smithy.BuildTask among them
+
+    dotnet build src/Hardened.Framework.sln -c Release -p:ContinuousIntegrationBuild=true
+    (same test command)
+        -> 19 assemblies, Hardened.Smithy.BuildTask absent, and two of the 23 cobertura files
+           come out with no <package> element at all
+
+CI always builds with ContinuousIntegrationBuild=true, so the assembly has never appeared in a
+CI report - its own 73 tests run and pass there, and their coverage is discarded. That is roughly
+8,600 lines ungated, counting the Idl.Emit and Idl.Shared sources it compiles in.
+
+The two empty cobertura files are the thing to chase: coverlet is producing a report and putting
+nothing in it, which is a collection failure rather than a merge one. Deterministic builds rewrite
+source paths to /_/..., and DeterministicReport is set below, so the path mapping is the first
+place to look. Until it is fixed, a missing assembly here means unmeasured, not untested.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Phase 0 from the test-gap review. Replaces #145, which was measured at `c3937d7` and went stale when #146 landed.

No test or product changes — `coverage-baseline.json` and a docstring.

> **⚠️ CI will fail at Pack on this PR, for a reason that is not this PR.** See the last section — `main` is currently red and every PR inherits it.

## The floors had stopped meaning anything

They had drifted 10–30 points below what CI reports. `Hardened.Web.AspNetCore.Runtime` could have fallen from 96.5% to 66.2% and the gate would have called it fine.

| Assembly | Old floor | New |
|---|---:|---:|
| `Hardened.Web.AspNetCore.Runtime` | 66.2 / 80.9 | 96.5 / 97.1 |
| `Hardened.Shared.Testing` | 75.9 / 56.5 | 96.2 / 81.5 |
| `Hardened.Requests.Runtime` | 82.7 / 83.9 | 96.9 / 92.9 |
| `Hardened.Requests.Serializers.Newtonsoft` | 0.0 / 0.0 | 100.0 / 100.0 |
| `Hardened.Shared.Runtime` | 90.4 / 85.2 | 95.6 / 91.7 |
| `Hardened.Requests.Testing` | 93.8 / 91.6 | 99.5 / 95.0 |
| `Hardened.Validation.SourceGenerator` | 12.4 / 3.2 | 21.1 / 13.4 |
| `Hardened.OpenApi.BuildTask` | 10.7 / 10.7 | 13.8 / 11.9 |

21 assemblies, including #146's two — those are raised as well (94.9 → 95.8 and 93.7 → 94.6), for the same reason: they were baselined from a slightly earlier state than the one that landed.

Written from main's own run at `732af1c` (32143124155), not a local one. That run **failed at Pack**, after the coverage steps had already succeeded and uploaded — the artifact is published on every run for exactly this case, and the docstring now says so.

## One floor goes down

`Hardened.Library.SourceGenerator`: 39.4 → 39.2 line, 19.1 → 18.8 branch. It reads 39.2/18.8 in three separate CI runs, 468 of 1192 lines each time. The old floor was set from an earlier tree and had been sitting above what CI measures ever since — inside `TOLERANCE`, so it never failed, and never true either.

## `Hardened.Smithy.BuildTask` still gets no entry, and that is not an oversight

I went to add one and found the assembly **never reaches CI's report at all**. Its 73 tests run and pass there; their coverage is discarded. Same tree, same test command:

```
build without ContinuousIntegrationBuild -> 20 assemblies, Smithy present
build with    ContinuousIntegrationBuild -> 19 assemblies, Smithy absent,
                                            and 2 of the 23 cobertura files
                                            contain no <package> element
```

CI always builds with that flag. Adding a baseline entry would make **every** run fail — a baseline entry no run reported is the gate's one hard error — rather than fix anything.

So the gate has a blind spot it never mentions: it errors on baselined-but-unreported, prints reported-but-unbaselined, and is silent about an assembly in neither. Roughly 8,600 lines, counting the `Idl.Emit` and `Idl.Shared` sources compiled into it. The docstring now records the diagnosis; the empty cobertura files are the thing to chase, since coverlet is producing a report and putting nothing in it.

## `main` is red, and it is not this

`732af1c` (#146) fails at Pack:

```
error : Could not find a part of the path '.../src/Web/Hardened.Web.StaticContent/build'
```

`.gitignore:14` is `build/`, which swallows `src/Web/Hardened.Web.StaticContent/build/Hardened.Web.StaticContent.targets`. The file exists locally and was never committed, so it works on the authoring machine and fails everywhere else.

No other package in the repo hits this: `Hardened.OpenApi.SourceGenerator` and `Hardened.Smithy.SourceGenerator` keep their targets in `Package/` and pack it *to* `build/`. Matching that convention is probably the cleaner fix; `!src/Web/Hardened.Web.StaticContent/build/` would also do it.

I have not touched it — the `.targets` content only exists on your machine, so committing the file is the one part I cannot do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFy7Z6gdXU6tr65TndEUS8