### PR TITLE
Float the Hardened.Amz pin, and gate the Lambda templates against the build in hand

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -19,7 +19,13 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # in the global packages folder, so a fixed version means the second run restores the first run's
 # content however many times the framework has been rebuilt since - a green run over stale
 # packages, which is worse than no run at all.
-VERSION="0.0.0-verify$(date +%s)"
+#
+# 99.0.0 rather than 0.0.0, and that is not cosmetic either. Hardened.Amz depends on published
+# Hardened packages with a floor - ">= 0.10.0-rc1000" today - and a 0.0.0 version sits below it,
+# so every Lambda project failed to restore with NU1605 rather than exercising anything. A real
+# release is always above that floor, so the verification version has to be too, or the Amz
+# templates can only ever be tested against the previous release instead of the build in hand.
+VERSION="99.0.0-verify$(date +%s)"
 FEED="${TMPDIR:-/tmp}/hardened-template-feed"
 WORK="${TMPDIR:-/tmp}/hardened-template-work"
 SMITHY_PIN=1.73.0
@@ -227,38 +233,32 @@ for TEMPLATE in hardened-library hardened-web; do
     fi
 done
 
-# The Amz-dependent variants cannot be verified against the framework build under test, and that
-# is a property of the dependency direction rather than an omission. Hardened.Amz depends on
-# published Hardened packages, so a generated project pinned to this run's 0.0.0-verify framework
-# also drags in whatever version Amz was built against - NU1605, every time. They are therefore
-# generated against the newest published version, which gates the templates themselves without
-# claiming to gate the build under test.
-say "AWS Lambda templates (published packages)"
-PUBLISHED=$(curl -s "https://api.nuget.org/v3-flatcontainer/hardened.amz.function.lambda.runtime/index.json" \
-    | tr ',' '\n' | tr -d '" ' | grep -E '^[0-9]' | tail -1)
+# The Amz pin floats, which is what lets these be gated against the build under test at all.
+# Hardened.Amz depends on published Hardened packages, so an exact pin here would name a version
+# that does not exist yet for the whole window between the two repositories' releases. Floating it
+# means the framework packages come from this run's feed while Hardened.Amz stays on its newest
+# published release - which is precisely the state a release leaves the world in, so verifying it
+# is verifying the thing that actually ships.
+say "AWS Lambda templates"
+for AMZ in "hardened-function --trigger invoke" "hardened-function --trigger sqs" "hardened-web --host aws-lambda"; do
+    set -- $AMZ
+    AMZ_TEMPLATE="$1"; shift
+    AMZ_OUT="$WORK/amz-$AMZ_TEMPLATE-$(echo "$*" | tr -cd 'a-z')"
 
-if [ -z "$PUBLISHED" ]; then
-    echo "   SKIPPED: could not reach nuget.org for the published Hardened.Amz version"
-else
-    echo "   pinned to $PUBLISHED, not this run's $VERSION"
+    dotnet new "$AMZ_TEMPLATE" -n Sample -o "$AMZ_OUT" "$@" --skip-restore
+    dotnet nuget add source "$FEED" --name template-verify-local --configfile "$AMZ_OUT/nuget.config" >/dev/null
 
-    for AMZ in "hardened-function --trigger invoke" "hardened-function --trigger sqs" "hardened-web --host aws-lambda"; do
-        set -- $AMZ
-        AMZ_TEMPLATE="$1"; shift
-        AMZ_OUT="$WORK/amz-$AMZ_TEMPLATE-$(echo "$*" | tr -cd 'a-z')"
-
-        # No local feed added: these restore from nuget.org alone, on purpose.
-        dotnet new "$AMZ_TEMPLATE" -n Sample -o "$AMZ_OUT" "$@" \
-            --hardened-version "$PUBLISHED" --skip-restore
-
-        if ( cd "$AMZ_OUT" && dotnet build -v q --nologo && dotnet test --no-build -v q --nologo ); then
-            echo "   $AMZ_TEMPLATE $*: builds and tests"
-        else
-            echo "   FAILED: $AMZ_TEMPLATE $*"
-            FAILED=1
-        fi
-    done
-fi
+    if ( cd "$AMZ_OUT" && dotnet build -v q --nologo && dotnet test --no-build -v q --nologo ); then
+        echo "   $AMZ_TEMPLATE $*: builds and tests"
+        # Worth printing: a float that silently stopped resolving would otherwise look identical
+        # to one that resolved to the right thing.
+        grep -hoE '"Hardened\.Amz\.[A-Za-z.]+/[^"]+"' "$AMZ_OUT"/src/*/obj/project.assets.json 2>/dev/null \
+            | tr -d '"' | sort -u | head -2 | sed 's/^/     resolved /'
+    else
+        echo "   FAILED: $AMZ_TEMPLATE $*"
+        FAILED=1
+    fi
+done
 
 say "host independence"
 # The framework's claim is that handlers, filters, binding and routing do not change with the

--- a/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
@@ -8,7 +8,19 @@
       Hardened.Amz releases on its own line, and this pins the same version the framework is on
       because the two are released together. If they ever diverge, this is the one line to change.
     -->
-    <HardenedAmzVersion>$(HardenedVersion)</HardenedAmzVersion>
+    <!--
+      Floated rather than pinned to $(HardenedVersion), because the two repositories release in
+      sequence and cannot both be at the new version at the same instant. Hardened.Amz depends on
+      published Hardened packages, so the framework releases first - and for the window between the
+      two, an exact pin here names a Hardened.Amz version that does not exist yet and every Lambda
+      project fails to restore.
+
+      The float resolves to the newest 0.x Hardened.Amz, prereleases included. During the window
+      that is the previous release, which still works: this file pins the framework packages
+      higher, and a dependency asking for a lower version is satisfied by a higher one.
+    -->
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <HardenedAmzVersion>0.*-*</HardenedAmzVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Hardened">

--- a/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
@@ -4,7 +4,19 @@
     <!-- One place to bump. The generated code and the runtime it targets ship together,
          so every Hardened package moves as a set. -->
     <HardenedVersion>0.0.0-HARDENED-VERSION</HardenedVersion>
-    <HardenedAmzVersion>$(HardenedVersion)</HardenedAmzVersion>
+    <!--
+      Floated rather than pinned to $(HardenedVersion), because the two repositories release in
+      sequence and cannot both be at the new version at the same instant. Hardened.Amz depends on
+      published Hardened packages, so the framework releases first - and for the window between the
+      two, an exact pin here names a Hardened.Amz version that does not exist yet and every Lambda
+      project fails to restore.
+
+      The float resolves to the newest 0.x Hardened.Amz, prereleases included. During the window
+      that is the previous release, which still works: this file pins the framework packages
+      higher, and a dependency asking for a lower version is satisfied by a higher one.
+    -->
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <HardenedAmzVersion>0.*-*</HardenedAmzVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Hardened">


### PR DESCRIPTION
## The pin had to float

The two repositories release in sequence and cannot both be at the new version at the same instant — Hardened.Amz depends on **published** Hardened packages, so the framework goes first.

An exact pin of `HardenedAmzVersion` to `$(HardenedVersion)` therefore named a Hardened.Amz version that did not exist yet for the whole window between the two releases. Every Lambda project generated in that window failed to restore — all of `hardened-function` among them, since none of its variants build without Amz.

This was asked for earlier and never built; the pin has only ever held the exact value. Tagging `v0.11.0-rc1000` without it would have shipped exactly that breakage.

Floating to `0.*-*` resolves to the newest 0.x Hardened.Amz, prereleases included. During the window that is the previous release, which still works: the template pins the framework packages *higher*, and a dependency asking for a lower version is satisfied by a higher one.

**Verified in that state**, not reasoned about — framework packed locally at a version newer than any published Hardened.Amz:

| | result |
|---|---|
| `hardened-function --trigger invoke` | builds, 2 tests pass |
| `hardened-function --trigger sqs` | builds, 2 tests pass |
| `hardened-web --host aws-lambda` | builds, 2 tests pass, `/docs` 200 dev / 404 prod |

Amz resolved to published `0.10.0-rc1000` alongside the local framework build.

## The gate's version had to move too

`verify-templates.sh` packed at `0.0.0-verify<timestamp>`, which sits **below** the `>= 0.10.0-rc1000` floor Hardened.Amz declares. Pointing the Lambda templates at the local feed produced `NU1605` rather than a test — the gate caught this on its first run.

A real release is always above that floor. `99.0.0-verify<timestamp>` keeps the per-run uniqueness that defeats NuGet's cache and clears any floor Amz will declare, so those variants now exercise the build in hand instead of the previous release — which is the point of a release gate. Previously that section pinned to published packages and logged that it was not testing the local build.

It also prints the Hardened.Amz version the float resolved to. A float that silently stopped resolving would otherwise look exactly like one that resolved correctly.

## Gate result

```
== AWS Lambda templates
   hardened-function --trigger invoke: builds and tests
     resolved Hardened.Amz.Function.Lambda.Runtime/0.10.0-rc1000
   hardened-function --trigger sqs: builds and tests
     resolved Hardened.Amz.Function.Lambda.Runtime/0.10.0-rc1000
   hardened-web --host aws-lambda: builds and tests
     resolved Hardened.Amz.Shared.Lambda.Runtime/0.10.0-rc1000
== templates verified
```

Full run green, zero failures, across every host/contract combination plus the library, dotted names, and host independence.

## Release order this unblocks

1. Framework `v0.11.0-rc1000` — publishes the framework packages and the templates
2. Hardened.Amz — bump its pins to `0.11.0-rc1000`, release
3. The float keeps every Lambda template working between the two

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnz6FBUjT29qfiMbzj85eD