### PR TITLE
Stop measuring coverage on a sibling repository's source

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -264,10 +264,16 @@ jobs:
           # report otherwise. Filtered here rather than in the runsettings: ModulePaths/Include did
           # not restrict it, and a report-level filter does not depend on one collector's schema -
           # which is the property being bought by this change in the first place.
+          #
+          # Hardened.DependencyModules.SourceGenerator is excluded because it is not this
+          # repository's code. It holds two files of its own - 148 lines - and compiles in the whole
+          # of DependencyModules.SourceGenerator.Impl, 8,554 lines, via Compile Include. A floor on
+          # that assembly is a floor on a sibling repository's source, moved by edits nobody here
+          # made, and it says nothing about whether the 148 lines are tested.
           reportgenerator \
             -reports:"coverage/**/*.cobertura.xml" \
             -targetdir:coverage-report \
-            -assemblyfilters:"+Hardened.*" \
+            -assemblyfilters:"+Hardened.*;-Hardened.DependencyModules.SourceGenerator" \
             -reporttypes:"TextSummary;MarkdownSummaryGithub;Html;JsonSummary"
           cat coverage-report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
           cat coverage-report/Summary.txt

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,8 +1,4 @@
 {
-  "Hardened.DependencyModules.SourceGenerator": {
-    "line": 97.2,
-    "branch": 87.5
-  },
   "Hardened.Idl.SourceGenerator": {
     "line": 59.5,
     "branch": 48.0


### PR DESCRIPTION
`Hardened.DependencyModules.SourceGenerator` holds two files of its own — 148 lines — and compiles in the whole of `DependencyModules.SourceGenerator.Impl` via `Compile Include`: **8,554 lines from a repository this one does not contain.**

```xml
<Compile Include="$(_DependencyModulesRoot)/src/DependencyModules.SourceGenerator.Impl/**/*.cs" ... />
<Compile Include="$(_DependencyModulesRoot)/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs">
```

So 98% of what that floor measures is somebody else's code, which makes it say nothing useful in either direction. It moves when DependencyModules is edited — by people who never touched this repository and cannot see the gate — and it says nothing about whether the 148 lines here are tested. A regression is a false alarm; a rise is unearned.

## What this changes

Excluded at the report filter, beside the existing `+Hardened.*` rationale, because that is already where this report decides what it is about:

```
-assemblyfilters:"+Hardened.*;-Hardened.DependencyModules.SourceGenerator"
```

The baseline entry is removed in the same commit, deliberately. An entry no run reports is fatal to the gate — *"an assembly that vanishes from the report is not passing, it is not being measured"* — so leaving it behind would fail CI with a message about missing tests, which is not what happened.

## How this surfaced

A coverage run during #186 reported this assembly down 37.5% on branch coverage. That particular run turned out to be a bad measurement, but checking it is what showed the floor was measuring a sibling repository all along.

## Verification

- Full solution builds clean under `ContinuousIntegrationBuild=true` — 0 errors, 0 warnings.
- Coverage gate passes: 21 assemblies at or above baseline, down from 22 by exactly this one.
- No other baseline entry touched; the floors set in #186 are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6UrQsfWzKhZiyjJ1sgoUx
