### PR TITLE
Let a registered IJsonTypeInfoResolver decide how a type reaches the wire

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -4,12 +4,12 @@
     "branch": 87.5
   },
   "Hardened.Idl.SourceGenerator": {
-    "line": 62.0,
-    "branch": 49.1
+    "line": 61.1,
+    "branch": 48.2
   },
   "Hardened.Library.SourceGenerator": {
-    "line": 36.5,
-    "branch": 15.6
+    "line": 34.2,
+    "branch": 13.8
   },
   "Hardened.OpenApi.BuildTask": {
     "line": 45.0,
@@ -56,8 +56,8 @@
     "branch": 100.0
   },
   "Hardened.Validation.SourceGenerator": {
-    "line": 21.6,
-    "branch": 14.2
+    "line": 20.2,
+    "branch": 12.4
   },
   "Hardened.Web.AspNetCore.Runtime": {
     "line": 97.1,

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/EnumVocabularyTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/EnumVocabularyTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// A code-first enum's wire vocabulary, through the whole application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An enum reaches a client by three routes that share no code - a body written, a body read, and a
+/// parameter bound from text - and is described to it by a fourth, the published document. They
+/// have disagreed in every combination. Before this, the serializer wrote <c>{"priority":0}</c>
+/// while the document declared <c>{"type":"string","enum":["InProgress"]}</c>, so a client
+/// generated from the contract could not talk to the application that published it.
+/// </para>
+/// <para>
+/// Held end to end rather than over the emitter, because that is the only level at which the four
+/// are the same fact. Each is asserted against a literal, since the literal is what a client sends.
+/// </para>
+/// </remarks>
+public class EnumVocabularyTests {
+
+    /// <summary>
+    /// No attribute anywhere: the default an application gets for saying nothing.
+    /// </summary>
+    [HardenedTest]
+    public async Task WriteUsesCamelCaseByDefault(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/enum-vocabulary/ticket");
+
+        Assert.Equal(200, response.StatusCode);
+
+        var body = await response.ReadTextAsync();
+
+        Assert.Contains("\"priority\":\"inProgress\"", body);
+        Assert.DoesNotContain("\"priority\":1", body);
+    }
+
+    /// <summary>
+    /// Reading has to accept what writing produces, or the application refuses its own output.
+    /// </summary>
+    [HardenedTest]
+    public async Task ReadAcceptsTheValueWriteProduces(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new Ticket("Ship it", Priority.OnHold), "/enum-vocabulary/ticket");
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Contains("onHold", await response.ReadTextAsync());
+    }
+
+    /// <summary>
+    /// A value the application does not declare is refused rather than guessed at.
+    /// </summary>
+    [HardenedTest]
+    public async Task ReadRefusesAnUndeclaredValue(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            "{\"title\":\"x\",\"priority\":\"urgent\"}",
+            "/enum-vocabulary/ticket",
+            request => request.Headers["Content-Type"] = "application/json");
+
+        Assert.Equal(400, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The per-enum override, in both directions: one enum opting out of naming entirely and one
+    /// choosing a vocabulary that is not a C# identifier at all.
+    /// </summary>
+    [HardenedTest]
+    public async Task ADeclaredNamingOverridesTheDefault(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/enum-vocabulary/order");
+
+        Assert.Equal(200, response.StatusCode);
+
+        var body = await response.ReadTextAsync();
+
+        Assert.Contains("\"code\":\"AB12\"", body);
+        Assert.Contains("\"shipping\":\"next-day\"", body);
+    }
+
+    /// <summary>
+    /// The route that never reaches a JSON converter.
+    /// </summary>
+    /// <remarks>
+    /// A path or query value is text, so the binder converts it rather than the serializer - and
+    /// without the same vocabulary registered there, an application accepts a value in a body and
+    /// answers 400 to it in a query string. <c>next-day</c> is the case that cannot work by
+    /// accident: it is not a valid C# identifier, so nothing reaches it through <c>Enum.Parse</c>.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AQueryParameterBindsTheSameVocabulary(ITestWebApp testWebApp) {
+        var byDefault = await testWebApp.Get("/enum-vocabulary/by-priority?priority=inProgress");
+
+        Assert.Equal(200, byDefault.StatusCode);
+        Assert.Contains("InProgress", await byDefault.ReadTextAsync());
+
+        var declared = await testWebApp.Get("/enum-vocabulary/by-shipping?shipping=next-day");
+
+        Assert.Equal(200, declared.StatusCode);
+        Assert.Contains("NextDay", await declared.ReadTextAsync());
+    }
+
+    /// <summary>
+    /// The document declares exactly what the serializer writes.
+    /// </summary>
+    /// <remarks>
+    /// The pairing this whole mechanism exists for. The document is the deliverable - consumers
+    /// generate clients from it rather than reading the C# - so a vocabulary it does not share with
+    /// the wire is a contract that cannot be honoured.
+    /// </remarks>
+    [HardenedTest]
+    public async Task TheDocumentDeclaresTheValuesTheWireCarries(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/openapi.json");
+
+        Assert.Equal(200, response.StatusCode);
+
+        var schemas = JsonDocument.Parse(await response.ReadTextAsync())
+            .RootElement.GetProperty("components").GetProperty("schemas");
+
+        Assert.Equal(
+            new[] { "low", "inProgress", "onHold" },
+            Values(schemas, "Ticket", "priority"));
+
+        Assert.Equal(new[] { "AB12", "CD34" }, Values(schemas, "Order", "code"));
+        Assert.Equal(new[] { "next-day", "two-day" }, Values(schemas, "Order", "shipping"));
+    }
+
+    private static string[] Values(JsonElement schemas, string schema, string property) =>
+        schemas.GetProperty(schema)
+            .GetProperty("properties")
+            .GetProperty(property)
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(value => value.GetString()!)
+            .ToArray();
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/EnumVocabularyController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/EnumVocabularyController.cs
@@ -1,0 +1,59 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Web.Runtime.Attributes;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// An enum with no attribute of its own, which is the case the default has to be right for.
+/// </summary>
+public enum Priority { Low, InProgress, OnHold }
+
+/// <summary>
+/// The opt-out, for an enum whose member names are already its wire values.
+/// </summary>
+[JsonEnumNaming(EnumNaming.MemberName)]
+public enum LegacyCode { AB12, CD34 }
+
+/// <summary>
+/// A vocabulary chosen for the API rather than for C#.
+/// </summary>
+[JsonEnumNaming(EnumNaming.KebabCaseLower)]
+public enum Shipping { NextDay, TwoDay }
+
+public record Ticket(string Title, Priority Priority);
+
+public record Order(LegacyCode Code, Shipping Shipping);
+
+/// <summary>
+/// An enum reaching the wire by all three routes it can take.
+/// </summary>
+/// <remarks>
+/// A body written, a body read and a query parameter bound, because they are served by different
+/// code and have disagreed before: the body resolves through the type-info chain and a parameter is
+/// text the binder converts, so an enum can be configured for one and not the other. The published
+/// document is asserted from the same values in
+/// <c>Hardened.IntegrationTests.WebApp.SUT.Tests.EnumVocabularyTests</c>.
+/// </remarks>
+[BasePath("/enum-vocabulary")]
+public class EnumVocabularyController {
+
+    [Get("/ticket")]
+    public Ticket DefaultNaming() => new("Ship it", Priority.InProgress);
+
+    [Post("/ticket")]
+    public Priority ReadDefaultNaming(Ticket ticket) => ticket.Priority;
+
+    [Get("/order")]
+    public Order DeclaredNaming() => new(LegacyCode.AB12, Shipping.NextDay);
+
+    /// <summary>
+    /// The route that never reaches a JSON converter. <c>?priority=inProgress</c> has to bind to
+    /// the same value the body carries under that name.
+    /// </summary>
+    [Get("/by-priority")]
+    public string FromQuery([FromQueryString] Priority priority) => priority.ToString();
+
+    [Get("/by-shipping")]
+    public string DeclaredNamingFromQuery([FromQueryString] Shipping shipping) =>
+        shipping.ToString();
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -6,6 +6,14 @@ namespace Hardened.Requests.Abstract.Attributes
         public ContentNegotiationAttribute(Hardened.Requests.Abstract.Serializer.ContentNegotiationMode mode) { }
         public Hardened.Requests.Abstract.Serializer.ContentNegotiationMode Mode { get; }
     }
+    public enum EnumNaming
+    {
+        MemberName = 0,
+        CamelCase = 1,
+        KebabCaseLower = 2,
+        SnakeCaseLower = 3,
+        SnakeCaseUpper = 4,
+    }
     public class FromBodyAttribute : System.Attribute
     {
         public FromBodyAttribute() { }
@@ -27,6 +35,12 @@ namespace Hardened.Requests.Abstract.Attributes
     public interface ICustomBindingAttribute
     {
         System.Threading.Tasks.ValueTask<T> BindValue<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context, Hardened.Requests.Abstract.Execution.IExecutionRequestParameter parameter);
+    }
+    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Enum, AllowMultiple=false)]
+    public class JsonEnumNamingAttribute : System.Attribute
+    {
+        public JsonEnumNamingAttribute(Hardened.Requests.Abstract.Attributes.EnumNaming naming) { }
+        public Hardened.Requests.Abstract.Attributes.EnumNaming Naming { get; }
     }
     [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
     public sealed class OutputAttribute<TOutput> : System.Attribute

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -719,7 +719,7 @@ namespace Hardened.Requests.Runtime.Serializer
         "stead.")]
     public class SystemTextJsonRequestDeserializer : Hardened.Requests.Abstract.Serializer.IRequestDeserializer
     {
-        public SystemTextJsonRequestDeserializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration, Microsoft.Extensions.Logging.ILogger<Hardened.Requests.Runtime.Serializer.SystemTextJsonRequestDeserializer> logger) { }
+        public SystemTextJsonRequestDeserializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration, Microsoft.Extensions.Logging.ILogger<Hardened.Requests.Runtime.Serializer.SystemTextJsonRequestDeserializer> logger, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
         public bool IsDefaultSerializer { get; }
         public bool CanProcessContext(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.ValueTask<T?> DeserializeRequestBody<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
@@ -732,7 +732,7 @@ namespace Hardened.Requests.Runtime.Serializer
         "stead.")]
     public class SystemTextJsonResponseSerializer : Hardened.Requests.Abstract.Serializer.IResponseSerializer
     {
-        public SystemTextJsonResponseSerializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration) { }
+        public SystemTextJsonResponseSerializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
         public bool IsDefaultSerializer { get; }
         public bool CanProduce(string mediaType, Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.Task SerializeResponse(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
@@ -263,6 +263,11 @@ namespace Hardened.Shared.Runtime.Json
     }
     public static class JsonTypeInfoLookup
     {
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification="Guarded on JsonSerializer.IsReflectionEnabledByDefault; the trimmer removes the b" +
+            "ranch.")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification="Guarded on JsonSerializer.IsReflectionEnabledByDefault; the trimmer removes the b" +
+            "ranch.")]
+        public static System.Text.Json.JsonSerializerOptions AppendReflectionFallback(System.Text.Json.JsonSerializerOptions options) { }
         public static System.Text.Json.Serialization.Metadata.JsonTypeInfo For(System.Text.Json.JsonSerializerOptions options, object value) { }
         public static System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> For<T>(System.Text.Json.JsonSerializerOptions options) { }
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification="Guarded on JsonSerializer.IsReflectionEnabledByDefault; the trimmer removes the b" +
@@ -270,6 +275,7 @@ namespace Hardened.Shared.Runtime.Json
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode", Justification="Guarded on JsonSerializer.IsReflectionEnabledByDefault; the trimmer removes the b" +
             "ranch.")]
         public static System.Text.Json.JsonSerializerOptions WithReflectionFallback(System.Text.Json.JsonSerializerOptions options) { }
+        public static System.Text.Json.JsonSerializerOptions WithResolvers(System.Text.Json.JsonSerializerOptions options, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
     }
     public sealed class PrimitiveJsonTypeInfoResolver : System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver
     {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
@@ -255,7 +255,7 @@ namespace Hardened.Shared.Runtime.Json
     [DependencyModules.Runtime.Attributes.SingletonService(Using=DependencyModules.Runtime.Attributes.RegistrationType.Try)]
     public class JsonSerializerImpl : Hardened.Shared.Runtime.Json.IJsonSerializer
     {
-        public JsonSerializerImpl(Microsoft.Extensions.Options.IOptions<Hardened.Shared.Runtime.Json.IJsonSerializerConfiguration> configuration) { }
+        public JsonSerializerImpl(Microsoft.Extensions.Options.IOptions<Hardened.Shared.Runtime.Json.IJsonSerializerConfiguration> configuration, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
         public T Deserialize<T>(string json) { }
         public System.Threading.Tasks.Task<T> DeserializeAsync<T>(System.IO.Stream jsonStream, System.Threading.CancellationToken cancellationToken = default) { }
         public string Serialize(object obj, bool pretty) { }

--- a/src/Requests/Hardened.Requests.Abstract/Attributes/JsonEnumNamingAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Attributes/JsonEnumNamingAttribute.cs
@@ -1,0 +1,85 @@
+namespace Hardened.Requests.Abstract.Attributes;
+
+/// <summary>
+/// The vocabulary an enum is written and read as.
+/// </summary>
+/// <remarks>
+/// Names for the wire, not for C#. The member name is a C# identifier and the wire value is part of
+/// an API's contract, and they are only the same thing by coincidence.
+/// </remarks>
+public enum EnumNaming {
+
+    /// <summary>The C# member name, unchanged - <c>InProgress</c>.</summary>
+    /// <remarks>
+    /// What System.Text.Json's own <c>UseStringEnumConverter</c> produces, and what a code-first
+    /// application wrote before this attribute existed. Set it explicitly on an enum whose values
+    /// are already the wire's.
+    /// </remarks>
+    MemberName,
+
+    /// <summary><c>inProgress</c>.</summary>
+    CamelCase,
+
+    /// <summary><c>in-progress</c>.</summary>
+    KebabCaseLower,
+
+    /// <summary><c>in_progress</c>.</summary>
+    SnakeCaseLower,
+
+    /// <summary><c>IN_PROGRESS</c>.</summary>
+    SnakeCaseUpper
+}
+
+/// <summary>
+/// How this application's enums reach the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// On the assembly it is the default for every enum that assembly serializes; on an enum it
+/// overrides that default for one type. An application that sets neither writes
+/// <see cref="EnumNaming.CamelCase"/>, which is what the property names beside it use.
+/// </para>
+/// <para>
+/// The assembly rather than the module class, and the target list is narrow so that a misplaced one
+/// is a compile error rather than a setting that reads as applied and is not. The document is
+/// written inside the syntax transform, where a handler's own symbol is reachable and the module's
+/// is not - and a naming the document did not get is the desynchronised contract this attribute
+/// exists to prevent.
+/// </para>
+/// <para>
+/// <b>This governs the published document as well as the wire.</b> The generated OpenAPI description
+/// declares each enum's values, and it is written from this same setting - so the contract a client
+/// generates against and the bytes the application actually produces cannot disagree. That was the
+/// defect this replaced: the document said <c>{"type":"string","enum":["ScienceFiction"]}</c> for
+/// every enum while the serializer wrote <c>0</c>.
+/// </para>
+/// <para>
+/// It governs parameters too. A path or query value is text rather than JSON, so it never reaches a
+/// JSON converter - <c>?priority=in-progress</c> would be answered 400 by an application whose body
+/// accepts exactly that value. The generated binder is given the same vocabulary.
+/// </para>
+/// <para>
+/// Contract-first applications do not use this. Their enum values come from the description, which
+/// is the vocabulary by definition, and the build already emits converters carrying it.
+/// </para>
+/// <example>
+/// <code>
+/// // AssemblyInfo.cs, or any file in the project
+/// [assembly: JsonEnumNaming(EnumNaming.KebabCaseLower)]
+///
+/// public enum Priority { Low, InProgress }            // "low", "in-progress"
+///
+/// [JsonEnumNaming(EnumNaming.MemberName)]
+/// public enum LegacyCode { AB12, CD34 }               // "AB12", "CD34"
+/// </code>
+/// </example>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Enum, AllowMultiple = false)]
+public class JsonEnumNamingAttribute : Attribute {
+
+    public JsonEnumNamingAttribute(EnumNaming naming) {
+        Naming = naming;
+    }
+
+    public EnumNaming Naming { get; }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequestDeserializerContentEncodingTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequestDeserializerContentEncodingTests.cs
@@ -38,7 +38,9 @@ public class RequestDeserializerContentEncodingTests {
     private static IRequestDeserializer DeserializerNamed(string name) => name switch {
         nameof(SystemTextJsonRequestDeserializer) =>
             new SystemTextJsonRequestDeserializer(
-                Config(), NullLogger<SystemTextJsonRequestDeserializer>.Instance),
+                Config(),
+                NullLogger<SystemTextJsonRequestDeserializer>.Instance,
+                Array.Empty<IJsonTypeInfoResolver>()),
         nameof(AotRequestDeserializer) =>
             new AotRequestDeserializer(
                 Config(),

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResolverPrecedenceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResolverPrecedenceTests.cs
@@ -1,0 +1,220 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Configuration;
+using Hardened.Requests.Runtime.Serializer;
+using Hardened.Requests.Runtime.Tests.Support;
+using Hardened.Shared.Runtime.Json;
+using IRequestsJsonConfiguration = Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration;
+using RequestsJsonConfiguration = Hardened.Requests.Runtime.Configuration.JsonSerializerConfiguration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Serializer;
+
+/// <summary>
+/// A registered <c>IJsonTypeInfoResolver</c> decides how a type is written, on every host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>services.AddSingleton&lt;IJsonTypeInfoResolver&gt;(MyContext.Default)</c> is the AOT-safe way
+/// to say how an enum reaches the wire, and it did not work on a JIT host in either direction. The
+/// reflection serializers did not take resolvers at all, so the registration was accepted and
+/// dropped. The AOT serializers took them and appended them behind a
+/// <c>DefaultJsonTypeInfoResolver</c>, which answers for nearly every type, so they were never
+/// reached.
+/// </para>
+/// <para>
+/// Neither failed. Both wrote <c>{"category":0}</c> from a context that says enums are strings,
+/// which is a defect no exception marks and no build reports - and it inverted where it matters,
+/// because a published AOT application installs no reflection resolver and therefore behaved
+/// correctly while the tests covering it did not.
+/// </para>
+/// </remarks>
+public class ResolverPrecedenceTests {
+
+    // Aliased because two public types share this name - see D10. Hardened.Shared.Runtime.Json
+    // has an IJsonSerializerConfiguration too, and importing both namespaces is enough to stop the
+    // file compiling.
+    private static IOptions<IRequestsJsonConfiguration> Config() =>
+        Options.Create<IRequestsJsonConfiguration>(new RequestsJsonConfiguration());
+
+    private static IExecutionContext ResponseContext(object value, out MemoryStream body) {
+        var context = Substitute.For<IExecutionContext>();
+        var request = Substitute.For<IExecutionRequest>();
+        var response = Substitute.For<IExecutionResponse>();
+
+        body = new MemoryStream();
+        request.Accept.Returns("application/json");
+        response.Body.Returns(body);
+        response.ResponseValue.Returns(value);
+        response.ShouldCompress.Returns(false);
+        context.Request.Returns(request);
+        context.Response.Returns(response);
+
+        return context;
+    }
+
+    private static IExecutionContext RequestContext(string json) {
+        var context = Pipeline.Context(method: "POST", body: Encoding.UTF8.GetBytes(json));
+
+        context.Request.Headers[KnownHeaders.ContentType] = new StringValues("application/json");
+
+        return context;
+    }
+
+    public static TheoryData<string> ResponseSerializers => new() {
+        nameof(SystemTextJsonResponseSerializer),
+        nameof(AotResponseSerializer),
+        nameof(StreamingJsonResponseSerializer)
+    };
+
+    private static IResponseSerializer ResponseSerializerNamed(
+        string name, params IJsonTypeInfoResolver[] resolvers) => name switch {
+        nameof(SystemTextJsonResponseSerializer) =>
+            new SystemTextJsonResponseSerializer(Config(), resolvers),
+        nameof(AotResponseSerializer) =>
+            new AotResponseSerializer(Config(), resolvers),
+        nameof(StreamingJsonResponseSerializer) =>
+            new StreamingJsonResponseSerializer(Config(), resolvers),
+        _ => throw new ArgumentOutOfRangeException(nameof(name), name, "unknown serializer")
+    };
+
+    /// <summary>
+    /// The D10 case: an enum reaches the wire as a name rather than as its ordinal.
+    /// </summary>
+    /// <remarks>
+    /// The member name, not a camel-cased form of it. <c>PropertyNamingPolicy</c> governs property
+    /// names and does not reach enum members, so <c>Web</c> defaults produce a camelCase property
+    /// holding a PascalCase value - <c>{"category":"ScienceFiction"}</c>. Asserted exactly, because
+    /// it is the wire format: an application wanting <c>science-fiction</c> supplies a converter
+    /// carrying that vocabulary, and changing this later breaks every consumer.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(ResponseSerializers))]
+    public async Task SerializeResponse_HonoursTheRegisteredContextForAnEnum(string serializerName) {
+        var serializer = ResponseSerializerNamed(serializerName, CatalogContext.Default);
+        var context = ResponseContext(new Listing(Category.ScienceFiction), out var body);
+
+        await serializer.SerializeResponse(context);
+
+        var json = Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.Equal("{\"category\":\"ScienceFiction\"}", json);
+        Assert.DoesNotContain("\"category\":0", json);
+    }
+
+    /// <summary>
+    /// Reading has to agree with writing, or the application answers 400 to its own output — which
+    /// is how this surfaced, as a test host posting a body the application under test refused.
+    /// </summary>
+    [Fact]
+    public async Task DeserializeRequestBody_HonoursTheRegisteredContextForAnEnum() {
+        var deserializer = new SystemTextJsonRequestDeserializer(
+            Config(),
+            NullLogger<SystemTextJsonRequestDeserializer>.Instance,
+            new IJsonTypeInfoResolver[] { CatalogContext.Default });
+
+        var listing = await deserializer.DeserializeRequestBody<Listing>(
+            RequestContext("""{"category":"ScienceFiction"}"""));
+
+        Assert.Equal(Category.ScienceFiction, listing!.Category);
+    }
+
+    /// <summary>
+    /// Reflection still covers what no context declares. A context knows the models the application
+    /// wrote and not much else, so putting it first must not amount to withholding the fallback.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ResponseSerializers))]
+    public async Task SerializeResponse_StillReflectsATypeNoContextDeclares(string serializerName) {
+        var serializer = ResponseSerializerNamed(serializerName, CatalogContext.Default);
+        var context = ResponseContext(new Undeclared("only reflection knows this"), out var body);
+
+        await serializer.SerializeResponse(context);
+
+        Assert.Contains("only reflection knows this", Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    /// <summary>
+    /// No resolver registered is still the common case, and still resolves by reflection.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ResponseSerializers))]
+    public async Task SerializeResponse_FallsBackToReflectionWhenNothingIsRegistered(string serializerName) {
+        var serializer = ResponseSerializerNamed(serializerName);
+        var context = ResponseContext(new Undeclared("reflection"), out var body);
+
+        await serializer.SerializeResponse(context);
+
+        Assert.Contains("reflection", Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    /// <summary>
+    /// The ordering rule itself, stated once where the serializers get it from.
+    /// </summary>
+    [Fact]
+    public void WithResolvers_PutsRegisteredResolversAheadOfReflection() {
+        var options = JsonTypeInfoLookup.WithResolvers(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web),
+            new IJsonTypeInfoResolver[] { CatalogContext.Default });
+
+        var chain = options.TypeInfoResolverChain;
+
+        Assert.Same(CatalogContext.Default, chain[0]);
+        Assert.IsType<DefaultJsonTypeInfoResolver>(chain[^1]);
+    }
+
+    /// <summary>
+    /// <c>WithReflectionFallback</c> installs reflection only onto an empty chain — any resolver at
+    /// all makes <c>TypeInfoResolver</c> non-null and silences it. That is the guard the serializers
+    /// used to build on, and this pins the difference so the two are not swapped back.
+    /// </summary>
+    [Fact]
+    public void AppendReflectionFallback_AddsReflectionEvenWhenTheChainIsNotEmpty() {
+        var withGuard = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        withGuard.TypeInfoResolverChain.Add(CatalogContext.Default);
+        JsonTypeInfoLookup.WithReflectionFallback(withGuard);
+
+        Assert.DoesNotContain(withGuard.TypeInfoResolverChain, r => r is DefaultJsonTypeInfoResolver);
+
+        var appended = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        appended.TypeInfoResolverChain.Add(CatalogContext.Default);
+        JsonTypeInfoLookup.AppendReflectionFallback(appended);
+
+        Assert.Contains(appended.TypeInfoResolverChain, r => r is DefaultJsonTypeInfoResolver);
+    }
+
+    [Fact]
+    public void AppendReflectionFallback_DoesNotAddASecondReflectionResolver() {
+        var options = JsonTypeInfoLookup.AppendReflectionFallback(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        JsonTypeInfoLookup.AppendReflectionFallback(options);
+
+        Assert.Single(options.TypeInfoResolverChain, r => r is DefaultJsonTypeInfoResolver);
+    }
+}
+
+internal enum Category { ScienceFiction, Tools }
+
+internal record Listing(Category Category);
+
+internal record Undeclared(string Name);
+
+/// <summary>
+/// What an application writes to say how its own enums are written, without an attribute on the
+/// enum and without a converter that Native AOT cannot build.
+/// </summary>
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web, UseStringEnumConverter = true)]
+[JsonSerializable(typeof(Listing))]
+internal partial class CatalogContext : JsonSerializerContext { }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResolverPrecedenceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResolverPrecedenceTests.cs
@@ -76,6 +76,15 @@ public class ResolverPrecedenceTests {
         nameof(StreamingJsonResponseSerializer)
     };
 
+    /// <summary>
+    /// The two that carry a reflection tail. <see cref="AotResponseSerializer"/> is absent by
+    /// design - it resolves only out of registered contexts, on every host.
+    /// </summary>
+    public static TheoryData<string> ReflectingResponseSerializers => new() {
+        nameof(SystemTextJsonResponseSerializer),
+        nameof(StreamingJsonResponseSerializer)
+    };
+
     private static IResponseSerializer ResponseSerializerNamed(
         string name, params IJsonTypeInfoResolver[] resolvers) => name switch {
         nameof(SystemTextJsonResponseSerializer) =>
@@ -133,7 +142,7 @@ public class ResolverPrecedenceTests {
     /// wrote and not much else, so putting it first must not amount to withholding the fallback.
     /// </summary>
     [Theory]
-    [MemberData(nameof(ResponseSerializers))]
+    [MemberData(nameof(ReflectingResponseSerializers))]
     public async Task SerializeResponse_StillReflectsATypeNoContextDeclares(string serializerName) {
         var serializer = ResponseSerializerNamed(serializerName, CatalogContext.Default);
         var context = ResponseContext(new Undeclared("only reflection knows this"), out var body);
@@ -147,7 +156,7 @@ public class ResolverPrecedenceTests {
     /// No resolver registered is still the common case, and still resolves by reflection.
     /// </summary>
     [Theory]
-    [MemberData(nameof(ResponseSerializers))]
+    [MemberData(nameof(ReflectingResponseSerializers))]
     public async Task SerializeResponse_FallsBackToReflectionWhenNothingIsRegistered(string serializerName) {
         var serializer = ResponseSerializerNamed(serializerName);
         var context = ResponseContext(new Undeclared("reflection"), out var body);
@@ -155,6 +164,47 @@ public class ResolverPrecedenceTests {
         await serializer.SerializeResponse(context);
 
         Assert.Contains("reflection", Encoding.UTF8.GetString(body.ToArray()));
+    }
+
+    /// <summary>
+    /// The Aot serializers never reflect, on any host.
+    /// </summary>
+    /// <remarks>
+    /// A class named for AOT that resolves by reflection wherever reflection happens to be
+    /// available makes the developer's build the one configuration in which a missing
+    /// <c>[JsonSerializable]</c> is invisible: it works locally and is a
+    /// <c>NotSupportedException</c> after publishing. A type no registered context declares has to
+    /// fail here too, which is what this asserts.
+    /// </remarks>
+    [Fact]
+    public async Task AotResponseSerializer_RefusesATypeNoContextDeclares() {
+        var serializer = new AotResponseSerializer(
+            Config(), new IJsonTypeInfoResolver[] { CatalogContext.Default });
+        var context = ResponseContext(new Undeclared("nothing declares this"), out _);
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => serializer.SerializeResponse(context));
+    }
+
+    [Fact]
+    public async Task AotResponseSerializer_RefusesEvenWithNoResolversRegistered() {
+        var serializer = new AotResponseSerializer(Config(), Array.Empty<IJsonTypeInfoResolver>());
+        var context = ResponseContext(new Undeclared("nothing declares this"), out _);
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => serializer.SerializeResponse(context));
+    }
+
+    /// <summary>
+    /// The shared configuration carries no reflection resolver of its own — the consumer decides,
+    /// because <c>JsonSerializerImpl</c> and <c>AotJsonSerializer</c> want opposite answers from the
+    /// same mutated instance.
+    /// </summary>
+    [Fact]
+    public void SharedJsonSerializerConfiguration_CarriesNoReflectionResolver() {
+        var options = new Hardened.Shared.Runtime.Json.JsonSerializerConfiguration().Options;
+
+        Assert.DoesNotContain(options.TypeInfoResolverChain, r => r is DefaultJsonTypeInfoResolver);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResponseSerializerCompressionTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResponseSerializerCompressionTests.cs
@@ -42,7 +42,8 @@ public class ResponseSerializerCompressionTests {
     }
 
     private static IEnumerable<IResponseSerializer> Serializers() {
-        yield return new SystemTextJsonResponseSerializer(Config());
+        yield return new SystemTextJsonResponseSerializer(
+            Config(), Array.Empty<IJsonTypeInfoResolver>());
         yield return new AotResponseSerializer(
             Config(), new IJsonTypeInfoResolver[] { PayloadContext.Default });
     }

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
@@ -14,14 +14,17 @@ public class AotResponseSerializer : IResponseSerializer {
 
     public AotResponseSerializer(IOptions<IJsonSerializerConfiguration> configuration,
         IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        // Resolvers before reflection, not after. The fallback used to be installed while building
+        // the options above, which put a DefaultJsonTypeInfoResolver at the head of the chain - and
+        // that answers for nearly every type, so the resolvers appended below were never reached on
+        // a JIT host. An AOT publish was unaffected, because reflection is not installed there at
+        // all, so an application's own JsonSerializerContext governed production and did not govern
+        // its tests.
         _serializerOptions =
-            configuration.Value.SerializeOptions ??
-            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithReflectionFallback(
-                new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        foreach (var resolver in resolvers) {
-            _serializerOptions.TypeInfoResolverChain.Add(resolver);
-        }
+            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
+                configuration.Value.SerializeOptions ??
+                new JsonSerializerOptions(JsonSerializerDefaults.Web),
+                resolvers);
 
         // Last, so a registered context still answers first - see PrimitiveJsonTypeInfoResolver.
         _serializerOptions.TypeInfoResolverChain.Add(

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/AotResponseSerializer.cs
@@ -14,17 +14,25 @@ public class AotResponseSerializer : IResponseSerializer {
 
     public AotResponseSerializer(IOptions<IJsonSerializerConfiguration> configuration,
         IEnumerable<IJsonTypeInfoResolver> resolvers) {
-        // Resolvers before reflection, not after. The fallback used to be installed while building
-        // the options above, which put a DefaultJsonTypeInfoResolver at the head of the chain - and
-        // that answers for nearly every type, so the resolvers appended below were never reached on
-        // a JIT host. An AOT publish was unaffected, because reflection is not installed there at
-        // all, so an application's own JsonSerializerContext governed production and did not govern
-        // its tests.
-        _serializerOptions =
-            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
-                configuration.Value.SerializeOptions ??
-                new JsonSerializerOptions(JsonSerializerDefaults.Web),
-                resolvers);
+        // No reflection resolver, on any host. This used to install one while building the options,
+        // which did two things wrong at once: it sat at the head of the chain, where it answered for
+        // nearly every type and the resolvers added below were never reached; and it meant the class
+        // named for AOT resolved by reflection whenever reflection happened to be available.
+        //
+        // The second is the one that matters. A type missing from every registered context is a
+        // NotSupportedException after publishing, and reflecting over it on a JIT host turns that
+        // into a defect the tests cannot see - the developer's build is the one configuration where
+        // the mistake is invisible. Matching AotRequestDeserializer, which has always built its
+        // options this way and says so.
+        //
+        // StreamingJsonResponseSerializer deliberately does not do this: it has no Aot twin and
+        // serves both hosts from one class, so it keeps a reflection tail that the trimmer removes.
+        _serializerOptions = configuration.Value.SerializeOptions ??
+                             new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
+        foreach (var resolver in resolvers) {
+            _serializerOptions.TypeInfoResolverChain.Add(resolver);
+        }
 
         // Last, so a registered context still answers first - see PrimitiveJsonTypeInfoResolver.
         _serializerOptions.TypeInfoResolverChain.Add(

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/StreamingJsonResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/StreamingJsonResponseSerializer.cs
@@ -51,14 +51,14 @@ public class StreamingJsonResponseSerializer : IResponseSerializer {
     public StreamingJsonResponseSerializer(
         IOptions<IJsonSerializerConfiguration> configuration,
         IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        // Resolvers before reflection - see JsonTypeInfoLookup.WithResolvers. A streamed item was
+        // written by whichever of the two answered first, so an enum in an IAsyncEnumerable<T> did
+        // not agree with the same enum in a buffered response.
         _serializerOptions =
-            configuration.Value.SerializeOptions ??
-            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithReflectionFallback(
-                new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        foreach (var resolver in resolvers) {
-            _serializerOptions.TypeInfoResolverChain.Add(resolver);
-        }
+            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
+                configuration.Value.SerializeOptions ??
+                new JsonSerializerOptions(JsonSerializerDefaults.Web),
+                resolvers);
 
         // Last, so a registered context still answers first - see PrimitiveJsonTypeInfoResolver.
         _serializerOptions.TypeInfoResolverChain.Add(

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonRequestDeserializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonRequestDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
@@ -39,13 +40,20 @@ public class SystemTextJsonRequestDeserializer : IRequestDeserializer {
     private readonly JsonSerializerOptions _serializerOptions;
     private readonly ILogger<SystemTextJsonRequestDeserializer> _logger;
 
+    /// <param name="resolvers">
+    /// Every <c>IJsonTypeInfoResolver</c> the application registered, ahead of reflection. The
+    /// response serializer takes the same set — a context that governs how an enum is written has
+    /// to govern how it is read, or the application answers 400 to its own output.
+    /// </param>
     public SystemTextJsonRequestDeserializer(IOptions<IJsonSerializerConfiguration> configuration,
-        ILogger<SystemTextJsonRequestDeserializer> logger) {
+        ILogger<SystemTextJsonRequestDeserializer> logger,
+        IEnumerable<IJsonTypeInfoResolver> resolvers) {
         _logger = logger;
         _serializerOptions =
-            configuration.Value.DeSerializerOptions ??
-            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithReflectionFallback(
-                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
+                configuration.Value.DeSerializerOptions ??
+                new JsonSerializerOptions(JsonSerializerDefaults.Web),
+                resolvers);
     }
 
     public bool IsDefaultSerializer => true;

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonResponseSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
@@ -43,11 +44,23 @@ public class SystemTextJsonResponseSerializer : IResponseSerializer {
 
     private readonly JsonSerializerOptions _serializerOptions;
 
-    public SystemTextJsonResponseSerializer(IOptions<IJsonSerializerConfiguration> configuration) {
+    /// <param name="resolvers">
+    /// Every <c>IJsonTypeInfoResolver</c> the application registered, ahead of reflection.
+    /// </param>
+    /// <remarks>
+    /// This class used to take the configuration alone, which made
+    /// <c>services.AddSingleton&lt;IJsonTypeInfoResolver&gt;(MyContext.Default)</c> - the way every
+    /// other serializer here is configured, and the only AOT-safe way to say how an enum is written
+    /// - do nothing at all on a JIT host. Nothing reported it: the registration succeeded, the
+    /// context was simply never asked.
+    /// </remarks>
+    public SystemTextJsonResponseSerializer(IOptions<IJsonSerializerConfiguration> configuration,
+        IEnumerable<IJsonTypeInfoResolver> resolvers) {
         _serializerOptions =
-            configuration.Value.SerializeOptions ??
-            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithReflectionFallback(
-                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
+                configuration.Value.SerializeOptions ??
+                new JsonSerializerOptions(JsonSerializerDefaults.Web),
+                resolvers);
     }
 
     public bool IsDefaultSerializer => true;

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SerializerPrecedenceTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SerializerPrecedenceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization.Metadata;
 using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Configuration;
 using Hardened.Requests.Runtime.Serializer;
@@ -40,14 +41,17 @@ public class SerializerPrecedenceTests {
         Pipeline.ResponseSerializer(Pipeline.Pool());
 
     private static IResponseSerializer SystemTextJson() =>
-        new SystemTextJsonResponseSerializer(JsonConfiguration());
+        new SystemTextJsonResponseSerializer(
+            JsonConfiguration(), Array.Empty<IJsonTypeInfoResolver>());
 
     private static IRequestDeserializer NewtonsoftReader() =>
         Pipeline.Deserializer(Pipeline.Pool());
 
     private static IRequestDeserializer SystemTextJsonReader() =>
         new SystemTextJsonRequestDeserializer(
-            JsonConfiguration(), NullLogger<SystemTextJsonRequestDeserializer>.Instance);
+            JsonConfiguration(),
+            NullLogger<SystemTextJsonRequestDeserializer>.Instance,
+            Array.Empty<IJsonTypeInfoResolver>());
 
     private static SerializationLocatorService Locator(
         IEnumerable<IRequestDeserializer> deserializers,

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Json/JsonSerializerImplTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Json/JsonSerializerImplTests.cs
@@ -29,7 +29,9 @@ public class JsonSerializerImplTests {
             PropertyNameCaseInsensitive = true
         });
 
-        return new JsonSerializerImpl(Options.Create(configuration));
+        return new JsonSerializerImpl(
+            Options.Create(configuration),
+            System.Array.Empty<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver>());
     }
 
     private static MemoryStream Json(string json) => new(Encoding.UTF8.GetBytes(json));

--- a/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerConfiguration.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerConfiguration.cs
@@ -49,7 +49,16 @@ public class JsonSerializerConfiguration : IJsonSerializerConfiguration {
             options.Converters.Add(new DeclaredEnumsFirstConverter());
         }
 
-        return JsonTypeInfoLookup.WithReflectionFallback(options);
+        // No reflection resolver here. This is the shared options instance, and both consumers of it
+        // mutate it in place - so installing reflection at construction put it at the head of the
+        // chain for whichever serializer was resolved, including AotJsonSerializer, which then
+        // reflected on a JIT host and did not after publishing.
+        //
+        // The consumer decides instead, because the two want opposite things: JsonSerializerImpl is
+        // the reflection-based serializer and appends it; AotJsonSerializer resolves out of
+        // registered contexts and a missing type is a NotSupportedException on every host, which is
+        // the answer AOT gives and the one its tests should get.
+        return options;
     }
 }
 

--- a/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerImpl.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerImpl.cs
@@ -1,5 +1,6 @@
 ﻿using DependencyModules.Runtime.Attributes;
 using Microsoft.Extensions.Options;
+using System.Text.Json.Serialization.Metadata;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,10 +26,21 @@ public class JsonSerializerImpl : IJsonSerializer {
     private readonly JsonSerializerOptions _serializerOptions;
     private readonly JsonSerializerOptions _prettyOptions;
 
-    public JsonSerializerImpl(IOptions<IJsonSerializerConfiguration> configuration) {
-        // Appended rather than installed only onto an empty chain: this is the reflection-based
-        // serializer, so reflection belongs in its chain whatever else is registered.
-        _serializerOptions = JsonTypeInfoLookup.AppendReflectionFallback(configuration.Value.Options);
+    /// <param name="resolvers">
+    /// Every registered <c>IJsonTypeInfoResolver</c>, ahead of reflection.
+    /// </param>
+    /// <remarks>
+    /// This is the serializer the test host writes a request body with, so a resolver it does not
+    /// see is one the harness does not honour while the application does - the harness then posts a
+    /// body its own application answers 400 to, and the test reads as a defect in the handler.
+    /// </remarks>
+    public JsonSerializerImpl(
+        IOptions<IJsonSerializerConfiguration> configuration,
+        IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        // Resolvers first, then reflection - and appended rather than installed only onto an empty
+        // chain, because this is the reflection-based serializer and reflection belongs in its
+        // chain whatever else is registered.
+        _serializerOptions = JsonTypeInfoLookup.WithResolvers(configuration.Value.Options, resolvers);
         _prettyOptions = new JsonSerializerOptions(_serializerOptions) { WriteIndented = true };
     }
 

--- a/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerImpl.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Json/JsonSerializerImpl.cs
@@ -26,7 +26,9 @@ public class JsonSerializerImpl : IJsonSerializer {
     private readonly JsonSerializerOptions _prettyOptions;
 
     public JsonSerializerImpl(IOptions<IJsonSerializerConfiguration> configuration) {
-        _serializerOptions = JsonTypeInfoLookup.WithReflectionFallback(configuration.Value.Options);
+        // Appended rather than installed only onto an empty chain: this is the reflection-based
+        // serializer, so reflection belongs in its chain whatever else is registered.
+        _serializerOptions = JsonTypeInfoLookup.AppendReflectionFallback(configuration.Value.Options);
         _prettyOptions = new JsonSerializerOptions(_serializerOptions) { WriteIndented = true };
     }
 

--- a/src/Shared/Hardened.Shared.Runtime/Json/JsonTypeInfoLookup.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Json/JsonTypeInfoLookup.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 
@@ -42,6 +44,66 @@ public static class JsonTypeInfoLookup {
     /// </summary>
     public static JsonTypeInfo For(JsonSerializerOptions options, object value) =>
         options.GetTypeInfo(value.GetType());
+
+    /// <summary>
+    /// Every registered resolver, in registration order, ahead of reflection.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The order is the whole point, and getting it backwards is silent. A
+    /// <see cref="DefaultJsonTypeInfoResolver"/> answers for very nearly every type, so a chain that
+    /// opens with one never consults anything after it: a registered
+    /// <c>JsonSerializerContext</c> is walked past, and the application serializes by reflection
+    /// while appearing to be configured. That is how a context carrying
+    /// <c>UseStringEnumConverter</c> still wrote <c>{"category":0}</c>.
+    /// </para>
+    /// <para>
+    /// It only shows on a JIT host. Under a trimmed or AOT publish
+    /// <see cref="JsonSerializer.IsReflectionEnabledByDefault"/> is false, nothing is appended, and
+    /// the context answers because it is the only thing in the chain - so production was right and
+    /// the tests covering it were wrong, which is the direction that gets found last.
+    /// </para>
+    /// <para>
+    /// Reflection is appended whenever it is available, rather than only onto an empty chain. A
+    /// context is almost never total - it knows the models the application declared and not
+    /// <c>string</c>, <c>DateTimeOffset</c>, or a framework error body - so "resolvers exist" is not
+    /// a reason to withhold the fallback.
+    /// </para>
+    /// </remarks>
+    public static JsonSerializerOptions WithResolvers(
+        JsonSerializerOptions options, IEnumerable<IJsonTypeInfoResolver> resolvers) {
+        foreach (var resolver in resolvers) {
+            options.TypeInfoResolverChain.Add(resolver);
+        }
+
+        return AppendReflectionFallback(options);
+    }
+
+    /// <summary>
+    /// Reflection at the end of the chain, whatever else is already in it.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="WithReflectionFallback"/>, which installs reflection only onto an
+    /// empty chain. That guard reads as strictness - an application that registered a context gets
+    /// told about a type it forgot - but it cannot be stated that way, because it also silently
+    /// withholds reflection for <c>string</c> and every other type no context declares. This one
+    /// makes no such trade: it is for the serializers whose contract is reflection.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Guarded on JsonSerializer.IsReflectionEnabledByDefault; the trimmer removes the branch.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Guarded on JsonSerializer.IsReflectionEnabledByDefault; the trimmer removes the branch.")]
+    public static JsonSerializerOptions AppendReflectionFallback(JsonSerializerOptions options) {
+        // Idempotent, because the options a serializer is handed may be shared and several
+        // serializers may pass them through here. Checked against the chain rather than against
+        // TypeInfoResolver, which any resolver at all makes non-null.
+        if (JsonSerializer.IsReflectionEnabledByDefault &&
+            !options.TypeInfoResolverChain.Any(r => r is DefaultJsonTypeInfoResolver)) {
+            options.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver());
+        }
+
+        return options;
+    }
 
     /// <summary>
     /// Puts reflection at the end of the chain, where reflection is available at all.

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Shared/EnumWireNamingTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Shared/EnumWireNamingTests.cs
@@ -1,0 +1,101 @@
+using Hardened.SourceGenerator.Shared;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Shared;
+
+/// <summary>
+/// The wire vocabulary a code-first enum resolves to.
+/// </summary>
+/// <remarks>
+/// Held directly rather than through a generated document, because this is the definition of a
+/// contract rather than a formatting detail: the JSON converter, the parameter binder and the
+/// <c>enum</c> array in the published description all read it, and changing what it produces
+/// changes what every existing client has to send.
+///
+/// <para>
+/// The single-word cases are first because they are the ones that were wrong. CamelCase stepped
+/// back past a leading capital that began no acronym run, so <c>Standard</c> returned
+/// <c>Standard</c> - the policy was a no-op for nearly every name there is, and the generated
+/// output looked plausible enough that only a character-level assertion would have caught it.
+/// </para>
+/// </remarks>
+public class EnumWireNamingTests {
+
+    [Theory]
+    [InlineData("Low", "low")]
+    [InlineData("Standard", "standard")]
+    [InlineData("Open", "open")]
+    [InlineData("InProgress", "inProgress")]
+    [InlineData("ScienceFiction", "scienceFiction")]
+    public void Value_CamelCasesASingleWordAndAPhrase(string member, string expected) =>
+        Assert.Equal(expected, EnumWireNaming.Value(member, "CamelCase"));
+
+    /// <summary>
+    /// An acronym is one word. The run ends at the last capital before a lower-case letter, so the
+    /// letter that starts the next word is not swallowed into it.
+    /// </summary>
+    [Theory]
+    [InlineData("IOStream", "ioStream")]
+    [InlineData("HTTPProxy", "httpProxy")]
+    [InlineData("HTTP", "http")]
+    [InlineData("XMLHTTPRequest", "xmlhttpRequest")]
+    public void Value_TreatsAnAcronymRunAsOneWord(string member, string expected) =>
+        Assert.Equal(expected, EnumWireNaming.Value(member, "CamelCase"));
+
+    [Theory]
+    [InlineData("Low", "low")]
+    [InlineData("InProgress", "in-progress")]
+    [InlineData("HTTPProxy", "http-proxy")]
+    [InlineData("Plus1", "plus1")]
+    public void Value_KebabCasesOnWordBoundaries(string member, string expected) =>
+        Assert.Equal(expected, EnumWireNaming.Value(member, "KebabCaseLower"));
+
+    [Theory]
+    [InlineData("InProgress", "in_progress")]
+    [InlineData("HTTPProxy", "http_proxy")]
+    public void Value_SnakeCasesLower(string member, string expected) =>
+        Assert.Equal(expected, EnumWireNaming.Value(member, "SnakeCaseLower"));
+
+    [Theory]
+    [InlineData("InProgress", "IN_PROGRESS")]
+    [InlineData("Low", "LOW")]
+    public void Value_SnakeCasesUpper(string member, string expected) =>
+        Assert.Equal(expected, EnumWireNaming.Value(member, "SnakeCaseUpper"));
+
+    /// <summary>
+    /// The opt-out, and it has to be exact: an application sets it because the member names are
+    /// already its wire values.
+    /// </summary>
+    [Theory]
+    [InlineData("InProgress")]
+    [InlineData("AB12")]
+    [InlineData("HTTPProxy")]
+    public void Value_LeavesMemberNameUntouched(string member) =>
+        Assert.Equal(member, EnumWireNaming.Value(member, "MemberName"));
+
+    /// <summary>
+    /// A name already lower-case, or empty, is returned rather than mangled.
+    /// </summary>
+    [Theory]
+    [InlineData("low", "low")]
+    [InlineData("", "")]
+    public void Value_LeavesAnAlreadyLowerNameAlone(string member, string expected) =>
+        Assert.Equal(expected, EnumWireNaming.Value(member, "CamelCase"));
+
+    /// <summary>
+    /// An unrecognised naming falls back to the member name rather than throwing. The value comes
+    /// from an attribute argument, and a consumer compiled against a newer Hardened can name one
+    /// this generator does not know.
+    /// </summary>
+    [Fact]
+    public void Value_FallsBackToTheMemberNameForAnUnknownNaming() =>
+        Assert.Equal("InProgress", EnumWireNaming.Value("InProgress", "SomethingElse"));
+
+    /// <summary>
+    /// CamelCase, and asserted here rather than only in prose: it is what every application that
+    /// says nothing gets, so changing it is a wire break for all of them at once.
+    /// </summary>
+    [Fact]
+    public void DefaultNaming_IsCamelCase() =>
+        Assert.Equal("CamelCase", EnumWireNaming.DefaultNaming);
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/EnumWireConverterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/EnumWireConverterTests.cs
@@ -1,0 +1,195 @@
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Web;
+
+/// <summary>
+/// The converters the build writes for a code-first application's enums, compiled rather than
+/// string-matched.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The vocabulary itself is covered in <c>Shared/EnumWireNamingTests</c> and the behaviour end to
+/// end in <c>Hardened.IntegrationTests.WebApp.SUT</c>. These cover the step between: turning a
+/// resolved vocabulary into C# that builds, in the same file as the routing table.
+/// </para>
+/// <para>
+/// Held here as well as end to end because a generator runs during a build rather than inside a
+/// test process. Everything it emits is exercised when the integration application compiles, and
+/// none of that is the generator's own code being executed under test - so an emitter can be
+/// entirely wrong in a way only a shipped application would show.
+/// </para>
+/// </remarks>
+public class EnumWireConverterTests {
+
+    private static string Application(string body) => $$"""
+        using System;
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Hardened.Requests.Abstract.Attributes;
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        public partial class Application { }
+
+        {{body}}
+        """;
+
+    private const string PriorityController = """
+        public enum Priority { Low, InProgress }
+
+        public record Ticket(Priority Priority);
+
+        public class TicketController {
+            [Get("/tickets")]
+            public Ticket Get() => new(Priority.Low);
+        }
+        """;
+
+    [Fact]
+    public void AnEnumOnTheWireGetsAConverterCarryingItsValues() {
+        var routing = RequestGeneratorHarness.Generate(Application(PriorityController))
+            .AssertNoErrors()
+            .SourceContaining("Application.Routing");
+
+        Assert.Contains("class PriorityWireConverter", routing);
+        Assert.Contains("=> \"inProgress\"", routing);
+        Assert.Contains("\"inProgress\" => global::TestApp.Priority.InProgress", routing);
+    }
+
+    /// <summary>
+    /// The binder's half. A path or query value is text and never reaches a JSON converter, so the
+    /// same vocabulary has to be registered for it separately.
+    /// </summary>
+    [Fact]
+    public void AnEnumOnTheWireGetsAStringConverterForTheBinder() {
+        var routing = RequestGeneratorHarness.Generate(Application(PriorityController))
+            .AssertNoErrors()
+            .SourceContaining("Application.Routing");
+
+        Assert.Contains("TryParseWire", routing);
+        Assert.Contains("DelegatingStringConverter<global::TestApp.Priority>", routing);
+    }
+
+    [Fact]
+    public void TheResolverAndTheStringConvertersAreRegistered() {
+        var routing = RequestGeneratorHarness.Generate(Application(PriorityController))
+            .AssertNoErrors()
+            .SourceContaining("Application.Routing");
+
+        Assert.Contains("IJsonTypeInfoResolver), global::TestApp.Application.JsonEnums.Resolver.Instance", routing);
+        Assert.Contains("foreach (var stringConverter in global::TestApp.Application.JsonEnums.StringConverters)", routing);
+    }
+
+    [Fact]
+    public void ADeclaredNamingOverridesTheDefault() {
+        var routing = RequestGeneratorHarness.Generate(Application("""
+            [JsonEnumNaming(EnumNaming.KebabCaseLower)]
+            public enum Shipping { NextDay, TwoDay }
+
+            public record Order(Shipping Shipping);
+
+            public class OrderController {
+                [Get("/orders")]
+                public Order Get() => new(Shipping.NextDay);
+            }
+            """)).AssertNoErrors().SourceContaining("Application.Routing");
+
+        Assert.Contains("=> \"next-day\"", routing);
+        Assert.DoesNotContain("=> \"nextDay\"", routing);
+    }
+
+    /// <summary>
+    /// An assembly-wide default, and one enum opting back out of it.
+    /// </summary>
+    [Fact]
+    public void AnAssemblyDefaultAppliesAndAnEnumCanOptOut() {
+        // Written out rather than through Application(), because an assembly attribute has to
+        // precede every other element in the file - after the namespace it is CS1730.
+        var routing = RequestGeneratorHarness.Generate("""
+            using System;
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            [assembly: JsonEnumNaming(EnumNaming.SnakeCaseUpper)]
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class Application { }
+
+            public enum Priority { InProgress }
+
+            [JsonEnumNaming(EnumNaming.MemberName)]
+            public enum LegacyCode { AB12 }
+
+            public record Ticket(Priority Priority, LegacyCode Code);
+
+            public class TicketController {
+                [Get("/tickets")]
+                public Ticket Get() => new(Priority.InProgress, LegacyCode.AB12);
+            }
+            """).AssertNoErrors().SourceContaining("Application.Routing");
+
+        Assert.Contains("=> \"IN_PROGRESS\"", routing);
+        Assert.Contains("=> \"AB12\"", routing);
+    }
+
+    /// <summary>
+    /// A flags enum has no single member to name, and a framework enum's vocabulary is not this
+    /// application's to redefine - so neither gets a converter.
+    /// </summary>
+    [Fact]
+    public void AFlagsEnumIsLeftAlone() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            [Flags]
+            public enum Access { None = 0, Read = 1, Write = 2 }
+
+            public record Grant(Access Access);
+
+            public class GrantController {
+                [Get("/grants")]
+                public Grant Get() => new(Access.Read);
+            }
+            """)).AssertNoErrors();
+
+        Assert.DoesNotContain(
+            result.GeneratedSources.Values, source => source.Contains("AccessWireConverter"));
+    }
+
+    [Fact]
+    public void AFrameworkEnumIsLeftAlone() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public record Job(System.Threading.Tasks.TaskStatus Status);
+
+            public class JobController {
+                [Get("/jobs")]
+                public Job Get() => new(System.Threading.Tasks.TaskStatus.Running);
+            }
+            """)).AssertNoErrors();
+
+        Assert.DoesNotContain(
+            result.GeneratedSources.Values, source => source.Contains("TaskStatusWireConverter"));
+    }
+
+    /// <summary>
+    /// An application with no enum on the wire carries no container at all, rather than an empty
+    /// one and two registrations that iterate nothing.
+    /// </summary>
+    [Fact]
+    public void NoEnumOnTheWireEmitsNoContainer() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class PlainController {
+                [Get("/plain")]
+                public string Get() => "x";
+            }
+            """)).AssertNoErrors();
+
+        Assert.DoesNotContain(
+            result.GeneratedSources.Values, source => source.Contains("class JsonEnums"));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/HandlerSchema.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/HandlerSchema.cs
@@ -31,13 +31,86 @@ public sealed class SchemaComponent : System.IEquatable<SchemaComponent> {
     }
 }
 
+/// <summary>One enum member, and the value it goes on the wire as.</summary>
+public sealed class EnumWireValue : System.IEquatable<EnumWireValue> {
+    public EnumWireValue(string member, string wire) {
+        Member = member;
+        Wire = wire;
+    }
+
+    /// <summary>The C# member name.</summary>
+    public string Member { get; }
+
+    /// <summary>What a client sends and receives.</summary>
+    public string Wire { get; }
+
+    public bool Equals(EnumWireValue? other) =>
+        other is not null && Member == other.Member && Wire == other.Wire;
+
+    public override bool Equals(object? obj) => Equals(obj as EnumWireValue);
+
+    public override int GetHashCode() {
+        unchecked {
+            return (Member.GetHashCode() * 397) ^ Wire.GetHashCode();
+        }
+    }
+}
+
+/// <summary>
+/// An enum a handler puts on the wire, with the vocabulary it was resolved to.
+/// </summary>
+/// <remarks>
+/// Collected while the schema is written, because that is the only point at which a Roslyn symbol
+/// still exists and the members can be read at all - the same reason the schema itself is converted
+/// to text there. The routing table generator turns these into converters, so the bytes and the
+/// document are produced from one resolution rather than two.
+/// </remarks>
+public sealed class EnumVocabulary : System.IEquatable<EnumVocabulary> {
+    public EnumVocabulary(
+        string qualifiedName, string name, string naming, IReadOnlyList<EnumWireValue> values) {
+        QualifiedName = qualifiedName;
+        Name = name;
+        Naming = naming;
+        Values = values;
+    }
+
+    /// <summary>Fully qualified and <c>global::</c>-prefixed, as emitted code names it.</summary>
+    public string QualifiedName { get; }
+
+    /// <summary>The bare type name, which names the converter and appears in binding errors.</summary>
+    public string Name { get; }
+
+    /// <summary>The resolved <c>EnumNaming</c> member name.</summary>
+    public string Naming { get; }
+
+    public IReadOnlyList<EnumWireValue> Values { get; }
+
+    public bool Equals(EnumVocabulary? other) =>
+        other is not null &&
+        QualifiedName == other.QualifiedName &&
+        Naming == other.Naming &&
+        Values.SequenceEqual(other.Values);
+
+    public override bool Equals(object? obj) => Equals(obj as EnumVocabulary);
+
+    public override int GetHashCode() {
+        unchecked {
+            return (QualifiedName.GetHashCode() * 397) ^ Naming.GetHashCode();
+        }
+    }
+}
+
 /// <summary>
 /// A type's JSON Schema, and every named schema it reaches.
 /// </summary>
 public sealed class HandlerSchema : System.IEquatable<HandlerSchema> {
-    public HandlerSchema(string schema, IReadOnlyList<SchemaComponent> components) {
+    public HandlerSchema(
+        string schema,
+        IReadOnlyList<SchemaComponent> components,
+        IReadOnlyList<EnumVocabulary>? enums = null) {
         Schema = schema;
         Components = components;
+        Enums = enums ?? System.Array.Empty<EnumVocabulary>();
     }
 
     /// <summary>The schema itself, usually a <c>$ref</c> into <see cref="Components"/>.</summary>
@@ -45,8 +118,14 @@ public sealed class HandlerSchema : System.IEquatable<HandlerSchema> {
 
     public IReadOnlyList<SchemaComponent> Components { get; }
 
+    /// <summary>Every enum this type reaches, with its wire vocabulary.</summary>
+    public IReadOnlyList<EnumVocabulary> Enums { get; }
+
     public bool Equals(HandlerSchema? other) =>
-        other is not null && Schema == other.Schema && Components.SequenceEqual(other.Components);
+        other is not null &&
+        Schema == other.Schema &&
+        Components.SequenceEqual(other.Components) &&
+        Enums.SequenceEqual(other.Enums);
 
     public override bool Equals(object? obj) => Equals(obj as HandlerSchema);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Shared;
 using Microsoft.CodeAnalysis;
 
 namespace Hardened.SourceGenerator.OpenApiDocument;
@@ -27,20 +28,36 @@ public static class JsonSchemaWriter {
     /// <summary>
     /// The schema for <paramref name="type"/>, and every named schema it depends on.
     /// </summary>
-    public static HandlerSchema? Write(ITypeSymbol? type) {
+    /// <param name="compilationAssembly">
+    /// The assembly being compiled, which decides which enums this application owns - see
+    /// <c>EnumWireNaming.IsOwned</c>.
+    /// <para>
+    /// The compilation's assembly rather than the root type's. A handler whose response is itself a
+    /// framework type anchors the walk in that framework's assembly, and every enum below it then
+    /// looks locally declared - which is how <c>System.Reflection.MethodImplAttributes</c> and
+    /// <c>TaskStatus</c> acquired generated converters renaming their members.
+    /// </para>
+    /// </param>
+    public static HandlerSchema? Write(ITypeSymbol? type, IAssemblySymbol? compilationAssembly = null) {
         if (type == null || type.SpecialType == SpecialType.System_Void) {
             return null;
         }
 
         var components = new Dictionary<string, string>();
+        var enums = new Dictionary<string, EnumVocabulary>(System.StringComparer.Ordinal);
 
-        var root = SchemaFor(Unwrap(type), components, new HashSet<string>());
+        var root = SchemaFor(
+            Unwrap(type), components, new HashSet<string>(), enums, compilationAssembly);
 
         return new HandlerSchema(
             root,
             components
                 .OrderBy(pair => pair.Key, System.StringComparer.Ordinal)
                 .Select(pair => new SchemaComponent(pair.Key, pair.Value))
+                .ToList(),
+            enums
+                .OrderBy(pair => pair.Key, System.StringComparer.Ordinal)
+                .Select(pair => pair.Value)
                 .ToList());
     }
 
@@ -74,10 +91,11 @@ public static class JsonSchemaWriter {
     }
 
     private static string SchemaFor(
-        ITypeSymbol type, Dictionary<string, string> components, HashSet<string> inProgress) {
+        ITypeSymbol type, Dictionary<string, string> components, HashSet<string> inProgress,
+        Dictionary<string, EnumVocabulary> enums, IAssemblySymbol? compilationAssembly) {
         if (type is INamedTypeSymbol { IsGenericType: true } nullable &&
             nullable.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T) {
-            return SchemaFor(nullable.TypeArguments[0], components, inProgress);
+            return SchemaFor(nullable.TypeArguments[0], components, inProgress, enums, compilationAssembly);
         }
 
         var primitive = Primitive(type);
@@ -88,22 +106,22 @@ public static class JsonSchemaWriter {
 
         if (type is IArrayTypeSymbol array) {
             return "{\"type\":\"array\",\"items\":" +
-                   SchemaFor(array.ElementType, components, inProgress) + "}";
+                   SchemaFor(array.ElementType, components, inProgress, enums, compilationAssembly) + "}";
         }
 
         if (type is INamedTypeSymbol named) {
-            var collection = Collection(named, components, inProgress);
+            var collection = Collection(named, components, inProgress, enums, compilationAssembly);
 
             if (collection != null) {
                 return collection;
             }
 
             if (named.TypeKind == TypeKind.Enum) {
-                return EnumSchema(named);
+                return EnumSchema(named, enums, compilationAssembly);
             }
 
             if (named.TypeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Interface) {
-                return ObjectRef(named, components, inProgress);
+                return ObjectRef(named, components, inProgress, enums, compilationAssembly);
             }
         }
 
@@ -112,7 +130,8 @@ public static class JsonSchemaWriter {
     }
 
     private static string? Collection(
-        INamedTypeSymbol named, Dictionary<string, string> components, HashSet<string> inProgress) {
+        INamedTypeSymbol named, Dictionary<string, string> components, HashSet<string> inProgress,
+        Dictionary<string, EnumVocabulary> enums, IAssemblySymbol? compilationAssembly) {
         if (!named.IsGenericType) {
             return null;
         }
@@ -122,31 +141,64 @@ public static class JsonSchemaWriter {
         if (name is "List" or "IList" or "IReadOnlyList" or "ICollection" or "IReadOnlyCollection"
             or "IEnumerable" or "HashSet" or "ISet") {
             return "{\"type\":\"array\",\"items\":" +
-                   SchemaFor(named.TypeArguments[0], components, inProgress) + "}";
+                   SchemaFor(named.TypeArguments[0], components, inProgress, enums, compilationAssembly) + "}";
         }
 
         if (name is "Dictionary" or "IDictionary" or "IReadOnlyDictionary") {
             return "{\"type\":\"object\",\"additionalProperties\":" +
-                   SchemaFor(named.TypeArguments[1], components, inProgress) + "}";
+                   SchemaFor(named.TypeArguments[1], components, inProgress, enums, compilationAssembly) + "}";
         }
 
         return null;
     }
 
-    private static string EnumSchema(INamedTypeSymbol named) {
+    /// <summary>
+    /// The enum's declared values, in the vocabulary the serializer will actually write.
+    /// </summary>
+    /// <remarks>
+    /// This used to write <c>member.Name</c> unconditionally, and the JSON serializer wrote the
+    /// ordinal - so the published description said <c>{"type":"string","enum":["ScienceFiction"]}</c>
+    /// about a property that went out as <c>0</c>. The document is the deliverable here, and a
+    /// client generated from it could not talk to the application it was generated from.
+    ///
+    /// Resolved through <see cref="EnumWireNaming"/> rather than formatted here, because the
+    /// converter and the parameter binder resolve the same way from the same place. A document that
+    /// disagrees with the wire is the defect; two implementations of one policy is how it returns.
+    /// </remarks>
+    private static string EnumSchema(
+        INamedTypeSymbol named, Dictionary<string, EnumVocabulary> enums, IAssemblySymbol? compilationAssembly) {
+        var owned = EnumWireNaming.IsOwned(named, compilationAssembly);
+
+        // An enum the application does not own keeps the member name it always had here, and gets
+        // no converter. A model graph reaches further than it looks - a property typed Exception
+        // pulls in System.Reflection.MethodAttributes - and renaming those is redefining a
+        // vocabulary that is not the application's to redefine.
+        var naming = owned
+            ? EnumWireNaming.For(named, EnumWireNaming.AssemblyDefault(named))
+            : "MemberName";
+
+        var members = EnumWireNaming.Members(named, naming);
+        var qualified = "global::" + named.ToDisplayString();
+
+        // Recorded whether or not it is new: the same enum reached from two handlers resolves to the
+        // same vocabulary, and the dictionary is what keeps one converter emitted for it.
+        if (owned && members.Count > 0) {
+            enums[qualified] = new EnumVocabulary(
+                qualified,
+                named.Name,
+                naming,
+                members.Select(pair => new EnumWireValue(pair.Member, pair.Wire)).ToList());
+        }
+
         var builder = new StringBuilder("{\"type\":\"string\",\"enum\":[");
         var first = true;
 
-        foreach (var member in named.GetMembers().OfType<IFieldSymbol>()) {
-            if (!member.IsConst) {
-                continue;
-            }
-
+        foreach (var (_, wire) in members) {
             if (!first) {
                 builder.Append(',');
             }
 
-            builder.Append('"').Append(Escape(member.Name)).Append('"');
+            builder.Append('"').Append(Escape(wire)).Append('"');
             first = false;
         }
 
@@ -154,7 +206,8 @@ public static class JsonSchemaWriter {
     }
 
     private static string ObjectRef(
-        INamedTypeSymbol named, Dictionary<string, string> components, HashSet<string> inProgress) {
+        INamedTypeSymbol named, Dictionary<string, string> components, HashSet<string> inProgress,
+        Dictionary<string, EnumVocabulary> enums, IAssemblySymbol? compilationAssembly) {
         var name = named.Name;
         var reference = "{\"$ref\":\"#/components/schemas/" + Escape(name) + "\"}";
 
@@ -181,7 +234,7 @@ public static class JsonSchemaWriter {
             properties
                 .Append('"').Append(Escape(CamelCase(property.Name))).Append("\":")
                 .Append(SchemaConstraintWriter.Apply(
-                    SchemaFor(property.Type, components, inProgress), property));
+                    SchemaFor(property.Type, components, inProgress, enums, compilationAssembly), property));
 
             // A non-nullable reference type is one the author said would always be there, and so
             // is one carrying [Required] - which is the only way to say it about a value type.

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -33,7 +33,8 @@ public abstract class BaseRequestModelGenerator {
             response,
             filters) {
             ResponseSchema = OpenApiDocument.JsonSchemaWriter.Write(
-                SchemaSubject(context, methodDeclaration, response)),
+                SchemaSubject(context, methodDeclaration, response),
+                context.SemanticModel.Compilation.Assembly),
             ResponseSchemas = DeclaredResponses(context, response),
             RequestSchema = BodySchema(context, methodDeclaration, parameters)
         };
@@ -77,7 +78,10 @@ public abstract class BaseRequestModelGenerator {
             responses.Add(new ResponseSchemaModel(
                 unionCase.Status,
                 HttpResponseDescription.For(unionCase.Status),
-                unionCase.HasBody ? OpenApiDocument.JsonSchemaWriter.Write(symbol) : null));
+                unionCase.HasBody
+                    ? OpenApiDocument.JsonSchemaWriter.Write(
+                        symbol, context.SemanticModel.Compilation.Assembly)
+                    : null));
         }
 
         return responses;
@@ -140,7 +144,9 @@ public abstract class BaseRequestModelGenerator {
 
         return syntax?.Type == null
             ? null
-            : OpenApiDocument.JsonSchemaWriter.Write(context.SemanticModel.GetTypeInfo(syntax.Type).Type);
+            : OpenApiDocument.JsonSchemaWriter.Write(
+                context.SemanticModel.GetTypeInfo(syntax.Type).Type,
+                context.SemanticModel.Compilation.Assembly);
     }
 
     protected abstract RequestHandlerNameModel GetRequestNameModel(

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/EnumWireNaming.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/EnumWireNaming.cs
@@ -1,0 +1,233 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// The wire vocabulary of a code-first enum, resolved once and used everywhere it shows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Four places have to agree about what an enum's values are: the JSON converter that writes them,
+/// the converter that reads them back, the string converter a path or query parameter binds
+/// through, and the <c>enum</c> array in the generated OpenAPI document. Any two of those
+/// disagreeing is a defect no build reports - the last pairing is the one that shipped, with the
+/// document declaring <c>"type":"string"</c> for enums the serializer wrote as integers.
+/// </para>
+/// <para>
+/// So the policy is resolved here and the callers ask rather than deciding. It is not a formatting
+/// helper; it is the single definition of a contract.
+/// </para>
+/// </remarks>
+internal static class EnumWireNaming {
+
+    private const string AttributeName = "JsonEnumNamingAttribute";
+    private const string AttributeNamespace = "Hardened.Requests.Abstract.Attributes";
+
+    /// <summary>
+    /// What an application that has said nothing gets.
+    /// </summary>
+    /// <remarks>
+    /// CamelCase, to match the property names an enum value sits beside - a camelCase document
+    /// carrying a PascalCase value reads as an oversight, because it was one.
+    /// </remarks>
+    public const string DefaultNaming = "CamelCase";
+
+    /// <summary>
+    /// The naming an enum resolves to: its own attribute, else the assembly's, else the default.
+    /// </summary>
+    public static string For(INamedTypeSymbol enumType, string? assemblyNaming) =>
+        Declared(enumType) ?? assemblyNaming ?? DefaultNaming;
+
+    /// <summary>
+    /// The default declared by the assembly an enum is defined in, if it declared one.
+    /// </summary>
+    /// <remarks>
+    /// The enum's own assembly rather than the one being compiled: a model type referenced from a
+    /// shared library carries its own vocabulary, and re-naming someone else's enum from the
+    /// consuming application would change a contract that library already publishes.
+    /// </remarks>
+    public static string? AssemblyDefault(INamedTypeSymbol enumType) =>
+        enumType.ContainingAssembly == null ? null : Declared(enumType.ContainingAssembly);
+
+    /// <summary>
+    /// The naming declared directly on a symbol, or null when it carries no attribute.
+    /// </summary>
+    public static string? Declared(ISymbol symbol) {
+        foreach (var attribute in symbol.GetAttributes()) {
+            var attributeClass = attribute.AttributeClass;
+
+            if (attributeClass?.Name != AttributeName ||
+                attributeClass.ContainingNamespace?.ToDisplayString() != AttributeNamespace) {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 0) {
+                continue;
+            }
+
+            var value = attribute.ConstructorArguments[0].Value;
+
+            // The argument is the enum's underlying int. Its member name is the naming's name,
+            // which is what every consumer here switches on.
+            if (value is int ordinal) {
+                return NameOf(ordinal);
+            }
+        }
+
+        return null;
+    }
+
+    private static string? NameOf(int ordinal) => ordinal switch {
+        0 => "MemberName",
+        1 => "CamelCase",
+        2 => "KebabCaseLower",
+        3 => "SnakeCaseLower",
+        4 => "SnakeCaseUpper",
+        _ => null
+    };
+
+    /// <summary>
+    /// The wire value for one member, under a resolved naming.
+    /// </summary>
+    public static string Value(string memberName, string naming) => naming switch {
+        "CamelCase" => CamelCase(memberName),
+        "KebabCaseLower" => Delimited(memberName, '-', upper: false),
+        "SnakeCaseLower" => Delimited(memberName, '_', upper: false),
+        "SnakeCaseUpper" => Delimited(memberName, '_', upper: true),
+        _ => memberName
+    };
+
+    /// <summary>
+    /// Whether Hardened gives this enum a vocabulary at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only enums the application owns. A model graph reaches further than it looks - a property
+    /// typed <c>Exception</c> or <c>Type</c> pulls in <c>System.Reflection.MethodAttributes</c> -
+    /// and renaming a BCL enum's values is redefining a vocabulary that is not the application's to
+    /// redefine. Ownership is the enum's own assembly matching the model's, or that assembly having
+    /// declared a default, which is how a shared model library opts in.
+    /// </para>
+    /// <para>
+    /// <c>[Flags]</c> is excluded whoever owns it. A flags value is a combination of members rather
+    /// than one of them, so there is no member name to write and no single value to read back;
+    /// <c>Static | Final</c> is a number and belongs on the wire as one.
+    /// </para>
+    /// </remarks>
+    public static bool IsOwned(INamedTypeSymbol enumType, IAssemblySymbol? modelAssembly) {
+        if (HasFlags(enumType)) {
+            return false;
+        }
+
+        var assembly = enumType.ContainingAssembly;
+
+        if (assembly == null) {
+            return false;
+        }
+
+        return SymbolEqualityComparer.Default.Equals(assembly, modelAssembly) ||
+               Declared(assembly) != null;
+    }
+
+    private static bool HasFlags(INamedTypeSymbol enumType) =>
+        enumType.GetAttributes().Any(attribute =>
+            attribute.AttributeClass?.Name == "FlagsAttribute" &&
+            attribute.AttributeClass.ContainingNamespace?.ToDisplayString() == "System");
+
+    /// <summary>
+    /// Every distinct member of an enum, paired with the value it goes out as.
+    /// </summary>
+    /// <remarks>
+    /// Distinct by underlying value and by wire value, because neither is guaranteed unique and a
+    /// duplicate is not a warning. Two members sharing a value - <c>PrivateScope</c> and
+    /// <c>ReuseSlot</c> are both 0 - give two switch arms on one constant, which is CS8510 and does
+    /// not compile; two members naming the same wire value give the same on the read side. The first
+    /// declared wins, which is the same one <c>Enum.ToString</c> picks.
+    /// </remarks>
+    public static IReadOnlyList<(string Member, string Wire)> Members(
+        INamedTypeSymbol enumType, string naming) {
+        var members = new List<(string Member, string Wire)>();
+        var seenValues = new HashSet<object>();
+        var seenWire = new HashSet<string>(System.StringComparer.Ordinal);
+
+        foreach (var field in enumType.GetMembers().OfType<IFieldSymbol>()) {
+            if (!field.IsConst || field.ConstantValue == null) {
+                continue;
+            }
+
+            if (!seenValues.Add(field.ConstantValue)) {
+                continue;
+            }
+
+            var wire = Value(field.Name, naming);
+
+            if (!seenWire.Add(wire)) {
+                continue;
+            }
+
+            members.Add((field.Name, wire));
+        }
+
+        return members;
+    }
+
+    private static string CamelCase(string name) {
+        if (name.Length == 0 || !char.IsUpper(name[0])) {
+            return name;
+        }
+
+        // An acronym run keeps going until the last capital before a lower-case letter, so IOStream
+        // becomes ioStream rather than iOStream. A name that is all capitals lowercases entirely.
+        var prefix = 1;
+
+        while (prefix < name.Length && char.IsUpper(name[prefix])) {
+            prefix++;
+        }
+
+        // Only when a run of capitals actually ran on into a word. Without the first test a
+        // single leading capital steps back to zero and nothing is lowered at all, so CamelCase
+        // returned its input for every ordinary name - Standard, Low, Open - which is nearly all
+        // of them.
+        if (prefix > 1 && prefix < name.Length) {
+            prefix--;
+        }
+
+        return name.Substring(0, prefix).ToLowerInvariant() + name.Substring(prefix);
+    }
+
+    /// <summary>
+    /// Word boundaries become <paramref name="separator"/>.
+    /// </summary>
+    /// <remarks>
+    /// A boundary is a capital following a lower-case letter or a digit, or the last capital of a
+    /// run that is followed by a lower-case letter - so <c>InProgress</c> is two words,
+    /// <c>HTTPProxy</c> is <c>http-proxy</c> rather than <c>h-t-t-p-proxy</c>, and <c>Plus1</c>
+    /// stays one word.
+    /// </remarks>
+    private static string Delimited(string name, char separator, bool upper) {
+        var builder = new StringBuilder(name.Length + 4);
+
+        for (var index = 0; index < name.Length; index++) {
+            var current = name[index];
+
+            if (index > 0 && char.IsUpper(current)) {
+                var previous = name[index - 1];
+                var startsWord = !char.IsUpper(previous);
+                var endsAcronym = char.IsUpper(previous) &&
+                                  index + 1 < name.Length &&
+                                  char.IsLower(name[index + 1]);
+
+                if (startsWord || endsAcronym) {
+                    builder.Append(separator);
+                }
+            }
+
+            builder.Append(upper ? char.ToUpperInvariant(current) : char.ToLowerInvariant(current));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/EnumWireConverterEmitter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/EnumWireConverterEmitter.cs
@@ -1,0 +1,287 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+
+namespace Hardened.SourceGenerator.Web;
+
+/// <summary>
+/// A converter per enum the application puts on the wire, carrying the vocabulary the document
+/// declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The code-first counterpart of what a description already gives a contract-first application.
+/// System.Text.Json writes an enum as its ordinal unless something says otherwise, and the setting
+/// that changes that - <c>UseStringEnumConverter</c> - writes the C# member name, which is an
+/// identifier rather than a wire value. Neither is a vocabulary anyone chose.
+/// </para>
+/// <para>
+/// Generated rather than attributed because the enum belongs to the application: nothing can add
+/// <c>[JsonConverter]</c> to a type someone else declared, and an enum is not partial. A converter
+/// reached through a <c>JsonTypeInfo</c> attaches to the type from outside, which is the same route
+/// a source-generated context uses and works identically under Native AOT.
+/// </para>
+/// <para>
+/// <c>TryParseWire</c> exists for the binder rather than the serializer. A path or query value
+/// arrives as text and never passes through a JSON converter, so without it
+/// <c>?priority=in-progress</c> is answered 400 by an application whose body accepts exactly that -
+/// and any declared value that is not a valid C# identifier is unreachable as a parameter.
+/// </para>
+/// </remarks>
+internal static class EnumWireConverterEmitter {
+
+    public const string ContainerName = "JsonEnums";
+    private const string ResolverName = "Resolver";
+
+    /// <summary>
+    /// Every enum reachable from a handler's request, response or declared response set.
+    /// </summary>
+    /// <remarks>
+    /// Deduplicated by type name. One enum reached from two handlers resolves to the same
+    /// vocabulary - it is a property of the type, not of the route - and emitting it twice would
+    /// not compile.
+    /// </remarks>
+    public static IReadOnlyList<EnumVocabulary> Collect(IReadOnlyList<RequestHandlerModel> handlers) {
+        var found = new SortedDictionary<string, EnumVocabulary>(System.StringComparer.Ordinal);
+
+        foreach (var handler in handlers) {
+            Add(found, handler.RequestSchema);
+            Add(found, handler.ResponseSchema);
+
+            foreach (var response in handler.ResponseSchemas) {
+                Add(found, response.Schema);
+            }
+        }
+
+        return found.Values.ToList();
+    }
+
+    private static void Add(IDictionary<string, EnumVocabulary> found, HandlerSchema? schema) {
+        if (schema == null) {
+            return;
+        }
+
+        foreach (var vocabulary in schema.Enums) {
+            found[vocabulary.QualifiedName] = vocabulary;
+        }
+    }
+
+    public static void Emit(ClassDefinition appClass, IReadOnlyList<EnumVocabulary> enums) {
+        if (enums.Count == 0) {
+            return;
+        }
+
+        var container = appClass.AddClass(ContainerName);
+
+        container.Modifiers |= ComponentModifier.Public | ComponentModifier.Static;
+        container.Comment =
+            "The wire vocabulary of every enum this application serializes. See [JsonEnumNaming].";
+
+        foreach (var vocabulary in enums) {
+            EmitConverter(container, vocabulary);
+        }
+
+        EmitResolver(container, enums);
+        EmitStringConverters(container, enums);
+    }
+
+    private static string ConverterName(EnumVocabulary vocabulary) => vocabulary.Name + "WireConverter";
+
+    private static void EmitConverter(ClassDefinition container, EnumVocabulary vocabulary) {
+        var enumType = TypeDefinition.Get("", vocabulary.QualifiedName);
+        var converter = container.AddClass(ConverterName(vocabulary));
+
+        converter.Modifiers |= ComponentModifier.Public | ComponentModifier.Sealed;
+        converter.AddBaseType(new GenericTypeDefinition(
+            TypeDefinitionEnum.ClassDefinition,
+            "System.Text.Json.Serialization",
+            "JsonConverter",
+            new[] { enumType }));
+
+        converter.Comment =
+            $"Reads and writes {vocabulary.Name} as the values the document declares " +
+            $"({vocabulary.Naming}).";
+
+        var instance = converter.AddField(
+            TypeDefinition.Get("", ConverterName(vocabulary)), "Instance");
+
+        instance.Modifiers |=
+            ComponentModifier.Public | ComponentModifier.Static | ComponentModifier.Readonly;
+        instance.InitializeValue = new CodeOutputComponent("new()") { Indented = false };
+
+        EmitRead(converter, vocabulary, enumType);
+        EmitWrite(converter, vocabulary, enumType);
+        EmitTryParseWire(converter, vocabulary, enumType);
+    }
+
+    private static void EmitRead(
+        ClassDefinition converter, EnumVocabulary vocabulary, ITypeDefinition enumType) {
+        var method = converter.AddMethod("Read");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        method.SetReturnType(enumType);
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json", "Utf8JsonReader"), "reader").Modifier =
+            ParameterModifier.Ref;
+        method.AddParameter(TypeDefinition.Get(typeof(System.Type)), "typeToConvert");
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json", "JsonSerializerOptions"), "options");
+
+        var lines = new List<string> {
+            "var value = reader.GetString();",
+            "",
+            "return value switch",
+            "{"
+        };
+
+        foreach (var value in vocabulary.Values) {
+            lines.Add($"    \"{Escape(value.Wire)}\" => {vocabulary.QualifiedName}.{value.Member},");
+        }
+
+        // A value the application does not declare is not guessed at. The JsonException lands as a
+        // 400, which is the same answer a malformed body gets and the right one for a value that is
+        // not in the document.
+        lines.Add("    _ => throw new global::System.Text.Json.JsonException(");
+        lines.Add($"        \"'\" + value + \"' is not a value {Escape(vocabulary.Name)} declares.\")");
+        lines.Add("};");
+
+        Write(method, lines);
+    }
+
+    private static void EmitWrite(
+        ClassDefinition converter, EnumVocabulary vocabulary, ITypeDefinition enumType) {
+        var method = converter.AddMethod("Write");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
+        method.AddParameter(TypeDefinition.Get("System.Text.Json", "Utf8JsonWriter"), "writer");
+        method.AddParameter(enumType, "value");
+        method.AddParameter(
+            TypeDefinition.Get("System.Text.Json", "JsonSerializerOptions"), "options");
+
+        var lines = new List<string> { "string wire = value switch", "{" };
+
+        foreach (var value in vocabulary.Values) {
+            lines.Add($"    {vocabulary.QualifiedName}.{value.Member} => \"{Escape(value.Wire)}\",");
+        }
+
+        // Reachable by casting an undeclared number to the enum. Refused rather than written, since
+        // the document does not describe it and a client has no way to read it.
+        lines.Add("    _ => throw new global::System.Text.Json.JsonException(");
+        lines.Add($"        \"The value is not one {Escape(vocabulary.Name)} declares.\")");
+        lines.Add("};");
+        lines.Add("");
+        lines.Add("writer.WriteStringValue(wire);");
+
+        Write(method, lines);
+    }
+
+    private static void EmitTryParseWire(
+        ClassDefinition converter, EnumVocabulary vocabulary, ITypeDefinition enumType) {
+        var method = converter.AddMethod("TryParseWire");
+
+        method.Modifiers |= ComponentModifier.Public | ComponentModifier.Static;
+        method.SetReturnType(typeof(bool));
+        method.AddParameter(typeof(string), "value");
+        method.AddParameter(enumType, "parsed").Modifier = ParameterModifier.Out;
+
+        method.Comment =
+            $"Parses one of {vocabulary.Name}'s declared values from text, as a parameter carries it.";
+
+        var lines = new List<string> { "switch (value)", "{" };
+
+        foreach (var value in vocabulary.Values) {
+            lines.Add($"    case \"{Escape(value.Wire)}\":");
+            lines.Add($"        parsed = {vocabulary.QualifiedName}.{value.Member};");
+            lines.Add("        return true;");
+        }
+
+        lines.Add("    default:");
+        lines.Add($"        parsed = default({vocabulary.QualifiedName});");
+        lines.Add("        return false;");
+        lines.Add("}");
+
+        Write(method, lines);
+    }
+
+    /// <summary>
+    /// The resolver that attaches each converter to its type.
+    /// </summary>
+    /// <remarks>
+    /// A resolver rather than an entry in <c>Options.Converters</c>. An options-level converter
+    /// outranks a <c>[JsonConverter]</c> attribute on a type, so putting these there would override
+    /// any converter a model declared for itself; a <c>JsonTypeInfo</c> answers only for the type it
+    /// is asked about. <c>JsonMetadataServices.CreateValueInfo</c> is the AOT-safe construction.
+    /// </remarks>
+    private static void EmitResolver(ClassDefinition container, IReadOnlyList<EnumVocabulary> enums) {
+        var resolver = container.AddClass(ResolverName);
+
+        resolver.Modifiers |= ComponentModifier.Public | ComponentModifier.Sealed;
+        resolver.AddBaseType(
+            TypeDefinition.Get("System.Text.Json.Serialization.Metadata", "IJsonTypeInfoResolver"));
+        resolver.Comment = "Metadata for this application's enums, ahead of reflection.";
+
+        var instance = resolver.AddField(TypeDefinition.Get("", ResolverName), "Instance");
+
+        instance.Modifiers |=
+            ComponentModifier.Public | ComponentModifier.Static | ComponentModifier.Readonly;
+        instance.InitializeValue = new CodeOutputComponent("new()") { Indented = false };
+
+        var method = resolver.AddMethod("GetTypeInfo");
+
+        method.Modifiers |= ComponentModifier.Public;
+        method.SetReturnType(
+            TypeDefinition.Get("System.Text.Json.Serialization.Metadata", "JsonTypeInfo")
+                .MakeNullable());
+        method.AddParameter(TypeDefinition.Get(typeof(System.Type)), "type");
+        method.AddParameter(TypeDefinition.Get("System.Text.Json", "JsonSerializerOptions"), "options");
+
+        var lines = new List<string>();
+
+        foreach (var vocabulary in enums) {
+            lines.Add($"if (type == typeof({vocabulary.QualifiedName})) {{");
+            lines.Add(
+                "    return global::System.Text.Json.Serialization.Metadata.JsonMetadataServices" +
+                $".CreateValueInfo<{vocabulary.QualifiedName}>(");
+            lines.Add($"        options, {ConverterName(vocabulary)}.Instance);");
+            lines.Add("}");
+            lines.Add("");
+        }
+
+        // Null rather than a guess, so the rest of the chain answers for everything else.
+        lines.Add("return null;");
+
+        Write(method, lines);
+    }
+
+    /// <summary>
+    /// The same vocabularies as the parameter binder consumes them.
+    /// </summary>
+    private static void EmitStringConverters(
+        ClassDefinition container, IReadOnlyList<EnumVocabulary> enums) {
+        var converters = enums
+            .Select(vocabulary =>
+                "new global::Hardened.Requests.Abstract.Serializer.DelegatingStringConverter<" +
+                $"{vocabulary.QualifiedName}>({ConverterName(vocabulary)}.TryParseWire, " +
+                $"\"{Escape(vocabulary.Name)}\")")
+            .ToList();
+
+        var field = container.AddField(
+            TypeDefinition.Get("Hardened.Requests.Abstract.Serializer", "IStringConverter").MakeArray(),
+            "StringConverters");
+
+        field.Modifiers |=
+            ComponentModifier.Public | ComponentModifier.Static | ComponentModifier.Readonly;
+        field.InitializeValue =
+            new CodeOutputComponent("{ " + string.Join(", ", converters) + " }") { Indented = false };
+    }
+
+    private static void Write(MethodDefinition method, List<string> lines) {
+        foreach (var line in lines) {
+            method.Add(new CodeOutputComponent(line) { Indented = true });
+        }
+    }
+
+    private static string Escape(string value) =>
+        value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/RoutingTableGenerator.cs
@@ -183,7 +183,13 @@ public static class RoutingTableGenerator {
         var routingType = TypeDefinition.Get(appModel.EntryPointType.Namespace,
             appModel.EntryPointType.Name + ".RoutingTable");
 
-        GenerateDependencyInjection(appClass, routingType, appModel, endPointModels, cancellationToken);
+        // Before the DI method, which registers what this emits.
+        var enums = EnumWireConverterEmitter.Collect(endPointModels);
+
+        EnumWireConverterEmitter.Emit(appClass, enums);
+
+        GenerateDependencyInjection(
+            appClass, routingType, appModel, endPointModels, enums, cancellationToken);
     }
 
     private static void CreateConstructor(ClassDefinition appClass) {
@@ -199,6 +205,7 @@ public static class RoutingTableGenerator {
     private static void GenerateDependencyInjection(ClassDefinition classDefinition,
         ITypeDefinition routingTableType,
         EntryPointSelector.Model applicationModel, IReadOnlyList<RequestHandlerModel> webEndPointModels,
+        IReadOnlyList<EnumVocabulary> enums,
         CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -246,8 +253,44 @@ public static class RoutingTableGenerator {
 
         RegisterAuthorizationPosture(diMethod, serviceCollection, applicationModel);
 
+        RegisterEnumWireConverters(diMethod, serviceCollection, applicationModel, enums);
+
         Validation.ParameterValidatorRegistration.Write(
             diMethod, serviceCollection, webEndPointModels, cancellationToken);
+    }
+
+    /// <summary>
+    /// The generated enum converters, as the serializers and the parameter binder consume them.
+    /// </summary>
+    /// <remarks>
+    /// Two registrations for one vocabulary, because a value reaches the application by two routes
+    /// that share nothing: a JSON body resolves through the type-info chain, and a path or query
+    /// value is text the binder converts. An enum registered for only the first is one whose body
+    /// accepts <c>"in-progress"</c> while <c>?priority=in-progress</c> is answered 400.
+    /// </remarks>
+    private static void RegisterEnumWireConverters(
+        MethodDefinition diMethod,
+        ParameterDefinition serviceCollection,
+        EntryPointSelector.Model applicationModel,
+        IReadOnlyList<EnumVocabulary> enums) {
+        if (enums.Count == 0) {
+            return;
+        }
+
+        var container = "global::" + applicationModel.EntryPointType.Namespace + "." +
+                        applicationModel.EntryPointType.Name + "." +
+                        EnumWireConverterEmitter.ContainerName;
+
+        diMethod.AddIndentedStatement(new CodeOutputComponent(
+            serviceCollection.Name +
+            ".AddSingleton(typeof(global::System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver), " +
+            container + ".Resolver.Instance)"));
+
+        diMethod.AddIndentedStatement(new CodeOutputComponent(
+            "foreach (var stringConverter in " + container + ".StringConverters) { " +
+            serviceCollection.Name +
+            ".AddSingleton(typeof(global::Hardened.Requests.Abstract.Serializer.IStringConverter), " +
+            "stringConverter); }"));
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/EnumWireVocabularyTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/EnumWireVocabularyTests.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests;
+
+/// <summary>
+/// The enum converters this generator writes, through the shipped generator rather than the
+/// library it compiles in.
+/// </summary>
+/// <remarks>
+/// The emitter itself is covered in <c>Hardened.SourceGenerator.Tests</c>. Held again here because
+/// the wrapper projects compile the library in as linked <c>Compile</c> items rather than
+/// referencing it, so the same source is a different assembly in each - and code covered in one
+/// wrapper's tests is uncovered in every other. That is a property of the layout, not duplication
+/// for its own sake: this suite is what says the generator an application actually loads produces
+/// the converters.
+/// </remarks>
+public class EnumWireVocabularyTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),          // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)      // Hardened.Requests.Abstract
+    ];
+
+    private static GeneratorResult Generate(string source) =>
+        GeneratorTestHarness.Run(source, new WebLibrarySourceGenerator(), Anchors);
+
+    private const string Application = """
+        using Hardened.Requests.Abstract.Attributes;
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        public partial class Application { }
+
+        public enum Priority { Low, InProgress }
+
+        [JsonEnumNaming(EnumNaming.KebabCaseLower)]
+        public enum Shipping { NextDay }
+
+        public record Ticket(Priority Priority, Shipping Shipping);
+
+        public class TicketController {
+            [Get("/tickets")]
+            public Ticket Get() => new(Priority.Low, Shipping.NextDay);
+
+            [Get("/by-priority")]
+            public string ByPriority([FromQueryString] Priority priority) => priority.ToString();
+        }
+        """;
+
+    [Fact]
+    public void TheGeneratedConvertersCarryTheResolvedVocabulary() {
+        var routing = Generate(Application).AssertNoErrors().SourceContaining("Application.Routing");
+
+        Assert.Contains("=> \"inProgress\"", routing);
+        Assert.Contains("=> \"next-day\"", routing);
+    }
+
+    [Fact]
+    public void TheResolverAndStringConvertersAreRegistered() {
+        var routing = Generate(Application).AssertNoErrors().SourceContaining("Application.Routing");
+
+        Assert.Contains("JsonEnums.Resolver.Instance", routing);
+        Assert.Contains("JsonEnums.StringConverters", routing);
+    }
+
+    /// <summary>
+    /// The document is written from the same resolution, which is the pairing the whole mechanism
+    /// exists for - a description declaring values the wire does not carry is a contract no client
+    /// can honour.
+    /// </summary>
+    [Fact]
+    public void TheDocumentDeclaresTheSameValues() {
+        var result = Generate($$"""
+            using Hardened.Requests.Abstract.Attributes;
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            {{GeneratedOpenApiDocument.EnableAttribute}}
+            public partial class Application { }
+
+            public enum Priority { Low, InProgress }
+
+            public record Ticket(Priority Priority);
+
+            public class TicketController {
+                [Get("/tickets")]
+                public Ticket Get() => new(Priority.Low);
+            }
+            """).AssertNoErrors();
+
+        // Selected by hint name, as the other document tests do. Several generated files mention
+        // OpenApiDocument; exactly one carries it.
+        var source = result.GeneratedSources
+            .Single(pair => pair.Key.Contains("OpenApiDocument")).Value;
+
+        using var document = JsonDocument.Parse(GeneratedOpenApiDocument.Extract(source));
+
+        var values = document.RootElement
+            .GetProperty("components").GetProperty("schemas")
+            .GetProperty("Ticket").GetProperty("properties").GetProperty("priority")
+            .GetProperty("enum")
+            .EnumerateArray().Select(value => value.GetString()).ToArray();
+
+        Assert.Equal(new[] { "low", "inProgress" }, values);
+    }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -179,6 +179,29 @@ second silently gives you `Production` while everything else says `development`.
 project on xunit 2.x fails with `CS0433` on `Assert`. v3 test projects are also self-executing,
 hence `<OutputType>Exe</OutputType>`.
 
+#if (codeFirst)
+**JSON is configured by registering a resolver, not by editing options.** One line in
+`TemplateModuleNameLibrary.ConfigureServices` registers `TemplateModuleNameJsonContext` as an
+`IJsonTypeInfoResolver`, and every JSON serializer in the pipeline reads it — request body,
+response body, streamed item. Adding a type to the wire means adding a `[JsonSerializable]` line
+to that context.
+
+**An enum is written as a number unless the context says otherwise.** That is System.Text.Json's
+default, not the framework's choice: without `UseStringEnumConverter` a `Priority` property leaves
+as `{"priority":0}` and a client sending `"high"` is answered 400, in an application that builds
+clean. The setting is already on in `TemplateModuleNameJsonContext`. The value written is the C# member name
+— `"High"`, PascalCase inside an otherwise camelCase document, because `PropertyNamingPolicy` does
+not reach enum members. Choose the wire vocabulary before the first client; changing it later
+breaks every consumer.
+
+**Do not reach for `[JsonConverter(typeof(JsonStringEnumConverter))]`.** It works on a JIT host and
+cannot work under Native AOT, so it fails when the application is published rather than when it is
+written. `SYSLIB1034` says so wherever the compiler can see the enum from a context. The generic
+`JsonStringEnumConverter<TEnum>` is the safe form if you want a per-enum attribute, and the context
+is the better answer.
+
+#endif
+
 **`[HardenedTest]` boots the real application.** Test method parameters are resolved from the
 application's own container, and `ITestWebApp` drives the real pipeline — routing, filters,
 binding, serialisation — without a socket or a port. Mark a parameter `[Mock]` to substitute a

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -186,19 +186,33 @@ hence `<OutputType>Exe</OutputType>`.
 response body, streamed item. Adding a type to the wire means adding a `[JsonSerializable]` line
 to that context.
 
-**An enum is written as a number unless the context says otherwise.** That is System.Text.Json's
-default, not the framework's choice: without `UseStringEnumConverter` a `Priority` property leaves
-as `{"priority":0}` and a client sending `"high"` is answered 400, in an application that builds
-clean. The setting is already on in `TemplateModuleNameJsonContext`. The value written is the C# member name
-— `"High"`, PascalCase inside an otherwise camelCase document, because `PropertyNamingPolicy` does
-not reach enum members. Choose the wire vocabulary before the first client; changing it later
-breaks every consumer.
+**An enum's wire vocabulary is `[JsonEnumNaming]`, and it governs the document too.** The build
+writes a converter for every enum this application serializes and registers it for both the JSON
+body and the parameter binder, and the `enum` array in the generated OpenAPI description is written
+from the same setting — so the contract a client generates against cannot disagree with the bytes
+this application produces.
 
-**Do not reach for `[JsonConverter(typeof(JsonStringEnumConverter))]`.** It works on a JIT host and
-cannot work under Native AOT, so it fails when the application is published rather than when it is
-written. `SYSLIB1034` says so wherever the compiler can see the enum from a context. The generic
-`JsonStringEnumConverter<TEnum>` is the safe form if you want a per-enum attribute, and the context
-is the better answer.
+The default is camelCase: `InProgress` goes out as `"inProgress"`. To choose something else, set it
+for the assembly, for one enum, or both:
+
+```csharp
+[assembly: JsonEnumNaming(EnumNaming.KebabCaseLower)]   // "in-progress"
+
+[JsonEnumNaming(EnumNaming.MemberName)]                 // opts out: "AB12"
+public enum LegacyCode { AB12, CD34 }
+```
+
+**Decide this before the first client.** Changing an enum's vocabulary later breaks every consumer
+and no compiler will say so.
+
+Only enums this assembly declares are given a vocabulary. A `[Flags]` enum is left alone — a
+combination of members has no single member name to write — and so is anything from a referenced
+framework, since renaming those would redefine a contract that is not this application's.
+
+**Do not reach for `[JsonConverter(typeof(JsonStringEnumConverter))]`.** It writes the C# member
+name rather than a wire value, it never reaches the published document, and the non-generic form
+cannot work under Native AOT — so it fails when the application is published rather than when it is
+written. `SYSLIB1034` says so where the compiler can see it.
 
 #endif
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
@@ -1,0 +1,54 @@
+#if (codeFirst)
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Hardened1;
+
+/// <summary>
+/// How this application's own types reach the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as an <c>IJsonTypeInfoResolver</c> in <c>TemplateModuleNameLibrary</c>, which is what
+/// puts it ahead of reflection for every serializer in the pipeline - the request body, the
+/// response body and a streamed item all resolve through the same chain.
+/// </para>
+/// <para>
+/// <b>Enums are the reason this is here rather than optional.</b> System.Text.Json writes an enum
+/// as its number unless something says otherwise, so a <c>Priority</c> property leaves as
+/// <c>{"priority":0}</c> and a client sending <c>"high"</c> is answered 400 - in an application
+/// that builds clean and has no obvious defect to find. <c>UseStringEnumConverter</c> is the
+/// setting that changes it, and it is set below.
+/// </para>
+/// <para>
+/// It is set <em>here</em>, rather than by attributing the enum with
+/// <c>[JsonConverter(typeof(JsonStringEnumConverter))]</c>, because that converter builds a
+/// converter per enum at run time and Native AOT cannot. The attribute works on a JIT host and
+/// stops working when the application is published - the direction of failure that is found last.
+/// A source-generated context has the enum at compile time and carries no such trap. If you do
+/// reach for the attribute, use the generic <c>JsonStringEnumConverter&lt;TEnum&gt;</c>; the
+/// compiler says so as SYSLIB1034 when it can see the enum from here.
+/// </para>
+/// <para>
+/// The value written is the C# member name - <c>{"priority":"High"}</c>, a PascalCase value in a
+/// camelCase property, because <c>PropertyNamingPolicy</c> governs property names and does not
+/// reach enum members. An application that wants <c>"high"</c> or <c>"in-progress"</c> on the wire
+/// says so with a converter carrying that vocabulary:
+/// <code>
+/// public sealed class KebabEnum&lt;T&gt; : JsonStringEnumConverter&lt;T&gt;
+///     where T : struct, Enum {
+///     public KebabEnum() : base(JsonNamingPolicy.KebabCaseLower) { }
+/// }
+/// </code>
+/// That is a wire-format decision, so make it before the first client rather than after.
+/// </para>
+/// <para>
+/// Every type serialized by name needs a <c>[JsonSerializable]</c> line. A type with none is still
+/// served by reflection on a JIT host, and is the exception a published AOT build throws.
+/// </para>
+/// </remarks>
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web, UseStringEnumConverter = true)]
+[JsonSerializable(typeof(Todo))]
+[JsonSerializable(typeof(NewTodo))]
+public partial class TemplateModuleNameJsonContext : JsonSerializerContext;
+#endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
@@ -14,40 +14,21 @@ namespace Hardened1;
 /// response body and a streamed item all resolve through the same chain.
 /// </para>
 /// <para>
-/// <b>Enums are the reason this is here rather than optional.</b> System.Text.Json writes an enum
-/// as its number unless something says otherwise, so a <c>Priority</c> property leaves as
-/// <c>{"priority":0}</c> and a client sending <c>"high"</c> is answered 400 - in an application
-/// that builds clean and has no obvious defect to find. <c>UseStringEnumConverter</c> is the
-/// setting that changes it, and it is set below.
+/// A model listed here is one a published Native AOT build can serialize. A type with no
+/// <c>[JsonSerializable]</c> line still works on a JIT host, by reflection, and is the
+/// <c>NotSupportedException</c> that build throws - so the list is worth keeping complete even
+/// while nothing here is published AOT.
 /// </para>
 /// <para>
-/// It is set <em>here</em>, rather than by attributing the enum with
-/// <c>[JsonConverter(typeof(JsonStringEnumConverter))]</c>, because that converter builds a
-/// converter per enum at run time and Native AOT cannot. The attribute works on a JIT host and
-/// stops working when the application is published - the direction of failure that is found last.
-/// A source-generated context has the enum at compile time and carries no such trap. If you do
-/// reach for the attribute, use the generic <c>JsonStringEnumConverter&lt;TEnum&gt;</c>; the
-/// compiler says so as SYSLIB1034 when it can see the enum from here.
-/// </para>
-/// <para>
-/// The value written is the C# member name - <c>{"priority":"High"}</c>, a PascalCase value in a
-/// camelCase property, because <c>PropertyNamingPolicy</c> governs property names and does not
-/// reach enum members. An application that wants <c>"high"</c> or <c>"in-progress"</c> on the wire
-/// says so with a converter carrying that vocabulary:
-/// <code>
-/// public sealed class KebabEnum&lt;T&gt; : JsonStringEnumConverter&lt;T&gt;
-///     where T : struct, Enum {
-///     public KebabEnum() : base(JsonNamingPolicy.KebabCaseLower) { }
-/// }
-/// </code>
-/// That is a wire-format decision, so make it before the first client rather than after.
-/// </para>
-/// <para>
-/// Every type serialized by name needs a <c>[JsonSerializable]</c> line. A type with none is still
-/// served by reflection on a JIT host, and is the exception a published AOT build throws.
+/// <b>Enums are not configured here.</b> The build writes a converter for every enum this
+/// application puts on the wire, carrying the values the generated OpenAPI document declares, and
+/// registers it alongside this. <c>[JsonEnumNaming]</c> chooses the vocabulary - see
+/// <c>AGENTS.md</c>. <c>UseStringEnumConverter</c> is deliberately absent: it writes the C# member
+/// name, which is an identifier rather than a wire value, and it would not reach the document at
+/// all.
 /// </para>
 /// </remarks>
-[JsonSourceGenerationOptions(JsonSerializerDefaults.Web, UseStringEnumConverter = true)]
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
 [JsonSerializable(typeof(Todo))]
 [JsonSerializable(typeof(NewTodo))]
 public partial class TemplateModuleNameJsonContext : JsonSerializerContext;

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
@@ -1,7 +1,10 @@
 using Hardened.Shared.Runtime.Attributes;
 #if (codeFirst)
+using System.Text.Json.Serialization.Metadata;
+using DependencyModules.Runtime.Interfaces;
 using Hardened.Web.Runtime.Attributes;
 using Hardened.Web.Runtime.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
 #endif
 using Hardened.Web.Runtime.DependencyInjection;
 
@@ -30,5 +33,25 @@ namespace Hardened1;
 // Spec-first applications do not use this at all: their document is a build input, published by
 // PublishUrl on the spec item instead.
 [Enable<OpenApiDocumentPublishing>]
-#endif
+public partial class TemplateModuleNameLibrary : IServiceCollectionConfiguration {
+
+    /// <summary>
+    /// Says how this application's types are written, ahead of reflection.
+    /// </summary>
+    /// <remarks>
+    /// One registration, read by every JSON serializer in the pipeline - the request body, the
+    /// response body, and a streamed item. Enums are not configured here: the build writes a
+    /// converter for each one and registers it alongside this - see
+    /// <see cref="TemplateModuleNameJsonContext"/> and [JsonEnumNaming].
+    ///
+    /// A resolver the container does not know about is a resolver the serializers never ask, and
+    /// nothing reports that - so this line is the difference between a configured context and a
+    /// decorative one.
+    /// </remarks>
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddSingleton<IJsonTypeInfoResolver>(TemplateModuleNameJsonContext.Default);
+    }
+}
+#else
 public partial class TemplateModuleNameLibrary;
+#endif


### PR DESCRIPTION
`services.AddSingleton<IJsonTypeInfoResolver>(MyContext.Default)` is how everything else in this framework is configured, and it did nothing on a JIT host. Pulling that thread found three more defects behind it.

## The registration was accepted and ignored

The two reflection serializers did not take resolvers at all. The Aot and streaming serializers did, but installed the reflection fallback while building their options — putting a `DefaultJsonTypeInfoResolver` at the head of the chain, where it answers for nearly every type, so the resolvers appended after it were never reached.

Neither failed. Both wrote `{"category":0}` from a context saying enums are strings. It also inverted where it matters: a published AOT application installs no reflection resolver, so the context governed production and did not govern the tests covering it.

`JsonTypeInfoLookup.WithResolvers` now states the order once — resolvers, then reflection — and the serializers build their chains through it. `AppendReflectionFallback` is separate from `WithReflectionFallback` because the latter installs reflection only onto an empty chain: any resolver at all makes `TypeInfoResolver` non-null and silences it, which withholds the fallback for `string` and everything else no context declares.

## The AOT serializers reflected

A class named for AOT that resolves by reflection wherever reflection is available makes the developer's build the one configuration where a missing `[JsonSerializable]` is invisible — it works locally and is a `NotSupportedException` after publishing. `AotJsonSerializer` inherited one because `DefaultConfiguration` baked it into the shared options instance both `IJsonSerializer` implementations mutate in place.

The shared configuration now carries no resolver and the consumer decides. `StreamingJsonResponseSerializer` keeps its reflection tail deliberately — it has no Aot twin and serves both hosts from one class.

## The published document contradicted the wire

`JsonSchemaWriter` declared every code-first enum as `{"type":"string","enum":["InProgress"]}` unconditionally while the serializer wrote `0`. The document is the deliverable — consumers run Kiota or NSwag against it rather than reading the C# — so that generated clients with string enums that could not talk to the API they were generated from.

`[JsonEnumNaming]` settles all four sites from one resolution: the converter that writes, the converter that reads, the `IStringConverter` the parameter binder uses, and the `enum` array in the description. Assembly-level default, per-enum override. This is the code-first counterpart of what `EnumConverterEmitter` already gives a contract-first application, driven by an attribute instead of a document.

Only enums the compilation declares, never a `[Flags]` enum. A model graph reaches much further than it looks — a property typed `Exception` pulls in `System.Reflection.MethodAttributes` — and the first cut anchored ownership on the root type's assembly, so a handler returning a framework type made every BCL enum below it look locally declared. Members are deduplicated by value and by wire form, since aliases are legal and two switch arms on one constant do not compile.

## Breaking

- **Enum wire format.** A code-first application carrying an enum goes from `{"priority":0}` to `{"priority":"inProgress"}`. The document already claimed the string form, so the published contract is unchanged — only the implementation catches up to it. **Needs a release note.**
- **Constructor signatures.** `SystemTextJsonResponseSerializer`, `SystemTextJsonRequestDeserializer`, `JsonSerializerImpl` and `HandlerSchema` take an added parameter. All are resolved from DI or constructed with a default in practice.

## Verified

Rebased onto `ec6ff3e` and re-run there:

- `dotnet build --configuration Release -p:ContinuousIntegrationBuild=true` — exit 0, no warnings
- `dotnet test --configuration Release` — exit 0, **4936 passing**, 0 failures
- `scripts/verify-templates.sh` — exit 0; seven host/contract/response combinations, the library template, dotted project names, the three AWS Lambda templates, host independence. The smithy contract was skipped, as that script does without the CLI pinned at 1.73.0.
- Six end-to-end tests in `Hardened.IntegrationTests.WebApp.SUT` cover write, read, undeclared-value refusal, per-enum override, query binding, and the document agreeing with all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG9KhWk7HngQ94VgqbhnK7