### PR TITLE
Say so when a description declares a keyword the parser does not map

### DIFF
--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
@@ -83,6 +83,71 @@ internal static class SpecDiagnostics {
     /// caller may send - which is the shape of defect the whole enum vocabulary work exists to
     /// close. The document has to say which it means.
     /// </remarks>
+    /// <summary>
+    /// Keywords the description declared and the parser did not map.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A warning, not an error. The application is correct in every other respect and refusing to
+    /// build it would be worse than the omission; what it must not do is accept the keyword in
+    /// silence, which is what happened for every keyword in this class until now. A caller reading
+    /// the description sees <c>multipleOf: 5</c> and expects 3 to be refused, and nothing anywhere
+    /// said otherwise.
+    /// </para>
+    /// <para>
+    /// <b>One warning per distinct keyword, not per site.</b> A large description declaring
+    /// <c>uniqueItems</c> on forty arrays has one thing wrong with it and forty messages would bury
+    /// it - the same failure as a Smithy CLI error emitting one MSBuild line per line of output.
+    /// The count and a representative location carry what the extra thirty-nine would have.
+    /// </para>
+    /// <para>
+    /// This does not catch a keyword that was read and then flattened. That is a different class,
+    /// found by auditing the parser rather than by asking the model, and the difference is worth
+    /// keeping straight: nothing here would have found <c>summary</c> being folded into
+    /// <c>description</c>, because the parser mapped it.
+    /// </para>
+    /// </remarks>
+    private static void FindUnmappedKeywords(ServiceSpecModel model, List<Problem> problems) {
+        if (model.UnmappedKeywords.Count == 0) {
+            return;
+        }
+
+        var byKeyword = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var order = new List<string>();
+
+        foreach (var unmapped in model.UnmappedKeywords) {
+            if (!byKeyword.TryGetValue(unmapped.Keyword, out var locations)) {
+                locations = new List<string>();
+                byKeyword[unmapped.Keyword] = locations;
+                order.Add(unmapped.Keyword);
+            }
+
+            locations.Add(unmapped.Location);
+        }
+
+        // Declared order rather than alphabetical, so the first message names the first thing the
+        // author would find reading their own document top to bottom.
+        foreach (var keyword in order) {
+            var locations = byKeyword[keyword];
+
+            var where = locations.Count == 1
+                ? $"at {locations[0]}"
+                : $"at {locations[0]} and {locations.Count - 1} other " +
+                  (locations.Count == 2 ? "place" : "places");
+
+            problems.Add(new Problem(
+                "HOAT013",
+                $"'{keyword}' is declared {where} and is not enforced. The description promises it " +
+                "and the generated application does not apply it, so a payload this rejects on " +
+                "paper is accepted at runtime. Remove it, or keep it and enforce the rule in the " +
+                "handler.",
+                // Explicitly, because the constructor's default is fatal. An application declaring
+                // a keyword this does not honour is otherwise correct, and refusing to build it
+                // would be a worse answer than the omission it is reporting.
+                fatal: false));
+        }
+    }
+
     private static void FindMixedEnums(ServiceSpecModel model, List<Problem> problems) {
         foreach (var schema in model.Schemas) {
             if (schema.Kind == SchemaKind.Enum && schema.Type == MixedEnumType) {
@@ -109,6 +174,7 @@ internal static class SpecDiagnostics {
         FindDuplicateSchemaNames(model, problems);
         FindUnresolvableChoices(model, problems);
         FindMixedEnums(model, problems);
+        FindUnmappedKeywords(model, problems);
 
         foreach (var schema in model.Schemas) {
             var typeName = NamingHelper.ToPascalCase(schema.Name);

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
@@ -75,15 +75,6 @@ internal static class SpecDiagnostics {
     }
 
     /// <summary>
-    /// An <c>enum</c> declaring both strings and numbers, which is not a C# enum in either form.
-    /// </summary>
-    /// <remarks>
-    /// Fatal rather than resolved. Honouring the strings puts the numbers out of reach and honouring
-    /// the numbers puts the strings out of reach, so either choice silently drops half the values a
-    /// caller may send - which is the shape of defect the whole enum vocabulary work exists to
-    /// close. The document has to say which it means.
-    /// </remarks>
-    /// <summary>
     /// Keywords the description declared and the parser did not map.
     /// </summary>
     /// <remarks>
@@ -115,7 +106,18 @@ internal static class SpecDiagnostics {
         var byKeyword = new Dictionary<string, List<string>>(StringComparer.Ordinal);
         var order = new List<string>();
 
+        // Deduped on keyword and location together, because a parser may meet the same member more
+        // than once and one member is one place however many times it was read. Smithy's does: an
+        // operation's input structure is walked for the schema and walked again for the request
+        // body's properties, so every member of it is built twice. Counting that as two sites would
+        // put "and 1 other place" on a message about one, which is worse than not counting at all.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
         foreach (var unmapped in model.UnmappedKeywords) {
+            if (!seen.Add(unmapped.Keyword + "\u001f" + unmapped.Location)) {
+                continue;
+            }
+
             if (!byKeyword.TryGetValue(unmapped.Keyword, out var locations)) {
                 locations = new List<string>();
                 byKeyword[unmapped.Keyword] = locations;
@@ -148,6 +150,15 @@ internal static class SpecDiagnostics {
         }
     }
 
+    /// <summary>
+    /// An <c>enum</c> declaring both strings and numbers, which is not a C# enum in either form.
+    /// </summary>
+    /// <remarks>
+    /// Fatal rather than resolved. Honouring the strings puts the numbers out of reach and honouring
+    /// the numbers puts the strings out of reach, so either choice silently drops half the values a
+    /// caller may send - which is the shape of defect the whole enum vocabulary work exists to
+    /// close. The document has to say which it means.
+    /// </remarks>
     private static void FindMixedEnums(ServiceSpecModel model, List<Problem> problems) {
         foreach (var schema in model.Schemas) {
             if (schema.Kind == SchemaKind.Enum && schema.Type == MixedEnumType) {

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/ServiceSpecModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/ServiceSpecModel.cs
@@ -80,6 +80,18 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     /// </remarks>
     public SpecResponseModel ResponseModel { get; set; } = SpecResponseModel.Standard;
 
+    /// <summary>
+    /// Keywords the description declared that the parser did not map, in the order they were met.
+    /// </summary>
+    /// <remarks>
+    /// Filled by the parser and read by <c>SpecDiagnostics</c>, which is the only reason it hangs
+    /// off the model at all: that pass takes a model and nothing else, and a dropped keyword is
+    /// invisible in one by definition. It is not serialized and it is deliberately absent from
+    /// <see cref="Equals(ServiceSpecModel?)"/> - a keyword nobody mapped generates no C#, so two
+    /// models differing only here generate the same code and must not miss a cache hit over it.
+    /// </remarks>
+    public List<UnmappedKeywordModel> UnmappedKeywords { get; set; } = new();
+
     public bool Equals(ServiceSpecModel? other) {
         if (other is not null && ContentNegotiation != other.ContentNegotiation) return false;
         if (other is not null && ResponseModel != other.ResponseModel) return false;

--- a/src/SourceGenerators/Hardened.Idl.Shared/Models/UnmappedKeywordModel.cs
+++ b/src/SourceGenerators/Hardened.Idl.Shared/Models/UnmappedKeywordModel.cs
@@ -1,0 +1,43 @@
+namespace Hardened.Idl.Models;
+
+/// <summary>
+/// A keyword the description declared and the parser did not map.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recorded as the document is read, because it cannot be recovered afterwards.
+/// <c>SpecDiagnostics.Find</c> is handed a <see cref="ServiceSpecModel"/> and nothing else, and a
+/// keyword nobody mapped left no trace in it - the model can say what it holds and never what it
+/// was told and dropped. So the parser is the only place with both halves in hand, and this is it
+/// writing one of them down.
+/// </para>
+/// <para>
+/// <b>This is not the same class as a collapsed keyword</b> and does not catch one. A collapse -
+/// <c>summary</c> folded into <c>description</c>, every tag after the first discarded - is a
+/// keyword that was read, used, and flattened; it is present in the model, wearing the wrong shape.
+/// Nothing here would notice. That class is found by auditing the parser, and was.
+/// </para>
+/// <para>
+/// Deliberately not serialized into the model file. The generator reads that file to write C#, and
+/// what the build declined to map changes nothing about the C# it writes - the build task reports
+/// this and the report is finished before a line is generated. Carrying it further would put a
+/// diagnostic in a cache key.
+/// </para>
+/// </remarks>
+internal sealed class UnmappedKeywordModel {
+
+    public UnmappedKeywordModel(string keyword, string location) {
+        Keyword = keyword;
+        Location = location;
+    }
+
+    /// <summary>The keyword as the description spells it - <c>multipleOf</c>, not <c>MultipleOf</c>.</summary>
+    /// <remarks>
+    /// The document's spelling rather than the parser's, because the reader is looking at the
+    /// document. A message naming a C# property sends them searching a file that does not contain it.
+    /// </remarks>
+    public string Keyword { get; }
+
+    /// <summary>Where it was declared, as far as the parser knows - a schema and member name.</summary>
+    public string Location { get; }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnmappedKeywordTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnmappedKeywordTests.cs
@@ -1,0 +1,249 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// A keyword the description declares and the parser does not map, said out loud.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>multipleOf</c>, <c>uniqueItems</c> and <c>not</c> were accepted and ignored, with no
+/// diagnostic anywhere. That is worse than not supporting them: the served description still
+/// promises the rule, so a caller reads <c>multipleOf: 5</c>, sends 3, and is told it was fine.
+/// </para>
+/// <para>
+/// <b>The check has to run in the parser</b>, because <c>SpecDiagnostics.Find</c> is handed a
+/// <c>ServiceSpecModel</c> and a dropped keyword is by definition not in one. The model carries the
+/// note; the parser is what writes it.
+/// </para>
+/// <para>
+/// <b>It is explicitly not a diff.</b> The reader hands back a typed object model with no record of
+/// which keywords the document spelled, so each keyword here is a deliberate entry rather than
+/// anything discovered. A keyword nobody has thought about is still silent - unchanged for that
+/// keyword, and better for these.
+/// </para>
+/// </remarks>
+public class UnmappedKeywordTests {
+
+    private const string Dropping = """
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            get:
+              operationId: listProducts
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Product' }
+        components:
+          schemas:
+            Product:
+              type: object
+              properties:
+                unitPriceCents:
+                  type: integer
+                  multipleOf: 5
+                tags:
+                  type: array
+                  uniqueItems: true
+                  items: { type: string }
+        """;
+
+    private const string TwiceDropped = """
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            get:
+              operationId: listProducts
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Product' }
+        components:
+          schemas:
+            Product:
+              type: object
+              properties:
+                labels:
+                  type: array
+                  uniqueItems: true
+                  items: { type: string }
+                tags:
+                  type: array
+                  uniqueItems: true
+                  items: { type: string }
+        """;
+
+    private const string Clean = """
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            get:
+              operationId: listProducts
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Product' }
+        components:
+          schemas:
+            Product:
+              type: object
+              properties:
+                sku:
+                  type: string
+                  minLength: 3
+                  maxLength: 32
+        """;
+
+    private static ServiceSpecModel Parse(string yaml) {
+        var model = OpenApiSpecParser.Parse(yaml, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    [Fact]
+    public void MultipleOfIsRecordedAsUnmapped() {
+        Assert.Contains(Parse(Dropping).UnmappedKeywords, u => u.Keyword == "multipleOf");
+    }
+
+    [Fact]
+    public void UniqueItemsIsRecordedAsUnmapped() {
+        Assert.Contains(Parse(Dropping).UnmappedKeywords, u => u.Keyword == "uniqueItems");
+    }
+
+    /// <summary>
+    /// <c>not</c> is the one of the three with no attribute anywhere that could enforce it, so it is
+    /// the one most likely to be assumed unsupported-and-therefore-rejected. It is neither.
+    /// </summary>
+    [Fact]
+    public void NotIsRecordedAsUnmapped() {
+        var withNot = Dropping.Replace(
+            "          type: integer\n          multipleOf: 5",
+            "          type: integer\n          not: { const: 0 }");
+
+        // The replacement has to have happened, or this asserts nothing.
+        Assert.DoesNotContain("multipleOf", withNot);
+
+        Assert.Contains(Parse(withNot).UnmappedKeywords, u => u.Keyword == "not");
+    }
+
+    /// <summary>
+    /// The location names the member, because "multipleOf is not enforced" in a description with
+    /// four hundred schemas is not an actionable sentence.
+    /// </summary>
+    [Fact]
+    public void TheLocationNamesTheDeclaringMember() {
+        var unmapped = Parse(Dropping).UnmappedKeywords.Single(u => u.Keyword == "multipleOf");
+
+        Assert.Contains("unitPriceCents", unmapped.Location);
+    }
+
+    /// <summary>
+    /// <c>uniqueItems: false</c> is the default restated, not a declaration, and warning about it
+    /// would train people to ignore the warning.
+    /// </summary>
+    [Fact]
+    public void UniqueItemsSetToFalseIsNotADeclaration() {
+        var model = Parse(Dropping.Replace("uniqueItems: true", "uniqueItems: false"));
+
+        Assert.DoesNotContain(model.UnmappedKeywords, u => u.Keyword == "uniqueItems");
+    }
+
+    /// <summary>
+    /// A description using only keywords the parser honours produces no noise at all. Without this,
+    /// the diagnostic could pass its other tests by firing on everything.
+    /// </summary>
+    [Fact]
+    public void ADescriptionUsingOnlyMappedKeywordsIsSilent() {
+        Assert.Empty(Parse(Clean).UnmappedKeywords);
+        Assert.DoesNotContain(SpecDiagnostics.Find(Parse(Clean)), p => p.Code == "HOAT013");
+    }
+
+    [Fact]
+    public void TheDiagnosticIsAWarningRatherThanAnError() {
+        var problems = SpecDiagnostics.Find(Parse(Dropping)).Where(p => p.Code == "HOAT013");
+
+        Assert.NotEmpty(problems);
+        Assert.All(problems, problem => Assert.False(problem.Fatal));
+    }
+
+    /// <summary>
+    /// One message per keyword rather than per site. Forty arrays with <c>uniqueItems</c> have one
+    /// thing wrong with them, and forty messages would bury it.
+    /// </summary>
+    [Fact]
+    public void OneMessagePerKeywordRegardlessOfHowManySitesDeclareIt() {
+        var model = Parse(TwiceDropped);
+
+        Assert.Equal(2, model.UnmappedKeywords.Count(u => u.Keyword == "uniqueItems"));
+        Assert.Single(
+            SpecDiagnostics.Find(model),
+            p => p.Code == "HOAT013" && p.Message.Contains("uniqueItems"));
+    }
+
+    /// <summary>
+    /// Two sites is enough to tell "one per keyword" from "one per site"; the message says how many
+    /// the rest are.
+    /// </summary>
+    [Fact]
+    public void TheMessageCountsTheSitesItDidNotName() {
+        var problem = SpecDiagnostics.Find(Parse(TwiceDropped))
+            .First(p => p.Code == "HOAT013" && p.Message.Contains("uniqueItems"));
+
+        Assert.Contains("1 other place", problem.Message);
+    }
+
+    /// <summary>
+    /// The message says the description and the application disagree, which is the part that costs
+    /// someone a debugging session. "Not supported" alone does not say a caller has been misled.
+    /// </summary>
+    [Fact]
+    public void TheMessageSaysThePromiseIsNotKept() {
+        var problem = SpecDiagnostics.Find(Parse(Dropping))
+            .First(p => p.Code == "HOAT013" && p.Message.Contains("multipleOf"));
+
+        Assert.Contains("not enforced", problem.Message);
+        Assert.Contains("accepted at runtime", problem.Message);
+    }
+
+    /// <summary>
+    /// The note is build-task state, not description. Serializing it would put a diagnostic in the
+    /// generator's cache key, and the generator has nothing to do with it.
+    /// </summary>
+    [Fact]
+    public void TheNoteDoesNotSurviveIntoTheModelFile() {
+        var restored = SpecModelSerializer.Read(SpecModelSerializer.Write(Parse(Dropping)));
+
+        Assert.Empty(restored.UnmappedKeywords);
+    }
+
+    /// <summary>
+    /// Two models differing only in what was dropped generate identical C#, so they must not miss a
+    /// cache hit over it.
+    /// </summary>
+    [Fact]
+    public void ADroppedKeywordDoesNotChangeModelEquality() {
+        var withKeyword = Parse(Dropping);
+        var withoutKeyword = Parse(Dropping.Replace("                  multipleOf: 5\n", ""));
+
+        Assert.NotEmpty(withKeyword.UnmappedKeywords);
+        Assert.Equal(withKeyword.Schemas.Count, withoutKeyword.Schemas.Count);
+        Assert.Equal(withKeyword, withoutKeyword);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -172,6 +172,11 @@ internal static class OpenApiSpecParser {
             model.Schemas.Add(schema);
         }
 
+        // Emptied onto the model beside the schemas, because SpecDiagnostics is handed a model and
+        // nothing else - and what the parser declined to map is the one thing a model cannot be
+        // asked about, since a dropped keyword left no field to look at.
+        model.UnmappedKeywords.AddRange(synthesized.Unmapped);
+
         foreach (var kvp in operationsByTag) {
             model.Services.Add(new ServiceModel {
                 Tag = kvp.Key,
@@ -1096,6 +1101,9 @@ internal static class OpenApiSpecParser {
         // Extract validation constraints
         ExtractValidationConstraints(prop, model);
 
+        // And note the ones it does not extract, while the document's own schema is still in hand.
+        NoteUnmappedConstraints(prop, parentName + "." + name, collector.Unmapped);
+
         // What the payload is allowed to be. Recorded whether or not it becomes a type of its own,
         // because the branches would otherwise leave no trace in the model - and a schema nothing
         // in the model points at is not generated.
@@ -1180,6 +1188,43 @@ internal static class OpenApiSpecParser {
         model.Type = SchemaType(prop);
         model.Format = prop.Format;
         return model;
+    }
+
+    /// <summary>
+    /// The constraint keywords this parser knows about and does not map, noted where they are met.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Sited here rather than in a walk of its own because this is the one place a property's own
+    /// schema is in hand, which is also why <c>ExtractValidationConstraints</c> reads readOnly and
+    /// writeOnly here despite neither being a constraint. A second walk would drift from this one.
+    /// </para>
+    /// <para>
+    /// An explicit list rather than "anything not read". The reader hands back a typed object model
+    /// and there is no way to ask it which keywords the document actually spelled, so a diff is not
+    /// available; each line here is a deliberate statement that the keyword is understood and not
+    /// honoured. The cost is that a keyword nobody has thought about is still silent - which is
+    /// the same position as before for that keyword, and better for these.
+    /// </para>
+    /// </remarks>
+    private static void NoteUnmappedConstraints(
+        IOpenApiSchema schema, string location, ICollection<UnmappedKeywordModel>? unmapped) {
+        if (unmapped == null) {
+            return;
+        }
+
+        if (schema.MultipleOf.HasValue) {
+            unmapped.Add(new UnmappedKeywordModel("multipleOf", location));
+        }
+
+        // True is the declaration; false is the default and says nothing.
+        if (schema.UniqueItems == true) {
+            unmapped.Add(new UnmappedKeywordModel("uniqueItems", location));
+        }
+
+        if (schema.Not != null) {
+            unmapped.Add(new UnmappedKeywordModel("not", location));
+        }
     }
 
     private static void ExtractValidationConstraints(IOpenApiSchema schema, PropertyModel model) {

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/SchemaCollector.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/SchemaCollector.cs
@@ -31,6 +31,16 @@ internal sealed class SchemaCollector {
 
     private readonly HashSet<string> _taken = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Keywords met while reading schemas that the parser does not map.
+    /// </summary>
+    /// <remarks>
+    /// Here because this is already the parse-scoped accumulator threaded through every schema
+    /// method, so noting a dropped keyword costs no new parameter on any of them. It is emptied
+    /// onto the model at the end of <c>Parse</c>, alongside the synthesized schemas.
+    /// </remarks>
+    public List<UnmappedKeywordModel> Unmapped { get; } = new();
+
     /// <param name="declared">
     /// The document's own schema names, reserved before anything is parsed - an inline object
     /// inside a declared schema is lifted while that schema is still being read, so seeding this

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/UnmappedTraitTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/UnmappedTraitTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Idl;
+using Hardened.Idl.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// A trait the model declares that the parser does not map, said out loud.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Smithy half of the same rule the OpenAPI parser applies. <c>@uniqueItems</c> and
+/// <c>@sparse</c> are both named in <c>SmithyTraits.Mapped</c> - the parser declares them as traits
+/// it handles - and then <c>ReadConstraints</c> asks for <c>@length</c>, <c>@range</c> and
+/// <c>@pattern</c> and nothing else. Being on that list and unread is precisely the gap.
+/// </para>
+/// <para>
+/// <b>Written as an inline AST rather than a fixture.</b> The checked-in fixtures come from the real
+/// CLI, and the only <c>@uniqueItems</c> among them is on a dependency's list shape rather than a
+/// member of anybody's model - which the member-level check correctly does not see. Generating a new
+/// fixture needs a CLI whose version is pinned away from the one on this machine, so the AST is
+/// spelled out here instead. It is the minimum the parser accepts: a service, an operation with an
+/// <c>@http</c> binding, and an input structure.
+/// </para>
+/// </remarks>
+public class UnmappedTraitTests {
+
+    /// <summary>
+    /// <c>tags</c> carries <c>@uniqueItems</c> and <c>labels</c> carries <c>@sparse</c>;
+    /// <c>name</c> carries <c>@length</c>, which the parser does map, so it is the control.
+    /// </summary>
+    private const string Ast = """
+        {
+          "smithy": "2.0",
+          "shapes": {
+            "com.example.depot#Depot": {
+              "type": "service",
+              "version": "2024-01-01",
+              "operations": [{ "target": "com.example.depot#CreateProduct" }]
+            },
+            "com.example.depot#CreateProduct": {
+              "type": "operation",
+              "input": { "target": "com.example.depot#CreateProductInput" },
+              "traits": {
+                "smithy.api#http": { "method": "POST", "uri": "/products", "code": 201 }
+              }
+            },
+            "com.example.depot#CreateProductInput": {
+              "type": "structure",
+              "members": {
+                "name": {
+                  "target": "smithy.api#String",
+                  "traits": { "smithy.api#length": { "min": 1, "max": 64 } }
+                },
+                "tags": {
+                  "target": "com.example.depot#TagList",
+                  "traits": { "smithy.api#uniqueItems": {} }
+                },
+                "labels": {
+                  "target": "com.example.depot#TagList",
+                  "traits": { "smithy.api#sparse": {} }
+                }
+              },
+              "traits": { "smithy.api#input": {} }
+            },
+            "com.example.depot#TagList": {
+              "type": "list",
+              "member": { "target": "smithy.api#String" }
+            }
+          }
+        }
+        """;
+
+    private static ServiceSpecModel Parse(string ast) {
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(ast, "depot", diagnostics);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    [Fact]
+    public void UniqueItemsOnAMemberIsRecordedAsUnmapped() {
+        Assert.Contains(Parse(Ast).UnmappedKeywords, u => u.Keyword == "@uniqueItems");
+    }
+
+    [Fact]
+    public void SparseOnAMemberIsRecordedAsUnmapped() {
+        Assert.Contains(Parse(Ast).UnmappedKeywords, u => u.Keyword == "@sparse");
+    }
+
+    /// <summary>
+    /// Named as the model spells it, <c>@uniqueItems</c> rather than <c>uniqueItems</c>, because a
+    /// reader searching their own file is looking for the form with the at-sign.
+    /// </summary>
+    [Fact]
+    public void TheTraitIsNamedAsSmithySpellsIt() {
+        Assert.All(
+            Parse(Ast).UnmappedKeywords,
+            unmapped => Assert.StartsWith("@", unmapped.Keyword));
+    }
+
+    [Fact]
+    public void TheLocationNamesTheDeclaringMember() {
+        var locations = Parse(Ast).UnmappedKeywords
+            .Where(u => u.Keyword == "@uniqueItems")
+            .Select(u => u.Location)
+            .Distinct();
+
+        Assert.Equal("tags", Assert.Single(locations));
+    }
+
+    /// <summary>
+    /// One member declaring a trait is one place, however many times the parser met it - and it
+    /// meets each one twice, because an operation's input is walked for the schema and walked again
+    /// for the request body's properties. The raw notes carry the repeat; the message must not.
+    /// </summary>
+    [Fact]
+    public void AMemberMetTwiceIsCountedOnce() {
+        var problem = SpecDiagnostics.Find(Parse(Ast))
+            .First(p => p.Code == "HOAT013" && p.Message.Contains("@uniqueItems"));
+
+        Assert.Contains("at tags", problem.Message);
+        Assert.DoesNotContain("other place", problem.Message);
+    }
+
+    /// <summary>
+    /// A trait the parser does map produces nothing, or the diagnostic would be noise on every
+    /// model that constrains anything.
+    /// </summary>
+    [Fact]
+    public void AMappedTraitIsNotReported() {
+        Assert.DoesNotContain(Parse(Ast).UnmappedKeywords, u => u.Keyword.Contains("length"));
+    }
+
+    /// <summary>
+    /// It reaches the same reporting pass the OpenAPI front end uses, which is the point of putting
+    /// the note on the model rather than in either parser.
+    /// </summary>
+    [Fact]
+    public void ItReachesTheSharedDiagnosticsPass() {
+        var problems = SpecDiagnostics.Find(Parse(Ast)).Where(p => p.Code == "HOAT013").ToList();
+
+        Assert.Equal(2, problems.Count);
+        Assert.All(problems, problem => Assert.False(problem.Fatal));
+    }
+
+    /// <summary>
+    /// A model declaring neither is silent. Without this the check could pass everything above by
+    /// firing unconditionally.
+    /// </summary>
+    [Fact]
+    public void AModelDeclaringNeitherIsSilent() {
+        var clean = Ast
+            .Replace("\"smithy.api#uniqueItems\": {}", "\"smithy.api#required\": {}")
+            .Replace("\"smithy.api#sparse\": {}", "\"smithy.api#required\": {}");
+
+        // The replacements have to have happened, or this asserts nothing.
+        Assert.DoesNotContain("uniqueItems", clean);
+        Assert.DoesNotContain("sparse", clean);
+
+        Assert.Empty(Parse(clean).UnmappedKeywords);
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -681,8 +681,40 @@ internal static class SmithySpecParser {
         }
 
         ApplyTo(ReadConstraints(context, member, target), property);
+        NoteUnmappedTraits(context, member, name);
 
         return property;
+    }
+
+    /// <summary>
+    /// Traits this parser knows about and does not map, noted where they are met.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The Smithy half of the same rule the OpenAPI parser applies: a constraint the model declares
+    /// and the application does not enforce is a promise to a caller that nothing keeps, and the
+    /// build should say so rather than read past it.
+    /// </para>
+    /// <para>
+    /// Both of these are already named in <c>SmithyTraits.Mapped</c>, which is what makes them worth
+    /// reporting rather than leaving to the unknown-trait path - the parser declares them as traits
+    /// it handles, and then <c>ReadConstraints</c> asks for <c>@length</c>, <c>@range</c> and
+    /// <c>@pattern</c> and nothing else. Being on that list and unread is the gap.
+    /// </para>
+    /// <para>
+    /// <c>@default</c> is deliberately absent. It is read - it decides nullability a few lines above
+    /// - so it is not this class; that its <i>value</i> never reaches the model is a collapse, and
+    /// belongs to the audit that finds those.
+    /// </para>
+    /// </remarks>
+    private static void NoteUnmappedTraits(ParseContext context, JsonElement member, string name) {
+        if (SmithyAst.HasTrait(member, SmithyTraits.UniqueItems)) {
+            context.Model.UnmappedKeywords.Add(new UnmappedKeywordModel("@uniqueItems", name));
+        }
+
+        if (SmithyAst.HasTrait(member, SmithyTraits.Sparse)) {
+            context.Model.UnmappedKeywords.Add(new UnmappedKeywordModel("@sparse", name));
+        }
     }
 
     /// <summary>Where a shape id lands in the IR: an inlined primitive, a reference, or a collection.</summary>


### PR DESCRIPTION
`multipleOf`, `uniqueItems` and `not` were read past in silence. The build was clean, the application ran, and a caller reading the served description saw `multipleOf: 5`, sent `3`, and was told it was fine.

That is worse than not supporting the keyword — the document still makes the promise, and nothing said it would not be kept.

### Why it lives in the parser

`SpecDiagnostics.Find` is handed a `ServiceSpecModel` and nothing else, and **a keyword nobody mapped is by definition not in one**. A model can say what it holds, never what it was told and dropped. So the parser writes the note as it reads, the model carries it, and the existing pass reports it — nothing new logs, `HOAT013` goes out through the same `LogWarning` as every other non-fatal problem.

It hangs off `SchemaCollector` because that is already the parse-scoped accumulator threaded through every schema method, so noting a drop cost no new parameter on any of them.

### Deliberate choices

- **A list, not a diff.** The reader returns a typed object model with no record of which keywords the document spelled, so no diff is available. Each entry is a deliberate statement that the keyword is understood and not honoured. A keyword nobody has thought about is still silent — unchanged for that keyword, better for these three.
- **A warning, passed explicitly**, because the constructor defaults to fatal. An application declaring one of these is otherwise correct. *A test asserts this, and it failed first — the default had made it fatal.*
- **One message per keyword, not per site.** Forty arrays with `uniqueItems` have one problem; forty messages would bury it. Same failure as one MSBuild error per line of CLI output.
- **Not serialized, and absent from equality.** What the build declined to map changes no generated C#, and the report finishes before a line is written. Carrying it further would put a diagnostic in a cache key.

### What this does not catch

A keyword that was **read and then flattened** — `summary` folded into `description`, tags after the first discarded. Those are present in the model wearing the wrong shape, so nothing here notices. That class is found by auditing the parser, and was, in #183.

### Verification

- **5,016 tests across 29 assemblies, none failing.**
- **Mutation-tested, both halves:** unwiring `FindUnmappedKeywords` fails 4 tests; stopping the parser recording fails 9. Both sets confined to the new class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pAyGDdBAyCNNb3kR6uzqP
