### PR TITLE
Five defects the 0.12.0-rc1000 review found, and the gates that let them through

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -200,6 +200,30 @@ for COMBO in "${COMBOS[@]}"; do
         BODY=$(curl -s --max-time 2 "http://localhost:$PORT/todos/1" || true)
         DOCS_DEV=$(status_of "http://localhost:$PORT/docs")
 
+        # How many operations the served document actually describes.
+        #
+        # /docs answering 200 was the only thing asserted here, and an empty document renders as a
+        # reference page with zero operations - which is indistinguishable from a working page by
+        # every check above. That is exactly how the template shipped with
+        # [Enable<OpenApiDocumentPublishing>] on the host module, where the generator sees no routes
+        # and writes "paths": {}.
+        #
+        # Counted rather than grepped. The strings "/todos" and "paths" appear in a document that
+        # describes nothing - in its own schema names, or in a Smithy AST's @http uri values - so a
+        # text match credits a document for operations it does not have.
+        #
+        # --compressed because the document is stored and served gzipped; without it this parses the
+        # gzip magic number.
+        #
+        # Code-first only. A spec-first document is the contract file itself, served verbatim, and
+        # cannot be empty without the input being empty.
+        DOC_OPS=-1
+        if [ "$CONTRACT" = "code" ]; then
+            DOC_OPS=$(curl -s --compressed --max-time 5 "http://localhost:$PORT/openapi.json" \
+                | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("paths") or {}))' \
+                2>/dev/null || echo 0)
+        fi
+
         # The declared error paths, over a real socket. A response model exercised only at 200 is
         # indistinguishable from having no declared set at all, which is the thing worth proving
         # here - and the sample's 404 and 409 are the two statuses every mode has to answer the
@@ -257,6 +281,23 @@ for COMBO in "${COMBOS[@]}"; do
 
         if [ "$CREATED" != "$EXPECT_CREATED" ]; then
             echo "   FAILED: $CONTRACT/$MODEL should create at $EXPECT_CREATED, got $CREATED"
+            FAILED=1
+        fi
+
+        if [ "$DOC_OPS" != "-1" ]; then
+            echo "   /openapi.json describes $DOC_OPS path(s)"
+
+            if [ "$DOC_OPS" -lt 1 ] 2>/dev/null; then
+                echo "   FAILED: the published document describes no operations"
+                FAILED=1
+            fi
+        fi
+
+        # Something on the console. A generated application that starts, serves and prints nothing
+        # gives whoever just ran it no reason to believe it is working - and no logging provider is
+        # registered by the framework, so this is the template's to get right.
+        if ! grep -q . "$OUT/run.log" 2>/dev/null; then
+            echo "   FAILED: the application produced no console output"
             FAILED=1
         fi
 

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
@@ -1,0 +1,136 @@
+using Hardened.Requests.Runtime.Validation;
+
+namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
+
+/// <summary>
+/// Two silent failures, over a real request: a required member the C# type cannot prove was sent,
+/// and a constraint one level below the body.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both used to answer success. A missing required member of a value type became
+/// <c>default(T)</c> - an omitted enum became its first declared member, so the API stored a
+/// species the caller never named and reported it back as though they had. A constraint on an
+/// array's items was emitted, its validator generated and registered in DI, and never called.
+/// </para>
+/// <para>
+/// Bodies are raw JSON rather than typed objects, because what is under test is a member that is
+/// <em>absent</em> - and a typed object has no way to leave one out.
+/// </para>
+/// </remarks>
+public class RequiredAndNestedValidationTests {
+
+    private const string Valid =
+        """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":2}]}""";
+
+    private static async Task<RequestValidationError> Rejected(ITestWebApp app, string body) {
+        var response = await app.Post(body, "/orders");
+
+        response.Assert.BadRequest();
+
+        var error = response.Deserialize<RequestValidationError>();
+
+        Assert.NotNull(error);
+        Assert.Equal("ValidationError", error.Type);
+        Assert.NotNull(error.Errors);
+
+        return error;
+    }
+
+    /// <summary>
+    /// A well-formed order is accepted, so every rejection below fails for the reason it names
+    /// rather than because the route never worked.
+    /// </summary>
+    [HardenedTest]
+    public async Task AWellFormedOrderIsAccepted(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(Valid, "/orders");
+
+        response.Assert.Ok();
+
+        Assert.Contains("cat", await response.ReadTextAsync());
+    }
+
+    /// <summary>
+    /// The one that invented data. Nothing rejects an enum's first declared member, so an omitted
+    /// <c>species</c> was stored as <c>dog</c> and answered 200.
+    /// </summary>
+    [HardenedTest]
+    public async Task AMissingRequiredEnumIsRejected(ITestWebApp testWebApp) {
+        var error = await Rejected(
+            testWebApp, """{"weightGrams":3000,"lines":[{"sku":"TLS-0001"}]}""");
+
+        var field = Assert.Single(error.Errors!, e => e.Field == "body.species");
+
+        Assert.Equal("required", field.Code);
+    }
+
+    /// <summary>
+    /// The same for an integer with no other constraint. <c>weightGrams</c> is deliberately
+    /// unbounded in the contract: a <c>minimum</c> would have caught the absence by accident, which
+    /// is how this stayed hidden on fields that happened to have one.
+    /// </summary>
+    [HardenedTest]
+    public async Task AMissingRequiredIntegerIsRejected(ITestWebApp testWebApp) {
+        var error = await Rejected(
+            testWebApp, """{"species":"cat","lines":[{"sku":"TLS-0001"}]}""");
+
+        var field = Assert.Single(error.Errors!, e => e.Field == "body.weightGrams");
+
+        Assert.Equal("required", field.Code);
+    }
+
+    /// <summary>
+    /// Both, in one answer. The caller fixes their request in one pass rather than one round trip
+    /// per field.
+    /// </summary>
+    [HardenedTest]
+    public async Task EveryMissingRequiredMemberIsNamedAtOnce(ITestWebApp testWebApp) {
+        var error = await Rejected(testWebApp, """{"lines":[{"sku":"TLS-0001"}]}""");
+
+        Assert.Contains(error.Errors!, e => e.Field == "body.species");
+        Assert.Contains(error.Errors!, e => e.Field == "body.weightGrams");
+    }
+
+    /// <summary>
+    /// A constraint on an array's items runs. The exact D2 repro: <c>quantity</c> declares
+    /// <c>minimum: 1</c> and a zero was accepted and the order placed.
+    /// </summary>
+    [HardenedTest]
+    public async Task AConstraintOnAnArrayItemIsEnforced(ITestWebApp testWebApp) {
+        var error = await Rejected(
+            testWebApp,
+            """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":0}]}""");
+
+        Assert.Contains(error.Errors!, e => e.Field.Contains("quantity"));
+    }
+
+    /// <summary>
+    /// The failing element is identified, not merely the array. An error naming <c>lines</c> alone
+    /// tells a caller with fifty lines nothing.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheFailingArrayElementIsIdentifiedByItsIndex(ITestWebApp testWebApp) {
+        var error = await Rejected(
+            testWebApp,
+            """
+            {"species":"cat","weightGrams":3000,"lines":[
+                {"sku":"TLS-0001","quantity":2},
+                {"sku":"TLS-0002","quantity":0}]}
+            """);
+
+        Assert.Contains(error.Errors!, e => e.Field.Contains("[1]"));
+        Assert.DoesNotContain(error.Errors!, e => e.Field.Contains("[0]"));
+    }
+
+    /// <summary>
+    /// A required member of a nested object is enforced too, not only a range on one.
+    /// </summary>
+    [HardenedTest]
+    public async Task ARequiredMemberOfAnArrayItemIsEnforced(ITestWebApp testWebApp) {
+        var error = await Rejected(
+            testWebApp,
+            """{"species":"cat","weightGrams":3000,"lines":[{"quantity":2}]}""");
+
+        Assert.Contains(error.Errors!, e => e.Field.Contains("sku"));
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OrderServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OrderServiceImpl.cs
@@ -1,0 +1,18 @@
+using Hardened.IntegrationTests.OpenApi.SUT.Models;
+using Hardened.IntegrationTests.OpenApi.SUT.Services;
+using Hardened.Requests.Abstract.Attributes;
+
+namespace Hardened.IntegrationTests.OpenApi.SUT;
+
+/// <summary>
+/// Echoes the order back, so a test can see what the framework decided the body was.
+/// </summary>
+/// <remarks>
+/// Deliberately does no checking of its own. The point of the route is that a request reaching this
+/// method at all is a failure of validation - both defects it covers ended with the handler running
+/// on a body the caller never sent.
+/// </remarks>
+[Handler]
+public class OrderServiceImpl : IOrderService {
+    public Task<OrderRequest> PlaceOrder(OrderRequest body) => Task.FromResult(body);
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -63,6 +63,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Account'
+  # Two defects meet on this one operation, and neither is visible in a green build.
+  #
+  # `species` and `weightGrams` are required members of value types: nothing rejects an enum's first
+  # declared member and nothing rejects a zero, so omitting either used to be answered 201 with a
+  # value the caller never sent. `lines` carries constraints on its *items*, which were generated,
+  # registered in DI, and never called.
+  /orders:
+    post:
+      tags:
+        - Order
+      operationId: placeOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderRequest'
+      responses:
+        '200':
+          description: The order as accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderRequest'
   /pets/search:
     get:
       tags:
@@ -317,6 +341,40 @@ components:
     # A value that is not a valid C# identifier. Reachable as a body value and a response value
     # since the generated converter existed; unreachable as a query parameter until the binder
     # stopped calling Enum.Parse on the member name.
+    OrderRequest:
+      type: object
+      required:
+        - species
+        - weightGrams
+        - lines
+      properties:
+        # An enum, and the reason this one matters: [Required] cannot be emitted against a value
+        # type, and nothing else rejects `dog` - the enum's first declared member. An omitted
+        # species was stored as a dog and answered 200.
+        species:
+          $ref: '#/components/schemas/PetSpecies'
+        # Deliberately unbounded. A `minimum: 1` here would catch the absence by accident, which is
+        # how the integer case stayed hidden while the enum case did not.
+        weightGrams:
+          type: integer
+          format: int32
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderLine'
+    # Constraints one level down from the body, which is where they stopped being run.
+    OrderLine:
+      type: object
+      required:
+        - sku
+      properties:
+        sku:
+          type: string
+          minLength: 1
+        quantity:
+          type: integer
+          format: int32
+          minimum: 1
     PetSpecies:
       type: string
       enum:

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ErrorHandlingTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ErrorHandlingTests.cs
@@ -112,18 +112,23 @@ public class ErrorHandlingTests {
     }
 
     /// <summary>
-    /// The failure is logged through <see cref="IRequestLogger"/> so it lands in the
-    /// application's request log rather than only in the response body.
+    /// The helper records and does not log. Logging is <c>ExceptionResponseSerializer</c>'s, because
+    /// that is where every failure arrives - a filter throw and an authorization refusal set the
+    /// same field and never come through here.
     /// </summary>
+    /// <remarks>
+    /// Pinned rather than left implied: this used to log, and a handler fault was the only failure
+    /// that produced a line. Restoring it here would report a handler fault twice.
+    /// </remarks>
     [Fact]
-    public async Task AHandlerExceptionIsReportedToTheRequestLogger() {
+    public async Task AHandlerExceptionIsNotLoggedHere() {
         var logger = Substitute.For<IRequestLogger>();
         var context = Pipeline.Context(configureServices: services => services.AddSingleton(logger));
         var failure = new InvalidOperationException("handler failed");
 
         await ControllerErrorHelper.HandleException(context, failure);
 
-        logger.Received(1).RequestFailed(context, failure);
+        logger.DidNotReceive().RequestFailed(Arg.Any<IExecutionContext>(), Arg.Any<Exception>());
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/MissingRequiredMembersTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/MissingRequiredMembersTests.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Hardened.Requests.Abstract.Errors;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Errors;
+using Hardened.Requests.Runtime.Validation;
+using Microsoft.Extensions.Primitives;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Errors;
+
+/// <summary>
+/// What a caller is told when they omit a required member the C# type cannot prove was sent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A required member of a value type carries no <c>[Required]</c> - the validation generator emits
+/// <c>value.x is null</c>, which is CS0037 against an <c>int</c> - so absence used to become
+/// <c>default(T)</c> in silence. An omitted enum became its first declared member and the API
+/// answered <b>201</b> with a category the caller never sent.
+/// </para>
+/// <para>
+/// The deserializer catches it now, and these pin the answer it produces being the same shape the
+/// validator produces for a reference type. Which layer caught it is the framework's business.
+/// </para>
+/// </remarks>
+public class MissingRequiredMembersTests {
+
+    private static readonly ExceptionToModelConverter Converter = new();
+
+    private static IExecutionContext Context() {
+        var response = Substitute.For<IExecutionResponse>();
+        response.Headers.Returns(new Dictionary<string, StringValues>());
+
+        var context = Substitute.For<IExecutionContext>();
+        context.Response.Returns(response);
+
+        return context;
+    }
+
+    private static RequestValidationError Convert(JsonException exception) {
+        var (status, model) = Converter.ConvertExceptionToModel(Context(), exception);
+
+        Assert.Equal(400, status);
+
+        return Assert.IsType<RequestValidationError>(model);
+    }
+
+    /// <summary>The message System.Text.Json actually produces - see the canary below.</summary>
+    private static JsonException Missing(params string[] members) =>
+        new("JSON deserialization for type 'Product' was missing required properties, " +
+            "including the following: " + string.Join(", ", members));
+
+    /// <summary>
+    /// One missing member, reported as the validator would report it: same field spelling, same
+    /// code, same wording.
+    /// </summary>
+    [Fact]
+    public void AMissingMemberIsReportedAsARequiredFieldError() {
+        var error = Assert.Single(Convert(Missing("category")).Errors!);
+
+        Assert.Equal("body.category", error.Field);
+        Assert.Equal("required", error.Code);
+        Assert.Equal("body.category is required.", error.Message);
+    }
+
+    /// <summary>
+    /// Every missing member, not the first. System.Text.Json aggregates, so the caller can fix
+    /// their request in one pass rather than one round trip per field.
+    /// </summary>
+    [Fact]
+    public void EveryMissingMemberIsReported() {
+        var errors = Convert(Missing("category", "unitPriceCents")).Errors!;
+
+        Assert.Equal(
+            new[] { "body.category", "body.unitPriceCents" },
+            errors.Select(error => error.Field));
+
+        Assert.All(errors, error => Assert.Equal("required", error.Code));
+    }
+
+    /// <summary>
+    /// Any other <c>JsonException</c> keeps the general body-read answer. Malformed JSON is not a
+    /// missing member, and claiming otherwise would name fields the caller never wrote.
+    /// </summary>
+    [Theory]
+    [InlineData("The JSON value could not be converted to Category. Path: $.category | LineNumber: 0 | BytePositionInLine: 29.")]
+    [InlineData("'x' is an invalid start of a value.")]
+    [InlineData("JSON deserialization for type 'Product' failed for some other reason")]
+    public void AnyOtherFailureKeepsTheGeneralAnswer(string message) {
+        var error = Assert.Single(Convert(new JsonException(message)).Errors!);
+
+        Assert.Equal("invalid", error.Code);
+    }
+}
+
+/// <summary>
+/// A canary over System.Text.Json's own behaviour.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ExceptionToModelConverter</c> reads the missing-member list out of the exception's message,
+/// because there is no typed exception for it and <c>JsonException</c> carries no structured member
+/// list - its <c>Path</c> is <c>$</c>, since the object rather than any one member is what failed.
+/// </para>
+/// <para>
+/// That is a dependency on wording, and this is the test that makes it safe: an SDK that changes the
+/// message fails here, naming the reason, rather than silently degrading every missing-member 400 to
+/// the general body-read answer in production.
+/// </para>
+/// </remarks>
+public class MissingRequiredMembersMessageTests {
+
+    private record Product(
+        [property: JsonPropertyName("sku")] string Sku,
+        [property: JsonPropertyName("category")] [property: JsonRequired] int Category,
+        [property: JsonPropertyName("unitPriceCents")] [property: JsonRequired] int UnitPriceCents,
+        [property: JsonPropertyName("stock")] int? Stock = default);
+
+    private static JsonException Deserialize(string json) =>
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Product>(
+            json, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+
+    /// <summary>
+    /// The prefix and marker the converter matches on, and the ": " the member list follows.
+    /// </summary>
+    [Fact]
+    public void TheMessageStillCarriesThePrefixTheConverterMatches() {
+        var message = Deserialize("""{"sku":"A"}""").Message;
+
+        Assert.StartsWith("JSON deserialization for type ", message);
+        Assert.Contains("missing required properties", message);
+        Assert.Contains(": ", message);
+    }
+
+    /// <summary>
+    /// Still aggregated, and still by wire name rather than by C# member name.
+    /// </summary>
+    [Fact]
+    public void EveryMissingMemberIsStillNamedByItsWireName() {
+        var message = Deserialize("""{"sku":"A"}""").Message;
+
+        Assert.Contains("category", message);
+        Assert.Contains("unitPriceCents", message);
+        Assert.DoesNotContain("UnitPriceCents", message);
+    }
+
+    /// <summary>
+    /// Still the object, not the member. This is why the member list cannot be read off
+    /// <c>Path</c>.
+    /// </summary>
+    [Fact]
+    public void ThePathIsStillTheObject() {
+        Assert.Equal("$", Deserialize("""{"sku":"A"}""").Path);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/InvokeFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/InvokeFilterTests.cs
@@ -112,8 +112,6 @@ public class InvokeFilterTests {
 
         Assert.NotNull(context.Response.ExceptionValue);
         Assert.Contains(nameof(Controller), context.Response.ExceptionValue!.Message);
-
-        logger.Received(1).RequestFailed(context, context.Response.ExceptionValue);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/IoFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/IoFilterTests.cs
@@ -1,6 +1,9 @@
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Logging;
 using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Serializer;
+using Hardened.Requests.Runtime.Errors;
+using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Filters;
 using Hardened.Requests.Runtime.Tests.Support;
 using Microsoft.Extensions.DependencyInjection;
@@ -238,6 +241,48 @@ public class IoFilterTests {
 
         Assert.Same(failure, context.Response.ExceptionValue);
         Assert.Equal(new[] { "wrapper-enter", "wrapper-exit", "serialize" }, log);
+    }
+
+    /// <summary>
+    /// An exception thrown by a <em>filter</em> is reported, the same as one thrown by a handler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The defect this was written for. A handler fault reached <c>ControllerErrorHelper</c>, which
+    /// logged it; anything thrown earlier in the chain was caught here, recorded on the response and
+    /// never mentioned again. A request refused by the validation filter produced <c>started</c>,
+    /// <c>mapped</c> and <c>finished status code '500'</c>, with nothing naming the exception - so
+    /// the one failure a developer could not see was the one their own filter caused.
+    /// </para>
+    /// <para>
+    /// Wired to the real <c>ExceptionResponseSerializer</c> rather than a substitute, because what
+    /// is being asserted is that the two meet. A test that stubbed the serializer would pass against
+    /// the defect.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task AnExceptionThrownByAFilterIsReported() {
+        var failure = new InvalidOperationException("thrown by a filter");
+
+        var logger = Substitute.For<IRequestLogger>();
+        var context = Pipeline.Context(
+            configureServices: services => services.AddSingleton(logger));
+
+        var responseSerializer = Substitute.For<IResponseSerializer>();
+        responseSerializer.SerializeResponse(Arg.Any<IExecutionContext>()).Returns(Task.CompletedTask);
+
+        var locator = Substitute.For<ISerializationLocatorService>();
+        locator.FindResponseSerializer(Arg.Any<IExecutionContext>()).Returns(responseSerializer);
+
+        var exceptions = new ExceptionResponseSerializer(
+            logger, locator, new ExceptionToModelConverter());
+
+        var filter = Filter(serialize: c => exceptions.Handle(c, c.Response.ExceptionValue!));
+
+        await Pipeline.Chain(context, filter, new Pipeline.Inline(_ => throw failure)).Next();
+
+        Assert.Same(failure, context.Response.ExceptionValue);
+        Assert.Equal(500, context.Response.Status);
 
         logger.Received(1).RequestFailed(context, failure);
     }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ExceptionResponseSerializerTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ExceptionResponseSerializerTests.cs
@@ -24,13 +24,14 @@ public class ExceptionResponseSerializerTests {
 
         public IResponseSerializer Serializer { get; } = Substitute.For<IResponseSerializer>();
 
+        public IRequestLogger Logger { get; } = Substitute.For<IRequestLogger>();
+
         public Fixture() {
             Locator.FindResponseSerializer(Arg.Any<IExecutionContext>()).Returns(Serializer);
             Serializer.SerializeResponse(Arg.Any<IExecutionContext>()).Returns(Task.CompletedTask);
         }
 
-        public ExceptionResponseSerializer Subject => new(
-            Substitute.For<IRequestLogger>(), Locator, Converter);
+        public ExceptionResponseSerializer Subject => new(Logger, Locator, Converter);
     }
 
     /// <summary>
@@ -107,5 +108,82 @@ public class ExceptionResponseSerializerTests {
         await fixture.Subject.Handle(context, failure);
 
         fixture.Converter.Received(1).ConvertExceptionToModel(context, failure);
+    }
+
+    // ------------------------------------------------------------------------------ logging
+
+    /// <summary>
+    /// The failure is reported, whatever produced it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the whole of the defect it was written for. Four things put an exception on the
+    /// response - a handler fault, a bind failure, an exception thrown by a filter, and a refusal
+    /// recorded by <c>AuthorizationFilter</c> or <c>RateLimitFilter</c> - and only the first two
+    /// logged. A request refused by the validation filter produced <c>started</c>, <c>mapped</c>
+    /// and <c>finished status code '500'</c>, with nothing anywhere naming the exception.
+    /// </para>
+    /// <para>
+    /// Asserted here rather than at each of the four, because the point of the fix is that none of
+    /// them has to know about logging.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task TheFailureIsReportedToTheRequestLogger() {
+        var fixture = new Fixture();
+        var context = Pipeline.Context();
+        var failure = new InvalidOperationException("thrown by a filter");
+
+        fixture.Converter.ConvertExceptionToModel(context, Arg.Any<Exception>())
+            .Returns((500, new ErrorModel()));
+
+        await fixture.Subject.Handle(context, failure);
+
+        fixture.Logger.Received(1).RequestFailed(context, failure);
+    }
+
+    /// <summary>
+    /// Reported after the status is assigned, so the logger can read the status this failure
+    /// answers with.
+    /// </summary>
+    /// <remarks>
+    /// Ordering rather than decoration: severity follows the answer, and a logger that ran first
+    /// would see whatever the response happened to carry before the converter decided.
+    /// </remarks>
+    [Fact]
+    public async Task TheStatusIsOnTheResponseBeforeTheFailureIsReported() {
+        var fixture = new Fixture();
+        var context = Pipeline.Context();
+        int? statusWhenLogged = null;
+
+        fixture.Converter.ConvertExceptionToModel(context, Arg.Any<Exception>())
+            .Returns((404, new ErrorModel()));
+
+        fixture.Logger
+            .When(logger => logger.RequestFailed(Arg.Any<IExecutionContext>(), Arg.Any<Exception>()))
+            .Do(_ => statusWhenLogged = context.Response.Status);
+
+        await fixture.Subject.Handle(context, new Exception("missing"));
+
+        Assert.Equal(404, statusWhenLogged);
+    }
+
+    /// <summary>
+    /// Reported once. The producers no longer log, so a handler fault that reaches here produces
+    /// one line rather than two.
+    /// </summary>
+    [Fact]
+    public async Task TheFailureIsReportedOnlyOnce() {
+        var fixture = new Fixture();
+        var context = Pipeline.Context();
+        var failure = new InvalidOperationException("handler failed");
+
+        fixture.Converter.ConvertExceptionToModel(context, Arg.Any<Exception>())
+            .Returns((500, new ErrorModel()));
+
+        await ControllerErrorHelper.HandleException(context, failure);
+        await fixture.Subject.Handle(context, context.Response.ExceptionValue!);
+
+        fixture.Logger.Received(1).RequestFailed(Arg.Any<IExecutionContext>(), Arg.Any<Exception>());
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ControllerErrorHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ControllerErrorHelper.cs
@@ -1,13 +1,26 @@
 ﻿using Hardened.Requests.Abstract.Execution;
-using Hardened.Requests.Abstract.Logging;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.Requests.Runtime.Errors;
 
+/// <summary>
+/// Where a generated handler puts an exception it caught.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recorded rather than rethrown: the response has to be produced by the same pipeline that
+/// produced the request, and the filter at <c>FilterOrder.Serialization</c> is what turns what is
+/// on the response into bytes.
+/// </para>
+/// <para>
+/// <b>It no longer logs.</b> It used to, and that made a handler fault the only kind of failure
+/// with a log line - an exception thrown by a filter, an authorization refusal and a rate-limit
+/// refusal all set the same field and reported nothing. <c>ExceptionResponseSerializer</c> logs
+/// instead, because that is the one place all four arrive at. Logging here as well would report a
+/// handler fault twice.
+/// </para>
+/// </remarks>
 public static class ControllerErrorHelper {
     public static Task HandleException(IExecutionContext context, Exception exception) {
-        context.RequestServices.GetRequiredService<IRequestLogger>().RequestFailed(context, exception);
-
         context.Response.ExceptionValue = exception;
 
         return Task.CompletedTask;

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -117,7 +117,7 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
         new() {
             Type = "ValidationError",
             Message = "One or more validation errors occurred.",
-            Errors = [
+            Errors = MissingMembers(exception.Message) ?? [
                 new RequestValidationFieldError {
                     Field = FieldFrom(exception.Path),
                     Code = "invalid",
@@ -125,6 +125,70 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
                 }
             ]
         };
+
+    /// <summary>
+    /// The members a required-member failure names, as the errors <c>[Required]</c> would have
+    /// produced - or null where this is some other <c>JsonException</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why the deserializer reports this at all.</b> A required member of a value type carries no
+    /// <c>[Required]</c>: the validation generator emits <c>value.x is null</c>, which is CS0037
+    /// against an <c>int</c>, so the constraint is suppressed and the validator never sees the
+    /// absence. <c>JsonTypeInfoEmitter</c> marks those members required on the deserializer instead,
+    /// and this is where the answer is shaped. Without it, an omitted enum silently became its first
+    /// declared member and the API answered 201 with a value the caller never sent.
+    /// </para>
+    /// <para>
+    /// <b>Indistinguishable from the validator's own answer, deliberately.</b> Same field spelling,
+    /// same <c>required</c> code, same <c>"{field} is required."</c> wording - so which layer caught
+    /// a missing member is this framework's business and not the caller's. System.Text.Json
+    /// aggregates, listing every member it missed, so the list is complete rather than first-only.
+    /// </para>
+    /// <para>
+    /// <b>Read from the message, which is the part worth being uneasy about.</b> There is no typed
+    /// exception for this and no structured member list on <c>JsonException</c>; the path is
+    /// <c>$</c>, because the object rather than any one member is what failed. So the shape is
+    /// matched conservatively and anything unrecognised falls through to the general branch above -
+    /// a caller gets a less precise 400, never a wrong one. <c>MissingRequiredMembersMessageTests</c>
+    /// pins the .NET behaviour, so an SDK that changes the wording fails a test here rather than
+    /// silently degrading in production.
+    /// </para>
+    /// </remarks>
+    private static List<RequestValidationFieldError>? MissingMembers(string message) {
+        const string prefix = "JSON deserialization for type ";
+        const string marker = "missing required properties";
+
+        if (!message.StartsWith(prefix, StringComparison.Ordinal) ||
+            message.IndexOf(marker, StringComparison.Ordinal) == -1) {
+            return null;
+        }
+
+        var listStart = message.IndexOf(": ", message.IndexOf(marker, StringComparison.Ordinal),
+            StringComparison.Ordinal);
+
+        if (listStart == -1) {
+            return null;
+        }
+
+        var errors = new List<RequestValidationFieldError>();
+
+        foreach (var name in message.Substring(listStart + 2).Split(',')) {
+            var member = name.Trim();
+
+            if (member.Length == 0) {
+                continue;
+            }
+
+            var field = "body." + member;
+
+            errors.Add(new RequestValidationFieldError {
+                Field = field, Code = "required", Message = field + " is required."
+            });
+        }
+
+        return errors.Count == 0 ? null : errors;
+    }
 
     /// <summary>
     /// <c>$.genre</c>, as <c>body.genre</c> - the spelling the constraint validators use.

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/ExceptionResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/ExceptionResponseSerializer.cs
@@ -21,11 +21,32 @@ public class ExceptionResponseSerializer : IExceptionResponseSerializer {
         _exceptionToModelConverter = exceptionToModelConverter;
     }
 
+    /// <summary>
+    /// Turns the exception into a response, and reports it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The logging is here because this is where every failure arrives.</b> It used to be
+    /// attached to the producers instead, and they did not agree: a handler fault logged through
+    /// <c>ControllerErrorHelper</c> and a bind failure through <c>RequestParameterBindFailed</c>,
+    /// while an exception thrown by a filter, an authorization refusal and a rate-limit refusal
+    /// logged nothing at all - four ways to fail a request, of which three were silent. Every one
+    /// of them sets <c>Response.ExceptionValue</c>, and every one of them reaches this method.
+    /// </para>
+    /// <para>
+    /// After the status is assigned rather than before, so the logger can read the status this
+    /// failure actually answers with. That is what lets severity follow the answer - a declared
+    /// 404 is a normal response and a 500 is a fault - without re-deriving the classification the
+    /// converter has already done.
+    /// </para>
+    /// </remarks>
     public Task Handle(IExecutionContext context, Exception exp) {
         var (status, model) = _exceptionToModelConverter.ConvertExceptionToModel(context, exp);
 
         context.Response.Status = status;
         context.Response.ResponseValue = model;
+
+        _requestLogger.RequestFailed(context, exp);
 
         return _serializationLocatorService.FindResponseSerializer(context).SerializeResponse(context);
     }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -46,6 +46,10 @@ internal static class JsonTypeInfoEmitter {
         resolver.AddUsingNamespace("System.Text.Json.Serialization");
         resolver.AddUsingNamespace("System.Text.Json.Serialization.Metadata");
 
+        if (AnyRequiresPresenceCheck(schemas)) {
+            AddRequireHelper(resolver);
+        }
+
         AddStringConverters(resolver, schemas, modelsNamespace);
 
         AddGetTypeInfo(resolver, schemas, modelsNamespace);
@@ -301,16 +305,92 @@ internal static class JsonTypeInfoEmitter {
         // the request body it describes unserializable; see ResponseOnlyAttribute.
         var getter = $"static obj => (({declaringTypeName})obj).{propName}";
 
-        sb.AppendLine($"                JsonMetadataServices.CreatePropertyInfo<{genericType}>(options, new JsonPropertyInfoValues<{genericType}>");
+        var required = RequiresPresenceCheck(prop, allSchemas);
+
+        var open = required ? RequireMethodName + "(" : "";
+        var close = required ? ")," : ",";
+
+        sb.AppendLine($"                {open}JsonMetadataServices.CreatePropertyInfo<{genericType}>(options, new JsonPropertyInfoValues<{genericType}>");
         sb.AppendLine("                {");
         sb.AppendLine("                    IsProperty = true,");
         sb.AppendLine("                    IsPublic = true,");
         sb.AppendLine($"                    DeclaringType = typeof({declaringTypeName}),");
         sb.AppendLine($"                    PropertyName = \"{prop.Name}\",");
         sb.AppendLine($"                    Getter = {getter},");
-        sb.AppendLine("                    Setter = null,");
-        sb.AppendLine("                }),");
+
+        // A setter that does nothing, and it has to exist: System.Text.Json refuses IsRequired on a
+        // property with a null setter - "marked required but does not specify a setter" - and these
+        // records are populated through their constructor, whose init-only members cannot be
+        // assigned through a delegate. The constructor still supplies the value; the setter is never
+        // the thing that fills it.
+        sb.AppendLine(required
+            ? $"                    Setter = static (object obj, {genericType} value) => {{ }},"
+            : "                    Setter = null,");
+
+        sb.AppendLine($"                }}){close}");
     }
+
+    /// <summary>
+    /// Whether absence of this member has to be caught by the deserializer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The exact complement of where <c>[Required]</c> is emitted.</b> A required member of a
+    /// reference type carries <c>[Required]</c> and is checked by the generated validator, which
+    /// aggregates its error with every other failed constraint in the same body. A required member
+    /// of a <em>value</em> type carries nothing: the validation generator answers
+    /// <c>value.x is null</c> against an <c>int</c>, which is CS0037, so the constraint is
+    /// suppressed - correctly - and nothing takes its place.
+    /// </para>
+    /// <para>
+    /// The result was that a missing required value silently became <c>default(T)</c>. An omitted
+    /// enum became its first declared member and the API answered 201 with a value the caller never
+    /// sent; an omitted integer became 0, caught only where some unrelated constraint happened to
+    /// reject 0. This is what closes that, and it is deliberately narrow: reference types keep the
+    /// aggregating validator path they already had.
+    /// </para>
+    /// <para>
+    /// <b>A declared <c>default</c> does not exempt it.</b> <c>required</c> and <c>default</c> are
+    /// contradictory - one says the caller must send the member, the other names what absence means
+    /// - and the contract's <c>required</c> wins. It is not a near miss either: a required member's
+    /// generated parameter carries no <c>= default</c>, so the specification's default is inert
+    /// today. Exempting these would preserve the silent zero for the one shape where the document
+    /// most obviously disagrees with itself.
+    /// </para>
+    /// </remarks>
+    private static bool RequiresPresenceCheck(PropertyModel prop, List<SchemaModel> allSchemas) {
+        if (!prop.ConstrainedAsRequired) {
+            return false;
+        }
+
+        return TypeMapper.IsNonNullableValueType(
+            TypeMapper.MapPropertyToCSharpType(prop), allSchemas);
+    }
+
+    private const string RequireMethodName = "Required";
+
+    /// <summary>
+    /// Marks a property the deserializer must see, as a method because <c>IsRequired</c> is set on
+    /// the built <c>JsonPropertyInfo</c> rather than declared in <c>JsonPropertyInfoValues</c>.
+    /// </summary>
+    private static void AddRequireHelper(ClassDefinition resolver) {
+        var method = resolver.AddMethod(RequireMethodName);
+
+        method.Modifiers |= ComponentModifier.Private | ComponentModifier.Static;
+        method.SetReturnType(
+            TypeDefinition.Get("System.Text.Json.Serialization.Metadata", "JsonPropertyInfo"));
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json.Serialization.Metadata", "JsonPropertyInfo"),
+            "property");
+
+        method.AddIndentedStatement(new CodeOutputComponent("property.IsRequired = true") );
+        method.AddIndentedStatement(new CodeOutputComponent("return property"));
+    }
+
+    /// <summary>Whether anything in this specification needs the helper above.</summary>
+    private static bool AnyRequiresPresenceCheck(List<SchemaModel> schemas) =>
+        schemas.Any(schema => schema.Kind == SchemaKind.Object &&
+                              schema.Properties.Any(prop => RequiresPresenceCheck(prop, schemas)));
 
     private static void EmitParameterInfo(StringBuilder sb, PropertyModel prop, int position,
         List<SchemaModel> allSchemas, string ns) {

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
@@ -136,9 +136,47 @@ internal static class SchemaEmitter {
         var emitRequired = property.ConstrainedAsRequired &&
                            !TypeMapper.IsNonNullableValueType(csType, allSchemas);
 
+        // The other half of that sentence. A required member of a value type gets no [Required] -
+        // the validation generator would emit `value.x is null` against an int, which is CS0037 -
+        // so absence used to become default(T) in silence: an omitted enum became its first
+        // declared member and the API answered 201 with a value the caller never sent.
+        //
+        // [JsonRequired] rather than a nullable member, so the model's shape is unchanged and a
+        // handler still reads an int. The deserializer is the only layer that still knows the
+        // member was absent, and this is how it is told to care.
+        //
+        // Emitted here *and* as IsRequired in JsonTypeInfoEmitter, because the two deserializers
+        // read different things: the reflection-based one reads this attribute, and the
+        // source-generated resolver builds JsonPropertyInfo by hand and never sees it. readOnly is
+        // enforced twice for the same reason - a null Setter there, [ResponseOnly] here.
+        if (property.ConstrainedAsRequired &&
+            TypeMapper.IsNonNullableValueType(csType, allSchemas)) {
+            parameter.AddAttribute(
+                TypeDefinition.Get("System.Text.Json.Serialization", "JsonRequiredAttribute"))
+                .Target = "property";
+        }
+
         foreach (var constraint in ConstraintAttributes.ForProperty(
                      property, emitRequired, patterns, csType)) {
             ValidationEmitter.Apply(parameter, constraint).Target = "property";
+        }
+
+        // Descend into a value that carries constraints of its own.
+        //
+        // This was emitted on an operation's body parameter and nowhere else, so a constraint on
+        // an array's items or on a nested object was generated, registered in DI, and never
+        // called: `lines: [{quantity: 0}]` against `minimum: 1` was accepted and the order placed.
+        // Only the mark was missing - ValidationModules already validates each element of a
+        // collection and each value of a dictionary, indexed, once told to.
+        //
+        // Guarded rather than unconditional: naming a validator the validation generator declined
+        // to emit is CS0234 in a file nobody can edit. NestedValidation is where both sides ask.
+        if (NestedValidation.Descends(property, allSchemas, patterns)) {
+            ValidationEmitter.Apply(
+                parameter,
+                new ConstraintAttributes.Model(
+                    ConstraintAttributes.ValidateNested(), System.Array.Empty<string>()))
+                .Target = "property";
         }
     }
 

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/NestedValidation.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/NestedValidation.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Idl;
+using Hardened.Idl.Emitters;
+using Hardened.Idl.Models;
+
+namespace Hardened.Idl.Validation;
+
+/// <summary>
+/// Which members a generated validator descends into, and whether the validator it would descend
+/// into exists.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>One definition, because a wrong answer does not fail here.</b> <c>[ValidateNested]</c> naming
+/// a validator the validation generator declined to emit is <c>CS0234</c> in a generated file, and
+/// the two sides derive their answer from different inputs - this task decides what to mark, and
+/// <c>ValidationModules.SourceGenerator</c> decides what to generate. <c>OperationParameters</c>
+/// already carried this rule inline for an operation's body and said so: "Both answers have to come
+/// from one place to stay in step." This is that place.
+/// </para>
+/// <para>
+/// <b>Per property, not by traversal.</b> A nested model's own nested members are marked when that
+/// schema is emitted, by this same rule - so descent composes without this file walking anything,
+/// and a schema that refers to itself needs no cycle guard because there is no walk to cycle.
+/// </para>
+/// <para>
+/// The descent itself is <c>ValidationModules</c>': <c>ValidateNestedAttribute</c> validates an
+/// object, each element of a collection, and each value of a dictionary, pathing the last as
+/// <c>map[key]</c>. Nothing here has to know which of the three it marked.
+/// </para>
+/// </remarks>
+internal static class NestedValidation {
+
+    /// <summary>
+    /// Whether this property's value is worth descending into.
+    /// </summary>
+    public static bool Descends(
+        PropertyModel property, IReadOnlyList<SchemaModel>? allSchemas, PatternRegistry patterns) {
+        if (!property.Constrained) {
+            return false;
+        }
+
+        var nested = Nested(property, allSchemas);
+
+        return nested != null && HasGeneratedValidator(nested, allSchemas, patterns);
+    }
+
+    /// <summary>
+    /// The object schema this property's value is made of, where there is one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The three shapes a generated model can appear in: the property itself, an array's elements,
+    /// or a dictionary's values.
+    /// </para>
+    /// <para>
+    /// A <c>oneOf</c> is excluded. It emits a generated union rather than a record, and whether that
+    /// carries a validator is a different question from this one - marking it would be the CS0234
+    /// this file exists to prevent.
+    /// </para>
+    /// <para>
+    /// An element type that could not be named is excluded for free: it degrades to
+    /// <c>JsonElement</c> and leaves no ref behind to resolve.
+    /// </para>
+    /// </remarks>
+    public static SchemaModel? Nested(
+        PropertyModel property, IReadOnlyList<SchemaModel>? allSchemas) {
+        if (property.OneOf.Count > 0) {
+            return null;
+        }
+
+        var reference = property.Ref ?? property.ArrayItemsRef ?? property.DictionaryValueRef;
+
+        if (reference == null) {
+            return null;
+        }
+
+        var name = NamingHelper.ToPascalCase(TypeMapper.GetRefName(reference));
+
+        return allSchemas?.FirstOrDefault(
+            candidate => candidate.Kind == SchemaKind.Object &&
+                         NamingHelper.ToPascalCase(candidate.Name) == name);
+    }
+
+    /// <summary>
+    /// Whether the validation generator will emit a validator for this schema.
+    /// </summary>
+    /// <remarks>
+    /// Asked by building the attributes rather than by re-deriving the rule that produces them. A
+    /// schema whose only constraint was <c>required</c> on a non-nullable value type gets no
+    /// attributes at all, so no validator is generated for it - and that outcome is reachable only
+    /// by asking <see cref="ConstraintAttributes"/> the same question the emitter asks.
+    ///
+    /// Declared members only. An inherited property is the base's to check, and the validation
+    /// generator sees it that way too - counting them here named a validator it had already
+    /// declined to generate.
+    /// </remarks>
+    public static bool HasGeneratedValidator(
+        SchemaModel schema, IReadOnlyList<SchemaModel>? allSchemas, PatternRegistry patterns) =>
+        SchemaShape.Declared(schema, allSchemas).Any(
+            property => property.Constrained &&
+                        Attributes(property, allSchemas, patterns).Count > 0);
+
+    /// <summary>
+    /// The constraint attributes a property would carry, by the same rules the model emitter
+    /// applies.
+    /// </summary>
+    public static IReadOnlyList<ConstraintAttributes.Model> Attributes(
+        PropertyModel property, IReadOnlyList<SchemaModel>? allSchemas, PatternRegistry patterns) {
+        var csType = TypeMapper.MapPropertyToCSharpType(property);
+
+        return ConstraintAttributes.ForProperty(
+            property,
+            property.ConstrainedAsRequired && !TypeMapper.IsNonNullableValueType(csType, allSchemas),
+            patterns,
+            csType);
+    }
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
@@ -82,17 +82,13 @@ internal static class OperationParameters {
             // Constrained excludes readOnly properties, whose constraints are never emitted - a
             // validator that descends into a body with nothing to check is dead code.
             //
-            // Asked by building the body's attributes rather than by re-deriving the rule. A body
-            // whose only constraint was `required` on a non-nullable value type now gets no
-            // attributes at all, so no validator is generated for it - and a [ValidateNested]
-            // naming a validator that does not exist is CS0234 in a generated file. Both answers
-            // have to come from one place to stay in step.
-            // Only what this type declares. An inherited property is the base's to check, and
-            // the validation generator sees it that way too - counting them here named a validator
-            // it had already declined to generate.
-            var attributes = SchemaShape.Declared(bodySchema, spec.Schemas).Any(
-                property => property.Constrained &&
-                            PropertyAttributes(property, spec, patterns).Count > 0)
+            // Asked by building the body's attributes rather than by re-deriving the rule, and
+            // asked through NestedValidation, which is the same call SchemaEmitter makes for a
+            // property. Both answers have to come from one place to stay in step: a body whose only
+            // constraint was `required` on a non-nullable value type gets no attributes at all, so
+            // no validator is generated for it - and a [ValidateNested] naming a validator that
+            // does not exist is CS0234 in a generated file.
+            var attributes = NestedValidation.HasGeneratedValidator(bodySchema, spec.Schemas, patterns)
                 ? new[] { new ConstraintAttributes.Model(
                     ConstraintAttributes.ValidateNested(), System.Array.Empty<string>()) }
                 : System.Array.Empty<ConstraintAttributes.Model>();
@@ -108,20 +104,6 @@ internal static class OperationParameters {
                 "I" + operation.MethodName + "Parameters",
                 members)
             : null;
-    }
-
-    /// <summary>
-    /// The attributes a property would carry, by the same rules the model emitter applies.
-    /// </summary>
-    private static IReadOnlyList<ConstraintAttributes.Model> PropertyAttributes(
-        PropertyModel property, ServiceSpecModel spec, PatternRegistry patterns) {
-        var csType = TypeMapper.MapPropertyToCSharpType(property);
-
-        return ConstraintAttributes.ForProperty(
-            property,
-            property.ConstrainedAsRequired && !TypeMapper.IsNonNullableValueType(csType, spec.Schemas),
-            patterns,
-            csType);
     }
 
     private static SchemaModel? BodySchema(OperationModel operation, ServiceSpecModel spec) {

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/EmitterHarness.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/EmitterHarness.cs
@@ -42,6 +42,20 @@ internal static class EmitterHarness {
         Write(ns => SchemaEmitter.Emit(
             ns, schema, ModelsNamespace, new PatternRegistry(RootNamespace + ".Validation", "petstore")));
 
+    /// <summary>
+    /// The same, with the schemas a property's <c>$ref</c> can resolve against.
+    /// </summary>
+    /// <remarks>
+    /// Needed to emit <c>[ValidateNested]</c> at all: whether a property is descended into depends
+    /// on whether the schema behind its ref will get a validator, and that cannot be answered from
+    /// the property alone.
+    /// </remarks>
+    internal static string Schema(
+        SchemaModel schema, System.Collections.Generic.List<SchemaModel> allSchemas) =>
+        Write(ns => SchemaEmitter.Emit(
+            ns, schema, ModelsNamespace,
+            new PatternRegistry(RootNamespace + ".Validation", "petstore"), allSchemas));
+
     internal static string ServiceInterface(ServiceModel service) =>
         Write(ns => ServiceInterfaceEmitter.Emit(ns, service, ModelsNamespace),
             RootNamespace + ".Services");

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/NestedValidationTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/NestedValidationTests.cs
@@ -1,0 +1,206 @@
+using Hardened.Idl.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// Which schema properties a generated validator descends into.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The defect these were written for: <c>[ValidateNested]</c> was emitted on an operation's
+/// <c>body</c> parameter and on nothing else, so a constraint on an array's items or on a nested
+/// object was generated, registered in DI, and never called.
+/// <c>POST /orders {"lines":[{"sku":"TLS-0001","quantity":0}]}</c> against <c>minimum: 1</c>
+/// answered 201 and placed the order.
+/// </para>
+/// <para>
+/// Only the mark was missing. <c>ValidationModules</c>' <c>[ValidateNested]</c> already validates an
+/// object, each element of a collection and each value of a dictionary, indexed through
+/// <c>ValidationContext.PushIndex</c>.
+/// </para>
+/// </remarks>
+public class NestedValidationTests {
+
+    /// <summary>A line item with a constraint of its own, and so a validator of its own.</summary>
+    private static SchemaModel ConstrainedLine() => new() {
+        Name = "OrderLine",
+        Kind = SchemaKind.Object,
+        Required = new List<string> { "sku", "quantity" },
+        Properties = new List<PropertyModel> {
+            new() { Name = "sku", Type = "string", IsRequired = true },
+            new() { Name = "quantity", Type = "integer", IsRequired = true, Minimum = 1 }
+        }
+    };
+
+    /// <summary>The same shape with nothing to check, so no validator is generated for it.</summary>
+    private static SchemaModel UnconstrainedLine() => new() {
+        Name = "OrderLine",
+        Kind = SchemaKind.Object,
+        Properties = new List<PropertyModel> {
+            new() { Name = "sku", Type = "string" },
+            new() { Name = "note", Type = "string" }
+        }
+    };
+
+    private static SchemaModel OrderWith(PropertyModel lines) => new() {
+        Name = "Order",
+        Kind = SchemaKind.Object,
+        Required = new List<string> { "lines" },
+        Properties = new List<PropertyModel> { lines }
+    };
+
+    private static PropertyModel ArrayOfLines() => new() {
+        Name = "lines",
+        IsArray = true,
+        ArrayItemsRef = "#/components/schemas/OrderLine",
+        IsRequired = true
+    };
+
+    /// <summary>
+    /// An array whose items carry constraints is descended into. The exact D2 repro.
+    /// </summary>
+    [Fact]
+    public void AnArrayOfConstrainedObjectsIsDescendedInto() {
+        var result = EmitterHarness.Schema(
+            OrderWith(ArrayOfLines()), [ConstrainedLine()]);
+
+        Assert.Contains("ValidateNested", result);
+    }
+
+    /// <summary>
+    /// A nested object carrying constraints is descended into, the same as an array's items.
+    /// </summary>
+    [Fact]
+    public void ANestedConstrainedObjectIsDescendedInto() {
+        var property = new PropertyModel {
+            Name = "line", Ref = "#/components/schemas/OrderLine", IsRequired = true
+        };
+
+        Assert.Contains("ValidateNested", EmitterHarness.Schema(
+            OrderWith(property), [ConstrainedLine()]));
+    }
+
+    /// <summary>
+    /// A dictionary of constrained objects too - ValidateNested validates each value, pathed as
+    /// <c>map[key]</c>.
+    /// </summary>
+    [Fact]
+    public void ADictionaryOfConstrainedObjectsIsDescendedInto() {
+        var property = new PropertyModel {
+            Name = "lines",
+            IsDictionary = true,
+            DictionaryValueRef = "#/components/schemas/OrderLine",
+            IsRequired = true
+        };
+
+        Assert.Contains("ValidateNested", EmitterHarness.Schema(
+            OrderWith(property), [ConstrainedLine()]));
+    }
+
+    /// <summary>
+    /// Not marked when the nested type has nothing to check.
+    /// </summary>
+    /// <remarks>
+    /// The guard that matters. <c>[ValidateNested]</c> naming a validator the validation generator
+    /// declined to emit is <c>CS0234</c> in a generated file - a build failure in code the author
+    /// cannot open, from a specification that is not wrong.
+    /// </remarks>
+    [Fact]
+    public void AnArrayOfUnconstrainedObjectsIsNotDescendedInto() {
+        var result = EmitterHarness.Schema(
+            OrderWith(ArrayOfLines()), [UnconstrainedLine()]);
+
+        Assert.DoesNotContain("ValidateNested", result);
+    }
+
+    /// <summary>
+    /// Not marked when the element type could not be named. It degrades to <c>JsonElement</c>,
+    /// which has no validator and no members to check.
+    /// </summary>
+    [Fact]
+    public void AnArrayOfPrimitivesIsNotDescendedInto() {
+        var property = new PropertyModel {
+            Name = "tags", IsArray = true, ArrayItemsType = "string", IsRequired = true
+        };
+
+        Assert.DoesNotContain("ValidateNested", EmitterHarness.Schema(
+            OrderWith(property), [ConstrainedLine()]));
+    }
+
+    /// <summary>
+    /// Not marked when the ref resolves to nothing. A misspelled <c>$ref</c> is already reported
+    /// elsewhere; what it must not do is name a validator that was never emitted.
+    /// </summary>
+    [Fact]
+    public void AnUnresolvableRefIsNotDescendedInto() {
+        var unrelated = UnconstrainedLine();
+        unrelated.Name = "SomethingElse";
+
+        Assert.DoesNotContain("ValidateNested", EmitterHarness.Schema(
+            OrderWith(ArrayOfLines()), [unrelated]));
+    }
+
+    /// <summary>
+    /// A <c>readOnly</c> property is not descended into. It is emitted outside the constructor and
+    /// carries no constraints at all - <c>required</c> on one means "always present in a response",
+    /// and validation runs on request binding.
+    /// </summary>
+    [Fact]
+    public void AReadOnlyNestedObjectIsNotDescendedInto() {
+        var property = new PropertyModel {
+            Name = "line", Ref = "#/components/schemas/OrderLine", IsReadOnly = true
+        };
+
+        Assert.DoesNotContain("ValidateNested", EmitterHarness.Schema(
+            OrderWith(property), [ConstrainedLine()]));
+    }
+
+    /// <summary>
+    /// Descent composes without this emitter walking anything: a nested model's own nested members
+    /// are marked when that schema is emitted, by the same rule.
+    /// </summary>
+    /// <remarks>
+    /// Which is also why a schema that refers to itself needs no cycle guard - there is no walk
+    /// here to cycle.
+    /// </remarks>
+    [Fact]
+    public void DescentComposesOneLevelAtATime() {
+        var line = ConstrainedLine();
+
+        var basket = new SchemaModel {
+            Name = "Basket",
+            Kind = SchemaKind.Object,
+            Required = new List<string> { "order" },
+            Properties = new List<PropertyModel> {
+                new() { Name = "order", Ref = "#/components/schemas/Order", IsRequired = true }
+            }
+        };
+
+        var order = OrderWith(ArrayOfLines());
+        var all = new List<SchemaModel> { basket, order, line };
+
+        Assert.Contains("ValidateNested", EmitterHarness.Schema(basket, all));
+        Assert.Contains("ValidateNested", EmitterHarness.Schema(order, all));
+    }
+
+    /// <summary>
+    /// A self-referencing schema is marked and does not hang the build.
+    /// </summary>
+    [Fact]
+    public void ASelfReferencingSchemaIsMarkedWithoutRecursing() {
+        var node = new SchemaModel {
+            Name = "Node",
+            Kind = SchemaKind.Object,
+            Required = new List<string> { "name" },
+            Properties = new List<PropertyModel> {
+                new() { Name = "name", Type = "string", IsRequired = true, MinLength = 1 },
+                new() {
+                    Name = "children", IsArray = true, ArrayItemsRef = "#/components/schemas/Node"
+                }
+            }
+        };
+
+        Assert.Contains("ValidateNested", EmitterHarness.Schema(node, [node]));
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/RequiredValueMemberTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/RequiredValueMemberTests.cs
@@ -1,0 +1,213 @@
+using Hardened.Idl.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// Catching a required member the C# type cannot prove was sent.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The defect these were written for: a missing required member of a value type silently became
+/// <c>default(T)</c>. <c>POST /products</c> omitting <c>category</c> answered <b>201</b> with
+/// <c>"category":"tools"</c> - the enum's first declared member - so the API invented data and
+/// reported success. An omitted integer became 0, caught only where some unrelated constraint
+/// happened to reject 0.
+/// </para>
+/// <para>
+/// <c>[Required]</c> cannot cover it: the validation generator emits <c>value.x is null</c>, which
+/// is CS0037 against an <c>int</c>, so the constraint is correctly suppressed and nothing replaced
+/// it. The deserializer is the only layer that still knows the member was absent.
+/// </para>
+/// </remarks>
+public class RequiredValueMemberTests {
+
+    private static string Emit(params PropertyModel[] properties) =>
+        EmitterHarness.JsonTypeInfo(
+            [new SchemaModel {
+                Name = "Product",
+                Kind = SchemaKind.Object,
+                Required = properties.Where(p => p.IsRequired).Select(p => p.Name).ToList(),
+                Properties = properties.ToList()
+            }],
+            "depot");
+
+    private static string EmitWithEnum(params PropertyModel[] properties) =>
+        EmitterHarness.JsonTypeInfo(
+            [
+                new SchemaModel {
+                    Name = "Product",
+                    Kind = SchemaKind.Object,
+                    Required = properties.Where(p => p.IsRequired).Select(p => p.Name).ToList(),
+                    Properties = properties.ToList()
+                },
+                new SchemaModel {
+                    Name = "Category",
+                    Kind = SchemaKind.Enum,
+                    EnumValues = ["tools", "toys"]
+                }
+            ],
+            "depot");
+
+    /// <summary>
+    /// A required integer is marked, so absence is a 400 rather than a zero.
+    /// </summary>
+    [Fact]
+    public void ARequiredIntegerIsMarkedRequired() {
+        var result = Emit(new PropertyModel {
+            Name = "unitPriceCents", Type = "integer", IsRequired = true
+        });
+
+        Assert.Contains("Required(JsonMetadataServices.CreatePropertyInfo", result);
+        Assert.Contains("property.IsRequired = true", result);
+    }
+
+    /// <summary>
+    /// The enum case, which is the one that invented data: nothing rejects an enum's first member,
+    /// so the request succeeded and stored a category the caller never sent.
+    /// </summary>
+    [Fact]
+    public void ARequiredEnumIsMarkedRequired() {
+        var result = EmitWithEnum(new PropertyModel {
+            Name = "category", Ref = "#/components/schemas/Category", IsRequired = true
+        });
+
+        Assert.Contains("Required(JsonMetadataServices.CreatePropertyInfo", result);
+    }
+
+    /// <summary>
+    /// The marked property gets a setter that does nothing, because System.Text.Json refuses
+    /// <c>IsRequired</c> without one - and these records are filled through their constructor, whose
+    /// init-only members cannot be assigned through a delegate.
+    /// </summary>
+    /// <remarks>
+    /// Pinned because it looks removable. Dropping it is
+    /// <c>InvalidOperationException: JsonPropertyInfo 'x' ... is marked required but does not
+    /// specify a setter</c> - thrown on the first request rather than at build time.
+    /// </remarks>
+    [Fact]
+    public void AMarkedPropertyCarriesANoOpSetter() {
+        var result = Emit(new PropertyModel {
+            Name = "unitPriceCents", Type = "integer", IsRequired = true
+        });
+
+        Assert.Contains("Setter = static (object obj, int value) => { },", result);
+    }
+
+    /// <summary>
+    /// A required reference type is left alone. It already carries <c>[Required]</c>, and the
+    /// generated validator aggregates its error with every other failed constraint in the same body
+    /// - which the deserializer, stopping at the first fault, would not.
+    /// </summary>
+    [Fact]
+    public void ARequiredStringIsLeftToTheValidator() {
+        var result = Emit(new PropertyModel { Name = "sku", Type = "string", IsRequired = true });
+
+        Assert.DoesNotContain("Required(JsonMetadataServices.CreatePropertyInfo", result);
+        Assert.DoesNotContain("property.IsRequired = true", result);
+    }
+
+    /// <summary>
+    /// An optional value type is left alone; absence is what optional means.
+    /// </summary>
+    [Fact]
+    public void AnOptionalIntegerIsNotMarked() {
+        Assert.DoesNotContain(
+            "Required(JsonMetadataServices.CreatePropertyInfo",
+            Emit(new PropertyModel { Name = "stock", Type = "integer" }));
+    }
+
+    /// <summary>
+    /// A declared <c>default</c> does not exempt a required member.
+    /// </summary>
+    /// <remarks>
+    /// <c>required</c> and <c>default</c> are contradictory - one says the caller must send the
+    /// member, the other names what absence means - and the contract's <c>required</c> wins. Nor is
+    /// it a near miss: a required member's generated parameter carries no <c>= default</c>, so the
+    /// specification's default never reaches the constructor. Exempting these would keep the silent
+    /// zero for the one shape where the document most obviously disagrees with itself.
+    /// </remarks>
+    [Fact]
+    public void ADeclaredDefaultDoesNotExemptARequiredMember() {
+        Assert.Contains(
+            "Required(JsonMetadataServices.CreatePropertyInfo",
+            Emit(new PropertyModel {
+                Name = "stock", Type = "integer", IsRequired = true, Default = "0"
+            }));
+    }
+
+    /// <summary>
+    /// A <c>readOnly</c> member is left alone. <c>required</c> on one means "always present in a
+    /// response", and validation runs on request binding - demanding it would reject the create
+    /// call of a client that correctly omitted a value the server assigns.
+    /// </summary>
+    [Fact]
+    public void ARequiredReadOnlyMemberIsNotMarked() {
+        Assert.DoesNotContain(
+            "Required(JsonMetadataServices.CreatePropertyInfo",
+            Emit(new PropertyModel {
+                Name = "id", Type = "integer", IsRequired = true, IsReadOnly = true
+            }));
+    }
+
+    /// <summary>
+    /// The helper is emitted only where something uses it.
+    /// </summary>
+    [Fact]
+    public void TheHelperIsNotEmittedWhenNothingNeedsIt() {
+        Assert.DoesNotContain(
+            "property.IsRequired = true",
+            Emit(new PropertyModel { Name = "sku", Type = "string", IsRequired = true }));
+    }
+
+    // ------------------------------------------------- the reflection deserializer's half
+
+    /// <summary>
+    /// The model carries <c>[JsonRequired]</c> as well.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both halves are needed because the two deserializers read different things.
+    /// <c>SystemTextJsonRequestDeserializer</c> is reflection-based and is what an application gets
+    /// unless it imports <c>AotSerializerModule</c>; it reads this attribute.
+    /// <c>AotRequestDeserializer</c> reads the resolver, which builds every
+    /// <c>JsonPropertyInfo</c> by hand and never looks at an attribute.
+    /// </para>
+    /// <para>
+    /// Marking only the resolver passed every unit test and changed nothing about a real request:
+    /// the integration application does not import <c>AotSerializerModule</c>, so the metadata that
+    /// carried <c>IsRequired</c> was never the metadata in use. <c>readOnly</c> is enforced twice
+    /// for the same reason - a null <c>Setter</c> in the resolver, <c>[ResponseOnly]</c> here.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ARequiredValueMemberAlsoCarriesJsonRequiredOnTheModel() {
+        var result = EmitterHarness.Schema(new SchemaModel {
+            Name = "Product",
+            Kind = SchemaKind.Object,
+            Required = ["unitPriceCents"],
+            Properties = [
+                new PropertyModel { Name = "unitPriceCents", Type = "integer", IsRequired = true }
+            ]
+        });
+
+        Assert.Contains("[property: JsonRequired]", result);
+    }
+
+    /// <summary>
+    /// A required reference type does not, because <c>[Required]</c> already covers it and the
+    /// validator aggregates where the deserializer stops at the first fault.
+    /// </summary>
+    [Fact]
+    public void ARequiredReferenceMemberDoesNotCarryJsonRequired() {
+        var result = EmitterHarness.Schema(new SchemaModel {
+            Name = "Product",
+            Kind = SchemaKind.Object,
+            Required = ["sku"],
+            Properties = [new PropertyModel { Name = "sku", Type = "string", IsRequired = true }]
+        });
+
+        Assert.Contains("[property: Required]", result);
+        Assert.DoesNotContain("JsonRequired", result);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
@@ -174,9 +174,29 @@
     <Target Name="HardenedOpenApiFilterStamp" DependsOnTargets="HardenedOpenApiResolveModelDir">
         <MakeDir Directories="$(HardenedOpenApiModelDir)"/>
 
+        <!--
+            The task that will do the writing, as an input in its own right.
+
+            Upgrading the package changes what the task emits and touches no spec file, so without
+            this the check below finds every input unmoved, skips the target, and leaves the previous
+            version's generated C# in obj/ - against a runtime and a Roslyn generator that have both
+            moved on. It builds, or it fails inside a generated file naming a member the new emitter
+            renamed. Neither says "your generated code is a version behind".
+
+            Both halves are needed. The path carries the package version for a consumer restoring
+            from a feed, which is what makes an upgrade visible even when the new assembly's own
+            timestamp is older than the obj/ it is replacing - a package built last week, installed
+            today, over output written yesterday. ModifiedTime carries a rebuild in place, which is
+            what a ProjectReference gives this repository's own integration tests, where the path
+            never changes.
+        -->
+        <ItemGroup>
+            <_HardenedOpenApiTaskIdentity Include="$(HardenedOpenApiTaskAssembly)"/>
+        </ItemGroup>
+
         <WriteLinesToFile
             File="$(HardenedOpenApiModelDir)filters.stamp"
-            Lines="@(HardenedOpenApiSpec->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)');$(HardenedResponseModel)"
+            Lines="@(HardenedOpenApiSpec->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)');$(HardenedResponseModel);@(_HardenedOpenApiTaskIdentity->'%(FullPath)|%(ModifiedTime)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
     </Target>
@@ -202,6 +222,22 @@
             <Output TaskParameter="ModelFiles" ItemName="_HardenedOpenApiModelWritten"/>
             <Output TaskParameter="GeneratedSources" ItemName="_HardenedOpenApiSourceWritten"/>
         </ExtractOpenApiSpec>
+
+        <!--
+            So the check above converges when the task had nothing new to write.
+
+            The task leaves a file alone when its content is unchanged, which is right - rewriting
+            identical bytes would make the compiler redo work for nothing. But an output whose
+            timestamp never moves is an output that never catches up to the input that moved, and
+            the target then re-runs on every single build, parsing every specification each time.
+            That only became reachable when the task assembly joined the stamp: a package upgrade
+            can move the input and produce byte-identical output.
+
+            Touch rather than forcing the task to rewrite, because what has to advance is the
+            timestamp, not the content - and the compiler's own up-to-date check is against the same
+            files, so it reconsiders exactly once rather than on every build afterwards.
+        -->
+        <Touch Files="@(_HardenedOpenApiModel);@(_HardenedOpenApiSource)" AlwaysCreate="false"/>
     </Target>
 
     <!--

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
@@ -279,9 +279,28 @@
     <Target Name="HardenedSmithyFilterStamp" DependsOnTargets="HardenedSmithyResolveModelDir">
         <MakeDir Directories="$(HardenedSmithyModelDir)"/>
 
+        <!--
+            The task that will do the writing, as an input in its own right.
+
+            Upgrading the package changes what the task emits and touches no source file, so without
+            this the check below finds every input unmoved, skips the target, and leaves the previous
+            version's generated C# in obj/. It builds, or it fails inside a generated file naming a
+            member the new emitter renamed. Neither says "your generated code is a version behind".
+
+            Both halves are needed. The path carries the package version for a consumer restoring
+            from a feed, which is what makes an upgrade visible even when the new assembly's own
+            timestamp is older than the obj/ it is replacing - a package built last week, installed
+            today, over output written yesterday. ModifiedTime carries a rebuild in place, which is
+            what a ProjectReference gives this repository's own integration tests, where the path
+            never changes.
+        -->
+        <ItemGroup>
+            <_HardenedSmithyTaskIdentity Include="$(HardenedSmithyTaskAssembly)"/>
+        </ItemGroup>
+
         <WriteLinesToFile
             File="$(HardenedSmithyModelDir)filters.stamp"
-            Lines="@(HardenedSmithyAst->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)');$(HardenedSmithyServiceShapeId);$(HardenedResponseModel)"
+            Lines="@(HardenedSmithyAst->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)');$(HardenedSmithyServiceShapeId);$(HardenedResponseModel);@(_HardenedSmithyTaskIdentity->'%(FullPath)|%(ModifiedTime)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
     </Target>
@@ -315,6 +334,15 @@
             <Output TaskParameter="ModelFiles" ItemName="_HardenedSmithyModelWritten"/>
             <Output TaskParameter="GeneratedSources" ItemName="_HardenedSmithySourceWritten"/>
         </ExtractSmithySpec>
+
+        <!--
+            So the check above converges when the task had nothing new to write - the same reason
+            HardenedSmithyGenerateAst declares a stamp rather than the AST. An output whose timestamp
+            never moves never catches up to an input that did, and the target then re-runs on every
+            build. That became reachable when the task assembly joined the stamp: an upgrade can move
+            the input and produce byte-identical output.
+        -->
+        <Touch Files="@(_HardenedSmithyModel);@(_HardenedSmithySource)" AlwaysCreate="false"/>
     </Target>
 
     <!--

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentDiagnostics.cs
@@ -1,0 +1,53 @@
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.OpenApiDocument;
+
+/// <summary>
+/// What <c>[Enable&lt;OpenApiDocumentPublishing&gt;]</c> reports when it cannot describe anything.
+/// </summary>
+public static class OpenApiDocumentDiagnostics {
+
+    /// <summary>The marker is on a module that declares no routes.</summary>
+    public const string EmptyDocumentId = "HRDOA003";
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the reason
+    /// <c>OpenApiVersionDiagnostics</c> gives: RS2008 looks for the field, and these projects set
+    /// <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    internal static DiagnosticDescriptor EmptyDocumentDescriptor() => new(
+        id: EmptyDocumentId,
+        title: "The published OpenAPI document describes no operations",
+        messageFormat:
+        "'{0}' enables OpenApiDocumentPublishing and declares no routes, so the document served " +
+        "at {1} is \"paths\": {{}}. The document is written from the routes in the same " +
+        "compilation as the attribute - move [Enable<OpenApiDocumentPublishing>] to the module " +
+        "that declares them. With it on both, the empty one shadows the real one.",
+        category: "Hardened.OpenApi",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports a marker that will publish an empty document.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The defect this exists for shipped in the template: the attribute sat on the host module,
+    /// which composes the library rather than declaring routes itself, so every code-first
+    /// application generated from it served an empty document. Nothing failed. The build was clean,
+    /// <c>/openapi.json</c> answered 200, and the reference page rendered zero operations - which
+    /// reads exactly like an API with no routes.
+    /// </para>
+    /// <para>
+    /// A warning rather than an error, because an application whose document is genuinely empty
+    /// still runs, and because a module that declares no routes today may declare some tomorrow.
+    /// What it must not do is publish emptiness silently.
+    /// </para>
+    /// </remarks>
+    public static void ReportEmptyDocument(
+        SourceProductionContext context, string entryPointName, string documentPath) {
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                EmptyDocumentDescriptor(), Location.None, entryPointName, documentPath));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
@@ -111,7 +111,16 @@ public static class RoutingTableGenerator {
         // Only for an entry point that asked. The document used to be emitted unconditionally on
         // the grounds that it cost one string, which understated it - see OpenApiDocumentSource -
         // and an application that does not serve one now does not carry one.
-        if (OpenApiDocumentFeature.Path(models.Left) != null) {
+        if (OpenApiDocumentFeature.Path(models.Left) is { } documentPath) {
+            // An empty document is the one outcome that looks like success from every angle: the
+            // build is clean, the route answers 200, and the reference page renders an API with no
+            // operations. Said out loud, because the alternative is discovering it from a client
+            // generator that produced nothing.
+            if (routable.Count == 0) {
+                OpenApiDocumentDiagnostics.ReportEmptyDocument(
+                    context, models.Left.EntryPointType.Name, documentPath);
+            }
+
             // A streamed response has no spelling before 3.2, so the document is emitted without one
             // and the handler is named rather than the omission being silent.
             if (!OpenApiVersionFacts.SupportsItemSchema(documentVersion)) {

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OpenApiEmptyDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OpenApiEmptyDocumentTests.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.OpenApiDocument;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests;
+
+/// <summary>
+/// What a module publishing a document it cannot fill is told.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The template shipped with <c>[Enable&lt;OpenApiDocumentPublishing&gt;]</c> on the host module,
+/// which composes the route library rather than declaring routes itself. The document is written
+/// from the routes in the same compilation as the attribute, so every code-first application
+/// generated from that template served <c>"paths": {}</c>.
+/// </para>
+/// <para>
+/// Nothing failed anywhere: the build was clean, <c>/openapi.json</c> answered 200, and the
+/// reference page rendered - as an API with no operations, which is what an API with no operations
+/// also looks like. These pin the diagnostic that makes the difference visible.
+/// </para>
+/// </remarks>
+public class OpenApiEmptyDocumentTests {
+
+    private static readonly Type[] Anchors = [typeof(GetAttribute)];
+
+    private const string Marker =
+        "[Hardened.Shared.Runtime.Attributes.Enable<" +
+        "Hardened.Web.Runtime.OpenApi.OpenApiDocumentPublishing>]";
+
+    /// <param name="controller">
+    /// Empty for the module that composes rather than declares - the host's position.
+    /// </param>
+    private static GeneratorResult Generate(string controller) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Test.cs"] = $$"""
+                    using Hardened.Shared.Runtime.Attributes;
+                    using Hardened.Web.Runtime.Attributes;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    {{Marker}}
+                    public partial class TestApplication { }
+
+                    {{controller}}
+                    """
+            },
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors,
+            additionalTexts: null,
+            buildProperties: null);
+
+    private const string Controller =
+        """
+        public class UserController {
+            [Get("/users/{id}")]
+            public string ById(string id) => id;
+        }
+        """;
+
+    private static Diagnostic? Reported(GeneratorResult result) =>
+        result.GeneratorDiagnostics.FirstOrDefault(
+            diagnostic => diagnostic.Id == OpenApiDocumentDiagnostics.EmptyDocumentId);
+
+    /// <summary>
+    /// A module that publishes a document and declares no routes is told so.
+    /// </summary>
+    [Fact]
+    public void PublishingFromAModuleWithNoRoutesIsReported() {
+        var reported = Reported(Generate(controller: ""));
+
+        Assert.NotNull(reported);
+        Assert.Equal(DiagnosticSeverity.Warning, reported!.Severity);
+        Assert.Contains("TestApplication", reported.GetMessage());
+        Assert.Contains("/openapi.json", reported.GetMessage());
+    }
+
+    /// <summary>
+    /// The message says where the attribute belongs, because "the document is empty" is a symptom
+    /// and the fix is not guessable from it.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheFix() {
+        var message = Reported(Generate(controller: ""))!.GetMessage();
+
+        Assert.Contains("same compilation", message);
+        Assert.Contains("Enable<OpenApiDocumentPublishing>", message);
+    }
+
+    /// <summary>
+    /// A module that declares the routes it publishes is not warned. This is the template's
+    /// arrangement after the fix, and a diagnostic that fired here would fire on every correct
+    /// application.
+    /// </summary>
+    [Fact]
+    public void PublishingBesideTheRoutesReportsNothing() {
+        Assert.Null(Reported(Generate(Controller)));
+    }
+
+    /// <summary>
+    /// The symptom itself, so the diagnostic is pinned against the thing it describes rather than
+    /// against its own message.
+    /// </summary>
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData(Controller, 1)]
+    public void TheDocumentDescribesOnlyTheRoutesInItsOwnCompilation(string controller, int paths) {
+        var source = Generate(controller).GeneratedSources
+            .First(pair => pair.Key.Contains("OpenApiDocument")).Value;
+
+        using var document = JsonDocument.Parse(GeneratedOpenApiDocument.Extract(source));
+
+        Assert.Equal(paths, document.RootElement.GetProperty("paths").EnumerateObject().Count());
+    }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
@@ -33,14 +33,15 @@ namespace Hardened1.Host;
 [LambdaWebModule]
 #endif
 #if (codeFirst)
-// Embeds the document the build wrote from this application's routes, and serves it at
-// /openapi.json. Spec-first applications do not use this: their document is a build input,
-// published by PublishUrl on the spec item instead.
-[Enable<OpenApiDocumentPublishing>]
 #if (OpenApiUi)
 // Development only. The page describes every operation this service exposes and renders them
 // with a script from a CDN, neither of which a deployed API obviously wants. Widen the list, or
 // drop the attribute, when you have decided otherwise.
+//
+// The page belongs here and the document does not. This attribute names a URL to fetch, which is
+// a hosting decision; [Enable<OpenApiDocumentPublishing>] makes the build write a document from
+// the routes it can see, and this module declares none - so it lives on the library module beside
+// them. Moving it here serves "paths": {} and nothing says so.
 [HardenedOpenApiUi(Title = "Hardened1", Environments = "development")]
 #endif
 #endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
@@ -1,6 +1,7 @@
 using Hardened.Shared.Runtime.Attributes;
 #if (codeFirst)
 using Hardened.Web.Runtime.Attributes;
+using Hardened.Web.Runtime.OpenApi;
 #endif
 using Hardened.Web.Runtime.DependencyInjection;
 
@@ -18,5 +19,16 @@ namespace Hardened1;
 #if (codeFirst)
 // This assembly's URL space. Every route below it is relative to this.
 [BasePath("/todos")]
+// Embeds the document the build wrote from this assembly's routes, and serves it at
+// /openapi.json.
+//
+// Here rather than on the host module, and that is not a style choice. The generator writes the
+// document from the routes in the compilation the attribute sits in, and the host declares none -
+// so on the host it emits "paths": {} and serves an empty document with no diagnostic. Worse, with
+// the attribute on both, the empty one shadows this one.
+//
+// Spec-first applications do not use this at all: their document is a build input, published by
+// PublishUrl on the spec item instead.
+[Enable<OpenApiDocumentPublishing>]
 #endif
 public partial class TemplateModuleNameLibrary;

--- a/src/Web/Hardened.Web.StaticContent/Package/Hardened.Web.StaticContent.targets
+++ b/src/Web/Hardened.Web.StaticContent/Package/Hardened.Web.StaticContent.targets
@@ -68,9 +68,29 @@
     <Target Name="HardenedStaticContentStamp" Condition="'@(HardenedStaticContent)' != ''">
         <MakeDir Directories="$(IntermediateOutputPath)staticcontent"/>
 
+
+        <!--
+        The task that will do the writing, as an input in its own right.
+
+        Upgrading the package changes what the task emits and touches no source file, so without
+        this the check below finds every input unmoved, skips the target, and leaves the previous
+        version's generated C# in obj/. It builds, or it fails inside a generated file naming a
+        member the new emitter renamed. Neither says "your generated code is a version behind".
+
+        Both halves are needed. The path carries the package version for a consumer restoring
+        from a feed, which is what makes an upgrade visible even when the new assembly's own
+        timestamp is older than the obj/ it is replacing - a package built last week, installed
+        today, over output written yesterday. ModifiedTime carries a rebuild in place, which is
+        what a ProjectReference gives this repository's own integration tests, where the path
+        never changes.
+        -->
+        <ItemGroup>
+            <_HardenedStaticContentTaskIdentity Include="$(HardenedStaticContentTaskAssembly)"/>
+        </ItemGroup>
+
         <WriteLinesToFile
             File="$(IntermediateOutputPath)staticcontent/options.stamp"
-            Lines="@(HardenedStaticContent->'%(Identity)|%(RoutePrefix)|%(FallBackFile)');$(HardenedStaticContentNamespace)|$(HardenedStaticContentEmbedThresholdBytes)"
+            Lines="@(HardenedStaticContent->'%(Identity)|%(RoutePrefix)|%(FallBackFile)');$(HardenedStaticContentNamespace)|$(HardenedStaticContentEmbedThresholdBytes);@(_HardenedStaticContentTaskIdentity->'%(FullPath)|%(ModifiedTime)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
     </Target>
@@ -96,6 +116,14 @@
             Namespace="$(HardenedStaticContentNamespace)"
             EmbedThresholdBytes="$(HardenedStaticContentEmbedThresholdBytes)"
             ExcludeFromCoverage="$(ExcludeGeneratedCodeFromCoverage)"/>
+
+        <!--
+            So the check above converges when the task had nothing new to write. An output whose
+            timestamp never moves never catches up to an input that did, and the target then re-runs
+            on every build - reachable now that the task assembly is one of those inputs, because an
+            upgrade can move it and still produce byte-identical output.
+        -->
+        <Touch Files="@(_HardenedStaticContentSource)" AlwaysCreate="false"/>
     </Target>
 
     <!--


### PR DESCRIPTION
Four of the ten defects the seven-agent review of `0.12.0-rc1000` recorded, plus one it
did not find. Each claim was re-verified against the source before it was planned — a
few needed correcting, and one turned out to be much smaller than reported.

## What is here

| | | |
|---|---|---|
| **D1** | `required` not enforced on value-typed members | *critical* |
| **D2** | constraints on array items and nested objects never invoked | *blocker* |
| **D4** | code-first publishes an empty OpenAPI document | *major* |
| **D6** | exceptions thrown by a filter are never logged | *major* |
| **N1** | generated code survives a package upgrade | **not in the review** |

One commit per defect, each carrying its own reasoning.

## D1 + D2 — the constraints a contract already declares

A missing required member of a value type silently became `default(T)`: an omitted enum
became its first declared member, and the API stored and echoed a category the caller
never sent. `[Required]` is suppressed there and correctly so — the validation generator
emits `value.x is null`, which is CS0037 against an `int` — but nothing took its place.

Four ways to close it were measured against real System.Text.Json before choosing.
**It needed two halves, and the first alone changed nothing**: the two deserializers read
different things, and the integration application does not import `AotSerializerModule`,
so the metadata carrying `IsRequired` was never the metadata in use. Every unit test was
green while the defect stood. Only the end-to-end test caught it.

The 400 a caller gets is the validator's own answer — same field spelling, same code, same
wording, every missing member at once.

`[ValidateNested]` was emitted on an operation's body parameter and nowhere else, so
`{"lines":[{"quantity":0}]}` against `minimum: 1` placed the order. **Smaller than
reported**: ValidationModules already validates each element of a collection and each value
of a dictionary, indexed. Only the mark was missing, and no recursion or cycle guard is
needed — the rule is per property and uniform.

## D4 — an empty document, and why the gate missed it

Every code-first application generated from the template served `"paths": {}`. The document
is written from the routes in the same compilation as the attribute, and the template put it
on the host module, which composes the route library rather than declaring routes.

`verify-templates.sh` probed `/docs` for a 200 and never looked at the document behind it —
an empty document renders as a page with zero operations, which is indistinguishable from a
working page by every check it made. It now counts the operations, through a JSON parse
rather than a grep: `/todos` and `paths` both appear in a document that describes nothing.

`HRDOA003` warns when the marker sits on a module with no routes, naming the fix.

## D6 — reporting a failure where every failure arrives

An exception thrown by a filter was logged nowhere. It was **four** silent producers, not
one — a filter throw, an authorization refusal, a rate-limit refusal and async-enumerable
faults — because logging was attached to producers rather than to the event.

The catch-all already existed and already had `IRequestLogger` injected and unused. So this
**deletes logging rather than adding it**: the funnel reports, `ControllerErrorHelper` stops,
and the four silent producers are fixed without being touched.

## N1 — generated code survives a package upgrade

Not in the review, and the one with the widest blast radius: **upgrading the package leaves
the previous version's generated C# in `obj/`.** The task assembly was not among the target's
inputs, so the check found everything unmoved and skipped.

Adding it to `Inputs` is the obvious move and does not work — a package's extracted timestamp
is its build date, so one released last week and installed today is *older* than the `obj/` it
must invalidate. The identity goes into the filter stamp instead.

That exposed a second defect: `HardenedOpenApiExtractSpecs` **re-ran on every single build**,
re-parsing every specification, because outputs whose content was unchanged never caught up to
the stamp.

| | repeat build | after upgrade |
|---|---|---|
| before | rebuilds every time | rebuilds, by accident of never being up to date |
| after | skips | rebuilds |

> Anyone upgrading from a version before this fix may still be sitting on stale generated code.
> A one-time `obj/` clean is the only way to clear it — worth a line in the release notes.

## Verification

**4,892 tests across 29 assemblies, 0 failures.** Clean build, 0 warnings, on a rebuild with
every build-task output deleted first.

D4 and N1 were verified **A/B** — reverted to the broken arrangement to confirm the new gate
and the new stamp actually catch it. An assertion that cannot fail looks exactly like an
assertion that works, which is how D4 shipped in the first place.

## Not in this PR

D3, D5, D7–D10, eleven lesser items and seven documentation defects remain. D3's design is
settled but unimplemented: generate `Created<T>` when a 201 declares a `Location`, a
`HardenedCreatedResponses` policy to force it, `HOAT012` when a 201 declares none, and a 3xx
response type, which does not exist at all today.

Two things deliberately left undone, both recorded in the commits: **severity by status** (a
declared 404 still logs at `fail:` with a full stack trace — now a one-line change in one
place, because D6 centralised it), and **`HardenedStaticContentManifest`**, which rebuilds
every build for an unrelated reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaVWVDCGLsE7xrTG1D8Jng
