### PR TITLE
Exercise both response models through real requests in the fast gate

### DIFF
--- a/src/Hardened.Framework.sln
+++ b/src/Hardened.Framework.sln
@@ -169,6 +169,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.Templates", "Templates\Hardened.Templates\Hardened.Templates.csproj", "{6B7E74B1-9900-4FBC-A611-F931E66968DA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.Responses.SUT", "IntegrationTests\Responses\Hardened.IntegrationTests.Responses.SUT\Hardened.IntegrationTests.Responses.SUT.csproj", "{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.Responses.SUT.Tests", "IntegrationTests\Responses\Hardened.IntegrationTests.Responses.SUT.Tests\Hardened.IntegrationTests.Responses.SUT.Tests.csproj", "{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.Union.SUT", "IntegrationTests\Union\Hardened.IntegrationTests.Union.SUT\Hardened.IntegrationTests.Union.SUT.csproj", "{26A690B0-96E0-4F12-B070-2CDEA538E0F5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hardened.IntegrationTests.Union.SUT.Tests", "IntegrationTests\Union\Hardened.IntegrationTests.Union.SUT.Tests\Hardened.IntegrationTests.Union.SUT.Tests.csproj", "{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1019,6 +1027,54 @@ Global
 		{6B7E74B1-9900-4FBC-A611-F931E66968DA}.Release|x64.Build.0 = Release|Any CPU
 		{6B7E74B1-9900-4FBC-A611-F931E66968DA}.Release|x86.ActiveCfg = Release|Any CPU
 		{6B7E74B1-9900-4FBC-A611-F931E66968DA}.Release|x86.Build.0 = Release|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Debug|x64.Build.0 = Debug|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Debug|x86.Build.0 = Debug|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Release|x64.ActiveCfg = Release|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Release|x64.Build.0 = Release|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Release|x86.ActiveCfg = Release|Any CPU
+		{F94CAB3E-D7F4-4524-A8B5-62D99BF6BF72}.Release|x86.Build.0 = Release|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Debug|x64.Build.0 = Debug|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Debug|x86.Build.0 = Debug|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Release|Any CPU.Build.0 = Release|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Release|x64.ActiveCfg = Release|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Release|x64.Build.0 = Release|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Release|x86.ActiveCfg = Release|Any CPU
+		{074D26E3-F6C2-4D3B-969C-B9DDCDFC9752}.Release|x86.Build.0 = Release|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Release|x64.Build.0 = Release|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{26A690B0-96E0-4F12-B070-2CDEA538E0F5}.Release|x86.Build.0 = Release|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Debug|x64.Build.0 = Debug|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Debug|x86.Build.0 = Debug|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Release|x64.ActiveCfg = Release|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Release|x64.Build.0 = Release|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Release|x86.ActiveCfg = Release|Any CPU
+		{8256DFAD-B4A7-4C57-9724-42B9D66CABFD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/Bootstrap.cs
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/Bootstrap.cs
@@ -1,0 +1,6 @@
+using Hardened.IntegrationTests.Responses.SUT;
+using Hardened.Shared.Testing.Attributes;
+using Hardened.Web.Testing;
+
+[assembly: WebTesting]
+[assembly: HardenedTestEntryPoint(typeof(ResponsesLibrary))]

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/DeclaredResponseTests.cs
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/DeclaredResponseTests.cs
@@ -1,0 +1,98 @@
+namespace Hardened.IntegrationTests.Responses.SUT.Tests;
+
+/// <summary>
+/// What a declared response set actually puts on the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The gap these close: every other test of this feature asserts a model or generated text, and a
+/// dispatch can satisfy all of them while sending the wrong thing. The specification-first path did
+/// exactly that - it recognised the set, assigned the container, and answered
+/// <c>{"value":{"id":1}}</c> at the operation's default status. Only a request shows it.
+/// </para>
+/// <para>
+/// Asserted on the wire rather than on the handler's return value, for the same reason: the point is
+/// what a client receives, and the wrapper is invisible from inside the application.
+/// </para>
+/// </remarks>
+public class DeclaredResponseTests {
+
+    private record TodoBody(int Id, string Title);
+
+    private record ApiErrorBody(string Code, string Message);
+
+    [HardenedTest]
+    public async Task TheSuccessCaseSendsThePayloadRatherThanTheContainer(ITestWebApp app) {
+        var response = await app.Get("/responses/1");
+
+        response.Assert.Ok();
+
+        // The container has a public Value; if it were serialised this would be 0.
+        Assert.Equal(1, response.Deserialize<TodoBody>().Id);
+    }
+
+    [HardenedTest]
+    public async Task AnErrorCaseAnswersItsOwnStatus(ITestWebApp app) {
+        (await app.Get("/responses/404")).Assert.NotFound();
+    }
+
+    /// <summary>
+    /// 201 from the case, not 200 from the handler having returned successfully.
+    /// </summary>
+    [HardenedTest]
+    public async Task CreatedAnswersTwoHundredAndOneWithItsLocation(ITestWebApp app) {
+        var response = await app.Post(new { Title = "fresh" }, "/responses");
+
+        Assert.Equal(201, response.StatusCode);
+        Assert.Equal("/responses/7", response.Headers["Location"].ToString());
+    }
+
+    /// <summary>
+    /// Created&lt;T&gt; carries the payload; sending the wrapper would nest it under Value and ship
+    /// the Location beside it.
+    /// </summary>
+    [HardenedTest]
+    public async Task CreatedSendsTheBodyItCarries(ITestWebApp app) {
+        var response = await app.Post(new { Title = "fresh" }, "/responses");
+
+        Assert.Equal("fresh", response.Deserialize<TodoBody>().Title);
+    }
+
+    [HardenedTest]
+    public async Task ADeclaredConflictAnswersFourHundredAndNine(ITestWebApp app) {
+        var response = await app.Post(new { Title = "taken" }, "/responses");
+
+        Assert.Equal(409, response.StatusCode);
+    }
+
+    /// <summary>
+    /// 204, and nothing in the body.
+    /// </summary>
+    /// <remarks>
+    /// The bodyless case is the one a response set had no way to express at all until the success
+    /// branch existed, and the one whose failure mode is a 200 carrying "null".
+    /// </remarks>
+    [HardenedTest]
+    public async Task NoContentAnswersTwoHundredAndFourWithAnEmptyBody(ITestWebApp app) {
+        var response = await app.Delete("/responses/1");
+
+        Assert.Equal(204, response.StatusCode);
+        Assert.Equal(string.Empty, await response.ReadTextAsync());
+    }
+
+    [HardenedTest]
+    public async Task RemoveStillAnswersItsDeclaredNotFound(ITestWebApp app) {
+        (await app.Delete("/responses/404")).Assert.NotFound();
+    }
+
+    /// <summary>
+    /// A typed error body puts the T on the wire, not the wrapper that named the status.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATypedErrorSendsItsBodyRatherThanTheWrapper(ITestWebApp app) {
+        var response = await app.Get("/responses/typed/404");
+
+        response.Assert.NotFound();
+        Assert.Equal("not_found", response.Deserialize<ApiErrorBody>().Code);
+    }
+}

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/Hardened.IntegrationTests.Responses.SUT.Tests.csproj
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/Hardened.IntegrationTests.Responses.SUT.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Web\Hardened.Web.Testing\Hardened.Web.Testing.csproj" />
+        <ProjectReference Include="..\Hardened.IntegrationTests.Responses.SUT\Hardened.IntegrationTests.Responses.SUT.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/Usings.cs
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/Usings.cs
@@ -1,0 +1,3 @@
+global using Xunit;
+global using Hardened.Shared.Testing.Attributes;
+global using Hardened.Web.Testing;

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/Hardened.IntegrationTests.Responses.SUT.csproj
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/Hardened.IntegrationTests.Responses.SUT.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <!-- A test fixture, not a shipped package. -->
+        <IsPackable>false</IsPackable>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Web.SourceGenerator\Hardened.Web.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.DependencyModules.SourceGenerator\Hardened.DependencyModules.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+    </ItemGroup>
+
+</Project>

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/ResponsesLibrary.cs
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/ResponsesLibrary.cs
@@ -1,0 +1,10 @@
+using Hardened.Shared.Runtime.Attributes;
+using Hardened.Web.Runtime.Attributes;
+using Hardened.Web.Runtime.DependencyInjection;
+
+namespace Hardened.IntegrationTests.Responses.SUT;
+
+[HardenedModule]
+[HardenedWebModule]
+[BasePath("/responses")]
+public partial class ResponsesLibrary;

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/TodoController.cs
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/TodoController.cs
@@ -1,0 +1,90 @@
+using Hardened.Requests.Abstract.Responses;
+using Hardened.Web.Runtime.Attributes;
+
+namespace Hardened.IntegrationTests.Responses.SUT;
+
+public record Todo(int Id, string Title);
+
+public record NewTodo(string Title);
+
+/// <summary>
+/// Handlers whose return type is the whole set of responses they can answer with.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The code-first half of <c>ResponseModel.Response</c>, exercised through a real request rather
+/// than through the generated text. Nothing did that before: the emitter tests assert what is
+/// written and the parser tests assert the model, so a dispatch that recognised the set and then
+/// sent the wrapper - which is exactly what the specification-first path did - passed every one of
+/// them.
+/// </para>
+/// <para>
+/// <c>Response&lt;T1..Tn&gt;</c> rather than a union, so this fixture builds on any compiler. The
+/// keyword's own coverage is the sibling Union fixture, which needs the .NET 11 SDK.
+/// </para>
+/// </remarks>
+public class TodoController {
+
+    /// <summary>200 or 404, both named in the signature.</summary>
+    [Get("/{id}")]
+    public Response<Todo, NotFound> ById(int id) {
+        if (id == 404) {
+            return new NotFound("todo", "no todo has that id");
+        }
+
+        return new Todo(id, "declared");
+    }
+
+    /// <summary>
+    /// 201 with a Location header, or 409.
+    /// </summary>
+    /// <remarks>
+    /// The status comes from the case rather than from anything this method does, and
+    /// <c>Created&lt;T&gt;</c> carries the body and the header together - so the wire receives the
+    /// Todo, not the wrapper that named the status.
+    /// </remarks>
+    [Post("/")]
+    public Response<Created<Todo>, Conflict> Create(NewTodo request) {
+        if (request.Title == "taken") {
+            return new Conflict("a todo with that title exists");
+        }
+
+        var todo = new Todo(7, request.Title);
+
+        return new Created<Todo>(todo, $"/responses/{todo.Id}");
+    }
+
+    /// <summary>
+    /// 204 or 404.
+    /// </summary>
+    /// <remarks>
+    /// The bodyless case. <c>NoContent</c> serialises nothing, which is what distinguishes a 204
+    /// from a 200 carrying the four characters "null".
+    /// </remarks>
+    [Delete("/{id}")]
+    public Response<NoContent, NotFound> Remove(int id) {
+        if (id == 404) {
+            return new NotFound("todo", "no todo has that id");
+        }
+
+        return new NoContent();
+    }
+
+    /// <summary>
+    /// A typed error body, which is the shape a real API uses.
+    /// </summary>
+    /// <remarks>
+    /// <c>NotFound&lt;T&gt;</c> puts the <c>T</c> on the wire rather than the wrapper - a schema
+    /// written from the wrapper would describe a shape no client ever receives.
+    /// </remarks>
+    [Get("/typed/{id}")]
+    public Response<Todo, NotFound<ApiError>> Typed(int id) {
+        if (id == 404) {
+            return new NotFound<ApiError>(new ApiError("not_found", "no todo has that id"));
+        }
+
+        return new Todo(id, "declared");
+    }
+}
+
+public record ApiError(string Code, string Message);

--- a/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/Bootstrap.cs
+++ b/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/Bootstrap.cs
@@ -1,0 +1,6 @@
+using Hardened.IntegrationTests.Union.SUT;
+using Hardened.Shared.Testing.Attributes;
+using Hardened.Web.Testing;
+
+[assembly: WebTesting]
+[assembly: HardenedTestEntryPoint(typeof(UnionLibrary))]

--- a/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/Hardened.IntegrationTests.Union.SUT.Tests.csproj
+++ b/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/Hardened.IntegrationTests.Union.SUT.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!-- net11.0 to reference the SUT, which needs it for the keyword. The testing packages are
+         net8.0 and resolve here the ordinary way. -->
+    <PropertyGroup>
+        <TargetFramework>net11.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <NoWarn>$(NoWarn);NETSDK1057</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+
+        <!--
+            Named directly because on net11.0 nothing else resolves it consistently.
+            Hardened.Shared.Testing floors Microsoft.Extensions.DependencyInjection at 8.0.1 and
+            DependencyModules.xUnit floors it at 10.0.0; on net8.0 the graph settles on 8.0.1 and the
+            two never meet, and on net11.0 NuGet sees a downgrade and fails restore with NU1605.
+            Selecting the higher version is the resolution NU1605 itself names, and it is scoped to
+            the one project here that targets net11.0.
+        -->
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Web\Hardened.Web.Testing\Hardened.Web.Testing.csproj" />
+        <ProjectReference Include="..\Hardened.IntegrationTests.Union.SUT\Hardened.IntegrationTests.Union.SUT.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/UnionResponseTests.cs
+++ b/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/UnionResponseTests.cs
@@ -1,0 +1,65 @@
+namespace Hardened.IntegrationTests.Union.SUT.Tests;
+
+/// <summary>
+/// A C# 15 union serving real requests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The claim under test is that Hardened recognises a keyword-declared union through the same
+/// structural check it uses for <c>Response&lt;T1..Tn&gt;</c>, and dispatches it identically.
+/// UNION-RESPONSES-PLAN.md Part 9 experiment 2 asked exactly that and had never been answered
+/// against a running application - only against generated text, which cannot show what a client
+/// receives.
+/// </para>
+/// <para>
+/// Deliberately the same assertions as the Responses fixture, against the same statuses. If the two
+/// ever disagree, the structural match has stopped treating the keyword and the struct as one shape,
+/// and that is a thing worth failing loudly rather than a thing to discover from a document.
+/// </para>
+/// </remarks>
+public class UnionResponseTests {
+
+    private record TodoBody(int Id, string Title);
+
+    [HardenedTest]
+    public async Task TheSuccessCaseSendsThePayloadRatherThanTheUnion(ITestWebApp app) {
+        var response = await app.Get("/union/1");
+
+        response.Assert.Ok();
+
+        Assert.Equal(1, response.Deserialize<TodoBody>().Id);
+    }
+
+    [HardenedTest]
+    public async Task AnErrorCaseAnswersItsOwnStatus(ITestWebApp app) {
+        (await app.Get("/union/404")).Assert.NotFound();
+    }
+
+    [HardenedTest]
+    public async Task CreatedAnswersTwoHundredAndOneWithItsLocation(ITestWebApp app) {
+        var response = await app.Post(new { Title = "fresh" }, "/union");
+
+        Assert.Equal(201, response.StatusCode);
+        Assert.Equal("/union/7", response.Headers["Location"].ToString());
+    }
+
+    [HardenedTest]
+    public async Task ADeclaredConflictAnswersFourHundredAndNine(ITestWebApp app) {
+        var response = await app.Post(new { Title = "taken" }, "/union");
+
+        Assert.Equal(409, response.StatusCode);
+    }
+
+    [HardenedTest]
+    public async Task NoContentAnswersTwoHundredAndFourWithAnEmptyBody(ITestWebApp app) {
+        var response = await app.Delete("/union/1");
+
+        Assert.Equal(204, response.StatusCode);
+        Assert.Equal(string.Empty, await response.ReadTextAsync());
+    }
+
+    [HardenedTest]
+    public async Task RemoveStillAnswersItsDeclaredNotFound(ITestWebApp app) {
+        (await app.Delete("/union/404")).Assert.NotFound();
+    }
+}

--- a/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/Usings.cs
+++ b/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT.Tests/Usings.cs
@@ -1,0 +1,3 @@
+global using Xunit;
+global using Hardened.Shared.Testing.Attributes;
+global using Hardened.Web.Testing;

--- a/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT/Hardened.IntegrationTests.Union.SUT.csproj
+++ b/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT/Hardened.IntegrationTests.Union.SUT.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <!--
+        net11.0, alone in this solution, and preview alongside it.
+
+        A C# 15 union is not purely a compiler feature: the compiler requires
+        System.Runtime.CompilerServices.IUnion and UnionAttribute, and those arrive with the .NET 11
+        reference assemblies. Measured on SDK 11.0.100-preview.7, net8.0 with LangVersion preview is
+        CS0518 and CS0656 rather than a working build, and net11.0 without preview is CS1001 - the
+        keyword does not parse, because the default is 14.0.
+
+        This is the only project here that needs either. Everything else stays net8.0, which is what
+        the packages target and what the Lambda runtime runs.
+    -->
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <TargetFramework>net11.0</TargetFramework>
+        <LangVersion>preview</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+
+        <!-- A preview SDK says so once per project; it is not news here. -->
+        <NoWarn>$(NoWarn);NETSDK1057</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Web.SourceGenerator\Hardened.Web.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.DependencyModules.SourceGenerator\Hardened.DependencyModules.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+    </ItemGroup>
+
+</Project>

--- a/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT/TodoController.cs
+++ b/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT/TodoController.cs
@@ -1,0 +1,69 @@
+using Hardened.Requests.Abstract.Responses;
+using Hardened.Web.Runtime.Attributes;
+
+namespace Hardened.IntegrationTests.Union.SUT;
+
+public record Todo(int Id, string Title);
+
+public record NewTodo(string Title);
+
+/// <summary>
+/// The declared sets, as C# 15 language unions.
+/// </summary>
+/// <remarks>
+/// Per-status wrapper types rather than bare payloads, for the reason that applies to the struct
+/// form equally: two identical case types give two identical conversions and the compiler rejects
+/// the use site. NotFound appearing in two different unions is fine; twice in one is not.
+/// </remarks>
+public union TodoResult(Todo, NotFound);
+
+public union NewTodoResult(Created<Todo>, Conflict);
+
+public union RemovedTodoResult(NoContent, NotFound);
+
+/// <summary>
+/// The same handlers as the Responses fixture, with the keyword instead of the struct.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Hardened matches both structurally - a public single-parameter constructor per case and a public
+/// object? Value - so this and its sibling should dispatch identically. That claim had never been
+/// checked against a running application: UNION-RESPONSES-PLAN.md Part 9 experiment 2 asked whether
+/// a keyword-declared union is recognised at all, and answered it only from generated text.
+/// </para>
+/// <para>
+/// If the structural match ever stops recognising the keyword, these fail and the sibling passes,
+/// which is what makes the pair worth having rather than either alone.
+/// </para>
+/// </remarks>
+public class TodoController {
+
+    [Get("/{id}")]
+    public TodoResult ById(int id) {
+        if (id == 404) {
+            return new NotFound("todo", "no todo has that id");
+        }
+
+        return new Todo(id, "declared");
+    }
+
+    [Post("/")]
+    public NewTodoResult Create(NewTodo request) {
+        if (request.Title == "taken") {
+            return new Conflict("a todo with that title exists");
+        }
+
+        var todo = new Todo(7, request.Title);
+
+        return new Created<Todo>(todo, $"/union/{todo.Id}");
+    }
+
+    [Delete("/{id}")]
+    public RemovedTodoResult Remove(int id) {
+        if (id == 404) {
+            return new NotFound("todo", "no todo has that id");
+        }
+
+        return new NoContent();
+    }
+}

--- a/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT/UnionLibrary.cs
+++ b/src/IntegrationTests/Union/Hardened.IntegrationTests.Union.SUT/UnionLibrary.cs
@@ -1,0 +1,10 @@
+using Hardened.Shared.Runtime.Attributes;
+using Hardened.Web.Runtime.Attributes;
+using Hardened.Web.Runtime.DependencyInjection;
+
+namespace Hardened.IntegrationTests.Union.SUT;
+
+[HardenedModule]
+[HardenedWebModule]
+[BasePath("/union")]
+public partial class UnionLibrary;


### PR DESCRIPTION
Neither `Response` nor `Union` had an integration fixture. Both **were** verified end to end — but only by `scripts/verify-templates.sh`, which packs the framework, generates applications, and runs in its own slow job against the packaged release. The `build` job that runs on every PR and gates coverage had no coverage of either.

That is the shape of gap that let the spec-first dispatch defect survive: the emitter tests assert generated text and the parser tests assert the model, and a dispatch can satisfy every one of them while sending the wrong thing. It did — the container went on the wire nested under its own `Value` at the operation's default status, and nothing failed.

`UNION-RESPONSES-IMPLEMENTATION.md` asked for both. **E.2** wanted a union test that compiles and runs; **E.4** wanted a net8.0 consumer in `Response` mode kept green in CI. Neither existed.

## What's covered

The **Responses** fixture is net8.0 and asserts what a client actually receives:

- the success case sending its payload rather than the container
- an error case answering its own status
- `Created<T>` at 201 with its `Location`, and its **body** rather than the wrapper
- a declared `Conflict` at 409
- `NoContent` at 204 with an empty body — not the four characters `null`
- a typed `NotFound<T>` putting the `T` on the wire

The **Union** fixture is the same assertions against the same statuses, with the keyword instead of the struct. That pairing is the point: Hardened matches both structurally, so the two must dispatch identically — and if the structural match ever stops recognising the keyword, these fail while the sibling passes.

## The net11.0 project

`Hardened.IntegrationTests.Union.SUT` is the only net11.0 project in the solution, with `LangVersion preview` beside it, because a union needs both:

```
net8.0   LangVersion=preview   CS0518, CS0656 — IUnion and UnionAttribute missing
net11.0  LangVersion=<default> CS1001 — the default is 14.0
net11.0  LangVersion=preview   builds
```

Its test project names `Microsoft.Extensions.DependencyInjection` directly — the two testing packages floor it at 8.0.1 and 10.0.0, which settles quietly on net8.0 and is `NU1605` on net11.0.

**The coverage gate is unaffected:** `coverage.runsettings` already excludes `.SUT.dll` and no SUT is baselined.

## One tooling note

Both were added to the solution by hand. `dotnet sln add` on the .NET 11 preview SDK reports success for a test project, pulls in its project references, hits a name conflict on one of them, and abandons the write — leaving the solution unchanged while claiming otherwise.

## Verification

```
solution build   exit 0, 0 warnings
tests            4820 passed across 29 assemblies, 0 failed
  Responses.SUT.Tests   8 passed (net8.0)
  Union.SUT.Tests       6 passed (net11.0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8y3k9gJ1Uzx6pTGQnz8Cj