### PR TITLE
Publish the template, and stamp it from the version the release sets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,7 +225,8 @@ jobs:
             src/Web/Hardened.Web.Kestrel.Runtime/Hardened.Web.Kestrel.Runtime.csproj \
             src/Web/Hardened.Web.StaticContent/Hardened.Web.StaticContent.csproj \
             src/Web/Hardened.Web.Testing/Hardened.Web.Testing.csproj \
-            src/Templates/Hardened.Templates.RazorBlade/Hardened.Templates.RazorBlade.csproj; do
+            src/Templates/Hardened.Templates.RazorBlade/Hardened.Templates.RazorBlade.csproj \
+            src/Templates/Hardened.Templates/Hardened.Templates.csproj; do
             dotnet pack "$project" --configuration Release --no-build --output ./artifacts \
               "/p:PackageVersion=${{ steps.version.outputs.version }}"
           done
@@ -254,7 +255,10 @@ jobs:
           # and were never listed, and Hardened.Web.StaticContent, which arrived in #146 and was
           # not either. The check above could not catch any of them - it compares the count against
           # this number, so a package nobody added is a package nobody misses.
-          EXPECTED=21
+          # 22 after Hardened.Templates, the dotnet new templates, arrived in #154. It was added to
+          # the solution and not here, so the coverage check above would have failed the next
+          # release - which is the check working, and the fourth time this list has drifted.
+          EXPECTED=22
           ACTUAL=$(ls -1 ./artifacts/*.nupkg 2>/dev/null | wc -l | tr -d ' ')
 
           if [ "$ACTUAL" != "$EXPECTED" ]; then

--- a/src/Templates/Hardened.Templates/Hardened.Templates.csproj
+++ b/src/Templates/Hardened.Templates/Hardened.Templates.csproj
@@ -35,6 +35,11 @@
 
         Staged into obj/ and packed from there, so pack leaves the working tree clean and the
         0.0.0-DEV token survives in source for the next build to substitute.
+
+        $(PackageVersion) rather than $(Version), because the release sets the first and not the
+        second - stamping the second would have shipped a template pinning 1.0.0 while the package
+        itself said 0.9.0. It defaults to $(Version) when unset, so an ordinary
+        `dotnet pack -p:Version=x` is unaffected.
     -->
     <PropertyGroup>
         <!-- obj/ spelled out rather than $(IntermediateOutputPath), which the SDK sets in its
@@ -50,7 +55,7 @@
         after the Exec has written the staged copy.
     -->
     <Target Name="StageTemplates" BeforeTargets="GenerateNuspec">
-        <Exec Command="python3 &quot;$(MSBuildProjectDirectory)/stage-templates.py&quot; &quot;$(MSBuildProjectDirectory)/templates&quot; &quot;$(_TemplateStage)&quot; &quot;$(Version)&quot;" />
+        <Exec Command="python3 &quot;$(MSBuildProjectDirectory)/stage-templates.py&quot; &quot;$(MSBuildProjectDirectory)/templates&quot; &quot;$(_TemplateStage)&quot; &quot;$(PackageVersion)&quot;" />
 
         <ItemGroup>
             <_PackageFiles Include="$(_TemplateStage)/**/*">


### PR DESCRIPTION
Two things that would have gone wrong at the next tag, both introduced by #154 and both found by asking "how does a released template get the latest packages?"

## The template was never going to be published

`Hardened.Templates` is packable and was added to the solution, but not to `release.yaml`'s pack list. The coverage check above that list would have caught it — it fails the release when a packable project is absent — so the tag would have stopped rather than shipped a template nobody could install.

That is the fourth time this list has drifted, and the fourth time the check has earned itself. Added; `EXPECTED` raised to 22.

## And it would have stamped the wrong version

The staging step read `$(Version)`. The release passes `/p:PackageVersion`.

Nothing would have failed loudly. The package would have carried the right version, and the template inside it would have pinned `1.0.0` — so every project generated from the release would try to restore a framework that does not exist. It now reads `$(PackageVersion)`, which defaults to `$(Version)` when unset. Verified by packing both ways and reading the stamp back out of the nupkg:

```
-p:Version=7.7.7-check         package=Hardened.Templates.7.7.7-check.nupkg  template stamps=7.7.7-check
-p:PackageVersion=7.7.7-check  package=Hardened.Templates.7.7.7-check.nupkg  template stamps=7.7.7-check
```

## What this means for keeping the template current

**The Hardened version needs no maintenance.** The template stamps whatever version it was packed at, so every release ships a template pinning that release. Confirmed by packing at `0.9.0-rc1000` and reading `<HardenedVersion>0.9.0-rc1000</HardenedVersion>` out of a generated project.

**The corollary is that the template must ship with the framework, never against an older one.** It can only use API present in the version it pins. It currently uses `HardenedOpenApiUi.Environments`, which does not exist in `0.9.0-rc1000`, so a template packed at that version generates a project that does not compile — correctly. The smoke packs both together, which is what keeps them in step.

**The third-party pins should not chase latest.** `xunit.v3` is at `3.2.2` in the template because `Hardened.Shared.Testing` depends on `xunit.v3.extensibility.core 3.2.2` and every test project in this repository pins the same. `4.0.0` is available and would put the template ahead of the framework with a conflicting extensibility core. That coupling is real and currently unchecked — a gate asserting the template's xunit pin equals what `Hardened.Shared.Testing` declares would close it.

## Verification

Full smoke green across all four combinations. The release coverage check run locally reports no missing projects, and the pack list has 22 entries matching `EXPECTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnz6FBUjT29qfiMbzj85eD