### PR TITLE
Generic problem types, and sending the body rather than the wrapper

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -644,8 +644,17 @@ namespace Hardened.Requests.Abstract.Responses
         public string Title { get; }
         public string Type { get; }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(409)]
+    public sealed class Conflict<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Conflict<T>>
+    {
+        public Conflict(T Body) { }
+        public T Body { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
     [Hardened.Requests.Abstract.Responses.HttpStatus(201)]
-    public sealed class Created<T> : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Created<T>>
+    public sealed class Created<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Created<T>>
     {
         public Created(T Value, string Location) { }
         public string Location { get; init; }
@@ -662,6 +671,15 @@ namespace Hardened.Requests.Abstract.Responses
         public string Title { get; }
         public string Type { get; }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(403)]
+    public sealed class Forbidden<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Forbidden<T>>
+    {
+        public Forbidden(T Body) { }
+        public T Body { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
     [Hardened.Requests.Abstract.Responses.HttpStatus(410)]
     public sealed class Gone : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Gone>
     {
@@ -671,11 +689,24 @@ namespace Hardened.Requests.Abstract.Responses
         public string Title { get; }
         public string Type { get; }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(410)]
+    public sealed class Gone<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Gone<T>>
+    {
+        public Gone(T Body) { }
+        public T Body { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited=false)]
     public sealed class HttpStatusAttribute : System.Attribute
     {
         public HttpStatusAttribute(int statusCode) { }
         public int StatusCode { get; }
+    }
+    public interface ICarriesResponseBody
+    {
+        object? Body { get; }
     }
     public interface IHttpStatusResponse
     {
@@ -703,11 +734,29 @@ namespace Hardened.Requests.Abstract.Responses
         public string Title { get; }
         public string Type { get; }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(404)]
+    public sealed class NotFound<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotFound<T>>
+    {
+        public NotFound(T Body) { }
+        public T Body { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
     [Hardened.Requests.Abstract.Responses.HttpStatus(412)]
     public sealed class PreconditionFailed : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed>
     {
         public PreconditionFailed(string? Detail = null) { }
         public string? Detail { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(412)]
+    public sealed class PreconditionFailed<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed<T>>
+    {
+        public PreconditionFailed(T Body) { }
+        public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
@@ -729,6 +778,17 @@ namespace Hardened.Requests.Abstract.Responses
     {
         public RateLimited(System.TimeSpan RetryAfter, string? Detail = null) { }
         public string? Detail { get; init; }
+        public System.TimeSpan RetryAfter { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+        public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+    }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(429)]
+    public sealed class RateLimited<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.RateLimited<T>>
+    {
+        public RateLimited(System.TimeSpan RetryAfter, T Body) { }
+        public T Body { get; init; }
         public System.TimeSpan RetryAfter { get; init; }
         public int Status { get; }
         public string Title { get; }
@@ -885,12 +945,34 @@ namespace Hardened.Requests.Abstract.Responses
         public string Type { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(503)]
+    public sealed class ServiceUnavailable<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.ServiceUnavailable<T>>
+    {
+        public ServiceUnavailable(T Body, System.TimeSpan? After = default) { }
+        public System.TimeSpan? After { get; init; }
+        public T Body { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+        public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+    }
     [Hardened.Requests.Abstract.Responses.HttpStatus(401)]
     public sealed class Unauthorized : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Unauthorized>
     {
         public Unauthorized(string? Detail = null, Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge = null) { }
         public Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge { get; init; }
         public string? Detail { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+        public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+    }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(401)]
+    public sealed class Unauthorized<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Unauthorized<T>>
+    {
+        public Unauthorized(T Body, Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge = null) { }
+        public T Body { get; init; }
+        public Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/GenericResponseTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/GenericResponseTests.cs
@@ -45,8 +45,8 @@ public class GenericResponseTests {
         }
     }
 
-    private static object Build(Type openGeneric) {
-        var closed = openGeneric.MakeGenericType(typeof(ApiError));
+    private static object Build(Type type) {
+        var closed = type.IsGenericTypeDefinition ? type.MakeGenericType(typeof(ApiError)) : type;
         var constructor = closed.GetConstructors().OrderBy(c => c.GetParameters().Length).First();
 
         var arguments = constructor.GetParameters()
@@ -105,13 +105,32 @@ public class GenericResponseTests {
 
     /// <summary>
     /// The <c>type</c> URI identifies what went wrong, not what shape the body is - so the generic
-    /// and non-generic forms of one status share it.
+    /// and non-generic forms of one status agree on it, and on the title.
     /// </summary>
-    [Fact]
-    public void TheGenericAndNonGenericFormsShareAProblemType() {
-        Assert.Equal(new NotFound("todo").Type, new NotFound<ApiError>(new ApiError("e","m")).Type);
-        Assert.Equal(new Conflict().Type, new Conflict<ApiError>(new ApiError("e","m")).Type);
-        Assert.Equal(new Gone().Type, new Gone<ApiError>(new ApiError("e","m")).Type);
+    /// <remarks>
+    /// Every pair rather than a sample. The two are written out separately, so a copied-and-edited
+    /// declaration that kept the wrong <c>ProblemTypes</c> constant would read correctly and
+    /// describe the wrong problem - which a client matching on <c>type</c> acts on.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(GenericProblemTypes))]
+    public void AGenericProblemAgreesWithItsNonGenericFormOnKind(Type openGeneric) {
+        var plain = openGeneric.Assembly.GetType(
+            openGeneric.Namespace + "." + openGeneric.Name.Split('`')[0]);
+
+        // Created<T> has no non-generic counterpart and is not a problem type.
+        if (plain == null) {
+            return;
+        }
+
+        var generic = Build(openGeneric);
+        var reference = Build(plain);
+
+        foreach (var member in new[] { "Type", "Title" }) {
+            Assert.Equal(
+                plain.GetProperty(member)!.GetValue(reference),
+                openGeneric.MakeGenericType(typeof(ApiError)).GetProperty(member)!.GetValue(generic));
+        }
     }
 
     [Theory]

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/GenericResponseTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/GenericResponseTests.cs
@@ -1,0 +1,201 @@
+using System.Reflection;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Responses;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Tests.Responses;
+
+/// <summary>
+/// The generic problem types, for a caller who already has a payload type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hand-written equivalent of what the specification-first emitter generates for a declared
+/// status - <c>GetPetNotFound(ApiError Body)</c> - so both front ends describe a declared error the
+/// same way. It also makes two statuses sharing one payload expressible:
+/// <c>Response&lt;Todo, NotFound&lt;ApiError&gt;, Conflict&lt;ApiError&gt;&gt;</c> is two distinct
+/// closed types, where <c>Response&lt;Todo, ApiError, ApiError&gt;</c> is CS0457.
+/// </para>
+/// <para>
+/// The property that has to hold is that the payload reaches the wire rather than a wrapper around
+/// it. That is <see cref="ICarriesResponseBody"/>, and the dispatch reads it at compile time.
+/// </para>
+/// </remarks>
+public class GenericResponseTests {
+
+    public sealed record ApiError(string Code, string Message);
+
+    /// <summary>
+    /// Every generic problem type, found by reflection rather than listed, so one added later is
+    /// covered without anyone remembering.
+    /// </summary>
+    public static TheoryData<Type> GenericProblemTypes {
+        get {
+            var data = new TheoryData<Type>();
+
+            foreach (var type in typeof(NotFound<>).Assembly.GetExportedTypes()) {
+                if (type.IsGenericTypeDefinition &&
+                    type.GetCustomAttribute<HttpStatusAttribute>() != null &&
+                    typeof(ICarriesResponseBody).IsAssignableFrom(type)) {
+                    data.Add(type);
+                }
+            }
+
+            return data;
+        }
+    }
+
+    private static object Build(Type openGeneric) {
+        var closed = openGeneric.MakeGenericType(typeof(ApiError));
+        var constructor = closed.GetConstructors().OrderBy(c => c.GetParameters().Length).First();
+
+        var arguments = constructor.GetParameters()
+            .Select(p =>
+                p.ParameterType == typeof(ApiError) ? new ApiError("e", "m") :
+                p.ParameterType == typeof(TimeSpan) ? TimeSpan.FromSeconds(5) :
+                p.ParameterType == typeof(string) ? "/things/1" :
+                p.HasDefaultValue ? p.DefaultValue :
+                Activator.CreateInstance(p.ParameterType))
+            .ToArray();
+
+        return constructor.Invoke(arguments);
+    }
+
+    #region the body reaches the wire
+
+    /// <summary>
+    /// The whole point. Sending the wrapper would nest the caller's payload under a Body member and
+    /// ship Type, Title and Status beside it - a shape they did not ask for and no client expects.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GenericProblemTypes))]
+    public void TheBodyIsThePayloadNotTheWrapper(Type openGeneric) {
+        var response = (ICarriesResponseBody)Build(openGeneric);
+
+        var body = Assert.IsType<ApiError>(response.Body);
+
+        Assert.Equal("e", body.Code);
+    }
+
+    /// <summary>
+    /// Declared explicitly, so it is reachable through the interface and not through the record's
+    /// own <c>Body</c> - which is what the generated cast in the dispatch goes through.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(GenericProblemTypes))]
+    public void EveryGenericProblemCarriesItsBody(Type openGeneric) {
+        Assert.True(
+            typeof(ICarriesResponseBody).IsAssignableFrom(openGeneric),
+            openGeneric.Name + " must implement ICarriesResponseBody.");
+    }
+
+    /// <summary>
+    /// Created&lt;T&gt; had this noted as outstanding when it was written; it is the same case.
+    /// </summary>
+    [Fact]
+    public void CreatedCarriesItsValueRatherThanItself() {
+        ICarriesResponseBody created = new Created<ApiError>(new ApiError("e", "m"), "/things/1");
+
+        Assert.IsType<ApiError>(created.Body);
+    }
+
+    #endregion
+
+    #region same problem kind as the non-generic form
+
+    /// <summary>
+    /// The <c>type</c> URI identifies what went wrong, not what shape the body is - so the generic
+    /// and non-generic forms of one status share it.
+    /// </summary>
+    [Fact]
+    public void TheGenericAndNonGenericFormsShareAProblemType() {
+        Assert.Equal(new NotFound("todo").Type, new NotFound<ApiError>(new ApiError("e","m")).Type);
+        Assert.Equal(new Conflict().Type, new Conflict<ApiError>(new ApiError("e","m")).Type);
+        Assert.Equal(new Gone().Type, new Gone<ApiError>(new ApiError("e","m")).Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericProblemTypes))]
+    public void TheAttributeAgreesWithTheStatusProperty(Type openGeneric) {
+        var declared = openGeneric.GetCustomAttribute<HttpStatusAttribute>()!.StatusCode;
+
+        Assert.Equal(declared, ((IHttpStatusResponse)Build(openGeneric)).Status);
+    }
+
+    [Theory]
+    [MemberData(nameof(GenericProblemTypes))]
+    public void EveryGenericProblemIsSealed(Type openGeneric) {
+        Assert.True(openGeneric.IsSealed, openGeneric.Name + " must be sealed.");
+    }
+
+    #endregion
+
+    #region headers still come from the response
+
+    [Fact]
+    public void TheGenericRateLimitedStillWritesRetryAfter() {
+        var headers = new Dictionary<string, StringValues>();
+
+        new RateLimited<ApiError>(TimeSpan.FromSeconds(30), new ApiError("e","m"))
+            .ApplyHeaders(headers);
+
+        Assert.Equal("30", headers["Retry-After"]);
+    }
+
+    [Fact]
+    public void TheGenericUnauthorizedStillChallenges() {
+        var headers = new Dictionary<string, StringValues>();
+
+        new Unauthorized<ApiError>(new ApiError("e","m")).ApplyHeaders(headers);
+
+        Assert.Equal("Bearer", headers[AuthorizationChallenge.HeaderName]);
+    }
+
+    [Fact]
+    public void TheGenericServiceUnavailableWritesNoRetryAfterWithoutOne() {
+        var headers = new Dictionary<string, StringValues>();
+
+        new ServiceUnavailable<ApiError>(new ApiError("e","m")).ApplyHeaders(headers);
+
+        Assert.False(headers.ContainsKey("Retry-After"));
+    }
+
+    #endregion
+
+    #region composing a response set
+
+    /// <summary>
+    /// Two statuses sharing one payload type, which is the shape this exists for.
+    /// <c>Response&lt;Todo, ApiError, ApiError&gt;</c> is CS0457; these are distinct closed types.
+    /// </summary>
+    [Fact]
+    public void TwoStatusesCanShareOnePayloadType() {
+        Response<string, NotFound<ApiError>, Conflict<ApiError>> notFound =
+            new NotFound<ApiError>(new ApiError("nf", "no such todo"));
+
+        Response<string, NotFound<ApiError>, Conflict<ApiError>> conflict =
+            new Conflict<ApiError>(new ApiError("cf", "already exists"));
+
+        Assert.IsType<NotFound<ApiError>>(notFound.Value);
+        Assert.IsType<Conflict<ApiError>>(conflict.Value);
+    }
+
+    /// <summary>
+    /// And it can be thrown, keeping its type - the generic exception composes with the generic
+    /// response because both are ordinary types.
+    /// </summary>
+    [Fact]
+    public void AGenericProblemCanBeThrownWithItsTypeIntact() {
+        var response = new NotFound<ApiError>(new ApiError("nf", "no such todo"));
+
+        try {
+            throw response.AsException();
+        }
+        catch (ResponseException<NotFound<ApiError>> e) {
+            Assert.Equal(404, e.StatusCode);
+            Assert.Equal("nf", e.Response.Body.Code);
+        }
+    }
+
+    #endregion
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ConflictOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ConflictOfT.cs
@@ -1,0 +1,35 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 409 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="Conflict"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>Conflict, Conflict</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(409)]
+public sealed record Conflict<T>(T Body)
+    : IHttpStatusResponse, ICarriesResponseBody {
+
+    public string Type => ProblemTypes.Conflict;
+
+    public string Title => "Conflict";
+
+    public int Status => 409;
+
+    object? ICarriesResponseBody.Body => Body;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Created.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Created.cs
@@ -20,16 +20,18 @@ namespace Hardened.Requests.Abstract.Responses;
 /// <para>
 /// <b>The body is <see cref="Value"/>, not this record.</b> Serializing the wrapper would put the
 /// caller's resource under a <c>value</c> member and the location in the body as well as the
-/// header, which is not what a 201 looks like anywhere. Unwrapping is the response-mode plumbing's
-/// job and arrives with it; until then this type is the declaration, and what reads it is the
-/// generator.
+/// header, which is not what a 201 looks like anywhere. <see cref="ICarriesResponseBody"/> is what
+/// says so, and the generated dispatch reads it at compile time rather than testing for it per
+/// request.
 /// </para>
 /// </remarks>
 [HttpStatus(201)]
 public sealed record Created<T>(T Value, string Location)
-    : IHttpStatusResponse, IProvidesResponseHeaders {
+    : IHttpStatusResponse, IProvidesResponseHeaders, ICarriesResponseBody {
 
     public int Status => 201;
+
+    object? ICarriesResponseBody.Body => Value;
 
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         headers[KnownHeaders.Location] = Location;

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ForbiddenOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ForbiddenOfT.cs
@@ -1,0 +1,35 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 403 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="Forbidden"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>Forbidden, Forbidden</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(403)]
+public sealed record Forbidden<T>(T Body)
+    : IHttpStatusResponse, ICarriesResponseBody {
+
+    public string Type => ProblemTypes.Forbidden;
+
+    public string Title => "Forbidden";
+
+    public int Status => 403;
+
+    object? ICarriesResponseBody.Body => Body;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/GoneOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/GoneOfT.cs
@@ -1,0 +1,35 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 410 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="Gone"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>Gone, Gone</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(410)]
+public sealed record Gone<T>(T Body)
+    : IHttpStatusResponse, ICarriesResponseBody {
+
+    public string Type => ProblemTypes.Gone;
+
+    public string Title => "Gone";
+
+    public int Status => 410;
+
+    object? ICarriesResponseBody.Body => Body;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ICarriesResponseBody.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ICarriesResponseBody.cs
@@ -1,0 +1,32 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A response type whose body is one of its members rather than the type itself.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Most responses <em>are</em> their body: a <c>NotFound</c> serializes as the problem document it
+/// describes. A few wrap one instead - <c>Created&lt;T&gt;</c> carries the resource that was made,
+/// and <c>NotFound&lt;T&gt;</c> carries a body the caller supplied - and serializing those as
+/// themselves would put the payload under a <c>Body</c> or <c>Value</c> member and send the
+/// wrapper's own fields with it. A 201 does not look like that anywhere.
+/// </para>
+/// <para>
+/// <b>Read at compile time, not per request.</b> The dispatch generator sees which cases implement
+/// this and emits the unwrapping into those arms only, so a handler whose cases are all ordinary
+/// responses carries no type test at all. That is the same treatment
+/// <see cref="IProvidesResponseHeaders"/> gets, and for the same reason.
+/// </para>
+/// </remarks>
+public interface ICarriesResponseBody {
+
+    /// <summary>
+    /// What is serialized for this response, or null to send nothing.
+    /// </summary>
+    /// <remarks>
+    /// Typed <c>object?</c> because the pipeline's <c>ResponseValue</c> is, so nothing is
+    /// transformed between here and the wire - the same property that lets a union's <c>Value</c> be
+    /// assigned straight across.
+    /// </remarks>
+    object? Body { get; }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotFoundOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotFoundOfT.cs
@@ -1,0 +1,35 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 404 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="NotFound"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>NotFound, NotFound</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(404)]
+public sealed record NotFound<T>(T Body)
+    : IHttpStatusResponse, ICarriesResponseBody {
+
+    public string Type => ProblemTypes.NotFound;
+
+    public string Title => "Not Found";
+
+    public int Status => 404;
+
+    object? ICarriesResponseBody.Body => Body;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailedOfT.cs
@@ -1,0 +1,35 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 412 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="PreconditionFailed"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>PreconditionFailed, PreconditionFailed</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(412)]
+public sealed record PreconditionFailed<T>(T Body)
+    : IHttpStatusResponse, ICarriesResponseBody {
+
+    public string Type => ProblemTypes.PreconditionFailed;
+
+    public string Title => "Precondition Failed";
+
+    public int Status => 412;
+
+    object? ICarriesResponseBody.Body => Body;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/RateLimitedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/RateLimitedOfT.cs
@@ -1,0 +1,41 @@
+using Hardened.Requests.Abstract.Headers;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 429 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="RateLimited"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>RateLimited, RateLimited</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(429)]
+public sealed record RateLimited<T>(TimeSpan RetryAfter, T Body)
+    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders {
+
+    public string Type => ProblemTypes.RateLimited;
+
+    public string Title => "Too Many Requests";
+
+    public int Status => 429;
+
+    object? ICarriesResponseBody.Body => Body;
+    public void ApplyHeaders(IDictionary<string, StringValues> headers) {
+        headers[KnownHeaders.RetryAfter] = Responses.RetryAfter.HeaderValue(RetryAfter);
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailableOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailableOfT.cs
@@ -1,0 +1,43 @@
+using Hardened.Requests.Abstract.Headers;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 503 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="ServiceUnavailable"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>ServiceUnavailable, ServiceUnavailable</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(503)]
+public sealed record ServiceUnavailable<T>(T Body, TimeSpan? After = null)
+    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders {
+
+    public string Type => ProblemTypes.ServiceUnavailable;
+
+    public string Title => "Service Unavailable";
+
+    public int Status => 503;
+
+    object? ICarriesResponseBody.Body => Body;
+    public void ApplyHeaders(IDictionary<string, StringValues> headers) {
+        if (After is { } after) {
+            headers[KnownHeaders.RetryAfter] = RetryAfter.HeaderValue(after);
+        }
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnauthorizedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnauthorizedOfT.cs
@@ -1,0 +1,43 @@
+using Hardened.Requests.Abstract.Authorization;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 401 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="Unauthorized"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// <para>
+/// This is the hand-written equivalent of what the specification-first emitter generates for a
+/// declared status - <c>GetPetNotFound(ApiError Body)</c> - so the two front ends describe a
+/// declared error the same way, and two statuses sharing one payload type are two distinct case
+/// types rather than the CS0457 that <c>Unauthorized, Unauthorized</c> would be.
+/// </para>
+/// </remarks>
+[HttpStatus(401)]
+public sealed record Unauthorized<T>(T Body, AuthorizationChallenge? Challenge = null)
+    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders {
+
+    public string Type => ProblemTypes.Unauthorized;
+
+    public string Title => "Unauthorized";
+
+    public int Status => 401;
+
+    object? ICarriesResponseBody.Body => Body;
+    public void ApplyHeaders(IDictionary<string, StringValues> headers) {
+        var challenge = Challenge ?? AuthorizationChallenge.AuthenticationRequired();
+
+        headers[AuthorizationChallenge.HeaderName] = challenge.HeaderValue;
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseSetSourceTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseSetSourceTests.cs
@@ -58,11 +58,15 @@ public class ResponseSetSourceTests {
     /// A malformed entry is skipped rather than throwing. This crosses an incremental cache as a
     /// string, and a generator that threw while decoding one would fail the build with a message
     /// about nothing the author wrote.
+    ///
+    /// The fixtures spell the encoding out rather than building it, which is deliberate: it is what
+    /// noticed the format gaining a field. A round trip through Encode would have agreed with itself
+    /// either way.
     /// </summary>
     [Theory]
     [InlineData("global::App.Todo")]
-    [InlineData("global::App.Todo|notanumber|01")]
-    [InlineData("global::App.Todo|200|1")]
+    [InlineData("global::App.Todo|notanumber|010|")]
+    [InlineData("global::App.Todo|200|1|")]
     public void AMalformedEntryIsSkipped(string encoded) {
         Assert.Empty(UnionResponseSelector.Decode(encoded));
     }
@@ -70,7 +74,7 @@ public class ResponseSetSourceTests {
     [Fact]
     public void AMalformedEntryDoesNotDiscardTheGoodOnesBesideIt() {
         var decoded = UnionResponseSelector.Decode(
-            "global::App.Todo|200|01;broken;global::App.Gone|410|01");
+            "global::App.Todo|200|010|;broken;global::App.Gone|410|010|");
 
         Assert.Equal(2, decoded.Count);
         Assert.Equal("global::App.Todo", decoded[0].TypeName);

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -66,8 +66,13 @@ public abstract class BaseRequestModelGenerator {
         var responses = new List<ResponseSchemaModel>();
 
         foreach (var unionCase in UnionResponseSelector.Decode(response.UnionCases)) {
+            // The body's type where the case wraps one, because that is what reaches the wire. A
+            // schema written from NotFound<ApiError> would describe a shape carrying the payload
+            // under a member, which no client ever receives.
+            var described = unionCase.BodyTypeName ?? unionCase.TypeName;
+
             var symbol = context.SemanticModel.Compilation.GetTypeByMetadataName(
-                unionCase.TypeName.Replace("global::", ""));
+                described.Replace("global::", ""));
 
             responses.Add(new ResponseSchemaModel(
                 unionCase.Status,

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeMethodCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeMethodCodeGenerator.cs
@@ -94,12 +94,14 @@ public static class InvokeMethodCodeGenerator {
         for (var i = 0; i < cases.Count; i++) {
             var unionCase = cases[i];
 
-            // A named binding only where an arm reads it. `case T _:` is a declaration pattern with
+            // A named binding where an arm reads it - to apply headers, or to take the body off a
+            // case that wraps one. `case T _:` is a declaration pattern with
             // a discard, which has been legal since C# 7 - lower than the bare type pattern `case
             // T:` a reader might reach for, and the difference matters because this is a consumer's
             // build rather than ours. The alternative was naming every binding and discarding the
             // unread ones, which put a `_ = __case0;` line in most arms of every handler.
-            var binding = unionCase.AppliesHeaders ? CaseVariable + i : "_";
+            var reads = unionCase.AppliesHeaders || (unionCase.CarriesBody && unionCase.HasBody);
+            var binding = reads ? CaseVariable + i : "_";
 
             var caseBlock = switchBlock.AddCase(
                 CodeOutputComponent.Get(unionCase.TypeName + " " + binding));
@@ -111,6 +113,18 @@ public static class InvokeMethodCodeGenerator {
                 caseBlock.AddIndentedStatement(
                     CodeOutputComponent.Get(binding)
                         .Invoke("ApplyHeaders", context.Property("Response.Headers")));
+            }
+
+            // Overrides the assignment made before the switch, for a case whose body is one of its
+            // members rather than the case itself - Created<T> and the generic problem types.
+            // Sending the wrapper would nest the caller's payload under a member and ship the
+            // wrapper's own fields beside it.
+            if (unionCase.CarriesBody && unionCase.HasBody) {
+                caseBlock
+                    .Assign(CodeOutputComponent.Get(
+                        "((global::Hardened.Requests.Abstract.Responses.ICarriesResponseBody)" +
+                        binding + ").Body"))
+                    .To(context.Property("Response.ResponseValue"));
             }
 
             if (!unionCase.HasBody) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnionResponseSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnionResponseSelector.cs
@@ -12,11 +12,15 @@ namespace Hardened.SourceGenerator.Requests;
 /// </summary>
 public readonly struct UnionCaseModel {
 
-    public UnionCaseModel(string typeName, int status, bool appliesHeaders, bool hasBody) {
+    public UnionCaseModel(
+        string typeName, int status, bool appliesHeaders, bool hasBody,
+        bool carriesBody = false, string? bodyTypeName = null) {
         TypeName = typeName;
         Status = status;
         AppliesHeaders = appliesHeaders;
         HasBody = hasBody;
+        CarriesBody = carriesBody;
+        BodyTypeName = bodyTypeName;
     }
 
     /// <summary>The case type, fully qualified with <c>global::</c>, ready to emit.</summary>
@@ -30,6 +34,27 @@ public readonly struct UnionCaseModel {
 
     /// <summary>Whether anything is serialized for this case.</summary>
     public bool HasBody { get; }
+
+    /// <summary>
+    /// Whether the case's body is one of its members rather than the case itself.
+    /// </summary>
+    /// <remarks>
+    /// <c>Created&lt;T&gt;</c> and the generic problem types wrap a payload the caller supplied.
+    /// Sending the wrapper would nest that payload under a member and ship the wrapper's own fields
+    /// beside it.
+    /// </remarks>
+    public bool CarriesBody { get; }
+
+    /// <summary>
+    /// The type actually sent for this case, where that is not the case type itself.
+    /// </summary>
+    /// <remarks>
+    /// What the document has to describe. A <c>NotFound&lt;ApiError&gt;</c> puts an
+    /// <c>ApiError</c> on the wire, so a schema written from the wrapper would describe a shape no
+    /// client ever receives - the same defect writing <c>Response&lt;T1..Tn&gt;</c>'s own schema
+    /// would have been.
+    /// </remarks>
+    public string? BodyTypeName { get; }
 }
 
 /// <summary>
@@ -64,6 +89,8 @@ public static class UnionResponseSelector {
     private const string HttpStatusAttributeName = "HttpStatusAttribute";
 
     private const string HeaderInterfaceName = "IProvidesResponseHeaders";
+
+    private const string BodyInterfaceName = "ICarriesResponseBody";
 
     private const string ResponsesNamespace = "Hardened.Requests.Abstract.Responses";
 
@@ -266,7 +293,9 @@ public static class UnionResponseSelector {
                 name,
                 Status(caseType, successStatus),
                 AppliesHeaders(caseType),
-                HasBody(Status(caseType, successStatus))));
+                HasBody(Status(caseType, successStatus)),
+                Implements(caseType, BodyInterfaceName),
+                BodyType(caseType)));
         }
 
         return cases;
@@ -307,8 +336,31 @@ public static class UnionResponseSelector {
     /// being an interface.
     /// </remarks>
     private static bool AppliesHeaders(ITypeSymbol caseType) =>
+        Implements(caseType, HeaderInterfaceName);
+
+    /// <summary>
+    /// The single type argument of a case that wraps a body, or null.
+    /// </summary>
+    /// <remarks>
+    /// Every wrapping response is generic in exactly the thing it carries -
+    /// <c>Created&lt;T&gt;</c>, <c>NotFound&lt;T&gt;</c> - so the argument is the body. A wrapper
+    /// with more than one is not a shape anything here produces, and guessing which argument was
+    /// the payload would be worse than describing the wrapper.
+    /// </remarks>
+    private static string? BodyType(ITypeSymbol caseType) {
+        if (!Implements(caseType, BodyInterfaceName)) {
+            return null;
+        }
+
+        return caseType is INamedTypeSymbol { TypeArguments.Length: 1 } generic
+            ? generic.TypeArguments[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+            : null;
+    }
+
+    /// <summary>Whether the case implements one of the response interfaces.</summary>
+    private static bool Implements(ITypeSymbol caseType, string interfaceName) =>
         caseType.AllInterfaces.Any(i =>
-            i.Name == HeaderInterfaceName &&
+            i.Name == interfaceName &&
             i.ContainingNamespace?.ToDisplayString() == ResponsesNamespace);
 
     /// <summary>
@@ -352,7 +404,9 @@ public static class UnionResponseSelector {
             builder.Append(cases[i].TypeName)
                 .Append(FieldSeparator).Append(cases[i].Status)
                 .Append(FieldSeparator).Append(cases[i].AppliesHeaders ? '1' : '0')
-                .Append(cases[i].HasBody ? '1' : '0');
+                .Append(cases[i].HasBody ? '1' : '0')
+                .Append(cases[i].CarriesBody ? '1' : '0')
+                .Append(FieldSeparator).Append(cases[i].BodyTypeName ?? "");
         }
 
         return builder.ToString();
@@ -368,7 +422,7 @@ public static class UnionResponseSelector {
         foreach (var part in encoded!.Split(CaseSeparator)) {
             var fields = part.Split(FieldSeparator);
 
-            if (fields.Length != 3 || fields[2].Length != 2) {
+            if (fields.Length != 4 || fields[2].Length != 3) {
                 continue;
             }
 
@@ -377,7 +431,8 @@ public static class UnionResponseSelector {
             }
 
             cases.Add(new UnionCaseModel(
-                fields[0], status, fields[2][0] == '1', fields[2][1] == '1'));
+                fields[0], status, fields[2][0] == '1', fields[2][1] == '1', fields[2][2] == '1',
+                fields[3].Length == 0 ? null : fields[3]));
         }
 
         return cases;

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDispatchTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDispatchTests.cs
@@ -150,6 +150,30 @@ public class ResponseSetDispatchTests {
             """).AssertNoErrors();
     }
 
+    /// <summary>
+    /// A case whose body is a member rather than the case itself. The generated arm casts to
+    /// ICarriesResponseBody and overrides the assignment made before the switch, so the caller's
+    /// payload reaches the wire rather than a wrapper with the payload nested inside it.
+    /// </summary>
+    [Fact]
+    public void ACaseCarryingItsBodyCompiles() {
+        Generate("""
+            using Hardened.Requests.Abstract.Responses;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            public record Todo(int Id);
+            public record ApiError(string Code);
+
+            public class TodoController {
+                [Get("/todos/{id}")]
+                public Response<Todo, NotFound<ApiError>, Conflict<ApiError>> ById(int id) =>
+                    new Todo(id);
+            }
+            """).AssertNoErrors();
+    }
+
     #endregion
 
     #region what it emits
@@ -240,6 +264,31 @@ public class ResponseSetDispatchTests {
 
         Assert.Contains("default:", handler, StringComparison.Ordinal);
         Assert.Contains("Response.Status = 500", handler, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Only a case that wraps a body overrides the assignment made before the switch. An ordinary
+    /// case sends itself, and nothing casts.
+    /// </summary>
+    [Fact]
+    public void OnlyAWrappingCaseUnwrapsItsBody() {
+        var handler = Handler((Generate("""
+            using Hardened.Requests.Abstract.Responses;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            public record Todo(int Id);
+            public record ApiError(string Code);
+
+            public class TodoController {
+                [Get("/todos/{id}")]
+                public Response<Todo, NotFound<ApiError>, Conflict> ById(int id) => new Todo(id);
+            }
+            """)));
+
+        // One unwrap, for the one case that wraps a payload.
+        Assert.Equal(1, handler.Split("ICarriesResponseBody").Length - 1);
     }
 
     /// <summary>


### PR DESCRIPTION
`NotFound<T>` and seven siblings, for a caller who already has a payload type and doesn't want a Hardened-shaped problem document.

```csharp
public Response<Todo, NotFound<ApiError>, Conflict<ApiError>> GetTodo(int id) =>
    _repo.Find(id) is { } todo ? todo : new NotFound<ApiError>(new ApiError("nf", "no such todo"));
```

## Why

This is the hand-written equivalent of what the specification-first emitter **already generates** for a declared status — `GetPetNotFound(ApiError Body)`. Code-first had no equivalent, which was the actual gap; the two front ends now describe a declared error the same way.

It also makes two statuses sharing one payload expressible. `Response<Todo, NotFound<ApiError>, Conflict<ApiError>>` is two distinct closed types, where `Response<Todo, ApiError, ApiError>` is CS0457 at the point of use.

The generic and non-generic forms of a status share a `type` URI — that identifies what went wrong, not what shape the body is.

## The part that makes them useful

Serializing the wrapper would nest the caller's payload under a `Body` member and ship `Type`, `Title` and `Status` beside it. `ICarriesResponseBody` says the body is a member rather than the type; the selector reads it off the symbol and the emitted arm overrides the assignment made before the switch:

```csharp
case global::…NotFound<global::App.ApiError> __case1:
    context.Response.Status = 404;
    context.Response.ResponseValue = ((global::…ICarriesResponseBody)__case1).Body;
    break;
```

Compile time, so a handler whose cases are all ordinary responses carries **no type test** — the same treatment `IProvidesResponseHeaders` gets.

**`Created<T>` was written with this noted as outstanding**, waiting on "the response-mode plumbing". Same case, same interface now — a 201 sends the resource rather than a wrapper carrying it beside a `Location` that is already a header.

## The document follows the wire

A case that wraps a body has its schema written from the **body's** type, not the wrapper's. Otherwise the document describes a shape no client receives — the same defect as writing `Response<T1..Tn>`'s own schema, which C.4 fixed one layer up.

## Note

The encoded case list gains a field for the body type. A test that spelled the old format out rather than round-tripping it is what caught that — a round trip through `Encode` would have agreed with itself either way — so those fixtures stay literal.

## Verified

Clean tree, Release build with `ContinuousIntegrationBuild=true`, no compiler or analyzer warnings; **4779 tests pass, 0 fail**. The dispatch is compiled rather than only read: a case that wraps a body goes through `AssertNoErrors` with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpMuMEGPtvkRgs5q1FCfCc