### PR TITLE
Put back the solution exclusions the launch-profile change dropped

### DIFF
--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
@@ -141,6 +141,24 @@
           ]
         },
         {
+          "comment": "One solution reaches the output and it is always named Hardened1.sln, so `dotnet build` in the generated folder has exactly one thing to build. Dropping these left both, and the generated application could not be built at all - MSB1011, from the bare `dotnet build` in scripts/verify-templates.sh.",
+          "condition": "(!lambda)",
+          "exclude": [
+            "src/Hardened1.Harness/**",
+            "Hardened1.Lambda.sln"
+          ]
+        },
+        {
+          "condition": "(lambda)",
+          "exclude": [
+            "src/Hardened1.Host/Program.cs",
+            "Hardened1.sln"
+          ],
+          "rename": {
+            "Hardened1.Lambda.sln": "Hardened1.sln"
+          }
+        },
+        {
           "comment": "The launch profile exists to open /docs on F5. Without the page there is nothing for it to open, and a profile pointing at a 404 is worse than no profile.",
           "condition": "(!OpenApiUi)",
           "exclude": [


### PR DESCRIPTION
`templates.yaml` has been red on `main` since #164, failing at the first probe it runs — `host: kestrel  contract: code`:

```
MSBUILD : error MSB1011: Specify which project or solution file to use
because this folder contains more than one project or solution file.
```

The run before it, `904815d`, was green.

#164 added a modifier excluding `launchSettings.json` when `--openapi-ui false`, and in doing so **replaced** the two blocks beside it rather than landing alongside them. The `(!lambda)` / `(lambda)` pair is what kept one solution in the generated output — without them both `Hardened1.sln` and `Hardened1.Lambda.sln` reach it, and the bare `dotnet build` in `scripts/verify-templates.sh:115` has two candidates and builds neither.

The `(lambda)` block also carried the rename that gives a Lambda application the same solution name as a plain one, so a generated app is `Hardened1.sln` either way, and `(!lambda)` kept the harness out of a non-Lambda application. Both are restored as they were; the launch-profile modifier keeps its comment and its place after them.

`hardened-function` and `hardened-library` declare one solution each and never had these blocks, so neither is affected.

## Verification

Ran `scripts/verify-templates.sh` locally. The `kestrel / code` probe now packs, installs, generates and **builds** — `0 Warning(s), 0 Error(s)` — where it previously died at `MSB1011`.

The generated application's own tests then pass on **8.0.401**, the SDK these workflows pin:

```
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2 - Sample.Tests.dll (net8.0)
```

### One thing found while verifying, not fixed here

On the **.NET 11 SDK preview** the same generated application fails those two tests:

```
System.IO.FileNotFoundException : Could not load file or assembly 'Sample, Version=1.0.0.0'
  at DependencyModules.Testing.Impl.AttributeUtility.GetOrderedCustomAttributes(Assembly)
```

The cause is that the preview SDK omits the `Sample` project from `Sample.Tests.deps.json` entirely, though it still copies `Sample.dll` to the output directory — so `[assembly: HardenedTestEntryPoint(typeof(SampleLibrary))]` cannot be resolved at run time.

| SDK | project entries in `deps.json` | tests |
|---|---|---|
| 8.0.401 | `Sample.Tests/1.0.0`, `Sample/1.0.0` | pass |
| 11.0.100-preview.7 | `Sample.Tests/1.0.0` only | fail |

Nothing to do about it in this PR — CI is on `8.0.x` and green. It matters because it blocks the planned move to the .NET 11 SDK, and it is recorded in `UNION-RESPONSES-IMPLEMENTATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKqDjvGjg7azh2z9GtB1er