### PR TITLE
Add hardened-function and hardened-library, --host aws-lambda, and fix the module environment

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
 # Verify the templates: build the framework, pack it and them, install the packed template,
-# generate a project from every supported combination, and prove each one restores, builds, tests
-# and serves. This is the gate a release runs.
+# generate a project from every supported combination of all three templates, and prove each one
+# restores, builds, tests and - where it serves HTTP - answers. This is the gate a release runs.
 #
 # The packed nupkg is installed rather than the template folder, deliberately. A template tested
 # from source proves nothing about packaging, which is where the 0.8.0-rc1000 quickstart broke.
@@ -84,7 +84,9 @@ say "installing the packed template"
 # package id, and it shadows the packed one with the same template identity - so the verification would
 # silently exercise the working tree instead of the artifact.
 dotnet new uninstall Hardened.Templates >/dev/null 2>&1 || true
-dotnet new uninstall "$REPO/src/Templates/Hardened.Templates/templates/hardened-web" >/dev/null 2>&1 || true
+for TEMPLATE_DIR in "$REPO"/src/Templates/Hardened.Templates/templates/*/; do
+    dotnet new uninstall "${TEMPLATE_DIR%/}" >/dev/null 2>&1 || true
+done
 dotnet new install "$FEED/Hardened.Templates.$VERSION.nupkg"
 
 FAILED=0
@@ -195,6 +197,68 @@ for COMBO in "${COMBOS[@]}"; do
         FAILED=1
     fi
 done
+
+say "hardened-library"
+# Framework packages only, so this one is verified against the build under test like hardened-web.
+LIB="$WORK/library"
+dotnet new hardened-library -n Sample -o "$LIB" --skip-restore
+dotnet nuget add source "$FEED" --name template-verify-local --configfile "$LIB/nuget.config" >/dev/null
+if ( cd "$LIB" && dotnet build -v q --nologo && dotnet test --no-build -v q --nologo ); then
+    echo "   builds and tests"
+else
+    echo "   FAILED: hardened-library"
+    FAILED=1
+fi
+
+# A dotted project name is the .NET norm and it is not merely cosmetic here: the module class is
+# named after the project, and an unfiltered substitution produced "public partial class
+# Acme.ApiLibrary" - which does not compile. Every template that names a class after the project
+# needs the safe-identifier form, so the check runs against a name that has a dot in it.
+say "dotted project names"
+for TEMPLATE in hardened-library hardened-web; do
+    DOTTED="$WORK/dotted-$TEMPLATE"
+    dotnet new "$TEMPLATE" -n Acme.Sample -o "$DOTTED" --skip-restore
+    dotnet nuget add source "$FEED" --name template-verify-local --configfile "$DOTTED/nuget.config" >/dev/null
+    if ( cd "$DOTTED" && dotnet build -v q --nologo ); then
+        echo "   $TEMPLATE builds as Acme.Sample"
+    else
+        echo "   FAILED: $TEMPLATE does not build with a dotted name"
+        FAILED=1
+    fi
+done
+
+# The Amz-dependent variants cannot be verified against the framework build under test, and that
+# is a property of the dependency direction rather than an omission. Hardened.Amz depends on
+# published Hardened packages, so a generated project pinned to this run's 0.0.0-verify framework
+# also drags in whatever version Amz was built against - NU1605, every time. They are therefore
+# generated against the newest published version, which gates the templates themselves without
+# claiming to gate the build under test.
+say "AWS Lambda templates (published packages)"
+PUBLISHED=$(curl -s "https://api.nuget.org/v3-flatcontainer/hardened.amz.function.lambda.runtime/index.json" \
+    | tr ',' '\n' | tr -d '" ' | grep -E '^[0-9]' | tail -1)
+
+if [ -z "$PUBLISHED" ]; then
+    echo "   SKIPPED: could not reach nuget.org for the published Hardened.Amz version"
+else
+    echo "   pinned to $PUBLISHED, not this run's $VERSION"
+
+    for AMZ in "hardened-function --trigger invoke" "hardened-function --trigger sqs" "hardened-web --host aws-lambda"; do
+        set -- $AMZ
+        AMZ_TEMPLATE="$1"; shift
+        AMZ_OUT="$WORK/amz-$AMZ_TEMPLATE-$(echo "$*" | tr -cd 'a-z')"
+
+        # No local feed added: these restore from nuget.org alone, on purpose.
+        dotnet new "$AMZ_TEMPLATE" -n Sample -o "$AMZ_OUT" "$@" \
+            --hardened-version "$PUBLISHED" --skip-restore
+
+        if ( cd "$AMZ_OUT" && dotnet build -v q --nologo && dotnet test --no-build -v q --nologo ); then
+            echo "   $AMZ_TEMPLATE $*: builds and tests"
+        else
+            echo "   FAILED: $AMZ_TEMPLATE $*"
+            FAILED=1
+        fi
+    done
+fi
 
 say "host independence"
 # The framework's claim is that handlers, filters, binding and routing do not change with the

--- a/src/Shared/Hardened.Shared.Testing.Tests/Impl/TestApplicationTests.cs
+++ b/src/Shared/Hardened.Shared.Testing.Tests/Impl/TestApplicationTests.cs
@@ -305,4 +305,45 @@ public class TestApplicationTests {
 
         public void Dispose() => Disposed = true;
     }
+
+    #region the environment is reachable under both interfaces
+
+    /// <summary>
+    /// The module system reads <see cref="IModuleEnvironment"/> while it is deciding what to
+    /// register, so a test host that registers the environment under
+    /// <see cref="IHardenedEnvironment"/> alone leaves <c>[IfEnvironment]</c> answering against
+    /// <c>ASPNETCORE_ENVIRONMENT</c> - <c>Production</c> - while the application under test says
+    /// <c>development</c>. Registration under both is what makes the two agree.
+    /// </summary>
+    [Theory]
+    [InlineData("staging")]
+    [InlineData("development")]
+    public void TheModuleSystemSeesTheEnvironmentTheTestWasGiven(string environmentName) {
+        var environment = new EnvironmentImpl(environmentName);
+
+        var application = new TestApplication(
+            new ApplicationModule((_, _) => { }), "test", environment, null);
+
+        Assert.Same(environment, application.Provider.GetRequiredService<IModuleEnvironment>());
+        Assert.Equal(
+            environmentName,
+            application.Provider.GetRequiredService<IModuleEnvironment>().EnvironmentName);
+    }
+
+    /// <summary>
+    /// Both constructors register the environment, and only one of them being fixed is exactly the
+    /// drift <see cref="BothModuleShapesProduceTheSameWiring"/> exists to catch.
+    /// </summary>
+    [Fact]
+    public void BothModuleShapesReachTheEnvironmentUnderBothInterfaces() {
+        foreach (var provider in new[] {
+                     FromApplicationModule().Provider, FromDependencyModule().Provider
+                 }) {
+            Assert.Same(
+                provider.GetRequiredService<IHardenedEnvironment>(),
+                provider.GetRequiredService<IModuleEnvironment>());
+        }
+    }
+
+    #endregion
 }

--- a/src/Shared/Hardened.Shared.Testing/Impl/TestApplication.cs
+++ b/src/Shared/Hardened.Shared.Testing/Impl/TestApplication.cs
@@ -24,7 +24,12 @@ public class TestApplication : IApplicationRoot {
         var serviceCollection = new ServiceCollection();
 
         serviceCollection.AddLogging();
-        serviceCollection.AddSingleton(environment);
+
+        // Both interfaces, because the module system reads IModuleEnvironment while it decides
+        // what to register. AddSingleton would register the parameter's static type alone, and
+        // [IfEnvironment] under test would answer against ASPNETCORE_ENVIRONMENT - Production -
+        // rather than the environment this application was handed.
+        serviceCollection.AddHardenedEnvironment(environment);
 
         applicationModule.ConfigureModule(environment, serviceCollection);
 
@@ -38,7 +43,12 @@ public class TestApplication : IApplicationRoot {
         var serviceCollection = new ServiceCollection();
 
         serviceCollection.AddLogging();
-        serviceCollection.AddSingleton(environment);
+
+        // Both interfaces, because the module system reads IModuleEnvironment while it decides
+        // what to register. AddSingleton would register the parameter's static type alone, and
+        // [IfEnvironment] under test would answer against ASPNETCORE_ENVIRONMENT - Production -
+        // rather than the environment this application was handed.
+        serviceCollection.AddHardenedEnvironment(environment);
 
         dependencyModule.PopulateServiceCollection(serviceCollection);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/DependencyInjection/ServiceProviderEmitTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/DependencyInjection/ServiceProviderEmitTests.cs
@@ -1,0 +1,99 @@
+using Hardened.SourceGenerator.DependencyInjection;
+using Hardened.SourceGenerator.Shared;
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Hardened.SourceGeneration.Testing;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.DependencyInjection;
+
+/// <summary>
+/// Runs <see cref="ServiceProviderFileGenerator"/> the way a shipped generator does, so the emitted
+/// <c>CreateServiceProvider</c> is compiled rather than string-matched.
+/// </summary>
+public class ServiceProviderGenerator : IIncrementalGenerator {
+
+    public void Initialize(IncrementalGeneratorInitializationContext context) {
+        var provider = context.SyntaxProvider.CreateSyntaxProvider(
+            EntryPointSelector.UsingAttribute(),
+            EntryPointSelector.TransformModel(true));
+
+        context.RegisterSourceOutput(
+            provider, (production, model) => new ServiceProviderFileGenerator().GenerateFile(production, model));
+    }
+}
+
+/// <summary>
+/// The service collection every host without a <c>Program.cs</c> of its own is built from — Lambda
+/// among them, through the writers in <c>Hardened.Amz</c>.
+/// </summary>
+public class ServiceProviderEmitTests {
+
+    /// <summary>
+    /// No <c>CreateServiceProvider</c> member of its own: that is the method under test, and
+    /// declaring one here would collide with the emitted partial.
+    ///
+    /// <para>
+    /// <c>PopulateServiceCollection</c> is the reverse — normally written by the DependencyModules
+    /// generator, which is not running here, so the emitted call has nothing to bind against
+    /// without it.
+    /// </para>
+    /// </summary>
+    private const string Application = """
+        using Hardened.Shared.Runtime.Attributes;
+        using Microsoft.Extensions.DependencyInjection;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        public partial class Application {
+            public void PopulateServiceCollection(IServiceCollection services) { }
+        }
+        """;
+
+    private static string Generate() {
+        var result = GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Test.cs"] = Application },
+            [new ServiceProviderGenerator()],
+            RequestGeneratorHarness.Anchors);
+
+        result.AssertNoErrors();
+
+        return result.SourceContaining("ServiceProvider");
+    }
+
+    /// <summary>
+    /// The environment has to be reachable as <c>IModuleEnvironment</c> as well as
+    /// <c>IHardenedEnvironment</c>, because the module system reads the first while it decides what
+    /// to register.
+    /// </summary>
+    /// <remarks>
+    /// This was <c>AddSingleton(environment)</c>, which registers the parameter's static type
+    /// alone. Every host built through this method — Lambda, and anything else without its own
+    /// <c>Program.cs</c> — therefore had <c>[IfEnvironment]</c> answering against
+    /// <c>ASPNETCORE_ENVIRONMENT</c>, defaulting to <c>Production</c>, while the same application
+    /// read <c>HARDENED_ENVIRONMENT</c> and said <c>development</c>. It compiled and it ran; the
+    /// only symptom was environment-gated services quietly not being registered.
+    /// </remarks>
+    [Fact]
+    public void TheEnvironmentIsRegisteredUnderBothInterfaces() {
+        var generated = Generate();
+
+        Assert.Contains("AddHardenedEnvironment(environment)", generated);
+        Assert.DoesNotContain("AddSingleton(environment)", generated);
+    }
+
+    /// <summary>
+    /// The environment must be in the collection before the modules read it, so ordering here is
+    /// behaviour rather than style.
+    /// </summary>
+    [Fact]
+    public void TheEnvironmentIsRegisteredBeforeTheModulesAreApplied() {
+        var generated = Generate();
+
+        Assert.True(
+            generated.IndexOf("AddHardenedEnvironment", StringComparison.Ordinal) <
+            generated.IndexOf("PopulateServiceCollection", StringComparison.Ordinal),
+            $"the environment is registered after the modules read it:{Environment.NewLine}{generated}");
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/DependencyInjection/ServiceProviderFileGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/DependencyInjection/ServiceProviderFileGenerator.cs
@@ -81,8 +81,16 @@ public class ServiceProviderFileGenerator {
 
         providerMethod.AddUsingNamespace(KnownTypes.Namespace.Hardened.Shared.Runtime.Logging);
 
+        // AddHardenedEnvironment rather than AddSingleton, because the environment has to be
+        // reachable as IModuleEnvironment as well as IHardenedEnvironment. AddSingleton registers
+        // the parameter's static type only, so [IfEnvironment] found nothing here and fell back to
+        // ASPNETCORE_ENVIRONMENT - Production - while the rest of the application read
+        // HARDENED_ENVIRONMENT and said development. This method builds the collection for every
+        // host that has no Program.cs of its own, Lambda among them.
+        providerMethod.AddUsingNamespace(KnownTypes.Namespace.Hardened.Shared.Runtime.Application);
+
         providerMethod.AddIndentedStatement(
-            serviceCollectionDefinition.Invoke("AddSingleton", "environment")
+            serviceCollectionDefinition.Invoke("AddHardenedEnvironment", "environment")
         );
 
         providerMethod.NewLine();

--- a/src/Templates/Hardened.Templates/templates/hardened-function/.template.config/dotnetcli.host.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/.template.config/dotnetcli.host.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "trigger": {
+      "longName": "trigger"
+    },
+    "HardenedVersion": {
+      "longName": "hardened-version"
+    },
+    "skipRestore": {
+      "longName": "skip-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-function/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/.template.config/template.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Ian Johnson",
+  "classifications": [
+    "Serverless",
+    "AWS",
+    "Hardened"
+  ],
+  "identity": "Hardened.Function.CSharp",
+  "groupIdentity": "Hardened.Function",
+  "name": "Hardened Lambda Function",
+  "shortName": "hardened-function",
+  "description": "A Hardened AWS Lambda function: a handler, its services, and a test project that invokes it without AWS.",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Hardened1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "trigger": {
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "invoke",
+      "description": "What invokes the function.",
+      "choices": [
+        {
+          "choice": "invoke",
+          "description": "A direct invocation. The payload is the handler's parameter and its return value is the response."
+        },
+        {
+          "choice": "sqs",
+          "description": "An SQS queue. The batch is unpacked, the handler runs per record, and failures are reported per record."
+        }
+      ]
+    },
+    "HardenedVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "0.0.0-DEV",
+      "description": "The Hardened package version to pin. Defaults to the version this template shipped with.",
+      "replaces": "0.0.0-HARDENED-VERSION"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Skip the automatic restore after creation."
+    },
+    "invoke": {
+      "type": "computed",
+      "value": "(trigger == 'invoke')"
+    },
+    "sqs": {
+      "type": "computed",
+      "value": "(trigger == 'sqs')"
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "src/Hardened1/Hardened1.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore the packages the template pinned.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ],
+  "specialCustomOperations": {
+    "**/*.md": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [
+              "#if"
+            ],
+            "else": [
+              "#else"
+            ],
+            "elseif": [
+              "#elseif"
+            ],
+            "endif": [
+              "#endif"
+            ],
+            "trim": true,
+            "wholeLine": true,
+            "evaluator": "C++"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-function/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/AGENTS.md
@@ -1,0 +1,55 @@
+# Hardened1
+
+Invariants and traps for anyone editing this code. `README.md` covers what this function is, how to
+build it and how the handler works; this file does not repeat any of that.
+
+## Most of this function is generated at build time
+
+Hardened is a compile-time framework. The Lambda entry point, the payload binding, the filter chain
+and the dependency injection registrations are written by source generators during the build, not
+resolved by reflection at run time.
+
+**They are ordinary C#, and you can read them.** `EmitCompilerGeneratedFiles` is on:
+
+```
+src/Hardened1/obj/Debug/net8.0/generated/     one directory per generator
+```
+
+Build first. Reading that directory answers most "how does this work" questions faster than reading
+the framework.
+
+## There is no Program.cs, and there should not be one
+
+The generator writes the entry point AWS invokes. Adding a `Main` does not override it — it gives
+the assembly a second entry point and the build fails. Local invocation goes through the test
+project, which is why the tests are the way this function is run.
+
+## Things that will not be obvious
+
+**`[assembly: LambdaFunctionTesting]` in the test project is load-bearing.** It registers the invoke
+filter provider and, at startup, puts the invoke filter into the chain. Without it the pipeline
+holds no filters at all, so an invocation builds a chain of length zero, returns an empty stream and
+never reaches the handler — with no error anywhere. A test that suddenly asserts against nothing is
+the symptom.
+
+**The source generator packages are required.** The runtime packages carry no analyzers, so removing
+`Hardened.Library.SourceGenerator` or `Hardened.Amz.Function.Lambda.SourceGenerator` does not fail
+with a missing package — it fails with `'Application' does not contain a definition for
+'PopulateServiceCollection'`, or it builds clean and the function has no entry point. All versions
+are pinned in one place, `Directory.Packages.props`.
+
+**Two package lines, one version.** `Hardened.*` and `Hardened.Amz.*` release together, and
+`Directory.Packages.props` pins the second to the first through `HardenedAmzVersion`. If they ever
+diverge, that is the one line to change.
+
+**Tests are xUnit v3.** `Hardened.Shared.Testing` builds on `xunit.v3.extensibility.core`; a test
+project on xunit 2.x fails with `CS0433` on `Assert`. v3 test projects are also self-executing,
+hence `<OutputType>Exe</OutputType>`.
+
+**`[HardenedTest]` boots the real application.** Test method parameters are resolved from the
+application's own container, and the test harness drives the real invocation path. Mark a parameter
+`[Mock]` to substitute a service.
+
+## Commands
+
+See `README.md`. Nothing here overrides it.

--- a/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Build.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <!-- Hardened writes your routing table, request handlers and parameter binding as ordinary
+         C#. Reading it is the fastest way to understand what the framework is doing:
+         obj/<configuration>/<tfm>/generated/, one directory per generator. -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  </PropertyGroup>
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
@@ -4,38 +4,33 @@
     <!-- One place to bump. The generated code and the runtime it targets ship together,
          so every Hardened package moves as a set. -->
     <HardenedVersion>0.0.0-HARDENED-VERSION</HardenedVersion>
+    <!--
+      Hardened.Amz releases on its own line, and this pins the same version the framework is on
+      because the two are released together. If they ever diverge, this is the one line to change.
+    -->
     <HardenedAmzVersion>$(HardenedVersion)</HardenedAmzVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Hardened">
     <PackageVersion Include="Hardened.Shared.Runtime" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Web.Runtime" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Web.Kestrel.Runtime" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Web.AspNetCore.Runtime" Version="$(HardenedVersion)" />
+    <PackageVersion Include="Hardened.Requests.Runtime" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Shared.Testing" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Web.Testing" Version="$(HardenedVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="AWS Lambda">
-    <!--
-      Hardened.Amz releases on its own line, and this pins the same version the framework is on
-      because the two are released together. If they ever diverge, this is the one line to change.
-    -->
     <PackageVersion Include="Hardened.Amz.Shared.Lambda.Runtime" Version="$(HardenedAmzVersion)" />
-    <PackageVersion Include="Hardened.Amz.Web.Lambda.Runtime" Version="$(HardenedAmzVersion)" />
-    <PackageVersion Include="Hardened.Amz.Web.Lambda.Harness" Version="$(HardenedAmzVersion)" />
-    <PackageVersion Include="Hardened.Amz.Web.Lambda.SourceGenerator" Version="$(HardenedAmzVersion)" />
+    <PackageVersion Include="Hardened.Amz.Function.Lambda.Runtime" Version="$(HardenedAmzVersion)" />
+    <PackageVersion Include="Hardened.Amz.Function.Lambda.SourceGenerator" Version="$(HardenedAmzVersion)" />
+    <PackageVersion Include="Hardened.Amz.Function.Lambda.Testing" Version="$(HardenedAmzVersion)" />
+    <PackageVersion Include="Hardened.Amz.Function.Sqs.Runtime" Version="$(HardenedAmzVersion)" />
+    <PackageVersion Include="Hardened.Amz.Function.Sqs.Testing" Version="$(HardenedAmzVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="Hardened source generators">
     <!-- Not optional. The runtime packages carry no analyzers, so without these the module's
          generated half never exists and PopulateServiceCollection does not compile. -->
     <PackageVersion Include="Hardened.Library.SourceGenerator" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Web.SourceGenerator" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.OpenApi.SourceGenerator" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Smithy.SourceGenerator" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Idl.SourceGenerator" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Validation.SourceGenerator" Version="$(HardenedVersion)" />
+    <PackageVersion Include="Hardened.Function.SourceGenerator" Version="$(HardenedVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="Testing">

--- a/src/Templates/Hardened.Templates/templates/hardened-function/Hardened1.sln
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/Hardened1.sln
@@ -1,0 +1,52 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E827A3D2-DCD7-4F09-B627-327F735B5423}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened1", "src\Hardened1\Hardened1.csproj", "{8D29C651-1DF0-44E8-9652-0FB0E7811184}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EE7EB54E-D3DB-4225-8D1A-9D0DD8B1076F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened1.Tests", "tests\Hardened1.Tests\Hardened1.Tests.csproj", "{5165DE36-27FB-4167-AB44-C3742537C94F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Debug|x64.ActiveCfg = Debug|x64
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Debug|x64.Build.0 = Debug|x64
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Debug|x86.ActiveCfg = Debug|x86
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Debug|x86.Build.0 = Debug|x86
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Release|x64.ActiveCfg = Release|x64
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Release|x64.Build.0 = Release|x64
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Release|x86.ActiveCfg = Release|x86
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184}.Release|x86.Build.0 = Release|x86
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Debug|x64.ActiveCfg = Debug|x64
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Debug|x64.Build.0 = Debug|x64
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Debug|x86.ActiveCfg = Debug|x86
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Debug|x86.Build.0 = Debug|x86
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Release|x64.ActiveCfg = Release|x64
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Release|x64.Build.0 = Release|x64
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Release|x86.ActiveCfg = Release|x86
+		{5165DE36-27FB-4167-AB44-C3742537C94F}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8D29C651-1DF0-44E8-9652-0FB0E7811184} = {E827A3D2-DCD7-4F09-B627-327F735B5423}
+		{5165DE36-27FB-4167-AB44-C3742537C94F} = {EE7EB54E-D3DB-4225-8D1A-9D0DD8B1076F}
+	EndGlobalSection
+EndGlobal

--- a/src/Templates/Hardened.Templates/templates/hardened-function/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/README.md
@@ -1,0 +1,126 @@
+# Hardened1
+
+An AWS Lambda function on [Hardened](https://github.com/ipjohnson/Hardened.Framework) — a
+compile-time, source-generated .NET framework. The entry point AWS calls, the payload
+deserialisation and the dependency injection are all written during the build.
+
+## Run it
+
+```bash
+dotnet build
+dotnet test
+```
+
+There is nothing to `dotnet run`. The tests are how this function is exercised locally: they invoke
+it through the real pipeline, with no AWS account and nothing to deploy.
+
+## The two projects
+
+| | |
+|---|---|
+| `src/Hardened1` | The function: its handler, its models and its services. |
+| `tests/Hardened1.Tests` | Tests, which invoke the function the way Lambda does. |
+
+There is no separate host project. On Lambda the deployed artifact is this assembly, and the
+generator writes the entry point the runtime calls — so the split that a web application makes
+between a library and a host has nothing to separate here.
+
+## The handler
+
+`[HardenedFunction]` on a method of a plain class. No base type, no interface, no registration:
+
+```csharp
+public class OrderHandler(OrderLog log) {
+
+    [HardenedFunction]
+#if (invoke)
+    public Task<OrderAccepted> Process(Order order) { ... }
+#endif
+#if (sqs)
+    public Task Process(Order order) { ... }
+#endif
+}
+```
+
+The generator writes an entry point bound to that exact signature. The payload is deserialised into
+the parameter, the dependencies come from the container, and a missing registration is a build
+error rather than something the first invocation discovers.
+
+#if (invoke)
+The return value is serialised back as the invocation's response.
+#endif
+#if (sqs)
+The handler is called once per record in the batch. Returning normally marks that record handled;
+throwing reports it as a batch item failure, so only the records that failed are redelivered.
+#endif
+
+A service is registered next to the class it belongs to, with `[SingletonService]`,
+`[ScopedService]` or `[TransientService]` — the module lists nothing, so it cannot fall out of step.
+
+## Changing the trigger
+
+`src/Hardened1/Application.cs` names the runtime:
+
+```csharp
+[HardenedModule]
+[LambdaFunctionModule]
+#if (sqs)
+[SqsLambda]
+#endif
+public partial class Application;
+```
+
+#if (invoke)
+`[LambdaFunctionModule]` is the invocation path itself. Adding an event source — `[SqsLambda]` from
+`Hardened.Amz.Function.Sqs.Runtime`, for instance — layers batch handling on top of it, and changes
+the handler's signature rather than the rest of the application.
+#endif
+#if (sqs)
+`[LambdaFunctionModule]` is the invocation path; `[SqsLambda]` is the event source layered on it.
+Swapping the event source changes this file and the handler's signature, and nothing else.
+#endif
+
+## Testing
+
+`[HardenedTest]` boots the real application — the module graph, configuration and startup services —
+and injects what the test asks for:
+
+```csharp
+#if (sqs)
+[HardenedTest]
+public async Task ARecordReachesTheHandler(TestSqsApp app, OrderLog log) {
+    var response = await app.SendMessage(new Order { Id = "A-1", Quantity = 2 });
+
+    Assert.Empty(response.BatchItemFailures);
+}
+#endif
+#if (invoke)
+[HardenedTest]
+public async Task ThePayloadReachesTheHandler(LambdaTestApp app, OrderLog log) {
+    var accepted = await app.Invoke<OrderAccepted>("Process", new Order { Id = "A-1" });
+
+    Assert.Equal("A-1", accepted.Id);
+}
+#endif
+```
+
+That is the real pipeline — deserialisation, the filter chain, the handler — rather than a method
+call. Mark a parameter `[Mock]` and that service is substituted for the whole container.
+
+## Reading the generated code
+
+The fastest way to understand any of this is to read what the build wrote. It is ordinary C#, and
+`EmitCompilerGeneratedFiles` is already on:
+
+```
+src/Hardened1/obj/Debug/net8.0/generated/
+```
+
+One directory per generator: the entry point, the handler and the module registration are all
+there.
+
+## Where to go next
+
+- [Documentation](https://ipjohnson.github.io/Hardened.Docs)
+- `AGENTS.md` in this directory — the invariants and gotchas, for anyone or anything editing the
+  code rather than reading it

--- a/src/Templates/Hardened.Templates/templates/hardened-function/nuget.config
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Hardened is on nuget.org. No other feed and no token are needed. -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Application.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Application.cs
@@ -1,0 +1,30 @@
+using Hardened.Amz.Function.Lambda.Runtime.DependencyInjection;
+#if (sqs)
+using Hardened.Amz.Function.Sqs.Runtime;
+#endif
+using Hardened.Shared.Runtime.Attributes;
+
+namespace Hardened1;
+
+/// <summary>
+/// The application module: which runtime this runs on, and which libraries come along.
+/// </summary>
+/// <remarks>
+/// [LambdaFunctionModule] brings the Lambda invocation path and, through the request module it
+/// carries, the filter pipeline the generated entry point runs a payload through.
+#if (sqs)
+///
+/// [SqsLambda] adds SQS batch handling on top: the runtime unpacks the batch, runs the handler
+/// once per record, and reports the ones that threw as batch item failures so only those are
+/// redelivered.
+#endif
+///
+/// partial is not optional - the generator writes the other half, including the entry point AWS
+/// invokes.
+/// </remarks>
+[HardenedModule]
+[LambdaFunctionModule]
+#if (sqs)
+[SqsLambda]
+#endif
+public partial class Application;

--- a/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Hardened1.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The function. There is no separate host project: on Lambda the deployed artifact is this
+    assembly, and the generator writes the entry point the runtime calls.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Hardened.Shared.Runtime" />
+    <PackageReference Include="Hardened.Requests.Runtime" />
+    <PackageReference Include="Hardened.Amz.Shared.Lambda.Runtime" />
+    <PackageReference Include="Hardened.Amz.Function.Lambda.Runtime" />
+<!--#if (sqs) -->
+    <PackageReference Include="Hardened.Amz.Function.Sqs.Runtime" />
+<!--#endif -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hardened.Library.SourceGenerator" />
+    <!--
+      PrivateAssets="all" on the generators so they stop at this project's boundary. They are
+      build-time only, and nothing that references this assembly should inherit them.
+    -->
+    <PackageReference Include="Hardened.Function.SourceGenerator" PrivateAssets="all" />
+    <PackageReference Include="Hardened.Amz.Function.Lambda.SourceGenerator" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Order.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Order.cs
@@ -1,0 +1,11 @@
+namespace Hardened1;
+
+/// <summary>
+/// The payload this function is invoked with. Deserialised into by the generated entry point,
+/// so it is an ordinary class with no attributes and no base type.
+/// </summary>
+public class Order {
+    public string Id { get; set; } = "";
+
+    public int Quantity { get; set; }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/OrderHandler.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/OrderHandler.cs
@@ -1,0 +1,40 @@
+using Hardened.Requests.Abstract.Attributes;
+
+namespace Hardened1;
+
+/// <summary>
+/// The function. A plain class - no base type, no interface, no registration.
+/// </summary>
+/// <remarks>
+/// [HardenedFunction] is what the generator finds. It writes an entry point bound to this
+/// method's exact signature: the payload is deserialised into the parameter, the dependencies
+/// come from the container, and the return value is serialised back.
+/// </remarks>
+public class OrderHandler(OrderLog log) {
+
+#if (sqs)
+    /// <summary>
+    /// Called once per record in the batch. Returning normally marks that record handled;
+    /// throwing reports it as a batch item failure, and only those are redelivered.
+    /// </summary>
+    [HardenedFunction]
+    public Task Process(Order order) {
+        log.Record(order);
+
+        return Task.CompletedTask;
+    }
+#endif
+#if (invoke)
+    [HardenedFunction]
+    public Task<OrderAccepted> Process(Order order) {
+        log.Record(order);
+
+        return Task.FromResult(new OrderAccepted(order.Id, log.Orders.Count));
+    }
+#endif
+}
+#if (invoke)
+
+/// <summary>What the caller gets back. Serialised by the generated entry point.</summary>
+public record OrderAccepted(string Id, int Received);
+#endif

--- a/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/OrderLog.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/OrderLog.cs
@@ -1,0 +1,19 @@
+using DependencyModules.Runtime.Attributes;
+
+namespace Hardened1;
+
+/// <summary>
+/// A service, registered where it is declared rather than by a line in the module.
+/// </summary>
+/// <remarks>
+/// It is here so the handler has a dependency worth injecting and the tests have something to
+/// assert against. Replace it with whatever the function actually talks to.
+/// </remarks>
+[SingletonService]
+public class OrderLog {
+    private readonly List<Order> _orders = [];
+
+    public IReadOnlyList<Order> Orders => _orders;
+
+    public void Record(Order order) => _orders.Add(order);
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/Bootstrap.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/Bootstrap.cs
@@ -1,0 +1,12 @@
+using Hardened.Amz.Function.Lambda.Testing;
+using Hardened.Shared.Testing.Attributes;
+using Hardened1;
+
+// The application under test. The real module graph is applied and startup services run, so there
+// is no separate test wiring to keep in step.
+[assembly: HardenedTestEntryPoint(typeof(Application))]
+
+// Registers the invoke filter provider and, at startup, puts the invoke filter into the chain.
+// Without it the pipeline holds no filters at all, so an invocation builds a chain of length zero,
+// returns an empty stream and never reaches the handler - with no error anywhere.
+[assembly: LambdaFunctionTesting]

--- a/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/Hardened1.Tests.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/Hardened1.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <!-- xUnit v3 test projects are self-executing. -->
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hardened.Shared.Testing" />
+    <PackageReference Include="Hardened.Amz.Function.Lambda.Testing" />
+<!--#if (sqs) -->
+    <PackageReference Include="Hardened.Amz.Function.Sqs.Testing" />
+<!--#endif -->
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hardened1\Hardened1.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/OrderHandlerTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/OrderHandlerTests.cs
@@ -1,0 +1,60 @@
+#if (sqs)
+using Hardened.Amz.Function.Sqs.Testing;
+#endif
+#if (invoke)
+using Hardened.Amz.Function.Lambda.Testing;
+#endif
+
+namespace Hardened1.Tests;
+
+/// <summary>
+/// [HardenedTest] boots the real application and resolves the test's parameters from its
+/// container, so an invocation here goes through the same pipeline a deployed function does -
+/// deserialisation, the filter chain, the handler - without AWS.
+/// </summary>
+public class OrderHandlerTests {
+
+#if (sqs)
+    [HardenedTest]
+    public async Task ARecordReachesTheHandler(TestSqsApp app, OrderLog log) {
+        var response = await app.SendMessage(new Order { Id = "A-1", Quantity = 2 });
+
+        Assert.Empty(response.BatchItemFailures);
+        Assert.Equal("A-1", Assert.Single(log.Orders).Id);
+    }
+
+    /// <summary>
+    /// The batch is unpacked and the handler runs once per record, which is the whole reason to
+    /// take an SQS trigger rather than read the event yourself.
+    /// </summary>
+    [HardenedTest]
+    public async Task EveryRecordInABatchIsHandled(TestSqsApp app, OrderLog log) {
+        var response = await app.SendMessage(
+            new Order { Id = "A-1", Quantity = 1 },
+            new Order { Id = "A-2", Quantity = 2 },
+            new Order { Id = "A-3", Quantity = 3 });
+
+        Assert.Empty(response.BatchItemFailures);
+        Assert.Equal(3, log.Orders.Count);
+    }
+#endif
+#if (invoke)
+    [HardenedTest]
+    public async Task ThePayloadReachesTheHandler(LambdaTestApp app, OrderLog log) {
+        var accepted = await app.Invoke<OrderAccepted>(
+            "Process", new Order { Id = "A-1", Quantity = 2 });
+
+        Assert.Equal("A-1", accepted.Id);
+        Assert.Equal("A-1", Assert.Single(log.Orders).Id);
+    }
+
+    /// <summary>The return value is serialised back to the caller, not discarded.</summary>
+    [HardenedTest]
+    public async Task TheHandlersReturnValueComesBack(LambdaTestApp app) {
+        var accepted = await app.Invoke<OrderAccepted>(
+            "Process", new Order { Id = "A-2", Quantity = 1 });
+
+        Assert.Equal(1, accepted.Received);
+    }
+#endif
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/Usings.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/tests/Hardened1.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using Hardened.Shared.Testing.Attributes;
+global using Xunit;

--- a/src/Templates/Hardened.Templates/templates/hardened-library/.template.config/dotnetcli.host.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/.template.config/dotnetcli.host.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "HardenedVersion": {
+      "longName": "hardened-version"
+    },
+    "skipRestore": {
+      "longName": "skip-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-library/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/.template.config/template.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Ian Johnson",
+  "classifications": [
+    "Library",
+    "Hardened"
+  ],
+  "identity": "Hardened.Library.CSharp",
+  "groupIdentity": "Hardened.Library",
+  "name": "Hardened Library",
+  "shortName": "hardened-library",
+  "description": "A reusable Hardened module: services a host picks up with one attribute, and a test project.",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Hardened1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "moduleClass": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "classIdentifier",
+      "replaces": "TemplateModuleName",
+      "fileRename": "TemplateModuleName"
+    },
+    "HardenedVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "0.0.0-DEV",
+      "description": "The Hardened package version to pin. Defaults to the version this template shipped with.",
+      "replaces": "0.0.0-HARDENED-VERSION"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Skip the automatic restore after creation."
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "src/Hardened1/Hardened1.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore the packages the template pinned.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ],
+  "specialCustomOperations": {
+    "**/*.md": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "if": [
+              "#if"
+            ],
+            "else": [
+              "#else"
+            ],
+            "elseif": [
+              "#elseif"
+            ],
+            "endif": [
+              "#endif"
+            ],
+            "trim": true,
+            "wholeLine": true,
+            "evaluator": "C++"
+          }
+        }
+      ]
+    }
+  },
+  "forms": {
+    "classIdentifier": {
+      "identifier": "replace",
+      "pattern": "[^\\w]",
+      "replacement": ""
+    }
+  }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-library/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/AGENTS.md
@@ -1,0 +1,49 @@
+# Hardened1
+
+Invariants and traps for anyone editing this code. `README.md` covers what this library is, how to
+build it and how an application consumes it; this file does not repeat any of that.
+
+## Most of this library is generated at build time
+
+Hardened is a compile-time framework. The module's registrations, and the `[TemplateModuleNameLibrary]`
+attribute applications apply, are written by source generators during the build rather than
+resolved by reflection at run time.
+
+**They are ordinary C#, and you can read them.** `EmitCompilerGeneratedFiles` is on:
+
+```
+src/Hardened1/obj/Debug/net8.0/generated/     one directory per generator
+```
+
+Build first. Reading that directory answers most "how does this work" questions faster than reading
+the framework.
+
+## The one structural rule
+
+**This library names no runtime.** Nothing in `src/Hardened1` may reference Kestrel, ASP.NET Core or
+Lambda, or a Hardened package that does. That is what lets one package serve every host, and it is
+the first thing to check when a consumer reports that it will not compose.
+
+## Things that will not be obvious
+
+**The module class stays empty, and stays `partial`.** The generator writes the other half. A
+service registers itself where it is declared, so there is no list in the module to keep in step —
+adding one is the mistake, not the fix.
+
+**The source generator package is required.** The runtime packages carry no analyzers, so removing
+`Hardened.Library.SourceGenerator` does not fail with a missing package — it fails with
+`'TemplateModuleNameLibrary' does not contain a definition for 'PopulateServiceCollection'`, and consumers
+lose the attribute entirely. Versions are pinned in one place, `Directory.Packages.props`.
+
+**Tests are xUnit v3.** `Hardened.Shared.Testing` builds on `xunit.v3.extensibility.core`; a test
+project on xunit 2.x fails with `CS0433` on `Assert`. v3 test projects are also self-executing,
+hence `<OutputType>Exe</OutputType>`.
+
+**`[HardenedTest]` boots the real module.** Test method parameters are resolved from its container.
+`[Mock]` substitutes a service there rather than in the test, which is why a substituted dependency
+is still used by the real service resolved alongside it — `NSubstitute` arrives with
+`Hardened.Shared.Testing`.
+
+## Commands
+
+See `README.md`. Nothing here overrides it.

--- a/src/Templates/Hardened.Templates/templates/hardened-library/Directory.Build.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <!-- Hardened writes your routing table, request handlers and parameter binding as ordinary
+         C#. Reading it is the fastest way to understand what the framework is doing:
+         obj/<configuration>/<tfm>/generated/, one directory per generator. -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  </PropertyGroup>
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-library/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/Directory.Packages.props
@@ -1,0 +1,27 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- One place to bump. The generated code and the runtime it targets ship together,
+         so every Hardened package moves as a set. -->
+    <HardenedVersion>0.0.0-HARDENED-VERSION</HardenedVersion>
+  </PropertyGroup>
+
+  <ItemGroup Label="Hardened">
+    <PackageVersion Include="Hardened.Shared.Runtime" Version="$(HardenedVersion)" />
+    <PackageVersion Include="Hardened.Shared.Testing" Version="$(HardenedVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Label="Hardened source generators">
+    <!-- Not optional. The runtime packages carry no analyzers, so without this the module's
+         generated half never exists and PopulateServiceCollection does not compile. -->
+    <PackageVersion Include="Hardened.Library.SourceGenerator" Version="$(HardenedVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Label="Testing">
+    <!-- xUnit v3. Hardened.Shared.Testing builds on xunit.v3.extensibility.core, so a test
+         project on xunit 2.x fails with CS0433 on Assert. -->
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+  </ItemGroup>
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-library/Hardened1.sln
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/Hardened1.sln
@@ -1,0 +1,52 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B1C9400C-49D2-47D1-91B1-B62525D8B7A7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened1", "src\Hardened1\Hardened1.csproj", "{6A62F57F-804E-4134-9B4B-D55429FBB1D4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E1FA01F1-5CE2-4197-A473-D7BFA5CDBA21}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened1.Tests", "tests\Hardened1.Tests\Hardened1.Tests.csproj", "{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Debug|x64.ActiveCfg = Debug|x64
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Debug|x64.Build.0 = Debug|x64
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Debug|x86.ActiveCfg = Debug|x86
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Debug|x86.Build.0 = Debug|x86
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Release|x64.ActiveCfg = Release|x64
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Release|x64.Build.0 = Release|x64
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Release|x86.ActiveCfg = Release|x86
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4}.Release|x86.Build.0 = Release|x86
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Debug|x64.ActiveCfg = Debug|x64
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Debug|x64.Build.0 = Debug|x64
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Debug|x86.ActiveCfg = Debug|x86
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Debug|x86.Build.0 = Debug|x86
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Release|x64.ActiveCfg = Release|x64
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Release|x64.Build.0 = Release|x64
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Release|x86.ActiveCfg = Release|x86
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6A62F57F-804E-4134-9B4B-D55429FBB1D4} = {B1C9400C-49D2-47D1-91B1-B62525D8B7A7}
+		{5D04FC27-A1CD-4C70-9E44-E79EE4DD13F5} = {E1FA01F1-5CE2-4197-A473-D7BFA5CDBA21}
+	EndGlobalSection
+EndGlobal

--- a/src/Templates/Hardened.Templates/templates/hardened-library/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/README.md
@@ -1,0 +1,90 @@
+# Hardened1
+
+A reusable module for [Hardened](https://github.com/ipjohnson/Hardened.Framework) — a compile-time,
+source-generated .NET framework. This library declares services; an application picks all of them
+up with one attribute.
+
+## Build it
+
+```bash
+dotnet build
+dotnet test
+```
+
+## Using it from an application
+
+The build writes a `[TemplateModuleNameLibrary]` attribute from the module class. An application composes it
+the same way it composes a runtime:
+
+```csharp
+[HardenedModule]
+[KestrelRuntime]
+[TemplateModuleNameLibrary]        // everything this library registers
+public partial class Application;
+```
+
+That is the whole integration. There is no `AddHardened1()` to call, no options object to thread
+through, and nothing to keep in step by hand — the attribute is generated from the module, so it
+cannot describe a service the library does not have.
+
+## The two projects
+
+| | |
+|---|---|
+| `src/Hardened1` | The module: its services, and nothing about where they run. |
+| `tests/Hardened1.Tests` | Tests, booted against the real module. |
+
+This library names no runtime, which is deliberate. Nothing in it mentions Kestrel, ASP.NET Core or
+Lambda, so the same package works behind any of them.
+
+## Adding to it
+
+A service is registered where it is declared:
+
+```csharp
+[SingletonService]
+public class GreetingService(IGreetingFormatter formatter) : IGreetingService {
+    public string Greet(string name) => formatter.Format($"Hello, {name}");
+}
+```
+
+`[SingletonService]` registers the class against every interface it implements. `[ScopedService]`
+and `[TransientService]` are the other two lifetimes. The module lists nothing, so a service cannot
+be written and then forgotten in a registration file somewhere else — and a dependency with no
+registration is a build error rather than something the first request discovers.
+
+To carry HTTP routes as well as services, add `[HardenedWebModule]` to the module class and
+reference `Hardened.Web.Runtime` and `Hardened.Web.SourceGenerator`. The library then contributes
+routes to whatever application composes it, and `[BasePath]` gives them a prefix.
+
+## Testing
+
+`[HardenedTest]` boots the real module and resolves the test's parameters from its container, so
+what runs is the registration a consuming application would get:
+
+```csharp
+[HardenedTest]
+public void GreetsByName(IGreetingService greeting) {
+    Assert.Equal("Hello, world!", greeting.Greet("world"));
+}
+```
+
+Mark a parameter `[Mock]` and that service is substituted for the whole container, including behind
+another service — so the code under test is still the library's own wiring.
+
+## Reading the generated code
+
+The fastest way to understand any of this is to read what the build wrote. It is ordinary C#, and
+`EmitCompilerGeneratedFiles` is already on:
+
+```
+src/Hardened1/obj/Debug/net8.0/generated/
+```
+
+The module registration and the generated attribute are both there.
+
+## Where to go next
+
+- [Documentation](https://ipjohnson.github.io/Hardened.Docs)
+- `AGENTS.md` in this directory — the invariants and gotchas, for anyone or anything editing the
+  code rather than reading it

--- a/src/Templates/Hardened.Templates/templates/hardened-library/nuget.config
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Hardened is on nuget.org. No other feed and no token are needed. -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/GreetingFormatter.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/GreetingFormatter.cs
@@ -1,0 +1,17 @@
+using DependencyModules.Runtime.Attributes;
+
+namespace Hardened1;
+
+/// <summary>
+/// A second service, so the library has something to inject and the tests have something to
+/// substitute.
+/// </summary>
+public interface IGreetingFormatter {
+    string Format(string message);
+}
+
+[SingletonService]
+public class GreetingFormatter : IGreetingFormatter {
+
+    public string Format(string message) => message + "!";
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/GreetingService.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/GreetingService.cs
@@ -1,0 +1,25 @@
+using DependencyModules.Runtime.Attributes;
+
+namespace Hardened1;
+
+/// <summary>What this library does, as a consumer sees it.</summary>
+public interface IGreetingService {
+    string Greet(string name);
+}
+
+/// <summary>
+/// Registered by the attribute on the class, rather than by a line in the module.
+/// </summary>
+/// <remarks>
+/// [SingletonService] registers this against every interface it implements. [ScopedService] and
+/// [TransientService] are the other two lifetimes and behave the same way.
+///
+/// The dependency arrives through the constructor with nothing declaring it anywhere else - the
+/// generator resolved it at build time, and a missing registration is a build error rather than
+/// something the first request finds out.
+/// </remarks>
+[SingletonService]
+public class GreetingService(IGreetingFormatter formatter) : IGreetingService {
+
+    public string Greet(string name) => formatter.Format($"Hello, {name}");
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/Hardened1.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A Hardened library. It names no runtime, which is the point: the same package is consumed by
+    a Kestrel service, an ASP.NET one and a Lambda without change.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Hardened.Shared.Runtime" />
+    <PackageReference Include="Hardened.Library.SourceGenerator" />
+  </ItemGroup>
+
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/TemplateModuleNameLibrary.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/src/Hardened1/TemplateModuleNameLibrary.cs
@@ -1,0 +1,18 @@
+using Hardened.Shared.Runtime.Attributes;
+
+namespace Hardened1;
+
+/// <summary>
+/// The module. A host picks up everything in this assembly with the single generated
+/// [TemplateModuleNameLibrary] attribute.
+/// </summary>
+/// <remarks>
+/// No runtime attribute here, deliberately - this assembly names no host, so it composes with
+/// whichever one the consuming application chose. partial is not optional: the generator writes
+/// the other half, including the attribute consumers apply.
+///
+/// The class body is empty because it stays empty. Services register themselves where they are
+/// declared, so there is no list here to fall out of step with the code.
+/// </remarks>
+[HardenedModule]
+public partial class TemplateModuleNameLibrary;

--- a/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/Bootstrap.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/Bootstrap.cs
@@ -1,0 +1,6 @@
+using Hardened.Shared.Testing.Attributes;
+using Hardened1;
+
+// The module under test. The real module graph is applied and startup services run, so there is
+// no separate test wiring to keep in step with the library.
+[assembly: HardenedTestEntryPoint(typeof(TemplateModuleNameLibrary))]

--- a/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/GreetingServiceTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/GreetingServiceTests.cs
@@ -1,0 +1,32 @@
+using NSubstitute;
+
+namespace Hardened1.Tests;
+
+/// <summary>
+/// [HardenedTest] boots the module and resolves the test's parameters from its container, so what
+/// runs is the registration a consuming application would get rather than a fresh `new`.
+/// </summary>
+public class GreetingServiceTests {
+
+    [HardenedTest]
+    public void GreetsByName(IGreetingService greeting) {
+        Assert.Equal("Hello, world!", greeting.Greet("world"));
+    }
+
+    /// <summary>
+    /// [Mock] substitutes a service for the whole container, including behind another service.
+    /// </summary>
+    /// <remarks>
+    /// IGreetingService here is the real registration, resolved from the module - and it used the
+    /// substitute, because the substitution happened in the container rather than in this test.
+    /// That is what makes it worth writing: the wiring under test is the application's.
+    /// </remarks>
+    [HardenedTest]
+    public void ASubstitutedDependencyIsUsedByTheRealService(
+        IGreetingService greeting,
+        [Mock] IGreetingFormatter formatter) {
+        formatter.Format(Arg.Any<string>()).Returns("substituted");
+
+        Assert.Equal("substituted", greeting.Greet("world"));
+    }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/Hardened1.Tests.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/Hardened1.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <!-- xUnit v3 test projects are self-executing. -->
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Brings NSubstitute with it, which is what [Mock] builds its substitutes from. -->
+    <PackageReference Include="Hardened.Shared.Testing" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hardened1\Hardened1.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/Usings.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/tests/Hardened1.Tests/Usings.cs
@@ -1,0 +1,2 @@
+global using Hardened.Shared.Testing.Attributes;
+global using Xunit;

--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
@@ -18,6 +18,13 @@
   "sourceName": "Hardened1",
   "preferNameDirectory": true,
   "symbols": {
+    "moduleClass": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "classIdentifier",
+      "replaces": "TemplateModuleName",
+      "fileRename": "TemplateModuleName"
+    },
     "host": {
       "type": "parameter",
       "datatype": "choice",
@@ -31,6 +38,10 @@
         {
           "choice": "aspnet",
           "description": "ASP.NET Core, when you need its middleware, authentication or hosting diagnostics."
+        },
+        {
+          "choice": "aws-lambda",
+          "description": "AWS Lambda behind API Gateway, with a harness that runs it locally over HTTP."
         }
       ]
     },
@@ -96,6 +107,10 @@
     "specFirst": {
       "type": "computed",
       "value": "(contract == 'openapi' || contract == 'smithy')"
+    },
+    "lambda": {
+      "type": "computed",
+      "value": "(host == 'aws-lambda')"
     }
   },
   "sources": [
@@ -124,6 +139,23 @@
           "exclude": [
             "src/Hardened1/contracts/greeting.smithy"
           ]
+        },
+        {
+          "condition": "(!lambda)",
+          "exclude": [
+            "src/Hardened1.Harness/**",
+            "Hardened1.Lambda.sln"
+          ]
+        },
+        {
+          "condition": "(lambda)",
+          "exclude": [
+            "src/Hardened1.Host/Program.cs",
+            "Hardened1.sln"
+          ],
+          "rename": {
+            "Hardened1.Lambda.sln": "Hardened1.sln"
+          }
         }
       ]
     }
@@ -170,6 +202,13 @@
           }
         }
       ]
+    }
+  },
+  "forms": {
+    "classIdentifier": {
+      "identifier": "replace",
+      "pattern": "[^\\w]",
+      "replacement": ""
     }
   }
 }

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -58,7 +58,7 @@ naming both versions, because different CLI versions can produce different ASTs.
 finds `[Get]`, `[Post]`, `[Put]`, `[Delete]` or `[Patch]` and emits a handler bound to that
 method's exact signature.
 
-`[BasePath]` on `Hardened1Library` prefixes every route in the assembly, so a route of `/{name}`
+`[BasePath]` on `TemplateModuleNameLibrary` prefixes every route in the assembly, so a route of `/{name}`
 is served at `/greeting/{name}`.
 #endif
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/Hardened1.Lambda.sln
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/Hardened1.Lambda.sln
@@ -1,0 +1,77 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened1", "src\Hardened1\Hardened1.csproj", "{B33FE15C-62D5-4CF3-BBB3-645543FD2433}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened1.Host", "src\Hardened1.Host\Hardened1.Host.csproj", "{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened1.Tests", "tests\Hardened1.Tests\Hardened1.Tests.csproj", "{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hardened1.Harness", "src\Hardened1.Harness\Hardened1.Harness.csproj", "{1A2B3C4D-5E6F-7081-9293-A4B5C6D7E8F9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Debug|x64.Build.0 = Debug|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Debug|x86.Build.0 = Debug|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Release|x64.ActiveCfg = Release|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Release|x64.Build.0 = Release|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Release|x86.ActiveCfg = Release|Any CPU
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433}.Release|x86.Build.0 = Release|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Debug|x86.Build.0 = Debug|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Release|x64.Build.0 = Release|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5}.Release|x86.Build.0 = Release|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Release|x64.Build.0 = Release|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E}.Release|x86.Build.0 = Release|Any CPU
+		{1A2B3C4D-5E6F-7081-9293-A4B5C6D7E8F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A2B3C4D-5E6F-7081-9293-A4B5C6D7E8F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A2B3C4D-5E6F-7081-9293-A4B5C6D7E8F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A2B3C4D-5E6F-7081-9293-A4B5C6D7E8F9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B33FE15C-62D5-4CF3-BBB3-645543FD2433} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{1E35EBBE-8B73-44DA-8764-4F9CA58767E5} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{AA1CCFE6-7D76-48EA-A436-6B6740AC450E} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+EndGlobal

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -48,7 +48,7 @@ A route is an attribute on a method of a plain class — no base type, no interf
 public Greeting Hello(string name) => new($"Hello, {name}!");
 ```
 
-`[BasePath]` on `Hardened1Library` prefixes every route in the assembly, so that one is served at
+`[BasePath]` on `TemplateModuleNameLibrary` prefixes every route in the assembly, so that one is served at
 `/greeting/{name}`. `[Get]`, `[Post]`, `[Put]`, `[Delete]` and `[Patch]` all behave the same way.
 
 A service is registered next to the class it belongs to, with `[SingletonService]`,

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Harness/Hardened1.Harness.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Harness/Hardened1.Harness.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <!--
+    Runs the Lambda application locally, behind an ordinary HTTP listener.
+
+    A Lambda application has no host to run: AWS invokes it. That makes it awkward to try, so this
+    project exists only for development - it is not part of what you deploy, and the ASP.NET
+    dependency it brings is exactly what the deployed artifact should not carry.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hardened.Amz.Shared.Lambda.Runtime" />
+    <PackageReference Include="Hardened.Amz.Web.Lambda.Runtime" />
+    <PackageReference Include="Hardened.Amz.Web.Lambda.Harness" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Hardened1.Host\Hardened1.Host.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Harness/Program.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Harness/Program.cs
@@ -1,0 +1,23 @@
+using Hardened.Amz.Web.Lambda.Harness;
+using Hardened.Shared.Runtime.Application;
+using Hardened1.Host;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+// Listens on 5080. Override with PORT.
+var port = int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var configured) ? configured : 5080;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Before the application is added, because the module system reads the environment while it is
+// deciding what to register - and on Lambda there is no Program.cs of your own to do it in, so
+// without this the modules see the process default rather than HARDENED_ENVIRONMENT.
+builder.Services.AddHardenedEnvironment(args);
+
+builder.Services.AddLambdaApplication<Application>();
+
+var app = builder.Build();
+
+app.UseLambdaApplication();
+
+app.Run($"http://localhost:{port}");

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
@@ -8,6 +8,9 @@ using Hardened.Web.Kestrel.Runtime;
 #if (aspnet)
 using Hardened.Web.AspNetCore.Runtime;
 #endif
+#if (lambda)
+using Hardened.Amz.Web.Lambda.Runtime.DependencyInjection;
+#endif
 
 namespace Hardened1.Host;
 
@@ -25,6 +28,10 @@ namespace Hardened1.Host;
 #if (aspnet)
 [AspNetCoreRuntime]
 #endif
+#if (lambda)
+// Brings the API Gateway host and, through the [HardenedWebModule] it carries, the web pipeline.
+[LambdaWebModule]
+#endif
 #if (codeFirst)
 // Embeds the document the build wrote from this application's routes, and serves it at
 // /openapi.json. Spec-first applications do not use this: their document is a build input,
@@ -37,5 +44,5 @@ namespace Hardened1.Host;
 [HardenedOpenApiUi(Title = "Hardened1", Environments = "development")]
 #endif
 #endif
-[Hardened1Library]
+[TemplateModuleNameLibrary]
 public partial class Application;

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Hardened1.Host.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Hardened1.Host.csproj
@@ -5,9 +5,11 @@
     cases: Hardened brings ASP.NET Core in through a framework reference where it needs it, and
     the Web SDK's Razor pipeline only gets in the way.
   -->
+<!--#if (!lambda) -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+<!--#endif -->
 
   <ItemGroup>
     <PackageReference Include="Hardened.Shared.Runtime" />
@@ -17,6 +19,11 @@
 <!--#endif -->
 <!--#if (aspnet) -->
     <PackageReference Include="Hardened.Web.AspNetCore.Runtime" />
+<!--#endif -->
+<!--#if (lambda) -->
+    <PackageReference Include="Hardened.Amz.Shared.Lambda.Runtime" />
+    <PackageReference Include="Hardened.Amz.Web.Lambda.Runtime" />
+    <PackageReference Include="Hardened.Amz.Web.Lambda.SourceGenerator" PrivateAssets="all" />
 <!--#endif -->
     <PackageReference Include="Hardened.Library.SourceGenerator" />
     <PackageReference Include="Hardened.Web.SourceGenerator" />

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
@@ -10,7 +10,7 @@ namespace Hardened1;
 /// The library module: this assembly's handlers, services and URL space.
 /// </summary>
 /// <remarks>
-/// The host imports it with the single generated [Hardened1Library] attribute. partial is not
+/// The host imports it with the single generated [TemplateModuleNameLibrary] attribute. partial is not
 /// optional - the generator writes the other half.
 /// </remarks>
 [HardenedModule]
@@ -19,4 +19,4 @@ namespace Hardened1;
 // This assembly's URL space. Every route below it is relative to this.
 [BasePath("/greeting")]
 #endif
-public partial class Hardened1Library;
+public partial class TemplateModuleNameLibrary;

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Bootstrap.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Bootstrap.cs
@@ -5,4 +5,4 @@ using Hardened1;
 // Two assembly attributes: the harness, and the module under test. The real module graph is
 // applied and startup services run, so there is no separate test wiring to keep in step.
 [assembly: WebTesting]
-[assembly: HardenedTestEntryPoint(typeof(Hardened1Library))]
+[assembly: HardenedTestEntryPoint(typeof(TemplateModuleNameLibrary))]


### PR DESCRIPTION
## The three templates

| | |
|---|---|
| `hardened-function` | A Lambda function, `--trigger invoke\|sqs`. One src project and tests — there is no host to separate from, because on Lambda the deployed artifact is the assembly and the generator writes the entry point. |
| `hardened-library` | A reusable module that names no runtime, so one package serves Kestrel, ASP.NET Core and Lambda alike. |
| `hardened-web --host aws-lambda` | The host loses its `Program.cs` and gains a `Harness` project that runs it locally over HTTP through API Gateway payloads. |

## The environment was registered under one interface, not two

`ServiceProviderFileGenerator` emitted `AddSingleton(environment)`, which infers the parameter's static type and so registered `IHardenedEnvironment` alone. The module system reads `IModuleEnvironment` while it decides what to register; finding none, it fell back to `ASPNETCORE_ENVIRONMENT` — `Production`.

So an application read `development` from one interface while every `[IfEnvironment]` registration in it had already been skipped as `Production`. It compiled, it ran, and the only symptom was a gated service quietly not being there.

`TestApplication` had the same line hand-copied in **both** constructors, so the test harness had it too.

Only hosts without a `Program.cs` of their own were affected — which is why it survived until `aws-lambda` existed. Kestrel and ASP.NET call `AddHardenedEnvironment` explicitly and masked the generator.

**Verified on the real host**, by building the Lambda template against a locally-packed framework carrying the fix:

| | `/docs` before | `/docs` after |
|---|---|---|
| `HARDENED_ENVIRONMENT=development` | 404 | **200** |
| `HARDENED_ENVIRONMENT=production` | 404 | **404** |
| `ASPNETCORE_ENVIRONMENT=development` | **200** | — |
| `ASPNETCORE_ENVIRONMENT=production` | — | **200** |

The ASP.NET variable no longer influences anything.

Five regression tests, each confirmed to go red with the fix reverted: three in `TestApplicationTests` for the registration, two in the new `ServiceProviderEmitTests` for what the generator emits and in what order.

**Why the suite missed it:** `[IfEnvironment]` appears nowhere in the framework — no runtime code, no SUT, no test — so no integration test could reach it. And every environment test hands an `IModuleEnvironment` in rather than asking whether the container holds one. `HardenedOpenApiUiTests` passes a stub straight to `ConfigureServices`, testing the predicate but never the supply.

## Dotted project names produced code that would not compile

`sourceName` is `Hardened1` and the module class was literally `Hardened1Library`, so `dotnet new hardened-web -n Acme.Api` emitted:

```csharp
public partial class Acme.ApiLibrary;
```

`Acme.Api` is how .NET libraries are normally named. Both templates now derive the class identifier through a value form that strips the separators.

## Verification

- `verify-templates.sh` green end to end, including the new sections
- 4,257 tests across 27 projects, zero failures
- All three templates install from the packed nupkg
- Every template builds and tests under both a plain and a dotted project name

The gate now also builds and tests `hardened-library`, checks a dotted name against both templates that name a class after the project, and covers the Amz variants against **published** packages — the most that dependency direction allows, since Hardened.Amz depends on published Hardened packages and cannot be pinned to the build under test. It logs that pin rather than implying it gated the local build.

## Known gap

`/docs` on the Lambda variant only works once the framework fix is published — the template pins released packages. That is the release, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnz6FBUjT29qfiMbzj85eD