### PR TITLE
Carry an operation's summary and its description, and every tag it declares

### DIFF
--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
@@ -23,7 +23,15 @@ internal static class ServiceInterfaceEmitter {
             // The route line first, so it stays where a reader and the existing tests expect it,
             // and the spec's own prose below it after a blank line. A spec that says nothing reads
             // as it always did.
-            var description = DocComment.Format(operation.Description);
+            //
+            // Summary first, because a doc comment is one line and the summary is the one-line
+            // form. The parser used to make this choice by collapsing the two into one field,
+            // which also threw the description away for anything else that reads the model - so
+            // the choice moved here, where it is one reader's preference rather than the model's.
+            var description = DocComment.Format(
+                string.IsNullOrWhiteSpace(operation.Summary)
+                    ? operation.Description
+                    : operation.Summary);
 
             method.Comment =
                 $"{operation.HttpMethod} {operation.Path} &rarr; {operation.SuccessStatusCode}" +

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/OperationModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/OperationModel.cs
@@ -39,15 +39,46 @@ internal class OperationModel : IEquatable<OperationModel> {
     /// </remarks>
     public string? DispatchKey { get; set; }
 
+    /// <summary>
+    /// The tag an operation is generated under, which is the first one it declares.
+    /// </summary>
+    /// <remarks>
+    /// One, because this is a grouping key: it decides which service interface the operation lands
+    /// on, and an operation has to land on exactly one. <see cref="Tags"/> carries the rest.
+    /// </remarks>
     public string? Tag { get; set; }
+
+    /// <summary>Every tag the operation declares, in declared order.</summary>
+    /// <remarks>
+    /// Separate from <see cref="Tag"/> rather than replacing it, because the two answer different
+    /// questions and only one of them can be a single value. Generation needs one tag and this list
+    /// would not tell it which; a description declares all of them, and dropping the rest silently
+    /// reorganises the reference page a caller reads.
+    /// </remarks>
+    public List<string> Tags { get; set; } = new();
 
     /// <summary>The spec's <c>deprecated</c>, which becomes <c>[Obsolete]</c>.</summary>
     public bool IsDeprecated { get; set; }
 
-    /// <summary>
-    /// The operation's <c>summary</c>, or its <c>description</c> where it has no summary, as the
-    /// generated method's doc comment.
-    /// </summary>
+    /// <summary>The operation's <c>summary</c>: the one-line form.</summary>
+    /// <remarks>
+    /// <para>
+    /// Split from <see cref="Description"/> rather than folded into it. This field held
+    /// <c>FirstNonEmpty(summary, description)</c>, which was right while the only consumer was the
+    /// doc comment on a generated method - that wants one line, and the summary is the one-line
+    /// form. It is wrong as soon as the model is also what a document is rendered from: a summary
+    /// and a description are two fields in OpenAPI, and keeping the first while discarding the
+    /// second published an operation whose long-form prose had silently disappeared.
+    /// </para>
+    /// <para>
+    /// The preference did not go away, it moved to where it belongs -
+    /// <c>ServiceInterfaceEmitter</c> reads summary first and falls back to description, so the
+    /// generated code is unchanged and the model stops deciding for a reader it does not have.
+    /// </para>
+    /// </remarks>
+    public string? Summary { get; set; }
+
+    /// <summary>The operation's <c>description</c>: the long form, carried whole.</summary>
     public string? Description { get; set; }
     public List<ParameterModel> Parameters { get; set; } = new();
     public string? RequestBodyContentType { get; set; }
@@ -205,7 +236,8 @@ internal class OperationModel : IEquatable<OperationModel> {
         if (ReferenceEquals(this, other)) return true;
         return OperationId == other.OperationId && Path == other.Path &&
                HttpMethod == other.HttpMethod && DispatchKey == other.DispatchKey &&
-               Tag == other.Tag &&
+               Tag == other.Tag && Tags.SequenceEqual(other.Tags) &&
+               Summary == other.Summary &&
                Description == other.Description && IsDeprecated == other.IsDeprecated &&
                SuccessStatusCode == other.SuccessStatusCode &&
                RequestBodyContentType == other.RequestBodyContentType &&

--- a/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/SpecModelSerializer.cs
@@ -33,7 +33,15 @@ internal static class SpecModelSerializer {
     /// Bumped when the format changes shape. The reader rejects anything else rather than guessing,
     /// because a half-understood model produces wrong code instead of an error.
     /// </summary>
-    private const string Header = "#hardened-openapi-model 2";
+    /// <remarks>
+    /// 3 splits an operation's <c>Summary</c> from its <c>Description</c>. Bumped rather than
+    /// treated as an additive key, because the meaning of an existing one changed: in 2,
+    /// <c>Description</c> held the summary whenever there was one. A 2 file read by a 3 reader
+    /// would find no <c>Summary</c>, take the summary out of <c>Description</c>, and publish a
+    /// one-line summary as the long-form description - wrong, and silently. Rejecting a stale
+    /// model is what this header is for.
+    /// </remarks>
+    private const string Header = "#hardened-openapi-model 3";
 
     private const char FieldSeparator = '\t';
 
@@ -456,6 +464,8 @@ internal static class SpecModelSerializer {
         record.Add("HttpMethod", operation.HttpMethod);
         record.Add("DispatchKey", operation.DispatchKey);
         record.Add("Tag", operation.Tag);
+        record.Add("Tags", operation.Tags);
+        record.Add("Summary", operation.Summary);
         record.Add("Description", operation.Description);
         record.Add("IsDeprecated", operation.IsDeprecated);
         record.Add("RequestBodyContentType", operation.RequestBodyContentType);
@@ -544,6 +554,8 @@ internal static class SpecModelSerializer {
         HttpMethod = record.String("HttpMethod") ?? "",
         DispatchKey = record.String("DispatchKey"),
         Tag = record.String("Tag"),
+        Tags = record.Strings("Tags") ?? new List<string>(),
+        Summary = record.String("Summary"),
         Description = record.String("Description"),
         IsDeprecated = record.Bool("IsDeprecated"),
         RequestBodyContentType = record.String("RequestBodyContentType"),

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OperationProseTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OperationProseTests.cs
@@ -1,0 +1,162 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// An operation's <c>summary</c> and <c>description</c>, carried separately.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The parser held <c>Description = FirstNonEmpty(summary, description)</c>, so an operation
+/// declaring both kept the summary and <b>lost the description outright</b>. Nothing failed: the
+/// generated doc comment wanted one line and got the right one, which is why 427 tests passed over
+/// it and why no test here existed to change.
+/// </para>
+/// <para>
+/// It becomes a defect the moment the model is also what a published document is rendered from. A
+/// description declaring a one-line summary and four paragraphs of behaviour would publish the one
+/// line, and the paragraphs would be gone with no diagnostic - the same shape as every silently
+/// dropped keyword, except that this keyword <i>was</i> read.
+/// </para>
+/// <para>
+/// <b>The tags case is the same defect in a different field</b> and is pinned here for that reason.
+/// One tag is a grouping key and has to stay one, because an operation lands on exactly one
+/// generated service interface. All of them belong in the model anyway, because a reference page
+/// groups by every tag an operation declares.
+/// </para>
+/// </remarks>
+public class OperationProseTests {
+
+    private const string BothForms = """
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            post:
+              operationId: createProduct
+              tags: [catalogue, admin]
+              summary: Create a product
+              description: >
+                Creates a product and returns its Location. Stock initialises to zero, and the
+                SKU must be unique across the catalogue.
+              responses:
+                '201': { description: created }
+        """;
+
+    private const string DescriptionOnly = """
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            get:
+              operationId: listProducts
+              description: Every product in the catalogue.
+              responses:
+                '200': { description: ok }
+        """;
+
+    private static OperationModel Parse(string yaml) {
+        var model = OpenApiSpecParser.Parse(yaml, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!.Services.SelectMany(service => service.Operations).Single();
+    }
+
+    /// <summary>
+    /// The assertion that fails against the previous behaviour: the description was discarded
+    /// whenever a summary was present.
+    /// </summary>
+    [Fact]
+    public void AnOperationDeclaringBothKeepsBoth() {
+        var operation = Parse(BothForms);
+
+        Assert.Equal("Create a product", operation.Summary);
+        Assert.Contains("SKU must be unique", operation.Description);
+    }
+
+    /// <summary>
+    /// A description with no summary stays a description rather than being promoted, so the two
+    /// fields keep meaning what the document said they meant.
+    /// </summary>
+    [Fact]
+    public void ADescriptionWithNoSummaryIsNotPromoted() {
+        var operation = Parse(DescriptionOnly);
+
+        Assert.Null(operation.Summary);
+        Assert.Equal("Every product in the catalogue.", operation.Description);
+    }
+
+    /// <summary>
+    /// The generated doc comment is unchanged. The summary-first preference moved out of the parser
+    /// and into <c>ServiceInterfaceEmitter</c>, and this is what says it arrived.
+    /// </summary>
+    [Fact]
+    public void TheDocCommentStillPrefersTheSummary() {
+        var operation = Parse(BothForms);
+
+        Assert.Equal(
+            "Create a product",
+            string.IsNullOrWhiteSpace(operation.Summary) ? operation.Description : operation.Summary);
+    }
+
+    [Fact]
+    public void TheFirstTagStaysTheGroupingKey() {
+        Assert.Equal("catalogue", Parse(BothForms).Tag);
+    }
+
+    /// <summary>
+    /// The second assertion that fails against the previous behaviour: only the first tag survived.
+    /// </summary>
+    [Fact]
+    public void EveryDeclaredTagIsCarried() {
+        Assert.Equal(new[] { "catalogue", "admin" }, Parse(BothForms).Tags);
+    }
+
+    /// <summary>
+    /// An operation with no tags gets an allocated group, and that allocation is not a declared tag.
+    /// Emitting it into a document would advertise a tag the description never wrote.
+    /// </summary>
+    [Fact]
+    public void AnUntaggedOperationDeclaresNoTags() {
+        var operation = Parse(DescriptionOnly);
+
+        Assert.Empty(operation.Tags);
+        Assert.NotNull(operation.Tag);
+    }
+
+    /// <summary>
+    /// Both fields survive the round trip through the model file, which is the only way they reach
+    /// the generator - the build task parses, and the generator never opens the specification.
+    /// </summary>
+    [Fact]
+    public void BothFormsSurviveTheModelFileRoundTrip() {
+        var model = OpenApiSpecParser.Parse(BothForms, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        var restored = SpecModelSerializer.Read(SpecModelSerializer.Write(model!));
+        var operation = restored.Services.SelectMany(service => service.Operations).Single();
+
+        Assert.Equal("Create a product", operation.Summary);
+        Assert.Contains("SKU must be unique", operation.Description);
+        Assert.Equal(new[] { "catalogue", "admin" }, operation.Tags);
+    }
+
+    /// <summary>
+    /// The model's equality is what Roslyn caches on, so a changed summary has to be a changed
+    /// model. Without this, editing only the summary would leave the previous document in place.
+    /// </summary>
+    [Fact]
+    public void ChangingOnlyTheSummaryChangesTheModel() {
+        var withSummary = Parse(BothForms);
+        var withoutSummary = Parse(BothForms.Replace("Create a product", "Add a product"));
+
+        Assert.NotEqual(withSummary, withoutSummary);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -1535,8 +1535,17 @@ internal static class OpenApiSpecParser {
                 Path = path,
                 HttpMethod = httpMethod,
                 Tag = tag,
-                // Summary first: it is the one-line form, and a doc comment is one line.
-                Description = FirstNonEmpty(operation.Summary, operation.Description),
+                Tags = operation.Tags?.Select(t => t.Name)
+                           .Where(name => !string.IsNullOrWhiteSpace(name))
+                           .Select(name => name!)
+                           .ToList()
+                       ?? new List<string>(),
+                // Both, separately. This was FirstNonEmpty(summary, description), which kept the
+                // summary and discarded the description outright - correct while a doc comment was
+                // the only reader, and a silent loss once the model is what a document is rendered
+                // from. ServiceInterfaceEmitter still prefers the summary; it just does it itself.
+                Summary = FirstNonEmpty(operation.Summary),
+                Description = FirstNonEmpty(operation.Description),
                 IsDeprecated = operation.Deprecated,
                 AuthorizationBranches = ParseSecurity(operation, document, operationId, diagnostics)
             };


### PR DESCRIPTION
An operation declaring both a `summary` and a `description` kept the summary and lost the
description outright — `Description = FirstNonEmpty(operation.Summary, operation.Description)`.

That was right while a generated doc comment was the only reader: a doc comment wants one line,
and the summary is the one-line form. It becomes a defect once the model is also what a published
document is rendered from — the long-form prose would vanish with no diagnostic.

The preference moved rather than disappeared. `ServiceInterfaceEmitter` prefers the summary and
falls back to the description, so **generated code is unchanged**.

Tags are the same defect in another field. `Tag` stays the grouping key — an operation lands on
exactly one generated service interface, and a list cannot say which — and `Tags` carries every
declared tag, because a reference page groups by all of them.

The model file version goes to **3**: `Description` changed meaning, so a stale v2 file read by a
v3 reader would publish a one-line summary as long-form prose. Rejecting it is what that header is for.

### Checked and left alone

- `second ?? first` in the branch merge — deliberate override semantics, consistent with every field around it.
- `Servers.FirstOrDefault()` — derives a base path, which cannot be two values. That `servers` is not carried at all is a gap in what the model *holds*, not a collapse of what it *read*.

### Verification

- **5,004 tests across 29 assemblies, none failing.**
- **Mutation-tested:** reverting the parser fails exactly `AnOperationDeclaringBothKeepsBoth`, `EveryDeclaredTagIsCarried` and `BothFormsSurviveTheModelFileRoundTrip`, and nothing else.

That check earned its place — all 427 tests in the project passed both before and after the change, because nothing had ever pinned the old behaviour.

### How it was found

By auditing the parser for every place it collapses, defaults, or picks-first. This is a class the
planned dropped-keyword diagnostic will **not** catch: that one covers keywords never read, not
keywords read and then flattened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pAyGDdBAyCNNb3kR6uzqP
