### PR TITLE
Scope the spec-first generators, and stop naming the port we avoid

### DIFF
--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -101,7 +101,7 @@ service.
 ```bash
 dotnet build
 dotnet test
-dotnet run --project src/Hardened1.Host        # PORT=5080 by default
+dotnet run --project src/Hardened1.Host        # listens on 5080, override with PORT
 curl localhost:5080/greeting/world
 ```
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
@@ -38,4 +38,4 @@ namespace Hardened1.Host;
 #endif
 #endif
 [Hardened1Library]
-public partial class Application { }
+public partial class Application;

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 #endif
 
-// PORT so the sample can move off 5000, which macOS hands to AirPlay Receiver.
+// Listens on 5080. Override with PORT.
 var port = int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var configured) ? configured : 5080;
 
 #if (kestrel)
@@ -28,6 +28,11 @@ new Application().PopulateServiceCollection(services);
 await using var app = HardenedKestrelApplication.Create(
     services,
     kestrel => kestrel.ListenAnyIP(port));
+
+// Printed, so the address is read rather than guessed. The ASP.NET host does this for you.
+app.Services.GetRequiredService<ILoggerFactory>()
+    .CreateLogger("Hardened1.Host")
+    .LogInformation("Listening on http://localhost:{Port}", port);
 
 await app.RunAsync();
 #endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
@@ -19,30 +19,24 @@
       later would otherwise compile and silently never run.
     -->
     <PackageReference Include="Hardened.Validation.SourceGenerator" />
+    <!--
+      PrivateAssets="all" so the generators stay in this project.
+      
+      The front end brings Hardened.Idl.SourceGenerator with it - the Roslyn generator that turns
+      the normalised contract into handlers and a routing table - and that package is deliberately
+      not a development dependency, so it can arrive transitively. Which means it also travels on
+      through this project's own ProjectReference into whatever references it. In the host, where
+      Hardened.Web.SourceGenerator is already emitting a routing table and a links type for the
+      application module, that is CS0101 on every generated name.
+
+      One attribute stops the whole subtree at this project's boundary, which is where a build-time
+      generator belongs anyway.
+    -->
 <!--#if (openapi) -->
-    <PackageReference Include="Hardened.OpenApi.SourceGenerator" />
+    <PackageReference Include="Hardened.OpenApi.SourceGenerator" PrivateAssets="all" />
 <!--#endif -->
 <!--#if (smithy) -->
-    <PackageReference Include="Hardened.Smithy.SourceGenerator" />
-<!--#endif -->
-<!--#if (specFirst) -->
-    <!--
-      Both. The OpenAPI and Smithy packages carry only an MSBuild task, which normalises the
-      contract into models, a service interface and validation. The Roslyn generator that turns
-      that model into request handlers and a routing table is this one, and it is a dependency of
-      neither - analyzers do not flow through a package reference anyway.
-
-      Leaving it out compiles, starts, and answers 404 to every route in the document.
-
-      It also replaces Hardened.Web.SourceGenerator rather than joining it: both emit the routing
-      table and the links type, so referencing the pair is CS0101 on every generated name.
-
-      PrivateAssets="all" because this one is not marked as a development dependency - by design,
-      so it can arrive transitively from the front-end package. That has not happened yet, so it
-      is referenced directly here, and without this it would flow on to the host project and
-      collide with the web generator there.
-    -->
-    <PackageReference Include="Hardened.Idl.SourceGenerator" PrivateAssets="all" />
+    <PackageReference Include="Hardened.Smithy.SourceGenerator" PrivateAssets="all" />
 <!--#endif -->
   </ItemGroup>
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1Library.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1Library.cs
@@ -19,4 +19,4 @@ namespace Hardened1;
 // This assembly's URL space. Every route below it is relative to this.
 [BasePath("/greeting")]
 #endif
-public partial class Hardened1Library { }
+public partial class Hardened1Library;


### PR DESCRIPTION
Two follow-ups to the template, both found by running it rather than reading it.

## One generator package per contract

#151 gave the OpenAPI and Smithy front ends a dependency on `Hardened.Idl.SourceGenerator` with `include="All"`, so the Roslyn generator that turns a normalised contract into handlers and a routing table now arrives on its own. The template was written before that landed and named it explicitly; that reference is gone.

What replaced it is one attribute, for the second-order effect the same design produces.

`Idl.SourceGenerator` is deliberately not a development dependency — that is what lets it arrive transitively, and what makes referencing OpenAPI and Smithy together yield exactly one analyzer. It also means it keeps travelling: out of the library, through the `ProjectReference`, into the host. There `Hardened.Web.SourceGenerator` is already emitting `ApplicationRoutes` and `ApplicationLinks` for the application module, so a second generator emitting the same names is `CS0101` on every one of them.

Two hops, opposite requirements, and NuGet treats them as the same kind of edge:

| Hop | Should the analyzer flow? |
|---|---|
| front-end package → library | **yes**, that is the point |
| library → host, via `ProjectReference` | **no**, it collides |

`PrivateAssets="all"` on the front-end reference stops the subtree at the library boundary, which is where a build-time generator belongs.

**Worth knowing beyond this PR:** any specification-first application with a library and a host hits this, and the symptom is duplicate-type errors inside generated code that name nothing about the cause. It deserves a line wherever spec-first is documented, or a diagnostic if it should be caught rather than read.

## Stop naming the port we avoid

The template listened on 5080 and carried a comment explaining that 5000 was avoided because macOS answers it with a 403 from AirPlay. Predictably, the number a reader took away was 5000 — including from a `403` that looked like the application refusing them.

So the template says 5080 and nothing else, and the Kestrel host now logs its address on start:

```
Listening on http://localhost:5080
```

The ASP.NET host already did this, which is why only one of the two needed the port documented at all. An address that is printed is not guessed.

`Hardened.Web.Kestrel.Runtime/README.md` still shows `ListenAnyIP(5000)`. That is the package README on nuget.org rather than the template, so it is left alone here.

## Also

The two module declarations use a semicolon body rather than an empty brace pair.

## Verification

Full smoke green across all four combinations — generated, restored, built, tested and curled from the packed nupkg, with the library and tests byte-identical across hosts.

```
kestrel:code     2 tests  200  /docs dev=200 prod=404
aspnet:code      2 tests  200  /docs dev=200 prod=404
kestrel:openapi  3 tests  200  /docs dev=200 prod=200
kestrel:smithy   3 tests  200  /docs dev=404 prod=404
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnz6FBUjT29qfiMbzj85eD