### PR TITLE
Read the permissions a description declares, and require them

### DIFF
--- a/docs/described-authorization.md
+++ b/docs/described-authorization.md
@@ -1,0 +1,177 @@
+# Described authorization
+
+What a description says an operation requires of its caller, and what Hardened does with it.
+
+## The short version
+
+A description carries **authorization**. It does not carry **authentication**.
+
+Which scheme a caller proves themselves with — which issuer, which token format, which JWKS
+endpoint — is configuration this application already owns, and a description cannot know it. Which
+*permissions* an operation needs is a fact about the operation, belongs beside it, and maps onto
+`Requirement` without an intermediary.
+
+So Hardened reads **scopes and ignores schemes**. The scheme decides only one thing: whether the
+entry carries scopes at all.
+
+## What is read
+
+| declaration | becomes |
+|---|---|
+| `oauth2: ["pets:read"]` | `Requirement.Grant("pets:read")` |
+| `oauth2: ["pets:read", "pets:write"]` | `Grant("pets:read") & Grant("pets:write")` |
+| `apiKey: []` — any scheme with no scopes | `Requirement.Authenticated()` |
+| `[{ oauth2: [...] }, { apiKey: [] }]` | `AnyOf(...)` — the array is an OR |
+| `{ oauth2: [...], apiKey: [] }` | `AllOf(...)` — keys in one entry are an AND |
+| `security: []` on an operation | **nothing** |
+| no `security` at all | the document-level default, or nothing |
+
+Only `oauth2` and `openIdConnect` may carry scopes. The specification requires every other type to
+declare an empty array, so those say "be someone" and nothing more.
+
+A scope name is read as a grant name, unchanged. No prefixing, no namespacing: prefixing would
+impose a naming convention on every application to solve a collision almost none of them have.
+
+### An empty array means two different things
+
+They are opposites and conflating them would be a bad defect.
+
+- **`{ oauth2: [] }`** — an empty *scope* array. The caller must be authenticated and needs no
+  particular permission.
+- **`security: []`** — an empty *security* array. The specification's way of opting one operation
+  out of a document-level default. It derives **nothing**.
+
+### Why an unscoped entry is a requirement, not the absence of one
+
+This is the load-bearing rule.
+
+```yaml
+security:
+  - oauth2: ["pets:write"]
+  - apiKey: []
+```
+
+Read the second entry as "requires nothing" and the OR is satisfied by everybody — a document that
+reads as protective would generate a requirement **weaker than declaring none at all**. It becomes
+`Authenticated()`, which is a real requirement, so the alternative stays an alternative.
+
+## It narrows, and can never open
+
+A described requirement arrives as one more entry in the handler's metadata, alongside anything the
+implementation declared. `IExecutionRequestHandlerInfo.RequirementFrom` conjoins every
+`IAuthorizeAttribute` it finds there, so:
+
+- A contract can **narrow** a route.
+- A contract can **never widen** one. `security: []` does not strip an `[AuthorizeGrants]` somebody
+  wrote on the implementation.
+- `[AllowAnonymous]` remains the single thing that cancels it — the same rule an attribute or a
+  convention is held to.
+
+This is why `security: []` derives nothing rather than deriving `[AllowAnonymous]`. An author who
+wants a route anonymous says so in code, where it is visible to whoever reads the handler.
+
+It is also why the requirement is metadata rather than the `requirement` parameter on
+`ExecutionRequestHandlerInfo`: that reads `requirement ?? RequirementFrom(Metadata)`, so passing it
+there would have **silenced** an attribute on the implementation instead of composing with it.
+
+## Enforcement needs no opt-in
+
+`AuthorizationFilterProvider`'s `requireAuthorization` flag decides what happens to a handler that
+declares **nothing**. A handler that declares something is guarded either way.
+
+So a contract that names a scope protects its route on the next build, rather than on the next time
+somebody remembers to turn a posture on.
+
+> **This makes adding `security` to an existing contract a breaking change for its callers.** An
+> operation that answered 200 to an anonymous request answers 401 once the description says it needs
+> a scope. That is the correct behaviour and it is not a quiet one — it is worth a release note when
+> it happens to a published contract.
+
+## Smithy carries less, and that is the language
+
+Smithy has no equivalent of an OAuth scope. A model can say a caller must be authenticated; it
+cannot say what they must hold.
+
+| declaration | becomes |
+|---|---|
+| service declares `@httpBearerAuth` (or any scheme) | `Requirement.Authenticated()` |
+| operation carries `@optionalAuth` | nothing |
+| `@auth([])` on the operation or the service | nothing |
+| service declares no scheme | nothing |
+
+The auth traits were previously classified `Ignorable`, on the grounds that "authentication is
+Hardened's own story rather than the IDL's". That is right about the *scheme* and wrong about
+whether an operation needs one at all, which is a fact about the operation.
+
+Making a stock Smithy model carry permissions would need a custom trait — `@grants(["pets:read"])`.
+Smithy's trait system is built for that and it would be small, but it puts a Hardened-specific
+extension in a model whose portability is usually the reason Smithy was chosen. Not done; nothing
+about the design forecloses it.
+
+## Diagnostics
+
+A `security` entry naming a scheme that `components.securitySchemes` does not declare is reported.
+The reference is dangling — the document's own error — and reading its scope list would invent
+authorization out of a name that resolves to nothing. The operation falls back to requiring an
+authenticated caller and **none of the permissions it names**, which is a downgrade nobody asked
+for, so it is a build message rather than a discovery in production.
+
+---
+
+# Not built: publishing security into a generated document
+
+Code-first does not emit `security` into the document it generates. This is the other half of the
+gap and it is **deliberately unbuilt**, with the design settled.
+
+## It must be opt-in
+
+Publishing OAuth scopes is normal — a client has to request them at authorization time, and
+RFC 6750 goes as far as telling a 403 to name the scope it wanted. That argument does **not**
+transfer to code-first.
+
+**Hardened grants are not OAuth scopes.** They are an arbitrary internal vocabulary. A contract-first
+application that wrote `oauth2: ["pets:read"]` has already declared those strings as OAuth scopes and
+published them by authorship. A code-first application that wrote
+`[AuthorizeGrants("billing:write", "feature:experimental-pricing")]` has declared nothing of the
+sort — and those names can disclose an unreleased feature, a capability that exists, or the shape of
+an internal permission tree.
+
+The codebase already treats document content as a deliberate exposure: the template gates its
+reference page to development because "the page describes every operation this service exposes …
+neither of which a deployed API obviously wants".
+
+## The opt-in is the scheme declaration, not a flag
+
+A document cannot carry `security` without `components.securitySchemes`, and nothing in code-first
+source says what the scheme is:
+
+```yaml
+security:
+  - ???: ["billing:write"]     # scheme name? type? token URL? flows?
+```
+
+`[AuthorizeGrants]` does not say whether the application is behind OAuth, an API key, or a gateway.
+The author has to describe the scheme regardless — so **that declaration is the opt-in**:
+
+- **Declare a scheme** → you have said what to emit against, and said it deliberately.
+- **Declare nothing** → nothing is emitted, because nothing valid can be.
+
+Opt-in by construction rather than by flag. There is no default to get wrong and no way to switch it
+on by accident.
+
+## Once opted in, publish every grant
+
+**Decided.** Declaring the scheme publishes the grants of every operation.
+
+The alternative — opting each grant in individually — is the kind of thing people forget, and what it
+leaves behind is a document that is confidently wrong about which endpoints are protected. A document
+that is complete or absent is more useful than one that is quietly partial.
+
+## The grant-to-scope mapping lives in the same place
+
+Reading a scope name as a grant name assumes one vocabulary. That holds when you own both and fails
+when scopes are `https://api.example.com/pets.read` and grants are `pets:read`.
+
+The scheme declaration is the natural home for that mapping too — an author writing "my scheme is
+`oauth2`, here is its token URL, here are the scopes it issues" is already writing the thing that
+says how a grant is spelled on the wire. Both open items are one feature rather than two.

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
@@ -1,0 +1,73 @@
+namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
+
+/// <summary>
+/// Authorization a description declared, over a real request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Neither handler carries an authorization attribute and this application registers no
+/// authorization of its own. Everything guarding these routes came from <c>security</c> in the
+/// document, which is the whole claim: a described requirement reaches the pipeline and refuses.
+/// </para>
+/// <para>
+/// <b>No opt-in was needed.</b> <c>AuthorizationFilterProvider</c>'s <c>requireAuthorization</c> flag
+/// decides what happens to a handler that declares <em>nothing</em>; a handler that declares
+/// something is guarded either way. So a contract that names a scope protects its route on the next
+/// build, rather than on the next time somebody remembers to turn a posture on.
+/// </para>
+/// </remarks>
+public class DescribedSecurityTests {
+
+    /// <summary>
+    /// A scope in the description refuses a caller who holds nothing.
+    /// </summary>
+    [HardenedTest]
+    public async Task ADescribedScopeRefusesAnAnonymousCaller(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/scoped");
+
+        Assert.Equal(401, response.StatusCode);
+    }
+
+    /// <summary>
+    /// An alternative that carries no scopes still refuses one - the case that would have been open
+    /// to everybody had an empty scope array been read as "requires nothing".
+    /// </summary>
+    /// <remarks>
+    /// The document offers two ways in: an OAuth token carrying <c>pets:read</c>, or an API key.
+    /// Neither is "nobody", so the OR must not be satisfied by an anonymous caller. Reading the
+    /// unscoped alternative as the absence of a requirement would have made this route public while
+    /// its description said otherwise.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnUnscopedAlternativeStillRefusesAnAnonymousCaller(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/either");
+
+        Assert.Equal(401, response.StatusCode);
+    }
+
+    /// <summary>
+    /// A route the description declares public is left alone, and answers.
+    /// </summary>
+    /// <remarks>
+    /// <c>listStores</c> declares <c>security: []</c>. That derives no requirement rather than
+    /// deriving <c>[AllowAnonymous]</c> - a described requirement is conjoined with what the handler
+    /// declared, so it may narrow a route and must never open one - and with nothing else guarding
+    /// this application the route answers.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ARouteDeclaredPublicIsNotGuarded(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/stores");
+
+        response.Assert.Ok();
+    }
+
+    /// <summary>
+    /// A route the description says nothing about is untouched.
+    /// </summary>
+    [HardenedTest]
+    public async Task ARouteWithNoDeclaredSecurityIsNotGuarded(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/pets");
+
+        response.Assert.Ok();
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
@@ -1,0 +1,18 @@
+using Hardened.IntegrationTests.OpenApi.SUT.Services;
+using Hardened.Requests.Abstract.Attributes;
+
+namespace Hardened.IntegrationTests.OpenApi.SUT;
+
+/// <summary>
+/// Handlers that exist to be refused.
+/// </summary>
+/// <remarks>
+/// Neither carries an authorization attribute. Everything guarding them came from the description,
+/// which is the point: reaching either method at all is the failure these routes test for.
+/// </remarks>
+[Handler]
+public class SecuredServiceImpl : ISecuredService {
+    public Task<string> SecuredScoped() => Task.FromResult("reached");
+
+    public Task<string> SecuredEither() => Task.FromResult("reached");
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -69,6 +69,38 @@ paths:
   # declared member and nothing rejects a zero, so omitting either used to be answered 201 with a
   # value the caller never sent. `lines` carries constraints on its *items*, which were generated,
   # registered in DI, and never called.
+  # Two operations whose only job is to be guarded. Kept apart from the routes the validation and
+  # enum suites drive: a requirement on one of those turns every test that calls it into an
+  # authorization test, which is how the first attempt at this broke fourteen of them.
+  /secured/scoped:
+    get:
+      tags:
+        - Secured
+      operationId: securedScoped
+      security:
+        - petstoreOAuth: ["pets:read"]
+      responses:
+        '200':
+          description: Allowed.
+          content:
+            application/json:
+              schema:
+                type: string
+  /secured/either:
+    get:
+      tags:
+        - Secured
+      operationId: securedEither
+      security:
+        - petstoreOAuth: ["pets:read"]
+        - petstoreApiKey: []
+      responses:
+        '200':
+          description: Allowed.
+          content:
+            application/json:
+              schema:
+                type: string
   /orders:
     post:
       tags:
@@ -245,6 +277,7 @@ paths:
       tags:
         - Store
       operationId: listStores
+      security: []
       responses:
         '200':
           description: A list of stores
@@ -255,6 +288,22 @@ paths:
                 items:
                   $ref: '#/components/schemas/Store'
 components:
+  securitySchemes:
+    # Carries scopes, so its entries become grants.
+    petstoreOAuth:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.invalid/token
+          scopes:
+            "pets:read": Read pets.
+            "pets:write": Create and change pets.
+    # Cannot carry scopes - the specification requires the array to be empty - so an entry naming
+    # this one says "be authenticated" and nothing more.
+    petstoreApiKey:
+      type: apiKey
+      name: X-Api-Key
+      in: header
   schemas:
     # readOnly and writeOnly, which make one schema describe two directions: the server assigns
     # the id and never accepts one, and the password is accepted and never returned.

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -70,6 +70,11 @@ namespace Hardened.Requests.Runtime.Authorization
         public System.Collections.Generic.IReadOnlyList<string> Grants { get; }
         public Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; }
     }
+    public sealed class DescribedAuthorization : Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute
+    {
+        public DescribedAuthorization(Hardened.Requests.Abstract.Authorization.Requirement requirement) { }
+        public Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; }
+    }
     public interface IAuthorizationConfiguration
     {
         bool RequireAuthorization { get; }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/DescribedAuthorizationTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/DescribedAuthorizationTests.cs
@@ -1,0 +1,82 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Authorization;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Authorization;
+
+/// <summary>
+/// The authorization a description declared, once it is on a handler.
+/// </summary>
+/// <remarks>
+/// A generated handler carries it as one more entry in its metadata, which is what makes it compose
+/// with whatever the implementation declared rather than replacing it. These pin that composition,
+/// because the failure mode is silent in both directions: a described requirement that replaced an
+/// attribute would drop a rule somebody wrote, and one that was ignored would drop the contract's.
+/// </remarks>
+public class DescribedAuthorizationTests {
+
+    /// <summary>
+    /// It is recognised the same way an attribute is - through the interface, not by type name.
+    /// </summary>
+    [Fact]
+    public void ADescribedRequirementReachesTheHandler() {
+        var requirement = Requirement.Grant("pets:write");
+
+        var result = IExecutionRequestHandlerInfo.RequirementFrom(
+            [new DescribedAuthorization(requirement)]);
+
+        Assert.NotNull(result);
+        Assert.Equal(new[] { "pets:write" }, result!.RequiredGrants);
+    }
+
+    /// <summary>
+    /// It conjoins with an attribute the implementation wrote, rather than replacing it.
+    /// </summary>
+    /// <remarks>
+    /// The reason this is metadata rather than the <c>requirement</c> parameter on
+    /// <c>ExecutionRequestHandlerInfo</c>: that reads <c>requirement ?? RequirementFrom(Metadata)</c>,
+    /// so passing it there would have silenced the attribute instead of composing with it.
+    /// </remarks>
+    [Fact]
+    public void ADescribedRequirementNarrowsRatherThanReplaces() {
+        var result = IExecutionRequestHandlerInfo.RequirementFrom([
+            new DescribedAuthorization(Requirement.Grant("pets:write")),
+            new AuthorizeGrantsAttribute("tenant:member")
+        ]);
+
+        Assert.NotNull(result);
+        Assert.Contains("pets:write", result!.RequiredGrants);
+        Assert.Contains("tenant:member", result.RequiredGrants);
+    }
+
+    /// <summary>
+    /// An alternative names every grant that would have satisfied it, so a refusal can say what it
+    /// wanted rather than picking one branch arbitrarily.
+    /// </summary>
+    [Fact]
+    public void AnAlternativeNamesEveryGrantThatWouldSatisfyIt() {
+        var described = new DescribedAuthorization(
+            Requirement.AnyOf(
+                Requirement.Grant("pets:read"),
+                Requirement.Grant("admin:all")));
+
+        Assert.Equal(
+            new[] { "pets:read", "admin:all" },
+            described.Requirement.RequiredGrants);
+    }
+
+    /// <summary>
+    /// A branch that only requires a caller is a requirement, not the absence of one - which is what
+    /// keeps an OR containing it from being satisfied by everybody.
+    /// </summary>
+    [Fact]
+    public void AuthenticatedIsARequirementInItsOwnRight() {
+        var anonymous = AnonymousCallerPrincipal.Instance;
+
+        var described = new DescribedAuthorization(
+            Requirement.AnyOf(Requirement.Grant("pets:read"), Requirement.Authenticated()));
+
+        Assert.False(described.Requirement.IsSatisfiedBy(anonymous, null!));
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/DescribedAuthorization.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/DescribedAuthorization.cs
@@ -1,0 +1,35 @@
+using Hardened.Requests.Abstract.Authorization;
+
+namespace Hardened.Requests.Runtime.Authorization;
+
+/// <summary>
+/// The authorization a description declared, as a handler's generated code carries it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Not an attribute, deliberately.</b> A handler's metadata is an <c>object[]</c> and
+/// <c>IExecutionRequestHandlerInfo.RequirementFrom</c> conjoins every
+/// <see cref="IAuthorizeAttribute"/> it finds there, whatever the concrete type - so this
+/// participates fully without being writable by hand. It could not be written by hand anyway: an
+/// attribute argument must be a constant, and a <see cref="Requirement"/> is a tree.
+/// </para>
+/// <para>
+/// <b>It composes rather than replaces.</b> Because it arrives as one more requirement among the
+/// handler's own, a described requirement is conjoined with anything the implementation declared -
+/// so a contract can narrow a route and cannot widen one. <c>[AllowAnonymous]</c> remains the single
+/// thing that cancels it, which is the same rule an attribute or a convention is held to.
+/// </para>
+/// <para>
+/// The alternative was passing the requirement to <c>ExecutionRequestHandlerInfo</c> directly, which
+/// reads <c>requirement ?? RequirementFrom(Metadata)</c> - so a described requirement would have
+/// <em>silenced</em> an <c>[AuthorizeGrants]</c> written on the implementation. Composition is the
+/// whole point; that spelling would have inverted it.
+/// </para>
+/// </remarks>
+public sealed class DescribedAuthorization : IAuthorizeAttribute {
+    public DescribedAuthorization(Requirement requirement) {
+        Requirement = requirement;
+    }
+
+    public Requirement Requirement { get; }
+}

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/AuthorizationBranchModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/AuthorizationBranchModel.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hardened.Idl.Models;
+
+/// <summary>
+/// One alternative way a caller may satisfy an operation's declared authorization.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A branch is an <b>AND</b>: every grant it names is required, and <see cref="RequiresAuthentication"/>
+/// is required alongside them. An operation holds a list of these and the list is an <b>OR</b> - which
+/// is OpenAPI's own shape, where <c>security</c> is an array of alternatives and the keys within one
+/// entry are conjoined.
+/// </para>
+/// <para>
+/// <b>Why authentication is a flag rather than a grant.</b> A scheme that carries no scopes -
+/// <c>apiKey</c>, <c>http</c> bearer, or an <c>oauth2</c> entry with an empty array - says the caller
+/// must be someone, not that they must hold something. Modelling that as "no grants" would make the
+/// branch require nothing, and an OR containing a branch that requires nothing is satisfied by
+/// everyone: a document that reads as protective would generate a requirement weaker than having
+/// none. It maps to <c>Requirement.Authenticated()</c>, which is a real requirement.
+/// </para>
+/// </remarks>
+internal class AuthorizationBranchModel : IEquatable<AuthorizationBranchModel> {
+
+    /// <summary>The scopes this branch requires, as grant names. All of them, not any.</summary>
+    public List<string> Grants { get; set; } = new();
+
+    /// <summary>Whether the caller must be authenticated beyond holding the grants above.</summary>
+    public bool RequiresAuthentication { get; set; }
+
+    public bool Equals(AuthorizationBranchModel? other) {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return RequiresAuthentication == other.RequiresAuthentication &&
+               Grants.SequenceEqual(other.Grants);
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as AuthorizationBranchModel);
+
+    public override int GetHashCode() {
+        unchecked {
+            var hash = RequiresAuthentication ? 397 : 0;
+
+            foreach (var grant in Grants) {
+                hash = (hash * 397) ^ grant.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/OperationModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/OperationModel.cs
@@ -152,6 +152,27 @@ internal class OperationModel : IEquatable<OperationModel> {
     // x-filters: typed filter attribute instances applied to this operation
     public List<FilterInstanceModel> FilterInstances { get; set; } = new();
 
+    /// <summary>
+    /// The alternatives a caller may satisfy this operation's declared authorization by, as an OR of
+    /// ANDs. Empty where the description declares none, or declares only what this cannot model.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only <c>oauth2</c> and <c>openIdConnect</c> carry scopes, and a scope name is read as a grant
+    /// name. Every other scheme type is required by the specification to declare an empty array, so
+    /// it says "be authenticated" and nothing more.
+    /// </para>
+    /// <para>
+    /// <b>Empty is not the same as public.</b> An operation declaring <c>security: []</c> - the
+    /// specification's way of opting out of a document-level default - lands here as empty, and so
+    /// does one that declares nothing at all. Neither produces a requirement, and neither may
+    /// <em>remove</em> one: a requirement derived from a description is conjoined with whatever the
+    /// handler declared, exactly as a convention's is, so a description cannot open a route the code
+    /// protected. <c>[AllowAnonymous]</c> stays the only thing that can.
+    /// </para>
+    /// </remarks>
+    public List<AuthorizationBranchModel> AuthorizationBranches { get; set; } = new();
+
     // Validation: body schema properties for validation filter generation
     public List<PropertyModel> RequestBodyProperties { get; set; } = new();
     public List<string> RequestBodyRequired { get; set; } = new();
@@ -203,6 +224,7 @@ internal class OperationModel : IEquatable<OperationModel> {
                ProducedContentTypes.SequenceEqual(other.ProducedContentTypes) &&
                Parameters.SequenceEqual(other.Parameters) &&
                FilterInstances.SequenceEqual(other.FilterInstances) &&
+               AuthorizationBranches.SequenceEqual(other.AuthorizationBranches) &&
                RequestBodyProperties.SequenceEqual(other.RequestBodyProperties) &&
                RequestBodyRequired.SequenceEqual(other.RequestBodyRequired);
     }

--- a/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
@@ -33,7 +33,7 @@ internal static class SpecModelSerializer {
     /// Bumped when the format changes shape. The reader rejects anything else rather than guessing,
     /// because a half-understood model produces wrong code instead of an error.
     /// </summary>
-    private const string Header = "#hardened-openapi-model 1";
+    private const string Header = "#hardened-openapi-model 2";
 
     private const char FieldSeparator = '\t';
 
@@ -194,6 +194,17 @@ internal static class SpecModelSerializer {
                     operation?.RequestBodyRequired.Add(record.String("Value") ?? "");
                     break;
 
+                // One line per OR-branch. Grants are tab-safe by construction - a scope name
+                // containing a tab would already have broken the format - so they travel joined by
+                // a space rather than as one record each, which keeps a document declaring the same
+                // requirement on 200 operations from doubling the file.
+                case "authbranch":
+                    operation?.AuthorizationBranches.Add(new AuthorizationBranchModel {
+                        RequiresAuthentication = record.Bool("Authenticated"),
+                        Grants = Split(record.String("Grants")),
+                    });
+                    break;
+
                 case "filterinstance":
                     filterInstance = new FilterInstanceModel {
                         FilterTypeName = record.String("FilterTypeName") ?? "",
@@ -304,6 +315,12 @@ internal static class SpecModelSerializer {
     /// barely switches on it - and a trap for any kind added later, which would have been silently
     /// collapsed the same way.
     /// </remarks>
+    /// <summary>A space-joined list back to its parts, with an absent or empty value as empty.</summary>
+    private static List<string> Split(string? value) =>
+        string.IsNullOrEmpty(value)
+            ? new List<string>()
+            : new List<string>(value!.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries));
+
     private static SchemaKind ReadSchemaKind(string? value) {
         switch (value) {
             case nameof(SchemaKind.Enum): return SchemaKind.Enum;
@@ -495,6 +512,13 @@ internal static class SpecModelSerializer {
             var required = new Record("bodyrequired");
             required.Add("Value", value);
             required.WriteTo(builder);
+        }
+
+        foreach (var branch in operation.AuthorizationBranches) {
+            var authBranch = new Record("authbranch");
+            authBranch.Add("Authenticated", branch.RequiresAuthentication);
+            authBranch.Add("Grants", string.Join(" ", branch.Grants));
+            authBranch.WriteTo(builder);
         }
 
         foreach (var instance in operation.FilterInstances) {

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
@@ -188,6 +188,20 @@ internal static class RequestModelBuilder {
                 ""));
         }
 
+        // What the description said this operation requires of its caller.
+        //
+        // Emitted as one more entry in the handler's metadata rather than handed to
+        // ExecutionRequestHandlerInfo directly, because that reads
+        // `requirement ?? RequirementFrom(Metadata)` - passing it there would silence an
+        // [AuthorizeGrants] written on the implementation instead of composing with it.
+        if (AuthorizationExpression(operation) is { } authorization) {
+            filters.Add(new AttributeModel(
+                TypeDefinition.Get(
+                    "Hardened.Requests.Runtime.Authorization", "DescribedAuthorization"),
+                authorization,
+                ""));
+        }
+
         // Wire in x-filters as typed attribute instances
         foreach (var filterInstance in operation.FilterInstances) {
             if (filterTypeLookup.TryGetValue(filterInstance.FilterTypeName, out var filterType)) {
@@ -410,6 +424,56 @@ internal static class RequestModelBuilder {
     }
 
 
+
+    /// <summary>
+    /// The described authorization as a <c>Requirement</c> expression, or null where the description
+    /// declared none.
+    /// </summary>
+    /// <remarks>
+    /// An OR of ANDs, which is the shape both sides already have: <c>security</c> is an array of
+    /// alternatives whose entries are conjoined, and <c>Requirement</c> is a boolean algebra over
+    /// grants. Written out rather than reduced - a single branch with a single grant emits
+    /// <c>Grant("x")</c> and not <c>AnyOf(AllOf(Grant("x")))</c> - because this lands in a generated
+    /// file somebody will read.
+    /// </remarks>
+    private static string? AuthorizationExpression(OperationModel operation) {
+        if (operation.AuthorizationBranches.Count == 0) {
+            return null;
+        }
+
+        var branches = new List<string>();
+
+        foreach (var branch in operation.AuthorizationBranches) {
+            var terms = new List<string>();
+
+            foreach (var grant in branch.Grants) {
+                terms.Add(RequirementType + ".Grant(\"" + grant.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\")");
+            }
+
+            if (branch.RequiresAuthentication) {
+                terms.Add(RequirementType + ".Authenticated()");
+            }
+
+            if (terms.Count == 0) {
+                continue;
+            }
+
+            branches.Add(terms.Count == 1
+                ? terms[0]
+                : RequirementType + ".AllOf(" + string.Join(", ", terms) + ")");
+        }
+
+        if (branches.Count == 0) {
+            return null;
+        }
+
+        return branches.Count == 1
+            ? branches[0]
+            : RequirementType + ".AnyOf(" + string.Join(", ", branches) + ")";
+    }
+
+    private const string RequirementType =
+        "global::Hardened.Requests.Abstract.Authorization.Requirement";
 
     /// <summary>
     /// The operation's declared response set, encoded for the shared dispatch emitter, or null

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
@@ -343,6 +343,13 @@ public class SpecModelSerializerTests {
                 new ErrorResponseModel { StatusCode = 503 },
             },
             FilterInstances = { filterInstance },
+            // Both shapes, because they serialize differently: one carries grants and the other
+            // carries only the authentication flag, and a reader that dropped the flag would turn
+            // "be someone" into "requires nothing".
+            AuthorizationBranches = {
+                new AuthorizationBranchModel { Grants = { "pets:read", "pets:write" } },
+                new AuthorizationBranchModel { RequiresAuthentication = true },
+            },
             RequestBodyProperties = { property },
             RequestBodyRequired = { "name", "tag" },
         };

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -164,7 +164,7 @@ internal static class OpenApiSpecParser {
             foreach (var pathKvp in document.Paths) {
                 cancellationToken.ThrowIfCancellationRequested();
                 ParsePath(basePath + pathKvp.Key, pathKvp.Value, operationsByTag, synthesized,
-                    groupUntaggedByPath);
+                    groupUntaggedByPath, document, diagnostics);
             }
         }
 
@@ -1407,9 +1407,115 @@ internal static class OpenApiSpecParser {
         return paramModel;
     }
 
+    /// <summary>
+    /// What the description says a caller must hold to invoke this operation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Scopes, not schemes.</b> A scheme names how a caller proves who they are - which issuer,
+    /// which token format - and that is configuration this application already owns; a description
+    /// cannot know it and should not try to. What a description <em>does</em> know is which
+    /// permissions an operation needs, and that maps onto <c>Requirement</c> without an intermediary.
+    /// So the scheme decides only whether the entry carries scopes at all.
+    /// </para>
+    /// <para>
+    /// Only <c>oauth2</c> and <c>openIdConnect</c> may carry them; the specification requires every
+    /// other type to declare an empty array. An entry with no scopes therefore says "be
+    /// authenticated" - which is a requirement, not the absence of one. Reading it as the absence of
+    /// one would be actively unsafe: <c>[{oauth2: [write]}, {apiKey: []}]</c> would become
+    /// "needs write, OR needs nothing", and the OR is then satisfied by everybody.
+    /// </para>
+    /// <para>
+    /// <b>An operation's own <c>security</c> replaces the document's, it does not merge with it.</b>
+    /// That includes an empty one: <c>security: []</c> is how a description opts a single operation
+    /// out of a document-level default, and it is <em>not</em> the same as an empty scope array one
+    /// level down. It produces no branches, which produces no requirement - deliberately not
+    /// <c>[AllowAnonymous]</c>, because a requirement derived from a description is conjoined with
+    /// what the handler declared and must not be able to remove one.
+    /// </para>
+    /// </remarks>
+    private static List<AuthorizationBranchModel> ParseSecurity(
+        OpenApiOperation operation, OpenApiDocument document, string operationId,
+        ICollection<string>? diagnostics) {
+        // Null is "declared nothing, inherit the default"; empty is "declared none, and means it".
+        var declared = operation.Security ?? document.Security;
+
+        if (declared == null || declared.Count == 0) {
+            return new List<AuthorizationBranchModel>();
+        }
+
+        var schemes = document.Components?.SecuritySchemes;
+        var branches = new List<AuthorizationBranchModel>();
+
+        foreach (var requirement in declared) {
+            var branch = new AuthorizationBranchModel();
+
+            foreach (var entry in requirement) {
+                var name = entry.Key?.Reference?.Id;
+                var scopes = entry.Value;
+
+                // A name that resolves to nothing is the document's own error, and a silent
+                // fallback to "be authenticated" is a downgrade nobody asked for: the operation
+                // stops requiring the permission it named. Reported so the misspelling is a build
+                // message rather than a discovery in production.
+                if (!string.IsNullOrEmpty(name) && !Declares(schemes, name!)) {
+                    diagnostics?.Add(
+                        $"operation '{operationId}' requires security scheme '{name}', which " +
+                        "'components.securitySchemes' does not declare. Its scopes were not read, " +
+                        "so the operation requires an authenticated caller and none of the " +
+                        "permissions it names.");
+                }
+
+                if (!string.IsNullOrEmpty(name) &&
+                    scopes is { Count: > 0 } &&
+                    CarriesScopes(schemes, name!)) {
+                    foreach (var scope in scopes) {
+                        if (!string.IsNullOrEmpty(scope) && !branch.Grants.Contains(scope)) {
+                            branch.Grants.Add(scope);
+                        }
+                    }
+                } else {
+                    // Either a scheme that cannot carry scopes, or one that can and declared none.
+                    // Both say the same thing about the caller.
+                    branch.RequiresAuthentication = true;
+                }
+            }
+
+            // An entry naming no schemes at all is not a way in. Dropping it rather than admitting
+            // an empty AND, which would be satisfied by anyone and would take the whole OR with it.
+            if (branch.Grants.Count > 0 || branch.RequiresAuthentication) {
+                branches.Add(branch);
+            }
+        }
+
+        return branches;
+    }
+
+    /// <summary>
+    /// Whether a named scheme is one the specification lets carry scopes.
+    /// </summary>
+    /// <remarks>
+    /// A scheme the document never declared is treated as not carrying them. The reference is
+    /// dangling, which is the document's own error, and reading its scope list would invent
+    /// authorization out of a name that resolves to nothing.
+    /// </remarks>
+    private static bool CarriesScopes(
+        IDictionary<string, IOpenApiSecurityScheme>? schemes, string name) {
+        if (schemes == null || !schemes.TryGetValue(name, out var scheme)) {
+            return false;
+        }
+
+        return scheme.Type is SecuritySchemeType.OAuth2 or SecuritySchemeType.OpenIdConnect;
+    }
+
+    /// <summary>Whether the document declares the named scheme at all.</summary>
+    private static bool Declares(
+        IDictionary<string, IOpenApiSecurityScheme>? schemes, string name) =>
+        schemes != null && schemes.ContainsKey(name);
+
     private static void ParsePath(string path, IOpenApiPathItem pathItem,
         Dictionary<string, List<OperationModel>> operationsByTag, SchemaCollector collector,
-        bool groupUntaggedByPath) {
+        bool groupUntaggedByPath, OpenApiDocument document, ICollection<string>? diagnostics) {
         if (pathItem.Operations == null) {
             return;
         }
@@ -1431,7 +1537,8 @@ internal static class OpenApiSpecParser {
                 Tag = tag,
                 // Summary first: it is the one-line form, and a doc comment is one line.
                 Description = FirstNonEmpty(operation.Summary, operation.Description),
-                IsDeprecated = operation.Deprecated
+                IsDeprecated = operation.Deprecated,
+                AuthorizationBranches = ParseSecurity(operation, document, operationId, diagnostics)
             };
 
             foreach (var param in MergeParameters(pathItem.Parameters, operation.Parameters)) {

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DescribedAuthorizationEmitTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DescribedAuthorizationEmitTests.cs
@@ -1,0 +1,121 @@
+using Hardened.SourceGeneration.Testing;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// The <c>Requirement</c> expression a described operation's handler carries.
+/// </summary>
+/// <remarks>
+/// Written out rather than reduced to a canonical form, because this lands in a generated file
+/// somebody will read while working out why a request was refused. One grant emits
+/// <c>Grant("x")</c>, not <c>AnyOf(AllOf(Grant("x")))</c>.
+/// </remarks>
+public class DescribedAuthorizationEmitTests {
+
+    private static string Handler(string security) {
+        var result = OpenApiGenerator.Run(
+            $$"""
+              openapi: "3.0.0"
+              info: { title: Pets, version: "1.0" }
+              paths:
+                /pets:
+                  get:
+                    tags: [Pet]
+                    operationId: listPets
+              {{security}}
+                    responses:
+                      '200':
+                        description: A pet
+                        content:
+                          application/json:
+                            schema:
+                              $ref: '#/components/schemas/Pet'
+              components:
+                securitySchemes:
+                  oauth:
+                    type: oauth2
+                    flows:
+                      clientCredentials:
+                        tokenUrl: https://example.invalid/token
+                        scopes:
+                          "pets:read": Read.
+                          "pets:write": Write.
+                  key:
+                    type: apiKey
+                    name: X-Api-Key
+                    in: header
+                schemas:
+                  Pet:
+                    type: object
+                    properties:
+                      id: { type: string }
+              """).AssertNoErrors();
+
+        return string.Join(
+            "\n",
+            result.GeneratedSources
+                .Where(pair => pair.Key.Contains("ListPets"))
+                .Select(pair => pair.Value));
+    }
+
+    private const string Prefix = "global::Hardened.Requests.Abstract.Authorization.Requirement";
+
+    /// <summary>One grant emits one term, with no wrapper around it.</summary>
+    [Fact]
+    public void OneGrantEmitsOneTerm() {
+        var handler = Handler("""      security: [{ oauth: ["pets:read"] }]""");
+
+        Assert.Contains(
+            "new global::Hardened.Requests.Runtime.Authorization.DescribedAuthorization(" +
+            Prefix + ".Grant(\"pets:read\")",
+            handler);
+
+        Assert.DoesNotContain(".AllOf(", handler);
+        Assert.DoesNotContain(".AnyOf(", handler);
+    }
+
+    /// <summary>Several grants on one scheme are conjoined.</summary>
+    [Fact]
+    public void SeveralGrantsAreConjoined() {
+        Assert.Contains(
+            Prefix + ".AllOf(" + Prefix + ".Grant(\"pets:read\"), " + Prefix + ".Grant(\"pets:write\"))",
+            Handler("""      security: [{ oauth: ["pets:read", "pets:write"] }]"""));
+    }
+
+    /// <summary>
+    /// Alternatives are an OR, and an unscoped one becomes <c>Authenticated()</c> rather than being
+    /// dropped - which would leave an OR that anybody satisfies.
+    /// </summary>
+    [Fact]
+    public void AlternativesBecomeAnOrAndAnUnscopedOneRequiresACaller() {
+        Assert.Contains(
+            Prefix + ".AnyOf(" + Prefix + ".Grant(\"pets:read\"), " + Prefix + ".Authenticated())",
+            Handler("""      security: [{ oauth: ["pets:read"] }, { key: [] }]"""));
+    }
+
+    /// <summary>
+    /// It sits in the handler's metadata beside whatever else is there, which is what makes it
+    /// compose with an attribute rather than replace one.
+    /// </summary>
+    [Fact]
+    public void ItIsCarriedAsHandlerMetadata() {
+        Assert.Contains(
+            "_metadata", Handler("""      security: [{ oauth: ["pets:read"] }]"""));
+    }
+
+    /// <summary>A description declaring none emits none.</summary>
+    [Fact]
+    public void NoDeclaredSecurityEmitsNothing() {
+        Assert.DoesNotContain("DescribedAuthorization", Handler(""));
+    }
+
+    /// <summary>
+    /// <c>security: []</c> emits nothing either - it opts out of a default rather than declaring the
+    /// route anonymous, and a described requirement may never remove one.
+    /// </summary>
+    [Fact]
+    public void AnEmptySecurityArrayEmitsNothing() {
+        Assert.DoesNotContain("DescribedAuthorization", Handler("""      security: []"""));
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DescribedAuthorizationTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DescribedAuthorizationTests.cs
@@ -1,0 +1,228 @@
+using System.Threading;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// What a description's <c>security</c> becomes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Scopes, not schemes. A scheme says how a caller proves who they are, which is configuration this
+/// application already owns and a description cannot know. Scopes say which permissions an operation
+/// needs, which is a fact about the operation and maps onto <c>Requirement</c> directly.
+/// </para>
+/// <para>
+/// Every rule here has a failure mode that produces a <em>weaker</em> API than the document
+/// describes, which is why they are pinned individually rather than through one round-trip.
+/// </para>
+/// </remarks>
+public class DescribedAuthorizationTests {
+
+    private const string Schemes =
+        """
+        components:
+          securitySchemes:
+            oauth:
+              type: oauth2
+              flows:
+                clientCredentials:
+                  tokenUrl: https://example.invalid/token
+                  scopes:
+                    "pets:read": Read.
+                    "pets:write": Write.
+            key:
+              type: apiKey
+              name: X-Api-Key
+              in: header
+          schemas:
+            Pet:
+              type: object
+              properties:
+                id: { type: string }
+        """;
+
+    private static OperationModel Operation(
+        string operationSecurity, string documentSecurity = "",
+        ICollection<string>? diagnostics = null) =>
+        Assert.Single(
+            Assert.Single(
+                OpenApiSpecParser.Parse(
+                    $$"""
+                     openapi: "3.0.0"
+                     info: { title: Pets, version: "1.0" }
+                     {{documentSecurity}}
+                     paths:
+                       /pets:
+                         get:
+                           tags: [Pet]
+                           operationId: listPets
+                     {{operationSecurity}}
+                           responses:
+                             '200':
+                               description: A pet
+                               content:
+                                 application/json:
+                                   schema:
+                                     $ref: '#/components/schemas/Pet'
+                     {{Schemes}}
+                     """,
+                    "test",
+                    CancellationToken.None,
+                    diagnostics: diagnostics)!.Services).Operations);
+
+    private static AuthorizationBranchModel Only(OperationModel operation) =>
+        Assert.Single(operation.AuthorizationBranches);
+
+    /// <summary>
+    /// The common shape: one scheme, one scope. Becomes one grant.
+    /// </summary>
+    [Fact]
+    public void AScopeBecomesAGrant() {
+        var branch = Only(Operation("""      security: [{ oauth: ["pets:read"] }]"""));
+
+        Assert.Equal(new[] { "pets:read" }, branch.Grants);
+        Assert.False(branch.RequiresAuthentication);
+    }
+
+    /// <summary>
+    /// Several scopes on one scheme are conjoined - the token needs all of them, not any.
+    /// </summary>
+    [Fact]
+    public void SeveralScopesOnOneSchemeAreAllRequired() {
+        var branch = Only(Operation("""      security: [{ oauth: ["pets:read", "pets:write"] }]"""));
+
+        Assert.Equal(new[] { "pets:read", "pets:write" }, branch.Grants);
+    }
+
+    /// <summary>
+    /// A scheme that cannot carry scopes says "be authenticated" - which is a requirement, not the
+    /// absence of one.
+    /// </summary>
+    /// <remarks>
+    /// The load-bearing one. Reading an empty scope array as "requires nothing" would make the OR
+    /// below satisfied by everybody, so a document that reads as protective would generate a
+    /// requirement weaker than declaring none at all.
+    /// </remarks>
+    [Fact]
+    public void AnUnscopedSchemeRequiresAuthenticationRatherThanNothing() {
+        var branch = Only(Operation("""      security: [{ key: [] }]"""));
+
+        Assert.Empty(branch.Grants);
+        Assert.True(branch.RequiresAuthentication);
+    }
+
+    /// <summary>
+    /// The array is an OR, and a scoped alternative beside an unscoped one keeps both.
+    /// </summary>
+    [Fact]
+    public void SeparateEntriesAreAlternatives() {
+        var operation = Operation(
+            """      security: [{ oauth: ["pets:read"] }, { key: [] }]""");
+
+        Assert.Collection(
+            operation.AuthorizationBranches,
+            first => {
+                Assert.Equal(new[] { "pets:read" }, first.Grants);
+                Assert.False(first.RequiresAuthentication);
+            },
+            second => {
+                Assert.Empty(second.Grants);
+                Assert.True(second.RequiresAuthentication);
+            });
+    }
+
+    /// <summary>
+    /// Two schemes inside one entry are conjoined, so the branch carries both what they require.
+    /// </summary>
+    [Fact]
+    public void SchemesWithinOneEntryAreConjoined() {
+        var branch = Only(Operation("""      security: [{ oauth: ["pets:write"], key: [] }]"""));
+
+        Assert.Equal(new[] { "pets:write" }, branch.Grants);
+        Assert.True(branch.RequiresAuthentication);
+    }
+
+    /// <summary>
+    /// An operation that declares nothing inherits the document's default, which is how most
+    /// documents express this - once at the top, overridden per operation.
+    /// </summary>
+    [Fact]
+    public void ADocumentLevelDefaultIsInherited() {
+        var branch = Only(Operation("", """security: [{ oauth: ["pets:read"] }]"""));
+
+        Assert.Equal(new[] { "pets:read" }, branch.Grants);
+    }
+
+    /// <summary>
+    /// An operation's own security replaces the document's rather than merging with it.
+    /// </summary>
+    [Fact]
+    public void AnOperationsOwnSecurityReplacesTheDocumentDefault() {
+        var branch = Only(Operation(
+            """      security: [{ oauth: ["pets:write"] }]""",
+            """security: [{ oauth: ["pets:read"] }]"""));
+
+        Assert.Equal(new[] { "pets:write" }, branch.Grants);
+    }
+
+    /// <summary>
+    /// <c>security: []</c> is the specification's way of opting one operation out of a document-level
+    /// default. It derives nothing.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>[AllowAnonymous]</c>. A described requirement is conjoined with whatever
+    /// the handler declared, so it can narrow a route and must not be able to open one; a document
+    /// that says "public" cannot be allowed to strip an <c>[AuthorizeGrants]</c> somebody wrote on
+    /// the implementation. An author who wants the route anonymous says so in code.
+    /// </remarks>
+    [Fact]
+    public void AnEmptySecurityArrayDerivesNothing() {
+        Assert.Empty(
+            Operation("""      security: []""", """security: [{ oauth: ["pets:read"] }]""")
+                .AuthorizationBranches);
+    }
+
+    /// <summary>
+    /// A document declaring none anywhere derives nothing.
+    /// </summary>
+    [Fact]
+    public void NoSecurityAnywhereDerivesNothing() {
+        Assert.Empty(Operation("").AuthorizationBranches);
+    }
+
+    /// <summary>
+    /// A misspelled scheme name is reported rather than quietly downgrading the operation.
+    /// </summary>
+    /// <remarks>
+    /// This is the shape of the whole dropped-keyword class: the operation stops requiring the
+    /// permission it names and still answers, so the only sign is a request that should have been
+    /// refused and was not.
+    /// </remarks>
+    [Fact]
+    public void AnUndeclaredSchemeIsReported() {
+        var diagnostics = new List<string>();
+
+        Operation("""      security: [{ ghost: ["pets:read"] }]""", diagnostics: diagnostics);
+
+        Assert.Contains(diagnostics, d => d.Contains("ghost") && d.Contains("listPets"));
+    }
+
+    /// <summary>
+    /// A scheme the document never declared contributes authentication, never grants.
+    /// </summary>
+    /// <remarks>
+    /// The reference is dangling - the document's own error - and reading its scope list would
+    /// invent authorization out of a name that resolves to nothing. Requiring a caller rather than
+    /// requiring a permission is the safe reading of a broken document.
+    /// </remarks>
+    [Fact]
+    public void AnUndeclaredSchemeContributesAuthenticationOnly() {
+        var branch = Only(Operation("""      security: [{ ghost: ["pets:read"] }]"""));
+
+        Assert.Empty(branch.Grants);
+        Assert.True(branch.RequiresAuthentication);
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/AuthorizationBranchModelTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/AuthorizationBranchModelTests.cs
@@ -1,0 +1,103 @@
+using Hardened.Idl.Models;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// Equality on a described authorization branch.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Not ceremony. <c>OperationModel.Equals</c> compares these, and the incremental generator compares
+/// <c>OperationModel</c> to decide whether anything has to be regenerated - so a branch that
+/// compared equal to a different branch would leave the previous build's authorization in place
+/// after somebody changed a scope. The failure is a route still guarded by the requirement it used
+/// to have, which nothing else would report.
+/// </para>
+/// <para>
+/// Here rather than beside the OpenAPI tests because the model is compiled into every front end
+/// separately: a test in one project exercises that project's copy and no other.
+/// </para>
+/// </remarks>
+public class AuthorizationBranchModelTests {
+
+    private static AuthorizationBranchModel Branch(bool authenticated, params string[] grants) =>
+        new() { RequiresAuthentication = authenticated, Grants = [.. grants] };
+
+    [Fact]
+    public void BranchesNamingTheSameGrantsAreEqual() {
+        Assert.Equal(Branch(false, "pets:read"), Branch(false, "pets:read"));
+    }
+
+    [Fact]
+    public void EqualBranchesHashEqual() {
+        Assert.Equal(
+            Branch(false, "pets:read", "pets:write").GetHashCode(),
+            Branch(false, "pets:read", "pets:write").GetHashCode());
+    }
+
+    [Fact]
+    public void ABranchEqualsItself() {
+        var branch = Branch(true);
+
+        Assert.True(branch.Equals(branch));
+    }
+
+    [Fact]
+    public void ABranchDoesNotEqualNull() {
+        Assert.False(Branch(true).Equals(null));
+        Assert.False(Branch(true).Equals((object?)null));
+    }
+
+    [Fact]
+    public void ABranchDoesNotEqualAnotherType() {
+        Assert.False(Branch(true).Equals("pets:read"));
+    }
+
+    /// <summary>
+    /// A different grant is a different requirement.
+    /// </summary>
+    [Fact]
+    public void DifferentGrantsAreNotEqual() {
+        Assert.NotEqual(Branch(false, "pets:read"), Branch(false, "pets:write"));
+    }
+
+    /// <summary>
+    /// So is one more grant. An AND that gained a term admits strictly fewer callers.
+    /// </summary>
+    [Fact]
+    public void AnExtraGrantIsNotEqual() {
+        Assert.NotEqual(Branch(false, "pets:read"), Branch(false, "pets:read", "pets:write"));
+    }
+
+    /// <summary>
+    /// Order matters, because the emitted expression is written in it and a generated file that
+    /// reshuffles between builds defeats the up-to-date check on the target.
+    /// </summary>
+    [Fact]
+    public void GrantOrderIsPartOfIdentity() {
+        Assert.NotEqual(
+            Branch(false, "pets:read", "pets:write"),
+            Branch(false, "pets:write", "pets:read"));
+    }
+
+    /// <summary>
+    /// The authentication flag is part of identity on its own - it is the difference between
+    /// "requires a caller" and "requires nothing", which is the distinction the whole design turns
+    /// on.
+    /// </summary>
+    [Fact]
+    public void TheAuthenticationFlagIsPartOfIdentity() {
+        Assert.NotEqual(Branch(true), Branch(false));
+        Assert.NotEqual(Branch(true, "pets:read"), Branch(false, "pets:read"));
+    }
+
+    /// <summary>
+    /// Two empty branches compare equal, which is what lets an unchanged model skip regeneration.
+    /// </summary>
+    [Fact]
+    public void EmptyBranchesAreEqual() {
+        Assert.Equal(Branch(false), Branch(false));
+        Assert.Equal(Branch(false).GetHashCode(), Branch(false).GetHashCode());
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyAuthTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyAuthTests.cs
@@ -113,4 +113,85 @@ public class SmithyAuthTests {
         Assert.DoesNotContain(diagnostics, d => d.Contains("httpBearerAuth"));
         Assert.DoesNotContain(diagnostics, d => d.Contains("optionalAuth"));
     }
+
+    /// <summary>
+    /// Every scheme the prelude defines is recognised, not only the one the other tests happen to
+    /// use.
+    /// </summary>
+    /// <remarks>
+    /// A model picks one of these and never all of them, so a set that recognised four out of five
+    /// would look correct in every test written against a service that chose the fifth.
+    /// </remarks>
+    [Theory]
+    [InlineData("smithy.api#httpApiKeyAuth")]
+    [InlineData("smithy.api#httpBasicAuth")]
+    [InlineData("smithy.api#httpBearerAuth")]
+    [InlineData("smithy.api#httpDigestAuth")]
+    [InlineData("aws.auth#sigv4")]
+    public void EverySchemeTheSetNamesRequiresAuthentication(string scheme) {
+        var branch = Assert.Single(Parse($"\"{scheme}\": {{}}").AuthorizationBranches);
+
+        Assert.True(branch.RequiresAuthentication);
+    }
+
+    /// <summary>
+    /// <c>@auth</c> naming a scheme is a narrowing rather than an opt-out, so it still requires one.
+    /// </summary>
+    [Fact]
+    public void AnAuthListNamingASchemeStillRequiresAuthentication() {
+        var branch = Assert.Single(
+            Parse(BearerAuth + ", \"smithy.api#auth\": [\"smithy.api#httpBearerAuth\"]")
+                .AuthorizationBranches);
+
+        Assert.True(branch.RequiresAuthentication);
+    }
+
+    /// <summary>
+    /// <c>@auth</c> answers on its own: a service narrowing to no scheme requires nothing even while
+    /// it declares one.
+    /// </summary>
+    [Fact]
+    public void AnAuthListTakesPrecedenceOverADeclaredScheme() {
+        Assert.Empty(
+            Parse(BearerAuth + ", \"smithy.api#auth\": []").AuthorizationBranches);
+    }
+
+    /// <summary>
+    /// An operation opting out of an authenticated service leaves every sibling guarded.
+    /// </summary>
+    /// <remarks>
+    /// The failure worth catching is an opt-out that leaks: one public operation making the whole
+    /// service public would be invisible until somebody called a different route.
+    /// </remarks>
+    [Fact]
+    public void AnOperationOptingOutDoesNotOptOutItsSiblings() {
+        var diagnostics = new List<string>();
+
+        var ast = $$"""
+                    { "smithy": "2.0", "shapes": {
+                        "com.example#Svc": {
+                          "type": "service", "version": "1",
+                          "operations": [
+                            { "target": "com.example#Open" }, { "target": "com.example#Shut" } ],
+                          "traits": { {{BearerAuth}} } },
+                        "com.example#Open": {
+                          "type": "operation",
+                          "traits": {
+                            "smithy.api#http": { "method": "GET", "uri": "/open", "code": 200 },
+                            "smithy.api#optionalAuth": {} } },
+                        "com.example#Shut": {
+                          "type": "operation",
+                          "traits": {
+                            "smithy.api#http": { "method": "GET", "uri": "/shut", "code": 200 } } } } }
+                    """;
+
+        var model = SmithySpecParser.Parse(ast, "auth", diagnostics);
+        var operations = Assert.Single(model!.Services).Operations;
+
+        Assert.Empty(
+            Assert.Single(operations, o => o.OperationId == "Open").AuthorizationBranches);
+
+        Assert.Single(
+            Assert.Single(operations, o => o.OperationId == "Shut").AuthorizationBranches);
+    }
 }

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyAuthTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyAuthTests.cs
@@ -1,0 +1,116 @@
+using Hardened.Idl.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// What a Smithy model's auth traits become.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Authentication, and never authorization. Smithy has no equivalent of an OAuth scope, so a model
+/// can say a caller must be someone and cannot say what they must hold - which is the whole
+/// difference between this front end and the OpenAPI one, and is a property of the language rather
+/// than a gap in the reading.
+/// </para>
+/// <para>
+/// These traits were previously <c>Ignorable</c>, on the grounds that "authentication is Hardened's
+/// own story rather than the IDL's". That is right about the <em>scheme</em> - which issuer, which
+/// token format - and wrong about whether an operation needs one at all, which is a fact about the
+/// operation.
+/// </para>
+/// </remarks>
+public class SmithyAuthTests {
+
+    private static string Model(string serviceTraits, string operationTraits) =>
+        $$"""
+          { "smithy": "2.0", "shapes": {
+              "com.example#Svc": {
+                "type": "service", "version": "1",
+                "operations": [ { "target": "com.example#Op" } ],
+                "traits": { {{serviceTraits}} } },
+              "com.example#Op": {
+                "type": "operation",
+                "traits": {
+                  "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 }
+                  {{operationTraits}} } } } }
+          """;
+
+    private static OperationModel Parse(string serviceTraits, string operationTraits = "") {
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(Model(serviceTraits, operationTraits), "auth", diagnostics);
+
+        Assert.NotNull(model);
+
+        return Assert.Single(Assert.Single(model!.Services).Operations);
+    }
+
+    private const string BearerAuth = "\"smithy.api#httpBearerAuth\": {}";
+
+    /// <summary>
+    /// A service declaring a scheme requires a caller, and says nothing about what they hold.
+    /// </summary>
+    [Fact]
+    public void AServiceDeclaringASchemeRequiresAuthentication() {
+        var branch = Assert.Single(Parse(BearerAuth).AuthorizationBranches);
+
+        Assert.True(branch.RequiresAuthentication);
+        Assert.Empty(branch.Grants);
+    }
+
+    /// <summary>
+    /// A service declaring no scheme requires nothing. There would be nothing to authenticate
+    /// against.
+    /// </summary>
+    [Fact]
+    public void AServiceDeclaringNoSchemeRequiresNothing() {
+        Assert.Empty(Parse("").AuthorizationBranches);
+    }
+
+    /// <summary>
+    /// <c>@optionalAuth</c> is how an operation on an authenticated service is made callable without
+    /// one.
+    /// </summary>
+    [Fact]
+    public void OptionalAuthOnAnOperationRequiresNothing() {
+        Assert.Empty(
+            Parse(BearerAuth, ", \"smithy.api#optionalAuth\": {}").AuthorizationBranches);
+    }
+
+    /// <summary>
+    /// <c>@auth([])</c> narrows the supported schemes to none, which is the other way to say the
+    /// same thing.
+    /// </summary>
+    [Fact]
+    public void AnEmptyAuthListOnAnOperationRequiresNothing() {
+        Assert.Empty(Parse(BearerAuth, ", \"smithy.api#auth\": []").AuthorizationBranches);
+    }
+
+    /// <summary>
+    /// A service that narrows to no scheme requires nothing of any operation under it.
+    /// </summary>
+    [Fact]
+    public void AnEmptyAuthListOnTheServiceRequiresNothing() {
+        Assert.Empty(
+            Parse(BearerAuth + ", \"smithy.api#auth\": []").AuthorizationBranches);
+    }
+
+    /// <summary>
+    /// The traits are no longer reported as unmodelled, because they are now read.
+    /// </summary>
+    /// <remarks>
+    /// The set is a claim about what the parser does, and a claim nobody tests is how
+    /// <c>@uniqueItems</c> came to sit in <c>Mapped</c> with no reader behind it.
+    /// </remarks>
+    [Fact]
+    public void TheAuthTraitsAreNotReportedAsUnmodelled() {
+        var diagnostics = new List<string>();
+
+        SmithySpecParser.Parse(
+            Model(BearerAuth, ", \"smithy.api#optionalAuth\": {}"), "auth", diagnostics);
+
+        Assert.DoesNotContain(diagnostics, d => d.Contains("httpBearerAuth"));
+        Assert.DoesNotContain(diagnostics, d => d.Contains("optionalAuth"));
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -188,7 +188,8 @@ internal static class SmithySpecParser {
                 continue;
             }
 
-            var parsed = ParseOperation(context, operationId, operation, tag, protocol);
+            var parsed = ParseOperation(
+                context, operationId, operation, tag, protocol, RequiresAuth(service));
 
             if (parsed != null) {
                 operations.Add(parsed);
@@ -253,12 +254,54 @@ internal static class SmithySpecParser {
         }
     }
 
+    /// <summary>
+    /// Whether a shape's own traits say a caller must be authenticated.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two ways to say no, and they mean different things to a reader of the model even though they
+    /// mean the same thing here. <c>@auth([])</c> narrows the supported schemes to none, which is how
+    /// an operation on an authenticated service is made public. <c>@optionalAuth</c> says a caller
+    /// may authenticate and need not - which, for a server deciding whether to refuse, is the same
+    /// answer.
+    /// </para>
+    /// <para>
+    /// A service that declares a scheme and an operation that neither opts out is the only shape
+    /// that requires anything. Smithy cannot say more than that: it has no scopes, so it can never
+    /// produce a grant.
+    /// </para>
+    /// </remarks>
+    /// <summary>Whether the shape narrows its supported schemes to none - <c>@auth([])</c>.</summary>
+    private static bool DeclaresNoAuth(JsonElement shape) =>
+        SmithyAst.TryGetTrait(shape, SmithyTraits.Auth, out var auth) &&
+        auth.ValueKind == JsonValueKind.Array &&
+        auth.GetArrayLength() == 0;
+
+    private static bool RequiresAuth(JsonElement shape) {
+        if (SmithyAst.HasTrait(shape, SmithyTraits.OptionalAuth)) {
+            return false;
+        }
+
+        if (SmithyAst.TryGetTrait(shape, SmithyTraits.Auth, out var auth)) {
+            return auth.ValueKind == JsonValueKind.Array && auth.GetArrayLength() > 0;
+        }
+
+        foreach (var scheme in SmithyTraits.AuthSchemes) {
+            if (SmithyAst.HasTrait(shape, scheme)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static OperationModel? ParseOperation(
         ParseContext context,
         string operationId,
         JsonElement operation,
         string tag,
-        ProtocolBinding protocol) {
+        ProtocolBinding protocol,
+        bool serviceRequiresAuth) {
         Note(context, operation);
 
         var name = SmithyPrelude.LocalName(operationId);
@@ -305,6 +348,16 @@ internal static class SmithySpecParser {
 
         model.Description = Text(operation, SmithyTraits.Documentation);
         model.IsDeprecated = SmithyAst.HasTrait(operation, SmithyTraits.Deprecated);
+
+        // Authentication only, because that is all the language carries. An operation may opt out of
+        // an authenticated service; it cannot opt in to one that declares no scheme, because there
+        // would be nothing to authenticate against.
+        if (serviceRequiresAuth &&
+            !SmithyAst.HasTrait(operation, SmithyTraits.OptionalAuth) &&
+            !DeclaresNoAuth(operation)) {
+            model.AuthorizationBranches.Add(
+                new AuthorizationBranchModel { RequiresAuthentication = true });
+        }
 
         ParseInput(context, operation, model, name, protocol);
         ParseOutput(context, operation, model, name, protocol);

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -277,17 +277,18 @@ internal static class SmithySpecParser {
         auth.ValueKind == JsonValueKind.Array &&
         auth.GetArrayLength() == 0;
 
-    private static bool RequiresAuth(JsonElement shape) {
-        if (SmithyAst.HasTrait(shape, SmithyTraits.OptionalAuth)) {
-            return false;
-        }
-
-        if (SmithyAst.TryGetTrait(shape, SmithyTraits.Auth, out var auth)) {
+    private static bool RequiresAuth(JsonElement service) {
+        // @auth narrows the schemes a shape supports, so it answers on its own when present - and
+        // an empty list is how a service supports none.
+        //
+        // No @optionalAuth check here. Smithy defines that trait on operations, so a service
+        // carrying one is not a model this has to answer for, and the operation is asked directly.
+        if (SmithyAst.TryGetTrait(service, SmithyTraits.Auth, out var auth)) {
             return auth.ValueKind == JsonValueKind.Array && auth.GetArrayLength() > 0;
         }
 
         foreach (var scheme in SmithyTraits.AuthSchemes) {
-            if (SmithyAst.HasTrait(shape, scheme)) {
+            if (SmithyAst.HasTrait(service, scheme)) {
                 return true;
             }
         }

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
@@ -62,6 +62,30 @@ internal static class SmithyTraits {
     internal const string Mixin = "smithy.api#mixin";
 
     /// <summary>
+    /// The auth traits, which say whether a caller must be someone - and nothing about what they
+    /// must hold.
+    /// </summary>
+    /// <remarks>
+    /// Smithy has no equivalent of an OAuth scope, so a model can require authentication and cannot
+    /// require a permission. That is the whole difference between what this front end can read and
+    /// what the OpenAPI one can: a description carries authorization, a Smithy model carries
+    /// authentication. These were <see cref="Ignorable"/> on the grounds that "authentication is
+    /// Hardened's own story rather than the IDL's", which is right about the <em>scheme</em> - which
+    /// issuer, which token format - and wrong about whether an operation needs one at all. That
+    /// second part is a fact about the operation and belongs to whoever wrote it.
+    /// </remarks>
+    internal const string Auth = "smithy.api#auth";
+
+    internal const string OptionalAuth = "smithy.api#optionalAuth";
+
+    /// <summary>The schemes a service can declare support for.</summary>
+    internal static readonly HashSet<string> AuthSchemes = new(StringComparer.Ordinal) {
+        "smithy.api#httpApiKeyAuth", "smithy.api#httpBasicAuth",
+        "smithy.api#httpBearerAuth", "smithy.api#httpDigestAuth",
+        "aws.auth#sigv4"
+    };
+
+    /// <summary>
     /// Traits read into the IR.
     /// </summary>
     /// <remarks>
@@ -74,6 +98,9 @@ internal static class SmithyTraits {
         Error, Required, Default, ClientOptional, Documentation, Deprecated, Title, Tags,
         EnumValue, JsonName, TimestampFormat, MediaType, Sparse,
         Length, Range, Pattern, UniqueItems,
+        Auth, OptionalAuth,
+        "smithy.api#httpApiKeyAuth", "smithy.api#httpBasicAuth",
+        "smithy.api#httpBearerAuth", "smithy.api#httpDigestAuth",
         Readonly, Idempotent, Input, Output, Private, Internal, Mixin,
         Trait
     };
@@ -101,9 +128,7 @@ internal static class SmithyTraits {
         "smithy.api#noReplace", "smithy.api#nestedProperties", "smithy.api#notProperty",
         "smithy.api#property", "smithy.api#resourceIdentifier", "smithy.api#unitType",
         "smithy.api#addedDefault", "smithy.api#box", "smithy.api#retryable",
-        "smithy.api#auth", "smithy.api#optionalAuth", "smithy.api#authDefinition",
-        "smithy.api#protocolDefinition", "smithy.api#httpApiKeyAuth", "smithy.api#httpBasicAuth",
-        "smithy.api#httpBearerAuth", "smithy.api#httpDigestAuth",
+        "smithy.api#authDefinition", "smithy.api#protocolDefinition",
         "smithy.api#xmlAttribute", "smithy.api#xmlFlattened", "smithy.api#xmlName",
         "smithy.api#xmlNamespace",
         "smithy.api#eventHeader", "smithy.api#eventPayload"


### PR DESCRIPTION
`security` appeared **zero times** in the OpenAPI parser. A contract declaring that an operation
requires `pets:write` generated a route with **no authorization on it** — while the served document
went on advertising that it was protected.

This is the `security` half of D9 from the release review, pulled out as its own item because it is
the only entry in that list whose failure is a security outcome rather than a correctness one.

## Scopes, not schemes

Which scheme a caller proves themselves with — issuer, token format, JWKS endpoint — is
configuration this application already owns and a description cannot know. Smithy says as much in
its own trait table, and it is right. Which *permissions* an operation needs is a fact about the
operation and maps onto `Requirement` with no intermediary: `security` is an array of alternatives
whose entries are conjoined, and `Requirement` is a boolean algebra over grants.

So the scheme decides exactly one thing — whether the entry carries scopes at all.

That is also why this is tractable here and not elsewhere. Frameworks that consume `security` map
*schemes*, and have to invent an extension binding each one to a verifier, because they have nothing
to map scopes onto — ASP.NET has opaque policy names, Spring has authority strings. Reading scopes
needs no binding.

| declaration | becomes |
|---|---|
| `oauth2: ["pets:read"]` | `Grant("pets:read")` |
| `oauth2: ["pets:read", "pets:write"]` | `Grant(…) & Grant(…)` |
| any scheme with `[]` | `Authenticated()` |
| `[{oauth2: […]}, {apiKey: []}]` | `AnyOf(…)` |
| `security: []` | nothing |
| nothing declared | the document default, or nothing |

## The rule the rest hangs on

An entry with no scopes becomes `Authenticated()`, **not nothing**:

```yaml
security:
  - oauth2: ["pets:write"]
  - apiKey: []
```

Read the second branch as "requires nothing" and the OR is satisfied by everybody — a document that
reads as protective would generate a requirement **weaker than declaring none at all**.

## Two empty arrays that mean opposite things

`{oauth2: []}` is an empty *scope* array and requires a caller. `security: []` is the specification's
way of opting one operation out of a document-level default, and derives **nothing** — deliberately
not `[AllowAnonymous]`. A described requirement is conjoined with whatever the handler declared, so
it may narrow a route and must never open one; a document must not be able to strip an
`[AuthorizeGrants]` somebody wrote. An author who wants a route anonymous says so in code.

Carried as handler **metadata** for the same reason: `ExecutionRequestHandlerInfo` reads
`requirement ?? RequirementFrom(Metadata)`, so passing it as the constructor's requirement would have
*silenced* an attribute on the implementation instead of composing with it.

## ⚠️ No opt-in is required, so this changes behaviour

`AuthorizationFilterProvider`'s `requireAuthorization` flag decides what happens to a handler
declaring **nothing**; one that declares something is guarded either way. So a contract naming a
scope protects its route on the next build.

**Adding `security` to a published contract is therefore a breaking change for its callers** — an
operation that answered 200 anonymously answers 401. Fourteen integration tests proved it by turning
red when the first draft put a requirement on routes the validation and enum suites drive, which is
why the guarded routes here are their own.

Worth a release note.

## Smithy gets the half its language carries

No equivalent of a scope exists, so a model can require a caller and can never require a permission.
A service declaring a scheme requires authentication; `@optionalAuth` and `@auth([])` opt out.

The auth traits move from `Ignorable` to `Mapped`, with a test asserting they are no longer reported
as unmodelled — `Mapped` is a claim about what the parser does, and an untested claim is how
`@uniqueItems` came to sit there with no reader behind it.

## Diagnostics

A scheme name `components.securitySchemes` does not declare is reported rather than falling back in
silence. The operation would keep answering while requiring an authenticated caller and **none of the
permissions it names** — the same shape as every other defect in the dropped-keyword class: nothing
fails, and the only sign is a request that should have been refused and was not.

## Deliberately not built

Emitting `security` **into** a code-first document. `docs/described-authorization.md` records the
design: it must be opt-in, and the opt-in is the **scheme declaration itself** rather than a flag,
since a document cannot carry `security` without `components.securitySchemes` and nothing in
`[AuthorizeGrants]` says what the scheme is. Once opted in, every grant publishes — per-grant opt-in
is the kind of thing people forget, and what it leaves is a document confidently wrong about which
endpoints are protected.

The reason it is not on by default: **Hardened grants are not OAuth scopes.** They are an arbitrary
internal vocabulary, and names like `feature:experimental-pricing` disclose something their author
never chose to publish.

## Verification

**4,923 tests across 29 assemblies, 0 failures**, on a rebuild with every build-task output deleted
first.

31 new tests — 11 parser rules, 6 emit-shape, 4 runtime composition, 6 Smithy, 4 end-to-end over real
requests, plus the serializer round trip. The end-to-end ones prove an anonymous caller is refused on
both a scoped route and an OR route, and that a `security: []` route still answers.

## Note for review

Conflicts with #181 on one file — `Approved/Hardened.Requests.Runtime.approved.txt` — because both
add a public type to that assembly. It is generated, so whichever lands second re-approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaVWVDCGLsE7xrTG1D8Jng
