### PR TITLE
Stop publishing Hardened.DependencyModules.SourceGenerator

### DIFF
--- a/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.DependencyModules.SourceGenerator/Hardened.DependencyModules.SourceGenerator.csproj
@@ -24,8 +24,22 @@
         -->
         <NoWarn>$(NoWarn);RS2008</NoWarn>
         <Nullable>enable</Nullable>
-        <IsPackable>True</IsPackable>
-        <PackageId>Hardened.DependencyModules.SourceGenerator</PackageId>
+        <!--
+          Not packable, deliberately.
+
+          This generator reaches consumers inside Hardened.Library.SourceGenerator, which packs
+          this project's DLL into its own analyzers/dotnet/cs by path - see the None Include there.
+          Nothing needs it on its own: a project that declares a module wants the configuration and
+          service-provider generators in the same breath, and referencing both packages would load
+          this analyzer twice and emit every generated type twice.
+
+          The standalone package was published once, at 0.1.0-rc1, and never again. It is still
+          named in the docs as what emits PopulateServiceCollection, which sends readers to a
+          version four release lines behind everything else. Publishing it on the line would put a
+          second copy of the same analyzer on the feed to solve a problem nobody has; this ends the
+          question the other way.
+        -->
+        <IsPackable>False</IsPackable>
         <IncludeBuildOutput>false</IncludeBuildOutput>
 
         <!--


### PR DESCRIPTION
The generator reaches consumers inside `Hardened.Library.SourceGenerator`, which packs this project's DLL into its own `analyzers/dotnet/cs` by path. Nothing needs it on its own — a project that declares a module wants the configuration and service-provider generators in the same breath, and referencing both packages would load the analyzer twice and emit every generated type twice.

It was published once, at `0.1.0-rc1`, and never again, while `reference/packages` still names it as what emits `PopulateServiceCollection` — sending readers to a version four release lines behind everything else. It was packable, so the next tag would have put a second copy of the same analyzer on the feed to solve a problem nobody has.

Verified by packing: no such package is produced, and `Hardened.Library.SourceGenerator` still carries both analyzer DLLs.

Leaves one thing that needs a nuget.org account rather than a commit: `0.1.0-rc1` is still listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnz6FBUjT29qfiMbzj85eD