### PR TITLE
Cover the branches a response set takes when it holds nothing

### DIFF
--- a/src/Requests/Hardened.Requests.Abstract.Tests/Execution/RequestParameterIndexerTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Execution/RequestParameterIndexerTests.cs
@@ -1,0 +1,102 @@
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.Requests.Abstract.Tests.Execution;
+
+/// <summary>
+/// The by-name indexer <see cref="IExecutionRequestParameters"/> supplies as a default
+/// implementation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Generated parameter classes implement the by-index members and inherit this one, so nothing in
+/// the framework calls it and nothing in the suite did either - it is what a filter or a
+/// hand-written handler reaches for when it knows a parameter's name rather than its position.
+/// </para>
+/// <para>
+/// Both halves throw <c>KeyNotFoundException</c> for a name the class does not carry, and the
+/// getter throws for a name it carries with a null value. That last one is the interesting case:
+/// the guard is <c>TryGetParameter(...) &amp;&amp; value != null</c>, so a parameter that exists and
+/// is null is indistinguishable from one that does not exist, and a caller cannot tell the two
+/// apart. Asserted rather than merely covered, because it is a decision.
+/// </para>
+/// </remarks>
+public class RequestParameterIndexerTests {
+
+    private sealed class Parameters : IExecutionRequestParameters {
+
+        private readonly Dictionary<string, object?> _values;
+
+        public Parameters(Dictionary<string, object?> values) => _values = values;
+
+        public bool TryGetParameter(string parameterName, out object? parameterValue) =>
+            _values.TryGetValue(parameterName, out parameterValue);
+
+        public bool TrySetParameter(string parameterName, object parameterValue) {
+            if (!_values.ContainsKey(parameterName)) {
+                return false;
+            }
+
+            _values[parameterName] = parameterValue;
+
+            return true;
+        }
+
+        public IReadOnlyList<IExecutionRequestParameter> Info => [];
+
+        public object this[int index] {
+            get => _values.Values.ElementAt(index)!;
+            set => _values[_values.Keys.ElementAt(index)] = value;
+        }
+
+        public int ParameterCount => _values.Count;
+
+        public IExecutionRequestParameters Clone() => new Parameters(new Dictionary<string, object?>(_values));
+    }
+
+    private static Parameters With(string name, object? value) =>
+        new(new Dictionary<string, object?> { [name] = value });
+
+    [Fact]
+    public void GettingAKnownParameterReturnsIt() {
+        IExecutionRequestParameters parameters = With("id", 42);
+
+        Assert.Equal(42, parameters["id"]);
+    }
+
+    [Fact]
+    public void GettingAnUnknownParameterThrows() {
+        IExecutionRequestParameters parameters = With("id", 42);
+
+        var exception = Assert.Throws<KeyNotFoundException>(() => parameters["missing"]);
+
+        Assert.Contains("missing", exception.Message);
+    }
+
+    /// <summary>
+    /// A parameter that exists and holds null throws too, rather than returning null.
+    /// </summary>
+    [Fact]
+    public void GettingAParameterHoldingNullThrows() {
+        IExecutionRequestParameters parameters = With("id", null);
+
+        Assert.Throws<KeyNotFoundException>(() => parameters["id"]);
+    }
+
+    [Fact]
+    public void SettingAKnownParameterReplacesIt() {
+        IExecutionRequestParameters parameters = With("id", 1);
+
+        parameters["id"] = 2;
+
+        Assert.Equal(2, parameters["id"]);
+    }
+
+    [Fact]
+    public void SettingAnUnknownParameterThrows() {
+        IExecutionRequestParameters parameters = With("id", 1);
+
+        var exception = Assert.Throws<KeyNotFoundException>(() => parameters["missing"] = 2);
+
+        Assert.Contains("missing", exception.Message);
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/DefaultResponseTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/DefaultResponseTests.cs
@@ -1,0 +1,128 @@
+using System.Globalization;
+using System.Linq;
+using Hardened.Requests.Abstract.Errors;
+using Hardened.Requests.Abstract.Responses;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Tests.Responses;
+
+/// <summary>
+/// The branches a response set takes when it holds nothing, and the ones ResponseException takes
+/// for a response that carries neither a body nor headers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ResponseArityTests</c> invokes every constructor and every conversion, so the populated half
+/// of <c>ToString</c> runs at all seven arities. The empty half never did: nothing constructs a
+/// <c>default</c> response set, because nothing is supposed to - and a branch nobody takes is still
+/// a branch the type declares seven times over.
+/// </para>
+/// <para>
+/// Worth asserting rather than only covering. <c>default(Response&lt;…&gt;)</c> is reachable from
+/// ordinary code - an uninitialised field, an array element, a <c>default</c> in a switch arm - and
+/// what it renders is what lands in a log line when a handler returns one by accident.
+/// </para>
+/// </remarks>
+public class DefaultResponseTests {
+
+    private static Type Closed(int arity) =>
+        typeof(Response<,>).Assembly
+            .GetExportedTypes()
+            .Single(t => t.IsGenericTypeDefinition &&
+                         t.Name == "Response`" + arity.ToString(CultureInfo.InvariantCulture))
+            .MakeGenericType(
+                new[] {
+                    typeof(string), typeof(int), typeof(bool), typeof(Guid),
+                    typeof(TimeSpan), typeof(Uri), typeof(NotFound), typeof(Conflict)
+                }.Take(arity).ToArray());
+
+    public static TheoryData<int> Arities {
+        get {
+            var data = new TheoryData<int>();
+
+            for (var arity = 2; arity <= 8; arity++) {
+                data.Add(arity);
+            }
+
+            return data;
+        }
+    }
+
+    /// <summary>
+    /// A response set holding nothing renders as the empty string rather than throwing or reading
+    /// "null" - at every arity, because the expression is written out once per arity.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Arities))]
+    public void ADefaultResponseRendersEmptyAtEveryArity(int arity) {
+        var closed = Closed(arity);
+
+        var empty = Activator.CreateInstance(closed);
+
+        Assert.Equal(string.Empty, empty!.ToString());
+    }
+
+    /// <summary>And it holds no case, which is what makes the render above the right answer.</summary>
+    [Theory]
+    [MemberData(nameof(Arities))]
+    public void ADefaultResponseHoldsNoCase(int arity) {
+        var closed = Closed(arity);
+
+        var empty = Activator.CreateInstance(closed);
+
+        Assert.Null(closed.GetProperty("Value")!.GetValue(empty));
+    }
+
+    /// <summary>
+    /// A bodyless response carries no value into the exception.
+    /// </summary>
+    /// <remarks>
+    /// <c>NoContent</c> is the case: <c>HasBody</c> is false, so there is nothing to serialise and
+    /// the exception must not offer one. The populated side of that conditional is covered by every
+    /// other response type; this is the side that decides whether a 204 answers with the four
+    /// characters "null".
+    /// </remarks>
+    [Fact]
+    public void ABodylessResponseGivesTheExceptionNoValue() {
+        var exception = new NoContent().AsException();
+
+        Assert.Equal(204, exception.StatusCode);
+        Assert.Null(exception.Value);
+    }
+
+    /// <summary>
+    /// A response that provides no headers leaves the collection untouched.
+    /// </summary>
+    /// <remarks>
+    /// <c>ApplyHeaders</c> type-tests for <c>IProvidesResponseHeaders</c>. The positive side is
+    /// covered by Unauthorized and the two Retry-After types; the negative side is every other
+    /// response, and it has to be a no-op rather than a throw.
+    /// </remarks>
+    [Fact]
+    public void AResponseProvidingNoHeadersAppliesNone() {
+        var headers = new Dictionary<string, StringValues>();
+
+        new Conflict("clash").AsException().ApplyHeaders(headers);
+
+        Assert.Empty(headers);
+    }
+
+    /// <summary>
+    /// The default message names the status, and an explicit one replaces it.
+    /// </summary>
+    /// <remarks>
+    /// Both sides of the same null-coalesce. The default is what a log shows for a response thrown
+    /// without explanation, which is the common case and the one nobody writes a test for.
+    /// </remarks>
+    [Fact]
+    public void TheDefaultMessageNamesTheStatus() {
+        Assert.Contains("404", new NotFound("todo").AsException().Message);
+    }
+
+    [Fact]
+    public void AnExplicitMessageReplacesTheDefault() {
+        var exception = new NotFound("todo").AsException("nothing by that id");
+
+        Assert.Equal("nothing by that id", exception.Message);
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/RemainingBranchTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/RemainingBranchTests.cs
@@ -1,0 +1,89 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Responses;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Tests.Responses;
+
+/// <summary>
+/// The branches CI's coverage report named as still uncovered, and nothing else.
+/// </summary>
+/// <remarks>
+/// Chosen from the report rather than guessed at. The first pass at this release's coverage
+/// shortfall was written from reading the new code and moved the number by a tenth of a point,
+/// because the branches it covered were mostly covered already - the four classes below were what
+/// actually remained, and three of them are nowhere near the response types the release is named
+/// for.
+/// </remarks>
+public class RemainingBranchTests {
+
+    /// <summary>
+    /// The generic 503 with no retry hint sets no Retry-After.
+    /// </summary>
+    /// <remarks>
+    /// Its non-generic twin already covered both sides of this. The two carry the same conditional
+    /// written out twice, which is exactly the shape where covering one and not the other looks
+    /// like coverage.
+    /// </remarks>
+    [Fact]
+    public void AGenericServiceUnavailableWithoutARetryHintSetsNoHeader() {
+        var headers = new Dictionary<string, StringValues>();
+
+        ((IProvidesResponseHeaders)new ServiceUnavailable<string>("down")).ApplyHeaders(headers);
+
+        Assert.Empty(headers);
+    }
+
+    /// <summary>And with one, it does - the side that was already covered, kept beside it.</summary>
+    [Fact]
+    public void AGenericServiceUnavailableWithARetryHintSetsIt() {
+        var headers = new Dictionary<string, StringValues>();
+
+        ((IProvidesResponseHeaders)new ServiceUnavailable<string>("down", TimeSpan.FromSeconds(30)))
+            .ApplyHeaders(headers);
+
+        Assert.Equal("30", headers["Retry-After"]);
+    }
+
+    /// <summary>
+    /// A predicate requirement with no description renders as "predicate".
+    /// </summary>
+    /// <remarks>
+    /// What a denied-authorization log line shows for a requirement whose author did not name it,
+    /// which is the common case and the one nobody asserts.
+    /// </remarks>
+    [Fact]
+    public void AnUndescribedPredicateRendersAsPredicate() {
+        var requirement = Requirement.Predicate((_, _) => true);
+
+        Assert.Equal("predicate", requirement.ToString());
+    }
+
+    [Fact]
+    public void ADescribedPredicateRendersItsDescription() {
+        var requirement = Requirement.Predicate((_, _) => true, "owns the record");
+
+        Assert.Equal("owns the record", requirement.ToString());
+    }
+
+    /// <summary>
+    /// A composite renders with the operator it actually is.
+    /// </summary>
+    /// <remarks>
+    /// One expression picks the separator for both kinds, so a composite that rendered "&amp;" for
+    /// an any-of would misreport every denial it appears in. Both sides asserted together, because
+    /// the bug is the two disagreeing rather than either alone being wrong.
+    /// </remarks>
+    [Fact]
+    public void AnAllOfRendersWithAmpersand() {
+        var requirement = Requirement.AllOf(Requirement.Grant("read"), Requirement.Grant("write"));
+
+        Assert.Equal("(read & write)", requirement.ToString());
+    }
+
+    [Fact]
+    public void AnAnyOfRendersWithPipe() {
+        var requirement = Requirement.AnyOf(Requirement.Grant("read"), Requirement.Grant("write"));
+
+        Assert.Equal("(read | write)", requirement.ToString());
+    }
+}


### PR DESCRIPTION
The `v0.12.0-rc1000` release run failed its coverage gate:

```
Hardened.Requests.Abstract branch: 95.7% is below the 96.4% baseline (-0.7)
Hardened.Requests.Abstract line:   94.9% (baseline 93.8%)
```

Nothing published — pack, nuget.org, GitHub Packages and the GitHub release were all skipped, so the tag is currently inert.

I first called this measurement drift, on the grounds that my branch didn't touch that assembly. That was the wrong test. `v0.11..v0.12` adds **1,681 lines** to `Hardened.Requests.Abstract` across #169, #171 and #175 — the built-in response types, `Response<T1..Tn>` and the generic problem types — and the baseline predates all of it. Line coverage rising while branch coverage falls is what under-tested new branches look like.

## What's covered

`ResponseArityTests` invokes every constructor and every conversion, so the populated half of `ToString` runs at all seven arities. The empty half never did — nothing in the suite constructs a default response set. That expression is written out once per arity, and `default(Response<…>)` is reachable from ordinary code: an uninitialised field, an array element, a `default` in a switch arm. What it renders is what lands in a log line when a handler returns one by accident.

Plus the three `ResponseException` branches whose negative side nothing took:

- a bodyless response carrying no value into the exception — which decides whether a 204 answers with the four characters `null`
- `ApplyHeaders` against a response implementing no header provider, which must be a no-op rather than a throw
- both sides of the default message

## What I can't tell you

**Whether this moves the number.** Collecting coverage over this project before and after adding sixteen passing tests reports `line 0.7344 branch 0.7197` both times — identical to four decimal places. The collector is not measuring under the .NET 11 preview SDK, which `bf33444` already recorded when it made the gate non-blocking in `build-package`.

So CI is the only instrument that can score this. If the gate still fails here, the honest next step is to read CI's own report for which branches remain uncovered rather than guess again.

424 tests pass in this project, none failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8y3k9gJ1Uzx6pTGQnz8Cj