### PR TITLE
Make the 0.8.0 generator packages consumable

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Hardened.OpenApi.SourceGenerator.csproj
@@ -34,10 +34,27 @@
         The generator half, as a real dependency rather than a copy. Both this package and
         Hardened.Smithy.SourceGenerator depend on it, so a project using both gets exactly one
         analyzer - which packing the DLL into each front end would not give.
+
+        Deliberately without ReferenceOutputAssembly="false", unlike the build task below. Pack
+        builds its dependency group from project references where that attribute is not false, so
+        setting it here does not merely skip an assembly reference - it drops the nuspec dependency
+        entirely. This package carried it through 0.6.0-rc1000 and shipped to nuget.org with an
+        empty <dependencies/> and no analyzers/ folder: the build task ran, wrote the normalised
+        model, and nothing generated code from it. Nothing in the repository could notice, because
+        every SUT references the generator as OutputItemType="Analyzer" directly.
+
+        The reference costs an unused assembly reference on a project that compiles no source, and
+        IncludeBuildOutput=false keeps it out of the package.
+
+        PrivateAssets="none" for the other half of the same failure. PrivateAssets defaults to
+        contentfiles;analyzers;build, and pack turns that into exclude="Build,Analyzers" on the
+        nuspec dependency - so a consumer would restore Hardened.Idl.SourceGenerator and then
+        suppress the only thing in it, an analyzers/dotnet/cs assembly. Restoring the generator and
+        not running it fails exactly the way not restoring it does.
     -->
     <ItemGroup>
         <ProjectReference Include="..\Hardened.Idl.SourceGenerator\Hardened.Idl.SourceGenerator.csproj"
-                          ReferenceOutputAssembly="false"/>
+                          PrivateAssets="none"/>
     </ItemGroup>
 
     <!--

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Hardened.Smithy.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Hardened.Smithy.SourceGenerator.csproj
@@ -27,10 +27,17 @@
         The generator half. Both front ends depend on this same package, so a project using Smithy
         and OpenAPI together resolves exactly one analyzer - which packing the DLL into each front
         end would not give.
+
+        Deliberately without ReferenceOutputAssembly="false", unlike the build task below: pack
+        omits a project reference carrying it from the nuspec dependency group, which is how the
+        OpenAPI front end shipped a release with no generator behind it. PrivateAssets="none"
+        because the default would write exclude="Build,Analyzers" onto the dependency, and an
+        analyzer package whose analyzer assets are excluded is restored and never run. See the note
+        on the same reference in Hardened.OpenApi.SourceGenerator.csproj.
     -->
     <ItemGroup>
         <ProjectReference Include="..\Hardened.Idl.SourceGenerator\Hardened.Idl.SourceGenerator.csproj"
-                          ReferenceOutputAssembly="false"/>
+                          PrivateAssets="none"/>
     </ItemGroup>
 
     <!--

--- a/src/SourceGenerators/Hardened.SourceGenerator/Hardened.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Hardened.SourceGenerator.csproj
@@ -54,6 +54,27 @@
             <PackagePath>src\Hardened.SourceGenerator\</PackagePath>
             <PackageCopyToOutput>true</PackageCopyToOutput>
         </Content>
+
+        <!--
+            Packed separately because the glob above cannot reach it: it matches relative to this
+            project directory, and GZipLiteral.cs lives outside it. The <Compile> link above is
+            enough to build this assembly, so the omission is invisible in this repository - but
+            this package ships as source, and OpenApiDocument/OpenApiDocumentSource.cs opens with
+            `using Hardened.Idl;`. A consumer that sets PackageHardenedIncludeSource=true compiles
+            src/**/*.cs from the package and nothing else, so without this the only file defining
+            that namespace is absent and the consumer fails with
+
+              OpenApiDocument/OpenApiDocumentSource.cs(3,16): error CS0234: The type or namespace
+                name 'Idl' does not exist in the namespace 'Hardened'
+
+            Hardened.Amz 0.8.0-rc1000 is where that surfaced. PackagePath matches the <Compile>
+            Link, so the file lands where the shipped source expects it.
+        -->
+        <Content Include="../Hardened.Idl.Shared/GZipLiteral.cs">
+            <Pack>true</Pack>
+            <PackagePath>src\Hardened.SourceGenerator\Shared\</PackagePath>
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
     </ItemGroup>
 
     <!--


### PR DESCRIPTION
0.8.0-rc1000 published three packages that cannot be used. Both defects are invisible
inside this repository and only appear to a consumer restoring from a feed.

**`Hardened.SourceGenerator`** ships as source. Its
`OpenApiDocument/OpenApiDocumentSource.cs` opens with `using Hardened.Idl;`, and the only
file defining that namespace — `Hardened.Idl.Shared/GZipLiteral.cs` — was never packed:
the pack glob is `**\*.cs`, which matches relative to the project directory and cannot
reach a file above it. The `<Compile>` link satisfies this repo's own build, so nothing
here could notice. Every external consumer gets `CS0234`.

**`Hardened.OpenApi.SourceGenerator`** and **`Hardened.Smithy.SourceGenerator`** both
reference `Hardened.Idl.SourceGenerator` with `ReferenceOutputAssembly="false"`. Pack
builds its dependency group from project references where that attribute is not false, so
both shipped with an empty `<dependencies/>` and no `analyzers/`. `PrivateAssets="none"`
covers the other half — the default writes `exclude="Build,Analyzers"`, which restores the
generator and suppresses the only thing in it. Recovered from
`fix/publish-idl-and-smithy-generators`, pushed 2026-08-18 and never merged; #150 landed
that branch's pack-list half but not this one.

## Verification

Ran the release's own pack loop at `0.9.0-rc1000` — 21/21 packages produced. Restored each
into a throwaway consumer from that feed alone and read what `csc` was actually handed:

| | build | Hardened analyzer at csc |
|---|---|---|
| published `0.8.0-rc1000` | exit 0 | **none** |
| this branch | exit 0 | `Hardened.Idl.SourceGenerator.dll` |

Both exit 0 — the broken one is a silent no-op, not a failure, which is why no gate caught
it. All 21 packages restore, build, and deliver every analyzer they ship.

The source-shipping package was checked in a `netstandard2.0` consumer of the shape
Hardened.Amz uses: 85 shipped files reach `csc` including `GZipLiteral.cs`, and pointing the
same project at published 0.8.0 fails with `CS0234` — so the check is not passing vacuously.

Framework: 4229 tests, 0 failures, clean under `ContinuousIntegrationBuild=true`.
Hardened.Amz against these packages: 41/41 projects, 675 tests, 0 failures.

Not tagged. Amz's bump is staged separately and waits on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bop7mv5MD91T2YZNngJHgk