### PR TITLE
Close the three defects a first adopter hit, and plan the docs and templates

### DIFF
--- a/docs/DOCS-PLAN.md
+++ b/docs/DOCS-PLAN.md
@@ -1,0 +1,201 @@
+# Documentation plan
+
+Written after a first-adopter run against 0.8.0-rc1000 that produced eleven findings, nine of
+them documentation rather than code. This is a plan for the docs, the README, and the structure
+underneath both.
+
+## The thing not to break
+
+The guide pages are genuinely good — better than most commercial framework documentation. They
+explain *why*, they own their mistakes in dated "Changed" notes, and `guide/routing` and
+`guide/content-negotiation` are the kind of pages people bookmark. `Hardened.Web.Kestrel.Runtime`'s
+README, which measures its own benefit and lists what you give up, is the best single document in
+the project.
+
+None of that is the problem, and a rewrite would destroy the main asset. **The docs are excellent
+essays and a poor map.** Everything below is about the map.
+
+---
+
+## Diagnosis
+
+### The structural cause: the docs are in a different repository
+
+`ipjohnson/Hardened.Docs` is a separate repo from the code it describes. Every failure below
+follows from that one fact:
+
+- Snippets cannot be compiled, because there is no compilation to compile them against.
+- The package table is hand-maintained, because nothing can generate it from the build.
+- A new package ships with no page, because no gate in this repo knows the docs exist.
+- `Hardened.Web.Kestrel.Runtime/README.md` — the document that would have prevented three of my
+  eleven findings — never reached the site, because nothing carries an in-repo README there.
+
+Three in-repo READMEs are invisible from the docs site today: Kestrel, RazorBlade, and Benchmarks.
+
+### Four failure classes, with what each cost
+
+**A — Prose that was never executed.** The quickstart is missing two `PackageReference` lines and
+says the generators "arrive with those packages"; it does not compile. The `guide/templates`
+callout recommends `EnableDefaultRazorBladeItems=false`, which I tested and which does not fix
+what it claims to. `guide/execution-pipeline` documents a filter keyed on `handlerInfo.Path`, which
+could not match a route under a module `[BasePath]` — a real defect, now fixed, that a compiled
+sample would have caught years earlier than a stranger did. Pipeline snippets omit their `using`
+lines; I had to grep the source for `IRequestFilterProvider`'s namespace.
+
+**B — Hand-maintained inventories that drift.** Six published packages are absent from
+`reference/packages`, including the recommended host. One listed package,
+`Hardened.DependencyModules.SourceGenerator`, is stuck at `0.1.0-rc1` on nuget.org and is a dead
+end. The installation page still routes people through GitHub Packages and a token; the same
+reference page contradicts itself about the feed within one screen. `Hardened.Templates.RazorBlade`
+is pinned four release lines stale in its own install snippet.
+
+**C — Shipped features with no page.** Kestrel hosting, static content, and validation all ship at
+0.8.0 and have no page. Validation works well and is nearly invisible: DataAnnotations plus one
+generator package, and the emitted validator is clean straight-line code.
+
+**D — No blessed path.** Nothing in the docs says which host to use. `guide/getting-started`, the
+repo README and `guide/routing` all lead with `[AspNetCoreRuntime]`, so that is what I built on —
+into a Razor SDK conflict and an `IStartupService` that never runs. Both evaporate on Kestrel.
+`guide/templates` and `guide/routing` do use `[KestrelRuntime]` in examples, without any page
+naming the package it comes from.
+
+### What an adopter actually does
+
+I read `guide/getting-started`, then reached for pages by name when stuck. I never opened
+`reference/packages` before my first build — which is where the two missing package references
+and the Kestrel package were both documented. That is not unusual behaviour and the structure
+should not depend on it: **anything a reader needs before their first successful build has to be
+on the first page they open.**
+
+---
+
+## Plan
+
+Five workstreams. The first two remove whole failure classes rather than fixing instances; the
+rest are cheaper and can run in any order after.
+
+### 1. A template, and make it the getting-started page
+
+`dotnet new hardened-web` — Kestrel, nuget.org, the two generator packages, one controller, one
+test. No such template is published today.
+
+The page then becomes four lines and a `curl`, and cannot drift, because the template is a project
+CI builds and runs. This alone removes findings 1, 2, 8 and 11 from my report and most of failure
+class A at the point where it does the most damage.
+
+`hardened-adopter/starter/` in the audit workspace is a working version of exactly this — four
+files, verified serving. Use it as the template body.
+
+Ship `hardened-console`, `hardened-lambda` and `hardened-library` behind the same door once the
+first one exists.
+
+### 2. Move the docs source into this repository, and compile every snippet
+
+The docs site can keep its own repo for theme and hosting, but **the prose and its code should
+live beside the code they describe.**
+
+Then the thing that matters becomes possible: no code in the docs that is not compiled.
+
+- `docs/samples/*` — real projects, in the solution, built and tested by CI.
+- Markdown includes named regions from those files rather than containing code:
+  `<<< @/samples/greeter/Program.cs#registration` (VitePress supports this natively today).
+- A lint step fails the build on a fenced `csharp` or `xml` block in `docs/` that is not an
+  include. Exceptions get an explicit marker so they are countable.
+
+Everything in class A becomes a build failure instead of a reader's afternoon. The
+`handlerInfo.Path` defect specifically: a sample exercising the documented filter pattern would
+have failed the moment the pattern stopped working.
+
+Cost is real — this is the expensive item — but it is the only one that stops class A recurring.
+
+### 3. Generate the inventories
+
+`reference/packages` should be generated from the pack output, not typed. Two CI gates, in the
+style of the existing `scripts/coverage-gate.py`:
+
+- **Every packable project appears in the generated table.** 21 projects are packable today; six
+  were missing from the table.
+- **Every version named in docs resolves on nuget.org.** Catches the stale RazorBlade pin and the
+  dead `Hardened.DependencyModules.SourceGenerator` entry.
+
+Then delete the GitHub Packages installation section and replace it with a "continuous builds"
+aside, and remove the self-contradiction on the reference page.
+
+### 4. A docs-coverage gate
+
+Every packable project must name a docs page, or carry an explicit exemption with a reason. Fails
+CI when a new package appears with neither. This is the check that would have caught Kestrel,
+static content and validation shipping into silence.
+
+Pair it with a one-time sweep: promote the three in-repo READMEs to real pages. The Kestrel one is
+close to publishable as written.
+
+### 5. Add a map layer; leave the essays alone
+
+Three new pages, and no rewrites:
+
+- **Start here.** The template, and nothing else.
+- **Choosing a host.** The missing page. Kestrel is the default and why; ASP.NET Core when you need
+  its middleware, authentication, or hosting diagnostics; Lambda for Lambda. The Kestrel README
+  already contains most of this, including the measurements and the honest "what you give up"
+  list — it just needs to be somewhere a reader will find it before choosing.
+- **How do I…** — a task index over the existing pages. Serve HTML. Read configuration. Add a
+  filter. Split into libraries. Validate a body. Serve static files.
+
+Then one editing pass over the existing pages to make Kestrel the default in every code sample,
+with ASP.NET Core shown as the alternative rather than the norm.
+
+---
+
+## Specific edits, independent of the above
+
+Small, and each one cost me time:
+
+| Page | Change |
+|---|---|
+| `guide/getting-started` | The two generator packages; delete the claim that they arrive on their own; nuget.org not GitHub Packages; Kestrel |
+| `reference/packages` | Generate it; fix the feed contradiction; `OutputItemType="Analyzer"` is `ProjectReference` syntax shown on a `PackageReference` |
+| `guide/modules` | How a service reads its own module's configured property — the `Tenant` example sets one and nothing shows reading it back. Note that module equality is by type, so two imports with different settings collapse unless the module overrides `Equals` (and cross-link DependencyModules) |
+| `guide/execution-pipeline` | `using` lines on every snippet; state that a response header must be set before the serializer runs, and that Hardened drops a late one silently where ASP.NET Core throws |
+| `guide/testing` | Say xUnit **v3**, and that v3 test projects need `<OutputType>Exe</OutputType>` |
+| `guide/templates` | Fix or delete the `EnableDefaultRazorBladeItems` workaround — it does not work; the answer is to not use the Web SDK. Update the stale `0.4.0-rc1000` pin |
+| `guide/routing` | `[Get]`'s `SuccessStatus`/`ErrorStatus` properties are already documented as ignored — good; keep that honesty when the map layer lands |
+| README | Same quick start as the template, and one line on choosing a host |
+
+Also worth a line somewhere: `[HardenedStaticContent]` has no `RoutePrefix` although the MSBuild
+item does, so the attribute and the item disagree about what is configurable.
+
+---
+
+## Re-running the adopter test
+
+The point of all this is that the next stranger gets further. That is measurable, and it should be
+run against a build rather than a memory.
+
+The audit workspace at `hardened-adopter/` is the harness:
+
+- `starter/` — the corrected quickstart, four files.
+- `Bookshelf/` — a two-project application with 14 tests, exercising modules, constraints, every
+  binding source, filters, configuration, validation, views, static content and links.
+- `repro-docs-quickstart/`, `repro-module-properties/` — minimal repros.
+
+Re-run it cold after the template lands: fresh workspace, published packages only, docs only, no
+source. The number worth tracking is **how long until the first successful `curl`**, and **how many
+times the reader has to open the source tree**. Mine were roughly thirty minutes and eight.
+
+Two of the three code defects that run found were invisible to a 4,000-test suite because every
+test used a double that could not fail — a `MemoryStream` that accepts synchronous writes, and a
+handler path nothing compared against a served URL. That is the argument for the sample projects in
+workstream 2 more than any doc-quality argument is.
+
+---
+
+## Order
+
+1. **Template** — biggest reduction in time-to-first-curl for the least work.
+2. **Docs into the repo, snippets compiled** — expensive, and the only thing that stops class A
+   coming back.
+3. **Generated package table + version gate** — small, mechanical, ends class B.
+4. **Docs-coverage gate + promote the three READMEs** — ends class C.
+5. **Map layer and the Kestrel default pass** — ends class D.
+6. **The specific edits table** — do opportunistically; none blocks anything else.

--- a/docs/TEMPLATE-PLAN.md
+++ b/docs/TEMPLATE-PLAN.md
@@ -1,0 +1,206 @@
+# Template plan
+
+Templates are named for the **workload**. Everything else — host, contract source, optional
+features — is an option on the template. No template name contains a host.
+
+## Why that factoring is right, and the stronger version of it
+
+Host in the name explodes: two workloads by five hosts by three contract sources is thirty
+templates, and adding Azure adds six more. Host as an option adds one directory.
+
+But there is a stronger claim available, and it is the framework's own:
+
+> Controllers, filters, binding and the generated routing table are identical to an
+> ASP.NET-hosted Hardened application.
+> — `Hardened.Web.Kestrel.Runtime/README.md`
+
+If that is true, then **the host affects exactly one project**. Not a flag threaded through a
+generated solution — one directory that gets swapped, with everything else bit-for-bit the same
+whether you deploy to Kestrel, Lambda, or eventually Azure Functions.
+
+That reframes the template suite from a convenience into a proof. If a generated
+`--host kestrel` and a generated `--host aws-lambda` differ anywhere outside the host project,
+either the template is wrong or the claim is. CI can assert it (below), and once it does, adding
+Azure means adding a host directory and watching the assertion hold.
+
+## Layout
+
+Three projects, the same in every combination:
+
+```
+Foo/
+  src/Foo/            implementation library — routes or handlers, services, contract
+  src/Foo.Host/       the ONLY host-specific project
+  tests/Foo.Tests/
+```
+
+The application module lives in the host, because naming the runtime is what a host does. The
+library module — `[HardenedModule] [HardenedWebModule] [BasePath("/foo")]` — lives in the library
+and knows nothing about where it runs.
+
+**Tests target the library module, not the host's application module.**
+`[assembly: HardenedTestEntryPoint(typeof(FooLibrary))]`. `ITestWebApp` drives the real pipeline
+with no host at all, so a test suite that names the host is coupled to a deployment target for no
+reason. The trade is that host-level composition — configuration amendments, services the host
+registers — is not covered by the default test; that is worth a separate host test in a real
+application and is not worth it in a template.
+
+This is also what makes the CI assertion possible: the library and the tests are byte-identical
+across hosts, and only `src/Foo.Host/` differs.
+
+## Templates
+
+| Short name | Workload | Phase |
+|---|---|---|
+| `hardened-web` | HTTP routes | 1 |
+| `hardened-function` | Event handlers | 2 |
+| `hardened-library` | A module in its own assembly, no host — added to an existing solution | 2 |
+
+`hardened-library` is worth its own template rather than a flag: it is the shape the framework's
+whole composition story is about, it has no host project at all, and it is where the cross-module
+links defect lived. Adding a library to a solution you already have is a real thing people do.
+
+## Options
+
+### hardened-web
+
+| Option | Values | Default | Affects |
+|---|---|---|---|
+| `--host` | `kestrel`, `aspnet`, `aws-lambda` | `kestrel` | `src/Foo.Host/` only |
+| `--contract` | `code`, `openapi`, `smithy` | `code` | one file + one csproj block in `src/Foo/` |
+| `--openapi-doc` | on/off | **on** | one attribute on the host module |
+| `--openapi-ui` | on/off | **on** | one attribute on the host module |
+| `--views` | on/off | off | RazorBlade packages, a view, an `[Output<T>]` route |
+| `--static-content` | on/off | off | package, `wwwroot`, the MSBuild item |
+
+`--contract` does not apply to `hardened-function`: event handlers have no routes, so there is no
+document to derive them from.
+
+Smithy is not a third programming model. Both OpenAPI and Smithy normalize through
+`Hardened.Idl.*` into the same generator, so a Smithy handler and an OpenAPI handler are the same
+C# — `[Handler]` on a class implementing a generated interface. Three contract sources, two
+shapes of code.
+
+### hardened-function
+
+| Option | Values | Default |
+|---|---|---|
+| `--host` | `aws-lambda` | `aws-lambda` |
+| `--trigger` | `invoke`, `sqs`, `ddb-stream` | `invoke` |
+
+`--trigger` values are host-scoped in a way `--host` values are not: SQS is AWS, Pub/Sub would be
+GCP. `template.json` choice symbols cannot express "valid only when `--host` is X", so an invalid
+pair has to fail somewhere. Fail it in a post-action with a message naming the valid pairs, and
+keep the smoke matrix to real combinations.
+
+## The default route
+
+The same route, the same shape, in every variant:
+
+```
+GET /greeting/{name}   ->   { "message": "Hello, name" }
+```
+
+A record rather than a bare string, so the generated OpenAPI document has a schema in it and the
+UI shows something on first load. Identical across `code`, `openapi` and `smithy`, which is what
+lets the generated test be identical too — and the identical test is half of the CI assertion.
+
+## Defaults on, opt out
+
+Publish, UI, and a test, all on. One caveat.
+
+`HardenedOpenApiUi` carries `Path`, `Title`, `DocumentPath`, `ScriptUrl`, `ScriptIntegrity` — and
+nothing about where it is allowed to run. Default-on therefore means every generated service ships
+a documentation page in production that fetches a script from a CDN at runtime. Swashbuckle
+defaults to development-only for exactly this reason, and `IStaticContentConfiguration` already
+carries a `Requirement` for the analogous problem.
+
+Keep it on — it is the right first run — and add an environment gate to the module rather than
+relying on people noticing an attribute. That is a framework change, not a template one, and it
+should land before or with the template.
+
+## What blocks what
+
+**`--host aws-lambda` cannot ship yet.** `Hardened.Amz.Web.Lambda.Runtime 0.6.0-rc1000` depends on
+`Hardened.Web.Runtime 0.6.0-rc1000`; the framework is at `0.8.0-rc1000`. A template pinning both
+would either put the whole application two release lines back or mix build lines, which
+`reference/packages` already says is unsupported — and already narrates going wrong:
+
+> Hardened.Amz tracked a framework three release lines old that way, with a green build throughout.
+
+The template is the forcing function. A smoke test that restores a generated Lambda project fails
+on the version conflict, where a green build did not. Ship `hardened-web --host kestrel|aspnet`
+first; add `aws-lambda` when Amz tracks the line.
+
+**Azure and GCP do not exist yet.** The point of this factoring is that they are additive: a host
+directory, one value in a choice symbol, one row in the smoke matrix. Nothing about the
+implementation library or the tests changes, and the CI assertion says so out loud.
+
+## Packaging and distribution
+
+One NuGet package, `Hardened.Templates`, containing every template:
+
+```
+content/hardened-web/.template.config/template.json
+content/hardened-function/.template.config/template.json
+content/hardened-library/.template.config/template.json
+```
+
+```xml
+<PackageId>Hardened.Templates</PackageId>
+<PackageType>Template</PackageType>
+<TargetFramework>netstandard2.0</TargetFramework>
+<IncludeContentInPack>true</IncludeContentInPack>
+<IncludeBuildOutput>false</IncludeBuildOutput>
+<ContentTargetFolders>content</ContentTargetFolders>
+<NoWarn>$(NoWarn);NU5128</NoWarn>
+```
+
+nuget.org is the central repo and the CLI already knows how to reach it:
+
+```bash
+dotnet new install Hardened.Templates
+dotnet new hardened-web -n Foo
+```
+
+`dotnet new search hardened` queries nuget.org directly and returns nothing today, so the name is
+free. Local install from a packed branch build works the same way.
+
+### The version-pinning trap
+
+The generated csproj must pin `Hardened.*` at a version, and a hardcoded one is exactly the drift
+that left the RazorBlade install snippet four release lines stale.
+
+One substitution point: emit a `Directory.Packages.props` with a single `<HardenedVersion>`, and
+stamp it from `$(Version)` at pack. Template and framework ship from the same release, so it is
+exact — and the generated project gets central package management, which the docs already
+recommend.
+
+## CI
+
+Two jobs, and the second is the one that matters.
+
+**Smoke, per variant.** Install the *packed* nupkg, `dotnet new`, restore, build, test, run,
+`curl` the default route. Not a project reference — the artifact users get. A template built in
+the solution with `ProjectReference`s proves nothing about packaging, which is where the
+0.8.0-rc1000 quickstart broke.
+
+**Host-independence assertion.** Generate the same project once per host and diff. `src/Foo/` and
+`tests/Foo.Tests/` must be byte-identical; only `src/Foo.Host/` may differ. This is the framework's
+central claim, checked mechanically, and it is the thing that will keep Azure and GCP honest when
+they arrive.
+
+Generate the smoke matrix from the choice symbol's values so a new host cannot be added without
+being tested.
+
+## Sequencing
+
+1. **`hardened-web`, hosts `kestrel` and `aspnet`, contract `code`.** Lift from
+   `hardened-adopter/starter/`, which is verified serving. Defaults on: document, UI, test.
+2. **Both CI jobs.** Before more variants, so nothing lands untested.
+3. **`--contract openapi` and `--contract smithy`.** One file and one csproj block each.
+4. **Environment gate on `HardenedOpenApiUi`.** Framework change; unblocks defaulting the UI on
+   without shipping it to production.
+5. **`hardened-library`.**
+6. **Amz onto the framework's release line**, then `--host aws-lambda`, then `hardened-function`.
+7. **Azure and GCP** — by then, one directory each.

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/HandlerInfoPathTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/HandlerInfoPathTests.cs
@@ -1,0 +1,98 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// A handler describes itself with the path it is actually served at.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>SomeController</c> lives in <c>WebLibrary</c>, which declares <c>[BasePath("/web-library")]</c>
+/// on the module and <c>[BasePath("/string-methods")]</c> on the controller. The route answers at
+/// <c>/web-library/string-methods/concat/{a}/{b}</c>, and the handler used to report
+/// <c>/string-methods/concat/{a}/{b}</c> — the module's prefix belongs to the entry point and never
+/// reached the handler class, which is generated from its own declarations.
+/// </para>
+/// <para>
+/// That is not cosmetic. <c>IGlobalFilterRegistry</c>'s per-handler overload is documented as
+/// deciding by path, so <c>handlerInfo.Path.StartsWith("/web-library")</c> matched nothing and the
+/// filter silently never ran — for every route in every library that owns a URL space, which is
+/// the arrangement <c>[BasePath]</c> on a module exists to support.
+/// </para>
+/// </remarks>
+public class HandlerInfoPathTests {
+
+    /// <summary>
+    /// Every handler's declared path is one the router would match.
+    /// </summary>
+    /// <remarks>
+    /// Asserted over the whole table rather than one route, because the defect was structural: any
+    /// handler reached through a module base path had it, and a test naming a single path would go
+    /// on passing if a second library were added with the same fault.
+    /// </remarks>
+    [HardenedTest]
+    public async Task EveryHandlerReportsThePathItIsServedAt(
+        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
+        var seen = PathsSeenByAPerHandlerFilter(registry);
+
+        await testWebApp.Get("/web-library/string-methods/concat/a/b");
+
+        Assert.Contains("/web-library/string-methods/concat/{a}/{b}", seen);
+        Assert.DoesNotContain("/string-methods/concat/{a}/{b}", seen);
+    }
+
+    /// <summary>
+    /// The documented pattern, run as written: a filter that gates on a path prefix.
+    /// </summary>
+    [HardenedTest]
+    public async Task APathPrefixFilterMatchesRoutesUnderAModuleBasePath(
+        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
+        registry.RegisterFilter(handlerInfo =>
+            handlerInfo.Path.StartsWith("/web-library", StringComparison.Ordinal)
+                ? new RequestFilterInfo(_ => new StampFilter(), FilterOrder.HandlerCreation)
+                : null);
+
+        var underLibrary = await testWebApp.Get("/web-library/string-methods/concat/a/b");
+
+        Assert.True(
+            underLibrary.Headers.ContainsKey(StampFilter.HeaderName),
+            "a filter gated on the module's base path did not run for a route under it");
+    }
+
+    /// <summary>
+    /// A handler with no module base path is unchanged — it already reported the right path, and
+    /// composing an empty prefix must not give it a different one.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerOutsideAnyModuleBasePathIsUnaffected(
+        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
+        var seen = PathsSeenByAPerHandlerFilter(registry);
+
+        await testWebApp.Get("/binding/path/42");
+
+        Assert.Contains("/binding/path/{id}", seen);
+    }
+
+    private static List<string> PathsSeenByAPerHandlerFilter(IGlobalFilterRegistry registry) {
+        var seen = new List<string>();
+
+        registry.RegisterFilter(handlerInfo => {
+            seen.Add(handlerInfo.Path);
+
+            return null;
+        });
+
+        return seen;
+    }
+
+    private class StampFilter : IExecutionFilter {
+        public const string HeaderName = "X-Under-Library";
+
+        public Task Execute(IExecutionChain chain) {
+            chain.Context.Response.Headers[HeaderName] = "yes";
+
+            return chain.Next();
+        }
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/LinkTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/LinkTests.cs
@@ -99,4 +99,40 @@ public class LinkTests {
 
         public string Absolute(string path) => Scheme + "://" + Host + Resolve(path);
     }
+
+    /// <summary>
+    /// The routes a library module declares are reachable from the application's own links type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Links are generated per module, so <c>WebLibrary</c>'s routes live on
+    /// <c>WebLibraryLinks</c> rather than on <c>ApplicationLinks</c>. A generated template base
+    /// hard-types its <c>Links</c> property to the application's, so before this an application
+    /// whose routes all lived in libraries handed its views an empty links type and
+    /// <c>@Links.Something.Route()</c> did not compile - the build-time guarantee was unavailable
+    /// to exactly the applications that split into libraries.
+    /// </para>
+    /// <para>
+    /// This test compiling is most of the assertion, as with the rest of this file: the property
+    /// and the method under it are both generated, and either one going away breaks the build.
+    /// </para>
+    /// </remarks>
+    [HardenedTest]
+    public Task AnImportedModulesRoutesAreReachableFromTheApplicationsLinks(ApplicationLinks links) {
+        Assert.Equal(
+            "/web-library/string-methods/concat/a/b",
+            links.WebLibrary.Some.Concat("a", "b"));
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The property is named for the module, which is the name already written at the import site.
+    /// </summary>
+    [HardenedTest]
+    public Task TheImportedPropertyIsNamedForTheModule(ApplicationLinks links) {
+        Assert.IsType<Hardened.IntegrationTests.Web.SUT.WebLibraryLinks>(links.WebLibrary);
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -254,6 +254,7 @@ namespace Hardened.Requests.Runtime.Execution
         public System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter> Parameters { get; }
         public string Path { get; }
         public Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; }
+        public Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo WithPath(string? path) { }
     }
     public class ExecutionRequestParameter : Hardened.Requests.Abstract.Execution.IExecutionRequestParameter
     {

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
@@ -39,4 +39,35 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
     /// so the walk over metadata happens once per handler type for the life of the process.
     /// </remarks>
     public Requirement? Requirement { get; }
+
+    /// <summary>
+    /// The same handler, addressed at <paramref name="path"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A handler class is generated from its own declarations, so the <see cref="Path"/> it is
+    /// born with is the controller's <c>[BasePath]</c> and the route template - <c>/books</c>.
+    /// The module's <c>[BasePath]</c> is not there to be seen: it belongs to the entry point, and
+    /// is applied where the routing table is built. So a handler served at
+    /// <c>/catalog/books</c> described itself as <c>/books</c>, and everything reading
+    /// <c>IExecutionRequestHandlerInfo.Path</c> - a global filter registered per handler, an
+    /// authorization convention, a log line - was given a path that matched no request the
+    /// application would ever receive.
+    /// </para>
+    /// <para>
+    /// The routing table calls this when it constructs a handler, passing the path it routed to.
+    /// Composition stays in the generator, which already computes exactly this string for the
+    /// route tree, the links and the OpenAPI document - so there is no second implementation of
+    /// the base-path rules to disagree with the first.
+    /// </para>
+    /// <para>
+    /// Returns <c>this</c> when there is nothing to change, so a handler under no module base
+    /// path costs nothing.
+    /// </para>
+    /// </remarks>
+    public ExecutionRequestHandlerInfo WithPath(string? path) =>
+        string.IsNullOrEmpty(path) || string.Equals(path, Path, StringComparison.Ordinal)
+            ? this
+            : new ExecutionRequestHandlerInfo(
+                path!, Method, HandlerType, InvokeMethod, Parameters, Metadata, Requirement);
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Links/LinkGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Links/LinkGenerator.cs
@@ -354,6 +354,59 @@ public static class LinkGenerator {
                 WriteLinkMethod(appModel, groupClass, group.Key, link, "Absolute", link.Name + "Absolute");
             }
         }
+
+        WriteImportedLinks(links, appModel, groups);
+    }
+
+    /// <summary>
+    /// A property per imported module that publishes links, so every route the application serves
+    /// is reachable from the one type a view is handed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Links are generated per module. An application that keeps its routes in a library therefore
+    /// had an empty <c>ApplicationLinks</c> and a <c>CatalogLibraryLinks</c> holding everything it
+    /// serves - and a view's generated <c>Links</c> property is typed as the first, so
+    /// <c>@Links.Book.ById(id)</c> did not compile. The build-time guarantee that a renamed route
+    /// breaks the <c>.cshtml</c> was unavailable to exactly the applications that split into
+    /// libraries.
+    /// </para>
+    /// <para>
+    /// Named for the module rather than for anything shorter - <c>@Links.CatalogLibrary.Book.ById(id)</c>
+    /// - because the module's name is the one thing already written at the import site, and any
+    /// trimming rule would be a second name to learn and to get wrong.
+    /// </para>
+    /// <para>
+    /// Constructed rather than resolved: a links type is a wrapper over <c>ILinkContext</c> and
+    /// takes nothing else, so there is no reason to make this depend on the imported module having
+    /// registered it.
+    /// </para>
+    /// </remarks>
+    private static void WriteImportedLinks(
+        ClassDefinition links,
+        EntryPointSelector.Model appModel,
+        IReadOnlyList<IGrouping<string, Link>> groups) {
+        foreach (var imported in appModel.ImportedLinks) {
+            // A controller group of the same name owns the name: it is declared in this assembly,
+            // and the imported module's links stay reachable by resolving their own type. Emitting
+            // both would be a duplicate member and a confusing error in generated code.
+            if (groups.Any(group => group.Key == imported.PropertyName)) {
+                continue;
+            }
+
+            var property = links.AddProperty(imported.LinksType, imported.PropertyName);
+
+            property.Modifiers |= ComponentModifier.Public;
+            property.Set = null;
+            property.Get.LambdaSyntax = true;
+            property.Get.AddCode(
+                $"_{imported.PropertyName} ??= new {imported.LinksType.Namespace}.{imported.LinksType.Name}(_context);");
+
+            var backing = links.AddField(
+                imported.LinksType.MakeNullable(), "_" + imported.PropertyName);
+
+            backing.Modifiers |= ComponentModifier.Private;
+        }
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeClassGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeClassGenerator.cs
@@ -80,7 +80,11 @@ public static class InvokeClassGenerator {
     /// </para>
     /// </remarks>
     private static void AddRoutePathParameter(MethodDefinition constructor) {
-        var routePath = constructor.AddParameter(typeof(string), "routePath");
+        // string?, not string. Every generated handler lands in a project with nullable
+        // reference types on, where "string routePath = null" is CS8625 - a warning locally and
+        // an error under TreatWarningsAsErrors, which is what CI builds with.
+        var routePath = constructor.AddParameter(
+            TypeDefinition.Get(typeof(string)).MakeNullable(), "routePath");
 
         routePath.DefaultValue = Null();
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeClassGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeClassGenerator.cs
@@ -61,6 +61,30 @@ public static class InvokeClassGenerator {
     /// claims it through ordinary selection. The parameter stays because
     /// <c>IExecutionContext.DefaultOutput</c> is public and an application may still set one.
     /// </remarks>
+    /// <summary>
+    /// The path the handler is actually served at, supplied by whoever constructed it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A handler class knows its controller's <c>[BasePath]</c> and its own route template, and
+    /// nothing else - the module's <c>[BasePath]</c> lives on the entry point and is applied when
+    /// the routing table is built. So a handler served at <c>/catalog/books</c> described itself
+    /// as <c>/books</c>, and every consumer of <c>IExecutionRequestHandlerInfo.Path</c> - a
+    /// per-handler global filter, an authorization convention, a log line - was handed a path
+    /// matching no request the application could receive.
+    /// </para>
+    /// <para>
+    /// Optional, and defaulted to null, because the web routing table is not the only thing that
+    /// constructs these: a function handler has no route and no base path, and must keep
+    /// compiling against a one-argument constructor.
+    /// </para>
+    /// </remarks>
+    private static void AddRoutePathParameter(MethodDefinition constructor) {
+        var routePath = constructor.AddParameter(typeof(string), "routePath");
+
+        routePath.DefaultValue = Null();
+    }
+
     private static void CreateConstructor(RequestHandlerModel handlerModel, ClassDefinition classDefinition) {
         IOutputComponent defaultOutput = Null();
 
@@ -100,13 +124,14 @@ public static class InvokeClassGenerator {
                 handlerModel.ControllerType
             },
             "serviceProvider",
-            "_handlerInfo",
+            "_handlerInfo.WithPath(routePath)",
             "InvokeMethod",
             GenerateFilterEnumerable(handlerModel, classDefinition)
         );
         var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
 
         constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+        AddRoutePathParameter(constructor);
     }
 
     private static void CreateAsyncParametersConstructor(RequestHandlerModel handlerModel,
@@ -118,7 +143,7 @@ public static class InvokeClassGenerator {
                 handlerModel.ControllerType, GenericParameters
             },
             "serviceProvider",
-            "_handlerInfo",
+            "_handlerInfo.WithPath(routePath)",
             "BindRequestParameters",
             "InvokeMethod",
             GenerateFilterEnumerable(handlerModel, classDefinition)
@@ -126,6 +151,7 @@ public static class InvokeClassGenerator {
         var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
 
         constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+        AddRoutePathParameter(constructor);
     }
 
     private static void CreateSyncNoParameterConstructor(RequestHandlerModel handlerModel,
@@ -138,13 +164,14 @@ public static class InvokeClassGenerator {
                 handlerModel.ControllerType
             },
             "serviceProvider",
-            "_handlerInfo",
+            "_handlerInfo.WithPath(routePath)",
             "InvokeMethod",
             GenerateFilterEnumerable(handlerModel, classDefinition)
         );
         var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
 
         constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+        AddRoutePathParameter(constructor);
     }
 
     private static void CreateSyncParametersConstructor(RequestHandlerModel handlerModel,
@@ -156,7 +183,7 @@ public static class InvokeClassGenerator {
                 handlerModel.ControllerType, GenericParameters
             },
             "serviceProvider",
-            "_handlerInfo",
+            "_handlerInfo.WithPath(routePath)",
             "BindRequestParameters",
             "InvokeMethod",
             GenerateFilterEnumerable(handlerModel, classDefinition)
@@ -164,6 +191,7 @@ public static class InvokeClassGenerator {
         var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
 
         constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+        AddRoutePathParameter(constructor);
     }
 
     private static void CreateAsyncEnumerableNoParameterConstructor(RequestHandlerModel handlerModel,
@@ -177,7 +205,7 @@ public static class InvokeClassGenerator {
                 handlerModel.ResponseInformation.AsyncEnumerableItemType!
             },
             "serviceProvider",
-            "_handlerInfo",
+            "_handlerInfo.WithPath(routePath)",
             "InvokeMethod",
             GenerateFilterEnumerable(handlerModel, classDefinition),
             FramingArgument(handlerModel)
@@ -185,6 +213,7 @@ public static class InvokeClassGenerator {
         var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
 
         constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+        AddRoutePathParameter(constructor);
     }
 
     private static void CreateAsyncEnumerableParametersConstructor(RequestHandlerModel handlerModel,
@@ -197,7 +226,7 @@ public static class InvokeClassGenerator {
                 handlerModel.ResponseInformation.AsyncEnumerableItemType!
             },
             "serviceProvider",
-            "_handlerInfo",
+            "_handlerInfo.WithPath(routePath)",
             "BindRequestParameters",
             "InvokeMethod",
             GenerateFilterEnumerable(handlerModel, classDefinition),
@@ -206,6 +235,7 @@ public static class InvokeClassGenerator {
         var constructor = classDefinition.AddConstructor(Base(filterMethod, defaultOutput));
 
         constructor.AddParameter(typeof(IServiceProvider), "serviceProvider");
+        AddRoutePathParameter(constructor);
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/EntryPointSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/EntryPointSelector.cs
@@ -23,6 +23,13 @@ public static class EntryPointSelector {
         /// </summary>
         public IReadOnlyList<EnabledFeatureModel> EnabledFeatures { get; set; } =
             Array.Empty<EnabledFeatureModel>();
+
+        /// <summary>
+        /// The links types belonging to modules this entry point imports, so a view can reach the
+        /// routes a library declares. See <see cref="ImportedLinksModel"/>.
+        /// </summary>
+        public IReadOnlyList<ImportedLinksModel> ImportedLinks { get; set; } =
+            Array.Empty<ImportedLinksModel>();
     }
 
     public class Comparer : IEqualityComparer<Model> {
@@ -42,7 +49,8 @@ public static class EntryPointSelector {
                    CompareAttributes(x, y) &&
                    CompareMethodDefinitions(x, y) &&
                    CompareProperties(x, y) &&
-                   x.EnabledFeatures.SequenceEqual(y.EnabledFeatures);
+                   x.EnabledFeatures.SequenceEqual(y.EnabledFeatures) &&
+                   x.ImportedLinks.SequenceEqual(y.ImportedLinks);
         }
 
         private bool CompareProperties(Model x, Model y) {
@@ -122,6 +130,7 @@ public static class EntryPointSelector {
 
             IReadOnlyList<AttributeModel> attributes = Array.Empty<AttributeModel>();
             IReadOnlyList<EnabledFeatureModel> features = Array.Empty<EnabledFeatureModel>();
+            IReadOnlyList<ImportedLinksModel> importedLinks = Array.Empty<ImportedLinksModel>();
 
             if (syntaxContext.Node is ClassDeclarationSyntax classDeclarationSyntax) {
                 attributes = AttributeModelHelper
@@ -132,6 +141,11 @@ public static class EntryPointSelector {
                 // is names, strings and type definitions - enough to emit from, and comparable by
                 // value so the model still keys the incremental cache.
                 features = EnabledFeatureSelector.Read(syntaxContext, classDeclarationSyntax, token);
+
+                // Resolved here for the same reason as the features above: the compilation is in
+                // reach, and what survives is names and type definitions that compare by value.
+                importedLinks =
+                    ImportedLinksModel.Read(syntaxContext, classDeclarationSyntax, attributes);
             }
 
             return new Model {
@@ -140,7 +154,8 @@ public static class EntryPointSelector {
                 RootEntryPoint = rootEntryPoint,
                 AttributeModels = attributes,
                 PropertyDefinitions = GeneratePropertyDefinitions(syntaxContext),
-                EnabledFeatures = features
+                EnabledFeatures = features,
+                ImportedLinks = importedLinks
             };
         };
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/ImportedLinksModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/ImportedLinksModel.cs
@@ -1,0 +1,90 @@
+using CSharpAuthor;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// A links type belonging to a module this entry point imports.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Links are generated per module, so an application that keeps its routes in a library has an
+/// <c>ApplicationLinks</c> with nothing on it and a <c>CatalogLibraryLinks</c> carrying every
+/// route it serves. A view's generated <c>Links</c> property is typed as the former, so
+/// <c>@Links.Book.ById(id)</c> did not compile and the build-time link guarantee was unavailable
+/// to exactly the applications that split into libraries - which is the arrangement
+/// <c>[BasePath]</c> on a module exists to support.
+/// </para>
+/// <para>
+/// Resolved from the compilation rather than assumed. An imported module only has a links type if
+/// its assembly was compiled with the web generator, and most are not - <c>[KestrelRuntime]</c>
+/// and <c>[HardenedStaticContent]</c> are modules with no routes and no links type - so emitting
+/// a property per import without checking would name types that do not exist.
+/// </para>
+/// </remarks>
+public record ImportedLinksModel(string PropertyName, ITypeDefinition LinksType) {
+
+    /// <summary>
+    /// The imported modules that have links, in a stable order.
+    /// </summary>
+    /// <remarks>
+    /// Ordered by property name so the generated file does not change when the attributes on the
+    /// entry point are reordered, which would otherwise recompute everything downstream.
+    /// </remarks>
+    public static IReadOnlyList<ImportedLinksModel> Read(
+        GeneratorSyntaxContext syntaxContext,
+        ClassDeclarationSyntax entryPoint,
+        IReadOnlyList<AttributeModel> attributes) {
+        var entryPointName = entryPoint.Identifier.Text;
+
+        List<ImportedLinksModel>? found = null;
+
+        foreach (var attribute in attributes) {
+            var moduleName = ModuleName(attribute.TypeDefinition.Name);
+
+            // The entry point imports itself in no useful sense, and its own links are already the
+            // type this property would hang off.
+            if (moduleName == entryPointName) {
+                continue;
+            }
+
+            var linksName = moduleName + "Links";
+            var metadataName = attribute.TypeDefinition.Namespace + "." + linksName;
+
+            // The one question that cannot be answered from syntax: does that module actually
+            // publish links?
+            if (syntaxContext.SemanticModel.Compilation.GetTypeByMetadataName(metadataName) == null) {
+                continue;
+            }
+
+            found ??= new List<ImportedLinksModel>();
+
+            found.Add(new ImportedLinksModel(
+                moduleName,
+                TypeDefinition.Get(attribute.TypeDefinition.Namespace, linksName)));
+        }
+
+        if (found == null) {
+            return Array.Empty<ImportedLinksModel>();
+        }
+
+        found.Sort((left, right) =>
+            string.Compare(left.PropertyName, right.PropertyName, StringComparison.Ordinal));
+
+        return found;
+    }
+
+    /// <summary>
+    /// The module behind an attribute, which is its name without the <c>Attribute</c> suffix.
+    /// </summary>
+    /// <remarks>
+    /// The generated companion of a module class is named after it, so this inverts the one naming
+    /// rule the module system has. Both spellings reach here depending on how the attribute was
+    /// written, which is why the suffix is trimmed rather than assumed present.
+    /// </remarks>
+    private static string ModuleName(string attributeTypeName) =>
+        attributeTypeName.EndsWith("Attribute", StringComparison.Ordinal)
+            ? attributeTypeName.Substring(0, attributeTypeName.Length - "Attribute".Length)
+            : attributeTypeName;
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
@@ -45,6 +45,17 @@ public static class RoutingTableGenerator {
     [ThreadStatic]
     private static IReadOnlyList<RouteConstraintModel>? _constraints;
 
+    /// <summary>
+    /// The entry point's <c>[BasePath]</c>, on the same terms as <see cref="_constraints"/>.
+    /// </summary>
+    /// <remarks>
+    /// Held here so the handler construction sites can compose it onto each route. A handler class
+    /// is generated from its own declarations and cannot see the module's base path, so without
+    /// this it reports the path it was declared with rather than the one it answers on.
+    /// </remarks>
+    [ThreadStatic]
+    private static string? _basePath;
+
     public static void GenerateRoute(SourceProductionContext context,
         (EntryPointSelector.Model Left, ImmutableArray<RequestHandlerModel> Right) models,
         WebGeneratorOptions? options = null,
@@ -117,6 +128,7 @@ public static class RoutingTableGenerator {
     public static string GenerateCSharpRouteFile(EntryPointSelector.Model appModel,
         IReadOnlyList<RequestHandlerModel> handlers, CancellationToken cancellationToken) {
         _caseInsensitive = IsCaseInsensitive(appModel);
+        _basePath = GetBasePath(appModel);
 
         var applicationFile = new CSharpFileDefinition(appModel.EntryPointType.Namespace);
 
@@ -728,7 +740,7 @@ public static class RoutingTableGenerator {
                         "_field" + leafNode.Value.InvokeHandlerType.Name);
 
                 var coalesceHandler = NullCoalesceEqual(field.Instance,
-                    New(leafNode.Value.InvokeHandlerType, "_rootServiceProvider"));
+                    NewHandler(leafNode));
 
                 coalesceHandler.PrintParentheses = false;
 
@@ -783,7 +795,7 @@ public static class RoutingTableGenerator {
                 var cachedInfo = NullCoalesceEqual(infoField.Instance,
                     New(
                         KnownTypes.Web.RequestHandlerInfo,
-                        New(leafNode.Value.InvokeHandlerType, "_rootServiceProvider"),
+                        NewHandler(leafNode),
                         EmptyTokens));
 
                 cachedInfo.PrintParentheses = false;
@@ -798,7 +810,7 @@ public static class RoutingTableGenerator {
                     "_field" + leafNode.Value.InvokeHandlerType.Name);
 
             var coalesceHandler = NullCoalesceEqual(field.Instance,
-                New(leafNode.Value.InvokeHandlerType, "_rootServiceProvider"));
+                NewHandler(leafNode));
 
             coalesceHandler.PrintParentheses = false;
 
@@ -1015,6 +1027,27 @@ public static class RoutingTableGenerator {
         appModel.AttributeModels != null &&
         appModel.AttributeModels.Any(model =>
             model.TypeDefinition.Name.StartsWith("CaseInsensitiveRoutes", StringComparison.Ordinal));
+
+    /// <summary>
+    /// Constructs the handler, telling it the path it is being routed at.
+    /// </summary>
+    /// <remarks>
+    /// The path is composed here, with the same <see cref="RoutePath.Combine"/> that built the
+    /// route tree, rather than at run time from the two parts - so there is no second
+    /// implementation of the base-path rules to drift from this one. The argument is omitted
+    /// entirely when the entry point declares no base path, which keeps the generated table
+    /// unchanged for every application that has none.
+    /// </remarks>
+    private static IOutputComponent NewHandler(RouteTreeLeafNode<RequestHandlerModel> leafNode) {
+        if (string.IsNullOrEmpty(_basePath)) {
+            return New(leafNode.Value.InvokeHandlerType, "_rootServiceProvider");
+        }
+
+        return New(
+            leafNode.Value.InvokeHandlerType,
+            "_rootServiceProvider",
+            QuoteString(RoutePath.Combine(_basePath, leafNode.Value.Name.Path)));
+    }
 
     private static string GetBasePath(EntryPointSelector.Model appModel) {
         if (appModel.AttributeModels != null) {

--- a/src/Templates/Hardened.Templates.RazorBlade.Tests/Support/Pipeline.cs
+++ b/src/Templates/Hardened.Templates.RazorBlade.Tests/Support/Pipeline.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Runtime.QueryString;
 using Hardened.Requests.Testing;
+using Hardened.Shared.Runtime.Collections;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -31,8 +32,46 @@ public static class Pipeline {
     }
 
     /// <summary>
+    /// A context whose body rejects synchronous writes, as a real server's does.
+    /// </summary>
+    /// <param name="withPool">
+    /// False composes the container the way an embedding host might - without the shared runtime
+    /// module, and so without a stream pool. Rendering must not depend on one being there.
+    /// </param>
+    public static IExecutionContext ServerLikeContext(
+        out SynchronousWritesRejectedStream body,
+        string? accept = "text/html",
+        bool withPool = true) {
+        var buffer = new SynchronousWritesRejectedStream();
+        body = buffer;
+
+        var collection = new ServiceCollection();
+
+        if (withPool) {
+            collection.AddSingleton<IMemoryStreamPool, MemoryStreamPool>();
+        }
+
+        var services = collection.BuildServiceProvider();
+
+        var request = new TestExecutionRequest(
+            "GET", "/", accept, new SimpleQueryStringCollection(new Dictionary<string, string>()));
+
+        return new TestExecutionContext(
+            services,
+            services,
+            Substitute.For<IKnownServices>(),
+            request,
+            new TestExecutionResponse(buffer),
+            CancellationToken.None);
+    }
+
+    /// <summary>
     /// What was written to the body, decoded as the bytes on the wire. A BOM survives this;
     /// <c>StreamWriter</c>'s default UTF8 encoding emits one and it is invisible in a debugger.
     /// </summary>
     public static string Rendered(MemoryStream body) => Encoding.UTF8.GetString(body.ToArray());
+
+    /// <inheritdoc cref="Rendered(MemoryStream)" />
+    public static string Rendered(SynchronousWritesRejectedStream body) =>
+        Encoding.UTF8.GetString(body.ToArray());
 }

--- a/src/Templates/Hardened.Templates.RazorBlade.Tests/Support/SynchronousWritesRejectedStream.cs
+++ b/src/Templates/Hardened.Templates.RazorBlade.Tests/Support/SynchronousWritesRejectedStream.cs
@@ -1,0 +1,62 @@
+namespace Hardened.Templates.RazorBlade.Tests.Support;
+
+/// <summary>
+/// A response body that refuses synchronous writes, the way a real server's does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Kestrel's <c>HttpResponseStream</c> throws <c>InvalidOperationException: Synchronous
+/// operations are disallowed</c> unless <c>AllowSynchronousIO</c> is turned on, and it is off by
+/// default on both the Kestrel and the ASP.NET host. A <c>MemoryStream</c> accepts synchronous
+/// writes happily, so a test that renders into one cannot tell the difference between an output
+/// that is safe on a server and one that is not.
+/// </para>
+/// <para>
+/// That gap is the whole reason the buffering defect shipped: the render was verified end to end
+/// against a <c>MemoryStream</c>, so a view over <c>StreamWriter</c>'s 1 KiB buffer looked fine
+/// here and returned an empty 200 in production.
+/// </para>
+/// </remarks>
+public sealed class SynchronousWritesRejectedStream : Stream {
+    private readonly MemoryStream _written = new();
+
+    public byte[] ToArray() => _written.ToArray();
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => _written.Length;
+
+    public override long Position {
+        get => _written.Position;
+        set => throw new NotSupportedException();
+    }
+
+    private static Exception Rejected() =>
+        new InvalidOperationException(
+            "Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO " +
+            "to true instead.");
+
+    public override void Write(byte[] buffer, int offset, int count) => throw Rejected();
+
+    public override void Write(ReadOnlySpan<byte> buffer) => throw Rejected();
+
+    public override void WriteByte(byte value) => throw Rejected();
+
+    public override void Flush() {
+        // Kestrel allows a synchronous Flush that writes nothing; only writes are rejected.
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token) =>
+        _written.WriteAsync(buffer, offset, count, token);
+
+    public override ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer, CancellationToken token = default) =>
+        _written.WriteAsync(buffer, token);
+
+    public override Task FlushAsync(CancellationToken token) => _written.FlushAsync(token);
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+}

--- a/src/Templates/Hardened.Templates.RazorBlade.Tests/SynchronousWriteRegressionTests.cs
+++ b/src/Templates/Hardened.Templates.RazorBlade.Tests/SynchronousWriteRegressionTests.cs
@@ -1,0 +1,113 @@
+using Hardened.Requests.Abstract.Outputs;
+using Hardened.Templates.RazorBlade.Tests.Models;
+using Hardened.Templates.RazorBlade.Tests.Support;
+using Xunit;
+
+namespace Hardened.Templates.RazorBlade.Tests;
+
+/// <summary>
+/// A view is rendered into a buffer and copied out asynchronously, so nothing writes
+/// synchronously to a response body that refuses it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These drive <see cref="SynchronousWritesRejectedStream"/> rather than a <c>MemoryStream</c>.
+/// That is the point of them: every other test in this project writes to a <c>MemoryStream</c>,
+/// which accepts synchronous writes, so none of them could see the defect these cover.
+/// </para>
+/// <para>
+/// What shipped: <c>WriteOutput</c> wrapped a <c>StreamWriter</c> around the response body with
+/// the default 1 KiB character buffer, and RazorBlade's <c>WriteLiteral</c> is synchronous. A view
+/// whose output passed 1 KiB flushed synchronously mid-render, Kestrel threw, and the client got
+/// <c>200</c> with an empty body because the status had already gone out.
+/// </para>
+/// </remarks>
+public class SynchronousWriteRegressionTests {
+
+    /// <summary>Long enough that rendering it must cross StreamWriter's 1 KiB buffer.</summary>
+    private static FortunePage LongPage() =>
+        new(Enumerable.Range(1, 40)
+            .Select(i => new Fortune(i, $"fortune number {i} with enough text to take up room"))
+            .ToList());
+
+    [Fact]
+    public async Task AViewLargerThanTheWriterBufferStillRenders() {
+        var context = Pipeline.ServerLikeContext(out var body);
+
+        context.Response.ResponseValue = LongPage();
+
+        await new Views.LongFortunes().WriteOutput(context);
+
+        var rendered = Pipeline.Rendered(body);
+
+        // The size is the whole point - assert it, so a smaller fixture cannot quietly stop
+        // covering the case.
+        Assert.True(
+            rendered.Length > 1024,
+            $"fixture must exceed StreamWriter's 1 KiB buffer to cover the regression, was {rendered.Length}");
+
+        Assert.Contains("fortune number 1 with enough text", rendered);
+        Assert.Contains("fortune number 40 with enough text", rendered);
+    }
+
+    /// <summary>
+    /// The failure was partial output followed by a throw, so a body that is merely non-empty is
+    /// not enough: the closing markup has to be there too.
+    /// </summary>
+    [Fact]
+    public async Task TheWholeViewArrivesRatherThanTheFirstBufferful() {
+        var context = Pipeline.ServerLikeContext(out var body);
+
+        context.Response.ResponseValue = LongPage();
+
+        await new Views.LongFortunes().WriteOutput(context);
+
+        var rendered = Pipeline.Rendered(body);
+
+        Assert.StartsWith("<ul>", rendered.TrimStart());
+        Assert.EndsWith("</ul>", rendered.TrimEnd());
+        Assert.Equal(40, rendered.Split("class=\"fortune\"").Length - 1);
+    }
+
+    /// <summary>A short view was never broken; it must not become so.</summary>
+    [Fact]
+    public async Task AViewSmallerThanTheWriterBufferStillRenders() {
+        var context = Pipeline.ServerLikeContext(out var body);
+
+        context.Response.ResponseValue = new FortunePage([new Fortune(1, "hello")]);
+
+        await new Views.AttachedFortunes().WriteOutput(context);
+
+        Assert.Contains("<li>1: hello</li>", Pipeline.Rendered(body));
+    }
+
+    /// <summary>
+    /// The buffer is taken from the pool when one is registered, and rendering still works when
+    /// none is - a container composed by hand has no shared-runtime module in it.
+    /// </summary>
+    [Fact]
+    public async Task RenderingWorksWithoutAPooledBuffer() {
+        var context = Pipeline.ServerLikeContext(out var body, withPool: false);
+
+        context.Response.ResponseValue = LongPage();
+
+        await new Views.LongFortunes().WriteOutput(context);
+
+        Assert.Contains("fortune number 40", Pipeline.Rendered(body));
+    }
+
+    [Fact]
+    public async Task NoByteOrderMarkReachesTheBody() {
+        var context = Pipeline.ServerLikeContext(out var body);
+
+        context.Response.ResponseValue = LongPage();
+
+        await new Views.LongFortunes().WriteOutput(context);
+
+        var bytes = body.ToArray();
+
+        Assert.False(
+            bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF,
+            "a BOM in the body shows up as stray characters ahead of the markup");
+    }
+}

--- a/src/Templates/Hardened.Templates.RazorBlade.Tests/Views/LongFortunes.cshtml
+++ b/src/Templates/Hardened.Templates.RazorBlade.Tests/Views/LongFortunes.cshtml
@@ -1,0 +1,15 @@
+@using Hardened.Templates.RazorBlade.Tests.Models
+@*
+    Deliberately more than a kilobyte of output. StreamWriter's default character buffer is 1 KiB,
+    so a view this size is the smallest thing that forces a flush mid-render - which is what used
+    to reach the response stream synchronously and fail on a real server.
+
+    global:: because this assembly's namespace ends in RazorBlade.
+*@
+@inherits global::Hardened.Templates.RazorBlade.HardenedHtmlTemplate<Hardened.Templates.RazorBlade.Tests.Models.FortunePage>
+<ul>
+@foreach (var fortune in Model.Fortunes)
+{
+    <li class="fortune" data-id="@fortune.Id"><span class="id">@fortune.Id</span><span class="message">@fortune.Message</span></li>
+}
+</ul>

--- a/src/Templates/Hardened.Templates.RazorBlade/HardenedHtmlTemplate.cs
+++ b/src/Templates/Hardened.Templates.RazorBlade/HardenedHtmlTemplate.cs
@@ -1,6 +1,8 @@
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Outputs;
 using Hardened.Requests.Abstract.Serializer;
+using Hardened.Shared.Runtime.Collections;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text;
 
 namespace Hardened.Templates.RazorBlade;
@@ -30,6 +32,8 @@ namespace Hardened.Templates.RazorBlade;
 /// Inheriting the non-generic base and declaring our own <see cref="Model"/> sidesteps both:
 /// parameterless construction is correct, and there is no constructor for anyone to generate.
 /// Verified end to end - <c>@inherits</c>, <c>@Model</c> and a generated links property all render.
+/// Note that "end to end" there means the inheritance shape; the render path itself is covered by
+/// <c>SynchronousWriteRegressionTests</c>, which drives a body that refuses synchronous writes.
 /// </para>
 /// </remarks>
 public abstract class HardenedHtmlTemplate<TModel> : global::RazorBlade.HtmlTemplate,
@@ -72,6 +76,33 @@ public abstract class HardenedHtmlTemplate<TModel> : global::RazorBlade.HtmlTemp
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// <b>Rendered into a buffer, then copied to the body in one asynchronous write.</b> The
+    /// obvious implementation - a <c>StreamWriter</c> around <c>Response.Body</c> - cannot work,
+    /// because RazorBlade's <c>WriteLiteral</c> is a synchronous <c>TextWriter.Write</c>. A
+    /// <c>StreamWriter</c> flushes when its character buffer fills, so a view whose output passed
+    /// the default 1 KiB flushed synchronously onto the response stream, and every server that
+    /// refuses synchronous IO - Kestrel and the ASP.NET host both, by default - threw
+    /// <c>Synchronous operations are disallowed</c> from the middle of the render.
+    /// </para>
+    /// <para>
+    /// The status line had already gone out by then, so the client got <c>200</c> with an empty
+    /// body. Views under 1 KiB rendered fine, which is what made it survive: it is a function of
+    /// how much a page emits rather than of anything the application does, so it passes every
+    /// small test and fails on the first real page.
+    /// </para>
+    /// <para>
+    /// Buffering removes the synchronous write rather than tolerating it - flushes to a
+    /// <c>MemoryStream</c> do no IO - and is what ASP.NET Core MVC does for the same reason. The
+    /// buffer comes from <see cref="IMemoryStreamPool"/> where the application registered one, so
+    /// a page costs a pooled stream rather than a fresh allocation per request.
+    /// </para>
+    /// <para>
+    /// The tests that missed this wrote to a <c>MemoryStream</c>, which accepts synchronous writes.
+    /// <c>SynchronousWritesRejectedStream</c> in the test project is the double that does not.
+    /// </para>
+    /// </remarks>
     public async Task WriteOutput(IExecutionContext context) {
         Attach(context.Response.ResponseValue, context);
 
@@ -82,13 +113,21 @@ public abstract class HardenedHtmlTemplate<TModel> : global::RazorBlade.HtmlTemp
             context.Response.ContentType = ContentType;
         }
 
-        // leaveOpen: the response body outlives this render - headers, trailers and the host's own
-        // completion all still need it.
-        await using var writer = new StreamWriter(context.Response.Body, Utf8NoBom, -1, true);
+        // GetService rather than GetRequiredService: the pool is registered by the shared runtime
+        // module, and a view rendered from a container composed by hand - which the tests do, and
+        // an embedding host may - must still render.
+        using var reservation = context.RequestServices.GetService<IMemoryStreamPool>()?.Get();
 
-        await RenderAsync(writer, context.CancellationToken);
+        var buffer = reservation?.Item ?? new MemoryStream(1024);
 
-        await writer.FlushAsync();
+        // leaveOpen so disposing the writer does not close a stream the pool is about to reclaim.
+        await using (var writer = new StreamWriter(buffer, Utf8NoBom, -1, true)) {
+            await RenderAsync(writer, context.CancellationToken);
+        }
+
+        buffer.Position = 0;
+
+        await buffer.CopyToAsync(context.Response.Body, context.CancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
A first-adopter run against 0.8.0-rc1000 — build a real application from the published packages, follow the public docs, read the source only when something breaks — produced eleven findings. Three were code defects. This closes all three and writes down the plan for the rest.

## The defects

All three were silent, and every one of them was covered by an existing test that could not fail.

**RazorBlade views over ~1 KiB returned HTTP 200 with an empty body.** `HardenedHtmlTemplate.WriteOutput` wrapped a `StreamWriter` around the response body, and RazorBlade's `WriteLiteral` is a synchronous `TextWriter.Write` — so once a view passed the writer's default 1 KiB buffer it flushed synchronously and Kestrel refused, mid-render, after the status line had gone out. Views under 1 KiB were fine, which is why it survived: it is a function of how much a page emits rather than of anything the application does.

Rendering now goes into a pooled buffer and out in one asynchronous write, which is what ASP.NET Core MVC does for the same reason. The tests missed it because they render into a `MemoryStream`, which accepts synchronous writes; `SynchronousWritesRejectedStream` is the double that does not.

**A handler reported the path it was declared with rather than the one it answers.** A handler class is generated from its own declarations, so it knew its controller's `[BasePath]` and not the module's — a route served at `/catalog/books` described itself as `/books`. `IGlobalFilterRegistry`'s per-handler overload is documented as deciding by path, so the documented `handlerInfo.Path.StartsWith("/catalog")` matched nothing and the filter silently never ran, for every route in every library that owns a URL space.

The routing table now passes the path it routed at, composed by the same `RoutePath.Combine` that built the tree — so there is no second implementation of the base-path rules to drift from the first.

**A view could not reach a library module's routes.** Links are generated per module, so an application whose routes live in libraries had an empty `ApplicationLinks`, and that is the type a generated template base hard-types its `Links` property to. `ApplicationLinks` now carries a property per imported module that publishes links, named for the module, so `@Links.CatalogLibrary.Book.ById(id)` binds. Resolved against the compilation rather than assumed, because most modules have no routes and so no links type to name.

## Verification

Each fix has a regression test confirmed to fail against the old code first — 3 of 5 for the template fix, 2 of 3 for the handler path.

Full suite: **4,239 passing, 0 failing.** One public API addition (`ExecutionRequestHandlerInfo.WithPath`); the surface guard caught it and the approved file is updated with that one line.

Verified end to end against a local pack: the audit sample now runs with zero workarounds — the hand-written template base deleted, the audit filter back on the documented `Path.StartsWith` shape, 14 tests green, no server errors.

## Plans

`docs/DOCS-PLAN.md` — nine of the eleven findings were documentation, in four classes that all follow from one structural fact: the docs live in a different repository from the code, so snippets cannot be compiled, inventories cannot be generated, and a package can ship with no page and nothing notices. The guide pages themselves are the asset; the plan does not touch them.

`docs/TEMPLATE-PLAN.md` — templates named for workload, host as an option, and a CI assertion that generating the same project per host differs only in the host project. That turns the framework's central claim into something checked rather than asserted.

Also worth knowing, found while packing locally: the conditional `ProjectReference` in `Hardened.Requests.Runtime.csproj` picks up a sibling `ValidationModules` checkout if one exists, and packs a dependency on a version that was never published. Harmless on a clean machine, silent when it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnz6FBUjT29qfiMbzj85eD