### PR TITLE
Two MSBuild defects the CLI hides: MSB4057 in IDE builds, and System.Memory unification

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Hardened.OpenApi.BuildTask.csproj
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Hardened.OpenApi.BuildTask.csproj
@@ -95,6 +95,31 @@
     -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
         <Reference Include="System.Net.Http"/>
+
+        <!--
+            Unifies System.Memory, and is the whole of this project's 84 MSB3277 warnings - one
+            conflict reported once per assembly that participates in it.
+
+            Nothing asks for System.Memory directly. The graph settles on 4.5.5, whose assembly
+            version is 4.0.1.2, while every modern package co-loaded here was compiled against
+            4.0.2.0: Microsoft.Build.Framework and Microsoft.Build.Utilities.Core 17.8.43,
+            Microsoft.IO.Redist, Microsoft.NET.StringTools, Microsoft.OpenApi and its YamlReader,
+            System.Collections.Immutable, System.Text.Encodings.Web, System.Text.Json. RAR picks
+            4.0.1.2 anyway, because a package asset is primary and a dependency is not, so the task
+            compiles against an older contract than the host it loads into supplies.
+
+            4.6.0 is the version that carries assembly 4.0.2.0. Unify upward rather than suppress:
+            MSBuild's own reference assemblies are on the 4.0.2.0 side, so the host must supply at
+            least that, and matching it removes a bind that currently only survives on MSBuild.exe's
+            binding redirects. That is the same class of failure the targets file routes the task
+            through TaskHostFactory to avoid - a FileLoadException at task execution rather than a
+            diagnostic at build.
+
+            net472 only; the net8.0 leg has no conflict and no warning. ExcludeAssets=runtime is
+            inherited from the property above, so this changes the compile-time reference and ships
+            nothing beside the task.
+        -->
+        <PackageReference Include="System.Memory" Version="4.6.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Web/Hardened.Web.StaticContent/Hardened.Web.StaticContent.csproj
+++ b/src/Web/Hardened.Web.StaticContent/Hardened.Web.StaticContent.csproj
@@ -51,12 +51,30 @@
     <!--
       Built before this can be packed, and not bound against: the task runs in MSBuild and the
       runtime runs in the application.
+
+      SetTargetFramework pins the reference to an inner build, and is not optional even though
+      nothing here binds against the output. The task cross-targets net472;net8.0, and a reference
+      to a cross-targeting project resolves to its outer build, where Microsoft.Common.CrossTargeting
+      .targets defines Build and Clean and not GetTargetPath. `dotnet build` never asks for it - it
+      builds the reference itself and ReferenceOutputAssembly="false" skips the path lookup - but an
+      IDE builds projects in dependency order with BuildProjectReferences=false, and in that mode
+      ResolveProjectReferences calls GetTargetPath on every project reference. Against the outer
+      build that is MSB4057, so the project failed in Rider and Visual Studio while CI stayed green.
+
+      Both TFMs still get built and packed: the task is its own solution member, so the solution
+      build runs its outer build regardless of what this reference asks for, and the tasks/net472
+      glob below keeps finding output.
+
+      Every other build task in this repository is referenced this way - see
+      Hardened.OpenApi.SourceGenerator, Hardened.Smithy.SourceGenerator, and
+      Hardened.IntegrationTests.StaticContent.Manifest.SUT, which references this same task.
     -->
     <ItemGroup>
         <ProjectReference Include="..\Hardened.Web.StaticContent.BuildTask\Hardened.Web.StaticContent.BuildTask.csproj"
                           ReferenceOutputAssembly="false"
                           SkipGetTargetFrameworkProperties="true"
-                          PrivateAssets="all"/>
+                          PrivateAssets="all"
+                          SetTargetFramework="TargetFramework=net8.0"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Two build defects found while working out why Rider reddens generated sources. Both are invisible to `dotnet build`, which is why neither has shown up in CI.

## MSB4057: static content fails to build in an IDE

`Hardened.Web.StaticContent` failed in Rider and Visual Studio with

```
Hardened.Web.StaticContent.BuildTask.csproj: Error MSB4057 :
The target "GetTargetPath" does not exist in the project.
```

The task cross-targets `net472;net8.0`, and a `ProjectReference` without `SetTargetFramework` resolves to the **outer** cross-targeting build. `Microsoft.Common.CrossTargeting.targets` defines `Build` and `Clean` there, not `GetTargetPath` — that exists only in the inner, single-TFM build.

The CLI never asks for it: it builds the reference itself, and `ReferenceOutputAssembly="false"` skips the output-path lookup. An IDE builds projects in dependency order with `BuildProjectReferences=false`, and in that mode `ResolveProjectReferences` calls `GetTargetPath` on every project reference.

Reproducible from the CLI, which is how it was confirmed rather than guessed:

```
$ dotnet build --configuration Debug -p:BuildProjectReferences=false
...BuildTask.csproj : error MSB4057: The target "GetTargetPath" does not exist
    1 Error(s)
```

This was the only build-task reference in the repository missing the metadata. `Hardened.OpenApi.SourceGenerator`, `Hardened.Smithy.SourceGenerator` and `Hardened.IntegrationTests.StaticContent.Manifest.SUT` — which references this same task — all carry it already.

## MSB3277: 84 warnings, one conflict

`Hardened.OpenApi.BuildTask` produced 84 `MSB3277`. They are a single conflict reported once per participating assembly:

```
There was a conflict between "System.Memory, Version=4.0.1.2" and "System.Memory, Version=4.0.2.0".
"4.0.1.2" was chosen because it was primary and "4.0.2.0" was not.
```

Nothing references `System.Memory` directly. The graph settles on 4.5.5 (assembly 4.0.1.2), while every modern package co-loaded in the task was compiled against 4.0.2.0 — `Microsoft.Build.Framework`/`Utilities.Core` 17.8.43, `Microsoft.IO.Redist`, `Microsoft.NET.StringTools`, `Microsoft.OpenApi` + `YamlReader`, `System.Collections.Immutable`, `System.Text.Encodings.Web`, `System.Text.Json` 8.0.5.

**Not only log noise.** `ExcludeAssets=runtime` was not keeping `System.Memory` out of the output — `bin/Release/net472` already carried the 4.5.5 file, and the package shipped it into `tasks/net472` beside `Microsoft.OpenApi.dll` and `System.Text.Json.dll`, both of which bind to 4.0.2.0. That is a load failure waiting on the one host that leg serves, and the class of fault the targets file routes through `TaskHostFactory` to avoid.

Unified upward rather than suppressed with `MSBuildWarningsAsMessages`: MSBuild's own reference assemblies are on the 4.0.2.0 side, so the host must supply at least that. net472 only, and scoped to this project — Smithy, Idl and StaticContent build tasks were already at zero.

## Verification

```
Hardened.OpenApi.BuildTask, Release, ContinuousIntegrationBuild=true   MSB3277 84 -> 0, 0 Warning(s)
Hardened.OpenApi.BuildTask.Tests                                       399 passed, 0 failed
Task still runs, regenerated from a deleted obj/Debug/net8.0/openapi   petstore.g.cs, 53077 bytes
Hardened.Web.StaticContent, -p:BuildProjectReferences=false            MSB4057 1 -> 0, exit 0
Solution, both build modes                                             0 Warning(s), 0 MSB3277, no MSB4057
```

Package contents, since one shipped file changes:

```
tasks/net472/System.Memory.dll   145192   (4.6.0, was 142240 / 4.5.5)
tasks/net472/Hardened.OpenApi.BuildTask.dll
tasks/net8.0/Hardened.OpenApi.BuildTask.dll
<dependency id="Hardened.Idl.SourceGenerator" version="1.0.0" include="All" />
```

Both task flavours intact for `Hardened.Web.StaticContent` as well, and the nuspec dependency that 0.6.0-rc1000 dropped is still present.

One local build error is unrelated and does not appear here: `HSMT011`, homebrew `smithy` 1.56.0 against the 1.73.0 pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8y3k9gJ1Uzx6pTGQnz8Cj