### PR TITLE
Finish the templates: kebab options, a README, Smithy metadata, one gate

### DIFF
--- a/.github/workflows/templates.yaml
+++ b/.github/workflows/templates.yaml
@@ -3,7 +3,7 @@ name: templates
 # Its own workflow rather than a job in build-package, because it packs the whole framework to a
 # temporary feed and installs the result. That is slow, and it answers a different question:
 # build-package asks whether the framework compiles, this asks whether a stranger running
-# `dotnet new hardened-web` gets something that runs.
+# `dotnet new hardened-web` gets something that builds, tests and serves.
 on:
   push:
     branches: [main]
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  smoke:
+  verify:
     runs-on: ubuntu-latest
 
     env:
@@ -30,12 +30,12 @@ jobs:
           dotnet-version: 8.0.x
 
       # The template pins net8.0 and its generated projects must build on the SDK a reader is
-      # most likely to have, not only on the newest one. Both are installed so the smoke run
+      # most likely to have, not only on the newest one. Both are installed so the verification run
       # exercises the floor rather than assuming it.
       - name: Show the SDKs in play
         run: dotnet --list-sdks
 
-      # The smoke packs the whole solution, which builds the Smithy fixtures, and the --contract
+      # Verification packs the whole solution, which builds the Smithy fixtures, and the --contract
       # smithy variant compiles a model of its own - so the CLI is needed twice over. The script
       # skips that variant when the pinned version is absent rather than failing, which would
       # quietly reduce what this gate covers; installing it here is what keeps the matrix whole.
@@ -73,4 +73,4 @@ jobs:
       # Everything the run needs is in the script, so the workflow is one line and the same
       # command works on a laptop. A CI-only invocation is one nobody can reproduce when it fails.
       - name: Generate, build, test and serve from the packed template
-        run: ./scripts/template-smoke.sh
+        run: ./scripts/verify-templates.sh

--- a/docs/TEMPLATE-PLAN.md
+++ b/docs/TEMPLATE-PLAN.md
@@ -91,7 +91,7 @@ shapes of code.
 `--trigger` values are host-scoped in a way `--host` values are not: SQS is AWS, Pub/Sub would be
 GCP. `template.json` choice symbols cannot express "valid only when `--host` is X", so an invalid
 pair has to fail somewhere. Fail it in a post-action with a message naming the valid pairs, and
-keep the smoke matrix to real combinations.
+keep the verification matrix to real combinations.
 
 ## The default route
 
@@ -128,12 +128,12 @@ would either put the whole application two release lines back or mix build lines
 
 > Hardened.Amz tracked a framework three release lines old that way, with a green build throughout.
 
-The template is the forcing function. A smoke test that restores a generated Lambda project fails
+The template is the forcing function. Verification that restores a generated Lambda project fails
 on the version conflict, where a green build did not. Ship `hardened-web --host kestrel|aspnet`
 first; add `aws-lambda` when Amz tracks the line.
 
 **Azure and GCP do not exist yet.** The point of this factoring is that they are additive: a host
-directory, one value in a choice symbol, one row in the smoke matrix. Nothing about the
+directory, one value in a choice symbol, one row in the verification matrix. Nothing about the
 implementation library or the tests changes, and the CI assertion says so out loud.
 
 ## Packaging and distribution
@@ -180,7 +180,7 @@ recommend.
 
 Two jobs, and the second is the one that matters.
 
-**Smoke, per variant.** Install the *packed* nupkg, `dotnet new`, restore, build, test, run,
+**Verify, per variant.** Install the *packed* nupkg, `dotnet new`, restore, build, test, run,
 `curl` the default route. Not a project reference — the artifact users get. A template built in
 the solution with `ProjectReference`s proves nothing about packaging, which is where the
 0.8.0-rc1000 quickstart broke.
@@ -190,7 +190,7 @@ the solution with `ProjectReference`s proves nothing about packaging, which is w
 central claim, checked mechanically, and it is the thing that will keep Azure and GCP honest when
 they arrive.
 
-Generate the smoke matrix from the choice symbol's values so a new host cannot be added without
+Generate the verification matrix from the choice symbol's values so a new host cannot be added without
 being tested.
 
 ## Sequencing

--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 #
-# Build the framework and the template, install the packed template, generate a project from it,
-# and prove the result restores, builds, tests and serves.
+# Verify the templates: build the framework, pack it and them, install the packed template,
+# generate a project from every supported combination, and prove each one restores, builds, tests
+# and serves. This is the gate a release runs.
 #
 # The packed nupkg is installed rather than the template folder, deliberately. A template tested
 # from source proves nothing about packaging, which is where the 0.8.0-rc1000 quickstart broke.
 #
-# Usage: scripts/template-smoke.sh [host:contract ...]
+# Usage: scripts/verify-templates.sh [host:contract ...]
 #        default: kestrel:code aspnet:code kestrel:openapi kestrel:smithy
 #
 # smithy is skipped unless the Smithy CLI is on PATH at the pinned version - a build without it
@@ -16,11 +17,11 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Unique per run, and that is not cosmetic. NuGet caches an extracted package by id and version
 # in the global packages folder, so a fixed version means the second run restores the first run's
-# content however many times the framework has been rebuilt since - a green smoke over stale
-# packages, which is worse than no smoke at all.
-VERSION="0.0.0-smoke$(date +%s)"
-FEED="${TMPDIR:-/tmp}/hardened-smoke-feed"
-WORK="${TMPDIR:-/tmp}/hardened-smoke-work"
+# content however many times the framework has been rebuilt since - a green run over stale
+# packages, which is worse than no run at all.
+VERSION="0.0.0-verify$(date +%s)"
+FEED="${TMPDIR:-/tmp}/hardened-template-feed"
+WORK="${TMPDIR:-/tmp}/hardened-template-work"
 SMITHY_PIN=1.73.0
 
 COMBOS=("$@")
@@ -41,7 +42,7 @@ rm -rf "$FEED" "$WORK"
 mkdir -p "$FEED" "$WORK"
 
 # Previous runs' packages, which are never referenced again.
-find "${NUGET_PACKAGES:-$HOME/.nuget/packages}" -maxdepth 2 -type d -name '0.0.0-smoke*' \
+find "${NUGET_PACKAGES:-$HOME/.nuget/packages}" -maxdepth 2 -type d -name '0.0.0-verify*' \
     -exec rm -rf {} + 2>/dev/null || true
 
 # Pack output is noisy with pre-existing NU5100/NU5128 about build tasks that deliberately sit
@@ -79,7 +80,11 @@ pack framework "$REPO/src/Hardened.Framework.sln" \
 pack template "$REPO/src/Templates/Hardened.Templates/Hardened.Templates.csproj"
 
 say "installing the packed template"
+# Both spellings: a folder install from the inner loop registers under its path rather than the
+# package id, and it shadows the packed one with the same template identity - so the verification would
+# silently exercise the working tree instead of the artifact.
 dotnet new uninstall Hardened.Templates >/dev/null 2>&1 || true
+dotnet new uninstall "$REPO/src/Templates/Hardened.Templates/templates/hardened-web" >/dev/null 2>&1 || true
 dotnet new install "$FEED/Hardened.Templates.$VERSION.nupkg"
 
 FAILED=0
@@ -93,11 +98,11 @@ for COMBO in "${COMBOS[@]}"; do
     # --HardenedVersion is deliberately NOT passed. The template stamps the version it was
     # packed with as the default, and that default is what a real user gets - so it is what
     # needs testing. Passing it here would test the flag and leave the default unexercised.
-    dotnet new hardened-web -n Smoke -o "$OUT" --host "$HOST" --contract "$CONTRACT" --skipRestore
+    dotnet new hardened-web -n Sample -o "$OUT" --host "$HOST" --contract "$CONTRACT" --skip-restore
 
     # The generated nuget.config names nuget.org only, which is what a real user wants. The
-    # smoke run also needs the framework build that has not been published yet.
-    dotnet nuget add source "$FEED" --name smoke-local --configfile "$OUT/nuget.config" >/dev/null
+    # verification run also needs the framework build that has not been published yet.
+    dotnet nuget add source "$FEED" --name template-verify-local --configfile "$OUT/nuget.config" >/dev/null
 
     ( cd "$OUT" && dotnet build -v q --nologo )
     ( cd "$OUT" && dotnet test --no-build -v q --nologo )
@@ -108,7 +113,7 @@ for COMBO in "${COMBOS[@]}"; do
     # second probe silently talks to the first probe's process.
     serve() {
         local port="$1" env_name="$2" log="$3"
-        ( cd "$OUT/src/Smoke.Host" && PORT="$port" HARDENED_ENVIRONMENT="$env_name" \
+        ( cd "$OUT/src/Sample.Host" && PORT="$port" HARDENED_ENVIRONMENT="$env_name" \
             dotnet run --no-build >"$log" 2>&1 & )
 
         for _ in $(seq 1 60); do
@@ -123,7 +128,7 @@ for COMBO in "${COMBOS[@]}"; do
     }
 
     stop() {
-        pkill -f "$OUT/src/Smoke.Host" 2>/dev/null || true
+        pkill -f "$OUT/src/Sample.Host" 2>/dev/null || true
         sleep 0.5
     }
 
@@ -172,22 +177,17 @@ for COMBO in "${COMBOS[@]}"; do
         # Both were probed while their server was up; re-asking here would ask a dead port.
         echo "   /docs  development=$DOCS_DEV  production=$DOCS_PROD"
 
-        # Asserted for code-first only, because that is the only path with a gate. A spec-first
-        # application installs its reference page through UiUrl metadata on the contract item,
-        # which has no environment story at all - so its page is served in every environment,
-        # and asserting otherwise here would be asserting a framework gap closed.
-        if [ "$CONTRACT" = "code" ]; then
-            if [ "$DOCS_DEV" != "200" ]; then
-                echo "   FAILED: the reference page should be served in development"
-                FAILED=1
-            fi
+        # Asserted for every contract. Code-first gates with
+        # [HardenedOpenApiUi(Environments = ...)]; spec-first with UiEnvironments metadata on the
+        # contract item. Both reach the same module, so both are held to the same answer.
+        if [ "$DOCS_DEV" != "200" ]; then
+            echo "   FAILED: the reference page should be served in development"
+            FAILED=1
+        fi
 
-            if [ "$DOCS_PROD" = "200" ]; then
-                echo "   FAILED: the reference page reached production"
-                FAILED=1
-            fi
-        else
-            echo "   note: spec-first installs its page from contract metadata, which is not gated"
+        if [ "$DOCS_PROD" = "200" ]; then
+            echo "   FAILED: the reference page reached production"
+            FAILED=1
         fi
     else
         echo "   FAILED: status=$CODE body='$BODY'"
@@ -204,7 +204,7 @@ A="$WORK/kestrel-code"; B="$WORK/aspnet-code"
 if [ -d "$A" ] && [ -d "$B" ]; then
     # Source only. bin/ and obj/ carry absolute paths and compiler output, which differ for
     # reasons that have nothing to do with the host.
-    for PART in src/Smoke tests/Smoke.Tests; do
+    for PART in src/Sample tests/Sample.Tests; do
         if diff -r -x bin -x obj "$A/$PART" "$B/$PART" >/dev/null 2>&1; then
             echo "   identical across hosts: $PART"
         else
@@ -217,5 +217,5 @@ fi
 
 dotnet new uninstall Hardened.Templates >/dev/null 2>&1 || true
 
-say "$([ $FAILED -eq 0 ] && echo 'smoke passed' || echo 'SMOKE FAILED')"
+say "$([ $FAILED -eq 0 ] && echo 'templates verified' || echo 'TEMPLATE VERIFICATION FAILED')"
 exit $FAILED

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.Web.SUT/Hardened.IntegrationTests.Web.SUT.csproj
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.Web.SUT/Hardened.IntegrationTests.Web.SUT.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
+++ b/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
@@ -283,6 +283,7 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
 
         model.PublishUrl = Absolute(publishUrl);
         model.UiUrl = Absolute(uiUrl);
+        model.UiEnvironments = spec.GetMetadata("UiEnvironments").Trim();
 
         return true;
     }

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/ServiceSpecModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/ServiceSpecModel.cs
@@ -36,6 +36,16 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     public string UiUrl { get; set; } = "";
 
     /// <summary>
+    /// The environments the reference page is served in, comma separated, or empty for all of them.
+    /// </summary>
+    /// <remarks>
+    /// From <c>UiEnvironments</c> metadata, and passed straight to <c>HardenedOpenApiUi</c> - so a
+    /// specification-first page is gated exactly the way an attribute-declared one is, rather than
+    /// being the one route in an application that cannot be.
+    /// </remarks>
+    public string UiEnvironments { get; set; } = "";
+
+    /// <summary>
     /// What the build task emitted for validation, per operation. Empty when nothing is constrained.
     /// </summary>
     public List<ValidatedOperationModel> ValidatedOperations { get; set; } = new();
@@ -47,6 +57,7 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
         if (JsonTypeInfoResolverName != other.JsonTypeInfoResolverName) return false;
         if (PublishUrl != other.PublishUrl) return false;
         if (UiUrl != other.UiUrl) return false;
+        if (UiEnvironments != other.UiEnvironments) return false;
         if (Schemas.Count != other.Schemas.Count) return false;
         if (Services.Count != other.Services.Count) return false;
         if (FilterTypes.Count != other.FilterTypes.Count) return false;

--- a/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
@@ -45,6 +45,7 @@ internal static class SpecModelSerializer {
         spec.Add("JsonTypeInfoResolverName", model.JsonTypeInfoResolverName);
         spec.Add("PublishUrl", model.PublishUrl);
         spec.Add("UiUrl", model.UiUrl);
+        spec.Add("UiEnvironments", model.UiEnvironments);
         spec.WriteTo(builder);
 
         foreach (var schema in model.Schemas) {
@@ -105,6 +106,7 @@ internal static class SpecModelSerializer {
                     model.JsonTypeInfoResolverName = record.String("JsonTypeInfoResolverName") ?? "";
                     model.PublishUrl = record.String("PublishUrl") ?? "";
                     model.UiUrl = record.String("UiUrl") ?? "";
+                    model.UiEnvironments = record.String("UiEnvironments") ?? "";
                     break;
 
                 case "schema":

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRegistration.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRegistration.cs
@@ -28,8 +28,14 @@ namespace Hardened.Idl.SourceGenerator;
 /// <param name="UiUrl">
 /// Where its reference page is served, from <c>UiUrl</c> metadata, or empty when there is none.
 /// </param>
+/// <param name="UiEnvironments">
+/// The environments that page is served in, from <c>UiEnvironments</c> metadata, or empty for all
+/// of them. Passed to <c>HardenedOpenApiUi</c> unchanged, so a specification-first page is gated
+/// the same way an attribute-declared one is.
+/// </param>
 internal record SpecRegistration(
     string ResolverName,
     string SpecificationTypeName,
     string PublishUrl,
-    string UiUrl);
+    string UiUrl,
+    string UiEnvironments);

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
@@ -221,7 +221,10 @@ internal static class SpecRoutingTableGenerator {
                 serviceCollection.Name +
                 ", new global::Hardened.Web.Runtime.OpenApi.HardenedOpenApiUi { Path = " +
                 Quote(registration.UiUrl) + ", DocumentPath = " +
-                Quote(registration.PublishUrl) + " })"));
+                Quote(registration.PublishUrl) +
+                (registration.UiEnvironments.Length == 0
+                    ? ""
+                    : ", Environments = " + Quote(registration.UiEnvironments)) + " })"));
         }
     }
 

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
@@ -145,7 +145,8 @@ public class SpecSourceGenerator : IIncrementalGenerator {
                         ? $"{pair.Right}.{NamingHelper.SpecificationTypeName(spec.FileName)}"
                         : "",
                     spec.PublishUrl,
-                    spec.UiUrl);
+                    spec.UiUrl,
+                    spec.UiEnvironments);
 
                 return registration.ResolverName.Length > 0 || registration.PublishUrl.Length > 0
                     ? registration

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
@@ -169,7 +169,7 @@
 
         <WriteLinesToFile
             File="$(HardenedOpenApiModelDir)filters.stamp"
-            Lines="@(HardenedOpenApiSpec->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(EmbedDocument)')"
+            Lines="@(HardenedOpenApiSpec->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
     </Target>

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
@@ -220,12 +220,68 @@
                AlwaysCreate="true"/>
     </Target>
 
+    <!--
+        Carries the serving metadata from the model onto the AST the CLI compiles it into.
+
+        A Smithy service is written across as many files as it likes and all of them form ONE model
+        in one CLI invocation, so the AST entry is synthesised rather than declared and has no
+        metadata of its own. Without this, PublishUrl and UiUrl written on a HardenedSmithyModel
+        item were read by nobody: the application served no document and no reference page, and
+        nothing said so.
+
+        Declared here rather than beside the item at evaluation, because only the paths need to
+        exist that early - that is what lets an IDE see the generated types before a build. The
+        metadata is not read until the two targets below.
+
+        Update= rather than a bare item group, so a hand-authored HardenedSmithyAst - which is one
+        document and does carry its own metadata - is left alone.
+    -->
+    <Target Name="HardenedSmithyModelMetadata"
+            Condition="'@(HardenedSmithyModel)' != ''"
+            BeforeTargets="HardenedSmithyFilterStamp;HardenedSmithyExtractModels">
+
+        <ItemGroup>
+            <_HardenedSmithyPublishUrl Include="%(HardenedSmithyModel.PublishUrl)"
+                                       Condition="'%(HardenedSmithyModel.PublishUrl)' != ''"/>
+            <_HardenedSmithyUiUrl Include="%(HardenedSmithyModel.UiUrl)"
+                                  Condition="'%(HardenedSmithyModel.UiUrl)' != ''"/>
+            <_HardenedSmithyUiEnvironments Include="%(HardenedSmithyModel.UiEnvironments)"
+                                           Condition="'%(HardenedSmithyModel.UiEnvironments)' != ''"/>
+        </ItemGroup>
+
+        <PropertyGroup>
+            <_HardenedSmithyPublishUrlValue>@(_HardenedSmithyPublishUrl->Distinct())</_HardenedSmithyPublishUrlValue>
+            <_HardenedSmithyUiUrlValue>@(_HardenedSmithyUiUrl->Distinct())</_HardenedSmithyUiUrlValue>
+            <_HardenedSmithyUiEnvironmentsValue>@(_HardenedSmithyUiEnvironments->Distinct())</_HardenedSmithyUiEnvironmentsValue>
+        </PropertyGroup>
+
+        <!--
+            Two files disagreeing is a mistake rather than something to pick a winner for: the model
+            is one service and it is served at one address.
+        -->
+        <Error Condition="$(_HardenedSmithyPublishUrlValue.Contains(';'))"
+               Code="HSMT012"
+               Text="The Smithy model declares more than one PublishUrl: $(_HardenedSmithyPublishUrlValue). Every .smithy file in a project compiles into one model served at one address, so set it on one item." />
+
+        <Error Condition="$(_HardenedSmithyUiUrlValue.Contains(';'))"
+               Code="HSMT012"
+               Text="The Smithy model declares more than one UiUrl: $(_HardenedSmithyUiUrlValue). Every .smithy file in a project compiles into one model with one reference page, so set it on one item." />
+
+        <ItemGroup>
+            <HardenedSmithyAst Update="$(IntermediateOutputPath)smithy/ast/$(HardenedSmithyModelName).json">
+                <PublishUrl>$(_HardenedSmithyPublishUrlValue)</PublishUrl>
+                <UiUrl>$(_HardenedSmithyUiUrlValue)</UiUrl>
+                <UiEnvironments>$(_HardenedSmithyUiEnvironmentsValue)</UiEnvironments>
+            </HardenedSmithyAst>
+        </ItemGroup>
+    </Target>
+
     <Target Name="HardenedSmithyFilterStamp" DependsOnTargets="HardenedSmithyResolveModelDir">
         <MakeDir Directories="$(HardenedSmithyModelDir)"/>
 
         <WriteLinesToFile
             File="$(HardenedSmithyModelDir)filters.stamp"
-            Lines="@(HardenedSmithyAst->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(EmbedDocument)');$(HardenedSmithyServiceShapeId)"
+            Lines="@(HardenedSmithyAst->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)');$(HardenedSmithyServiceShapeId)"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
     </Target>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/dotnetcli.host.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/dotnetcli.host.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+
+  "//": "The CLI name is kebab-case, which is what dotnet's own templates use - --use-controllers, --susi-policy-id. The symbol names stay identifier-safe because the #if conditionals in the content evaluate them.",
+
+  "symbolInfo": {
+    "host": {
+      "longName": "host",
+      "shortName": "ho"
+    },
+    "contract": {
+      "longName": "contract",
+      "shortName": "c"
+    },
+    "OpenApiUi": {
+      "longName": "openapi-ui",
+      "shortName": ""
+    },
+    "HardenedVersion": {
+      "longName": "hardened-version",
+      "shortName": ""
+    },
+    "skipRestore": {
+      "longName": "skip-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -1,7 +1,7 @@
 # Hardened1
 
-A Hardened application. Read this before editing — several things about it are not visible from
-the source tree.
+Invariants and traps for anyone editing this code. `README.md` covers what the application is, how
+to run it and how the projects fit together; this file does not repeat any of that.
 
 ## Most of this application is generated at build time
 
@@ -62,16 +62,11 @@ method's exact signature.
 is served at `/greeting/{name}`.
 #endif
 
-## Layout
+## The one structural rule
 
-| Project | What belongs in it |
-|---|---|
-| `src/Hardened1` | Everything the application does. Knows nothing about where it runs. |
-| `src/Hardened1.Host` | The only host-specific project: which runtime, and `Program.cs`. |
-| `tests/Hardened1.Tests` | Tests, against the library rather than the host. |
-
-Keep that split. The implementation library is host-independent by design — swapping the host
-should change no file in it.
+**The implementation library must stay host-independent.** Nothing in `src/Hardened1` may reference
+the host project or name a runtime. Swapping `src/Hardened1.Host` is expected to change no file
+outside it, and the tests target the library for the same reason.
 
 ## Things that will not be obvious
 
@@ -98,15 +93,4 @@ service.
 
 ## Commands
 
-```bash
-dotnet build
-dotnet test
-dotnet run --project src/Hardened1.Host        # listens on 5080, override with PORT
-curl localhost:5080/greeting/world
-```
-
-#if (OpenApiUi)
-A reference page is served at `/docs` in the `development` environment only — see the attribute on
-`Application`. Widen or remove it deliberately; it describes every operation the service exposes
-and loads a script from a CDN.
-#endif
+See `README.md`. Nothing here overrides it.

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -1,0 +1,110 @@
+# Hardened1
+
+A web application on [Hardened](https://github.com/ipjohnson/Hardened.Framework) — a compile-time,
+source-generated .NET framework. Routing, request handlers, parameter binding and dependency
+injection are written during the build rather than resolved by reflection at run time.
+
+## Run it
+
+```bash
+dotnet build
+dotnet test
+dotnet run --project src/Hardened1.Host
+```
+
+It prints its address and listens on **5080**. Set `PORT` to change it.
+
+```bash
+curl localhost:5080/greeting/world
+{"message":"Hello, world!"}
+```
+
+#if (OpenApiUi)
+There is a reference page at <http://localhost:5080/docs> and the document behind it at
+`/openapi.json`. The page is served in the `development` environment only.
+#endif
+
+## The three projects
+
+| | |
+|---|---|
+| `src/Hardened1` | Everything the application does — routes, services, models. Knows nothing about where it runs. |
+| `src/Hardened1.Host` | Which runtime hosts it, and `Program.cs`. The only host-specific project. |
+| `tests/Hardened1.Tests` | Tests, against the library rather than the host. |
+
+That split is the point rather than a convention. Swapping the host — Kestrel, ASP.NET Core, and
+Lambda in the Hardened.Amz packages — changes only the middle project. The other two are identical
+whichever one you pick, which is why the tests target the library: a test suite that named the host
+would be tied to a deployment target for no reason.
+
+## Adding to it
+
+#if (codeFirst)
+A route is an attribute on a method of a plain class — no base type, no interface, no registration.
+`src/Hardened1/GreetingController.cs` is the whole pattern:
+
+```csharp
+[Get("/{name}")]
+public Greeting Hello(string name) => new($"Hello, {name}!");
+```
+
+`[BasePath]` on `Hardened1Library` prefixes every route in the assembly, so that one is served at
+`/greeting/{name}`. `[Get]`, `[Post]`, `[Put]`, `[Delete]` and `[Patch]` all behave the same way.
+
+A service is registered next to the class it belongs to, with `[SingletonService]`,
+`[ScopedService]` or `[TransientService]` — the module lists nothing, so it cannot fall out of step.
+#endif
+#if (specFirst)
+#if (openapi)
+The contract is `src/Hardened1/contracts/greeting.yaml`. Add an operation there and the build writes
+the model, the route and the validation its constraints describe, then stops compiling until
+`GreetingService` implements the new method.
+#endif
+#if (smithy)
+The contract is `src/Hardened1/contracts/greeting.smithy`. Add an operation there and the build
+writes the model, the route and the validation its constraints describe, then stops compiling until
+`GreetingService` implements the new method.
+
+Building needs the [Smithy CLI](https://smithy.io/2.0/guides/smithy-cli/index.html) on `PATH`. The
+build names the version it expects if yours differs.
+#endif
+
+That is the trade a contract-first project makes: the specification and the code cannot disagree,
+because disagreeing is a build error. There are no route attributes anywhere in this project.
+#endif
+
+## Testing
+
+`[HardenedTest]` boots the real application — the module graph, configuration and startup services —
+and injects what the test asks for. `ITestWebApp` drives the real pipeline without a socket or a
+port, so a test exercises routing, filters, binding and serialisation rather than calling a method:
+
+```csharp
+[HardenedTest]
+public async Task GreetsByName(ITestWebApp app) {
+    var response = await app.Get("/greeting/world");
+
+    response.Assert.Ok();
+}
+```
+
+Mark a parameter `[Mock]` and that service is substituted for the whole graph, including behind a
+route.
+
+## Reading the generated code
+
+The fastest way to understand any of this is to read what the build wrote. It is ordinary C#, and
+`EmitCompilerGeneratedFiles` is already on:
+
+```
+src/Hardened1/obj/Debug/net8.0/generated/
+```
+
+One directory per generator: the routing table, the handler for each route, the parameter binding
+and the module registration are all there.
+
+## Where to go next
+
+- [Documentation](https://ipjohnson.github.io/Hardened.Docs)
+- `AGENTS.md` in this directory — the invariants and gotchas, for anyone or anything editing the
+  code rather than reading it

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Hardened.Shared.Runtime.Application;
 using Hardened1.Host;
 #if (kestrel)
@@ -9,19 +10,54 @@ using Microsoft.Extensions.Logging;
 using Hardened.Web.AspNetCore.Runtime;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+// WaitForShutdownAsync is an IHost extension rather than a WebApplication member.
+using Microsoft.Extensions.Hosting;
 #endif
 
 // Listens on 5080. Override with PORT.
 var port = int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var configured) ? configured : 5080;
+
+// Registered by the application, not the framework: only the application knows where its
+// environment name and arguments come from. HARDENED_ENVIRONMENT names it, or "development".
+var environment = new EnvironmentImpl(arguments: args);
+
+#if (OpenApiUi)
+// Opens the reference page once the server is up, so the first run shows the API rather than
+// asking for a second command.
+//
+// Three conditions, and each one is a case where opening a window would be wrong:
+//   - development only, matching where the page is served at all
+//   - a terminal only. Redirected output means a script, a container or CI, and none of those
+//     want a browser - the template's own verification run starts this application eight times
+//   - HARDENED_LAUNCH_BROWSER=false, for anyone who simply does not want it
+void OpenReferencePage() {
+    if (!environment.Matches("development") ||
+        Console.IsOutputRedirected ||
+        string.Equals(
+            Environment.GetEnvironmentVariable("HARDENED_LAUNCH_BROWSER"),
+            "false",
+            StringComparison.OrdinalIgnoreCase)) {
+        return;
+    }
+
+    try {
+        // UseShellExecute hands the URL to the operating system's handler, which is what makes
+        // one line work on Windows, macOS and Linux alike.
+        Process.Start(new ProcessStartInfo($"http://localhost:{port}/docs") { UseShellExecute = true });
+    }
+    catch (Exception) {
+        // A machine with no browser, or no handler registered for http. Not a reason to fail
+        // starting the application.
+    }
+}
+#endif
 
 #if (kestrel)
 var services = new ServiceCollection();
 
 services.AddLogging(logging => logging.AddSimpleConsole(options => options.SingleLine = true));
 
-// Registered by the application, not the framework: only the application knows where its
-// environment name and arguments come from. HARDENED_ENVIRONMENT names it, or "development".
-services.AddHardenedEnvironment(args);
+services.AddHardenedEnvironment(environment);
 
 new Application().PopulateServiceCollection(services);
 
@@ -29,19 +65,25 @@ await using var app = HardenedKestrelApplication.Create(
     services,
     kestrel => kestrel.ListenAnyIP(port));
 
+// Started rather than run, so the page is opened against a server that is already listening.
+// RunAsync below sees IsStarted and waits for shutdown rather than starting a second time.
+await app.StartAsync();
+
 // Printed, so the address is read rather than guessed. The ASP.NET host does this for you.
 app.Services.GetRequiredService<ILoggerFactory>()
     .CreateLogger("Hardened1.Host")
     .LogInformation("Listening on http://localhost:{Port}", port);
+
+#if (OpenApiUi)
+OpenReferencePage();
+#endif
 
 await app.RunAsync();
 #endif
 #if (aspnet)
 var builder = WebApplication.CreateBuilder(args);
 
-// Registered by the application, not the framework: only the application knows where its
-// environment name and arguments come from. HARDENED_ENVIRONMENT names it, or "development".
-builder.Services.AddHardenedEnvironment(args);
+builder.Services.AddHardenedEnvironment(environment);
 
 new Application().PopulateServiceCollection(builder.Services);
 
@@ -54,7 +96,15 @@ app.UseHardened();
 // filter, a warmed cache - needs this line to run at all.
 await ApplicationLogic.Start(app.Services, null);
 
-// The URL goes here rather than through builder.WebHost.UseUrls, which needs a
+// The URL is set here rather than through builder.WebHost.UseUrls, which needs a
 // Microsoft.AspNetCore.Hosting using this project does not otherwise want.
-app.Run($"http://localhost:{port}");
+app.Urls.Add($"http://localhost:{port}");
+
+await app.StartAsync();
+
+#if (OpenApiUi)
+OpenReferencePage();
+#endif
+
+await app.WaitForShutdownAsync();
 #endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
@@ -52,6 +52,12 @@
       <PublishUrl>/openapi.yaml</PublishUrl>
 <!--#if (OpenApiUi) -->
       <UiUrl>/docs</UiUrl>
+      <!--
+        Development only. The page describes every operation this service exposes and renders them
+        with a script from a CDN, neither of which a deployed API obviously wants. This is the same
+        gate [HardenedOpenApiUi(Environments = ...)] applies to an attribute-declared page.
+      -->
+      <UiEnvironments>development</UiEnvironments>
 <!--#endif -->
     </HardenedOpenApiSpec>
   </ItemGroup>
@@ -59,19 +65,23 @@
 <!--#if (smithy) -->
 
   <!--
-    The contract. The Smithy CLI turns this model into the JSON AST the generator reads, so a
-    build needs it on PATH at the pinned version - the build fails with HSMT011 naming both if
-    the version differs, because two CLI versions can produce different ASTs and therefore
-    different generated C#.
-  -->
-  <!--
-    PublishUrl and UiUrl are deliberately absent. The targets synthesise the HardenedSmithyAst
-    item from the compiled model without copying metadata across, so setting either here is
-    silently discarded - the document is not served and no reference page appears. Set them on a
-    HardenedSmithyAst item pointing at a checked-in AST if you need them today.
+    The contract. PublishUrl serves the document itself, UiUrl serves a reference page over it -
+    both facts about this model, so both live on the item that declares it, exactly as they do for
+    an OpenAPI spec.
+
+    The Smithy CLI turns this into the JSON AST the generator reads, so a build needs it on PATH at
+    the pinned version - the build fails with HSMT011 naming both if the version differs, because
+    two CLI versions can produce different ASTs and therefore different generated C#.
   -->
   <ItemGroup>
-    <HardenedSmithyModel Include="contracts\greeting.smithy" />
+    <HardenedSmithyModel Include="contracts\greeting.smithy">
+      <PublishUrl>/openapi.json</PublishUrl>
+<!--#if (OpenApiUi) -->
+      <UiUrl>/docs</UiUrl>
+      <!-- Development only; see the OpenAPI item above for why. -->
+      <UiEnvironments>development</UiEnvironments>
+<!--#endif -->
+    </HardenedSmithyModel>
   </ItemGroup>
 <!--#endif -->
 

--- a/src/Web/Hardened.Web.Kestrel.Runtime/README.md
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/README.md
@@ -6,11 +6,11 @@ Hosts Hardened on Kestrel without the ASP.NET Core request pipeline.
 var services = new ServiceCollection();
 
 services.AddLogging();
-services.AddTransient<IHardenedEnvironment>(_ => new EnvironmentImpl(arguments: args));
+services.AddHardenedEnvironment(args);
 new Application().PopulateServiceCollection(services);
 
 await using var app = HardenedKestrelApplication.Create(
-    services, kestrel => kestrel.ListenAnyIP(5000));
+    services, kestrel => kestrel.ListenAnyIP(5080));
 
 await app.RunAsync();
 ```
@@ -108,7 +108,7 @@ start. To keep configuration binding, logging setup and coordinated shutdown fro
 `Microsoft.Extensions.Hosting`, register the hosted service instead:
 
 ```csharp
-builder.Services.AddHardenedKestrel(kestrel => kestrel.ListenAnyIP(5000));
+builder.Services.AddHardenedKestrel(kestrel => kestrel.ListenAnyIP(5080));
 ```
 
 That keeps `Microsoft.Extensions.Hosting` and drops only `Microsoft.AspNetCore.Hosting`. Using


### PR DESCRIPTION
Six things before 0.10.0, all found by using the template rather than reading it.

## 1. Option names are kebab-case

The help screen showed `--host` beside `--HardenedVersion` and `--skipRestore` — three styles in one place. `dotnet`'s own templates use kebab (`--use-controllers`, `--susi-policy-id`), so:

```
--host  --contract  --openapi-ui  --hardened-version  --skip-restore
```

`dotnetcli.host.json` maps the CLI names, so the symbols stay identifier-safe for the `#if` conditionals that read them.

## 2. A README, and AGENTS.md stopped repeating it

The split is **narrative against invariants**, not human against agent — both read both.

**README** — what the application is, how to run it, how the three projects fit together, and adding a route. Owns every command.

**AGENTS.md** — what stays true while you edit. The code is generated and lives in `obj/`. Which side owns routing. The generator packages are load-bearing. The environment registers under two interfaces. Tests are xUnit v3. No narrative, and it points at the README for commands.

Rough rule: if a fact changes how you *edit*, it is the second file.

## 3. Smithy carries its serving metadata again

A Smithy service is written across as many files as it likes and all of them compile into one AST, so the AST item is synthesised and had no metadata of its own. `PublishUrl` and `UiUrl` written on a `HardenedSmithyModel` were read by nobody — the application served no document and no reference page, with no diagnostic.

A target now copies them onto the generated AST before the two targets that read them, scoped with `Update=` so a hand-authored `HardenedSmithyAst` keeps its own. Two files declaring different values is `HSMT012` rather than a guess.

I first proposed moving these to properties, on the grounds that N files have no single item to read from. That was wrong: it would have made Smithy and OpenAPI say the same thing two different ways, which costs more than the edge case it avoided — and the edge case has an honest answer.

## 4. The spec-first reference page is gated like the attribute-declared one

`SpecRoutingTableGenerator` already constructs a `HardenedOpenApiUi`, so the mechanism existed and nothing reached it. `UiEnvironments` metadata now threads through the extract task, the model, the serializer, the registration and the emitter.

All four combinations serve `/docs` in development and 404 in production, and verification asserts it for **every** contract rather than only code-first:

```
kestrel:code     /docs  development=200  production=404
aspnet:code      /docs  development=200  production=404
kestrel:openapi  /docs  development=200  production=404
kestrel:smithy   /docs  development=200  production=404
```

`[Enable<T>]` is untouched. It is compile-time — does the generator emit this — and environment is runtime; gating one with the other would make it mean two things.

## 5. The host opens the reference page on start

Not through `launchSettings.json`, which `dotnet run` reads and then ignores, nor `dotnet watch`, which waits for ASP.NET's "Now listening on:" line that the Kestrel host does not print. In code, both hosts behave alike.

Guarded three ways, each a case where a window would be wrong: development only; a terminal only, since redirected output means a script or CI and verification starts the application eight times; and `HARDENED_LAUNCH_BROWSER=false`.

## 6. Smaller ones

- The Kestrel package README taught `ListenAnyIP(5000)` — a port macOS answers with an AirPlay 403 — and the environment registration that produces two environments. Both fixed.
- `Microsoft.NET.Test.Sdk` was 17.10.0 in some projects and 17.12.0 in others. One version across 28.
- None of this is called a smoke test any more. `scripts/verify-templates.sh`, CI job `verify`, generated project `Sample`. It builds, tests, serves and asserts host independence.

## Verification

4,252 tests passing, public API unchanged, and the template verification green across all four combinations with the library and tests byte-identical across hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnz6FBUjT29qfiMbzj85eD