### PR TITLE
Carry every member when a handler is amended, and register the test environment under both interfaces

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -264,6 +264,10 @@ namespace Hardened.Requests.Runtime.Execution
         public int? SuccessStatus { get; }
         public Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo WithPath(string? path) { }
     }
+    public static class ExecutionRequestHandlerInfoExtensions
+    {
+        public static Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo WithRequirement(this Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Abstract.Authorization.Requirement? requirement) { }
+    }
     public class ExecutionRequestParameter : Hardened.Requests.Abstract.Execution.IExecutionRequestParameter
     {
         public ExecutionRequestParameter(string name, int index, System.Type type) { }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationConventionTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationConventionTests.cs
@@ -168,6 +168,56 @@ public class AuthorizationConventionTests {
         Assert.Same(declared, Setup(declared, []).HandlerInfo);
     }
 
+    /// <summary>
+    /// Amending a handler keeps every member the convention did not speak about.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The regression this file did not have. Applying a convention rebuilt the handler from seven
+    /// of its ten arguments, so <c>SuccessStatus</c>, <c>NullResponseBody</c> and
+    /// <c>ProducedContentTypes</c> were dropped the moment an application registered one: a route
+    /// declaring 201 answered 200, from a contract that said 201, with a clean build and no warning.
+    /// </para>
+    /// <para>
+    /// Asserted through <c>ExecutionHelper</c> rather than on the amendment directly, because the
+    /// defect was in the call rather than in the type it called - a test written against
+    /// <c>WithRequirement</c> would have passed against the broken version too.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void AnAmendedHandlerKeepsWhatTheConventionDidNotTouch() {
+        var declared = new ExecutionRequestHandlerInfo(
+            "/admin/users", "POST", typeof(Controller), "Create",
+            parameters: null,
+            metadata: [new AuthorizeGrantsAttribute("users:write")],
+            requirement: null,
+            successStatus: 201,
+            nullResponseBody: EmptyBody,
+            producedContentTypes: new[] { "application/json" });
+
+        var amended = Setup(declared, [new PrefixConvention("/admin", "admin:access")]).HandlerInfo;
+
+        // The convention did apply, so this is the rebuilt instance rather than the declared one.
+        Assert.NotSame(declared, amended);
+        Assert.Contains("admin:access", amended.Requirement!.RequiredGrants);
+        Assert.Contains("users:write", amended.Requirement!.RequiredGrants);
+
+        Assert.Equal(201, amended.SuccessStatus);
+        Assert.Same(EmptyBody, amended.NullResponseBody);
+        Assert.Equal(new[] { "application/json" }, amended.ProducedContentTypes);
+
+        // And the members that were being carried correctly stay carried.
+        Assert.Equal("/admin/users", amended.Path);
+        Assert.Equal("POST", amended.Method);
+        Assert.Equal(typeof(Controller), amended.HandlerType);
+        Assert.Equal("Create", amended.InvokeMethod);
+    }
+
+    /// <summary>
+    /// Reference-compared in the assertion above, so it has to be the same instance both times.
+    /// </summary>
+    private static readonly object EmptyBody = new();
+
     #endregion
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
@@ -248,11 +248,12 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
     /// at startup and nothing at all per request.
     /// </para>
     /// <para>
-    /// The amended handler is a plain <see cref="ExecutionRequestHandlerInfo"/> rather than a
-    /// wrapper delegating to the declared one. Every member of the interface is copied, so the two
-    /// carry the same answers - and the status members, the only ones with default implementations
-    /// an implementation could have overridden, are answered by that default everywhere in the tree.
-    /// A wrapper would be the right shape only once something needs to override one.
+    /// The amendment goes through <see cref="ExecutionRequestHandlerInfoExtensions.WithRequirement"/>
+    /// rather than reconstructing the handler here. Reconstructing here is what dropped
+    /// <c>SuccessStatus</c>, <c>NullResponseBody</c> and <c>ProducedContentTypes</c> for every
+    /// application that registered a convention: the call listed seven of the ten arguments, and
+    /// nothing about it looked incomplete. One copy path, in the type that owns the members, is
+    /// what keeps the next added member from going the same way.
     /// </para>
     /// </remarks>
     private static IExecutionRequestHandlerInfo ApplyConventions(
@@ -286,14 +287,7 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
             requirements.Insert(0, handlerInfo.Requirement);
         }
 
-        return new ExecutionRequestHandlerInfo(
-            handlerInfo.Path,
-            handlerInfo.Method,
-            handlerInfo.HandlerType,
-            handlerInfo.InvokeMethod,
-            handlerInfo.Parameters,
-            handlerInfo.Metadata,
-            Requirement.AllOf([..requirements]));
+        return handlerInfo.WithRequirement(Requirement.AllOf([..requirements]));
     }
 
     #endregion

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
@@ -27,6 +27,42 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         ProducedContentTypes = producedContentTypes ?? Array.Empty<string>();
     }
 
+    /// <summary>
+    /// A copy of <paramref name="source"/> with the named members replaced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The one place that enumerates every member of the interface. <see cref="WithPath"/> and
+    /// <see cref="ExecutionRequestHandlerInfoExtensions.WithRequirement"/> both route through it, so
+    /// a member added to <see cref="IExecutionRequestHandlerInfo"/> is carried by both amendments or
+    /// by neither, rather than by whichever one somebody remembered.
+    /// </para>
+    /// <para>
+    /// That is the defect this closes. Applying a convention used to rebuild the handler from seven
+    /// of the ten arguments, dropping <see cref="SuccessStatus"/>, <see cref="NullResponseBody"/>
+    /// and <see cref="ProducedContentTypes"/> on the floor - so a route declaring 201 answered 200
+    /// as soon as any authorization convention was registered, from a contract that said otherwise,
+    /// and nothing warned.
+    /// </para>
+    /// <para>
+    /// A null override keeps what the source carried. <see cref="Requirement"/> falls back to the
+    /// primary constructor's derivation from metadata, which is the same answer the source reached.
+    /// </para>
+    /// </remarks>
+    internal ExecutionRequestHandlerInfo(
+        IExecutionRequestHandlerInfo source, string? path, Requirement? requirement)
+        : this(
+            path ?? source.Path,
+            source.Method,
+            source.HandlerType,
+            source.InvokeMethod,
+            source.Parameters,
+            source.Metadata,
+            requirement ?? source.Requirement,
+            source.SuccessStatus,
+            source.NullResponseBody,
+            source.ProducedContentTypes) { }
+
     public string Path { get; }
 
     public string Method { get; }
@@ -83,7 +119,33 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
     public ExecutionRequestHandlerInfo WithPath(string? path) =>
         string.IsNullOrEmpty(path) || string.Equals(path, Path, StringComparison.Ordinal)
             ? this
-            : new ExecutionRequestHandlerInfo(
-                path!, Method, HandlerType, InvokeMethod, Parameters, Metadata, Requirement,
-                SuccessStatus, NullResponseBody, ProducedContentTypes);
+            : new ExecutionRequestHandlerInfo(this, path, requirement: null);
+}
+
+/// <summary>
+/// Amendments to a handler that carry every other member across unchanged.
+/// </summary>
+public static class ExecutionRequestHandlerInfoExtensions {
+
+    /// <summary>
+    /// The same handler, requiring <paramref name="requirement"/> of its caller.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An extension rather than an interface member, because the amendment has to work on whatever
+    /// implementation reached it and the interface is one an application may implement. The result
+    /// is a plain <see cref="ExecutionRequestHandlerInfo"/>: every member of the source is copied,
+    /// so nothing an implementation answered differently is lost except the identity of the type
+    /// that answered it.
+    /// </para>
+    /// <para>
+    /// Returns <c>this</c> when there is nothing to change, so a handler no convention spoke about
+    /// costs nothing.
+    /// </para>
+    /// </remarks>
+    public static IExecutionRequestHandlerInfo WithRequirement(
+        this IExecutionRequestHandlerInfo handlerInfo, Requirement? requirement) =>
+        requirement is null || ReferenceEquals(requirement, handlerInfo.Requirement)
+            ? handlerInfo
+            : new ExecutionRequestHandlerInfo(handlerInfo, path: null, requirement);
 }

--- a/src/Shared/Hardened.Shared.Testing.Tests/Attributes/HardenedTestEntryPointSetupTests.cs
+++ b/src/Shared/Hardened.Shared.Testing.Tests/Attributes/HardenedTestEntryPointSetupTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Runtime.Interfaces;
 using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Runtime.Configuration;
 using Hardened.Shared.Testing.Attributes;
@@ -356,5 +357,35 @@ public class HardenedTestEntryPointSetupTests {
         var (provider, _) = Setup<UsesTheAssemblyEnvironment>(nameof(UsesTheAssemblyEnvironment.Method));
 
         Assert.IsType<TestEnvironment>(provider.GetRequiredService<IHardenedEnvironment>());
+    }
+
+    /// <summary>
+    /// The same environment answers under both service types, so the module system and application
+    /// code agree about which environment a test is running in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The harness used to register the environment under <see cref="IHardenedEnvironment"/> alone.
+    /// <see cref="IModuleEnvironment"/> then fell back to its own default and reported
+    /// <c>Production</c> however the test was annotated, which made <c>[IfEnvironment]</c> — a
+    /// shipped, template-default feature — impossible to exercise from a test at all.
+    /// </para>
+    /// <para>
+    /// Asserted as identity rather than as two equal names, because two objects agreeing today is
+    /// what the previous version looked like from the outside right up until one of them was asked
+    /// something the other would have answered differently.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TheEnvironmentIsRegisteredUnderBothInterfaces() {
+        var (provider, _) = Setup<DeclaresClassLevelEnvironment>(
+            nameof(DeclaresClassLevelEnvironment.Method));
+
+        var hardened = provider.GetRequiredService<IHardenedEnvironment>();
+        var module = provider.GetRequiredService<IModuleEnvironment>();
+
+        Assert.Same(hardened, module);
+        Assert.Equal("class-environment", hardened.Name);
+        Assert.Equal("class-environment", module.EnvironmentName);
     }
 }

--- a/src/Shared/Hardened.Shared.Testing/Attributes/HardenedTestEntryPointAttribute.cs
+++ b/src/Shared/Hardened.Shared.Testing/Attributes/HardenedTestEntryPointAttribute.cs
@@ -32,7 +32,13 @@ public class HardenedTestEntryPointAttribute
         var environment = BuildEnvironment(attributeCollection, methodInfo);
 
         serviceCollection.AddLogging();
-        serviceCollection.AddSingleton<IHardenedEnvironment>(environment);
+
+        // AddHardenedEnvironment rather than AddSingleton, which registers only IHardenedEnvironment
+        // and leaves IModuleEnvironment unanswered - so the module system read Production however the
+        // test was annotated, and [IfEnvironment], a template-default feature, could not be exercised
+        // from a test at all. TestApplication has always done it this way; this is the path that had
+        // not caught up.
+        serviceCollection.AddHardenedEnvironment(environment);
         serviceCollection.AddSingleton<IApplicationRoot>(sp => new ServiceProviderApplicationRoot(sp));
         serviceCollection.AddSingleton<ITestContext>(sp => {
             var loggerType = typeof(ILogger<>).MakeGenericType(methodInfo.DeclaringType!);

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -106,8 +106,16 @@ The thrown value is an ordinary response record, so the body a client sees is th
 declared modes return. What differs is that nothing in the signature says the route can answer it.
 
 #if (codeFirst)
-This mode cannot put a status beside its success type, which is why `Create` answers 200 rather
-than 201. Regenerate with `--response-model response` and the same route answers 201.
+A single success status is nameable here: `SuccessStatus` on the verb attribute carries it, and it
+reaches the generated document.
+
+```csharp
+[Post("/todos", SuccessStatus = 201)]
+```
+
+`Create` is left at the default 200 so the three response models differ in one thing at a time, not
+because the mode cannot say 201. What this mode cannot express is *more than one* success status -
+for that, regenerate with `--response-model response`.
 #endif
 #if (specFirst)
 The contract still names each operation's success status and the dispatch carries it, so `POST

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -109,8 +109,9 @@ signature that the route can answer it - so the generated document describes few
 the application actually has.
 
 #if (codeFirst)
-It also cannot name a status beside its success type, which is why creating a todo answers 200
-rather than 201.
+A single success status is nameable — `[Post("/todos", SuccessStatus = 201)]` answers 201 and says
+so in the generated document. Creating a todo is left at the default 200 here so the three response
+models differ in one thing at a time. What this mode cannot express is more than one success status.
 #endif
 #if (specFirst)
 The contract still names each operation's success status and the dispatch carries it, so creating a


### PR DESCRIPTION
Three statements in the tree that the code contradicted. From the Atlas Matrix study — closes **D2** (critical), **D6** (major) and recommendation **08**.

## D2 — a convention silently discarded three declared members

`ExecutionHelper.ApplyConventions` rebuilt `ExecutionRequestHandlerInfo` from **seven of its ten** constructor arguments, so registering any `IAuthorizationConvention` dropped `SuccessStatus`, `NullResponseBody` and `ProducedContentTypes`. A route declaring 201 answered 200, from a contract that said 201, with a clean build and no diagnostic.

The XML comment above it asserted the opposite — *"Every member of the interface is copied, so the two carry the same answers"* — which is what stopped an agent looking there for an hour.

The amendment now goes through `WithRequirement`, alongside the existing `WithPath`, and both route through one copy constructor that is the single place listing every member. A member added to `IExecutionRequestHandlerInfo` is now carried by both amendments or by neither.

## D6 — the test harness registered one of the two environment interfaces

`HardenedTestEntryPointAttribute` called `AddSingleton<IHardenedEnvironment>` rather than `AddHardenedEnvironment`, so `IModuleEnvironment` fell back to its own default and reported `Production` however the test was annotated. `[IfEnvironment]` — a shipped, template-default feature — could not be exercised from a test at all.

`TestApplication` in the same package has always done it correctly; this is the path that had not caught up.

## Recommendation 08 — the template denied a capability it ships

`AGENTS.md` and `README.md` said standard mode *"cannot put a status beside its success type"*. `SuccessStatus` is a wired property on all five verb attributes and is exercised by integration tests (`[Post("/created", SuccessStatus = 201)]`). One paragraph was sending teams through a response-model migration they do not need.

The narrower claim the template also makes — that the mode cannot express *more than one* success status — is correct and is kept.

## Verification

Both regression tests were confirmed to fail against the unfixed code, not merely to pass against the fixed one:

```
AnAmendedHandlerKeepsWhatTheConventionDidNotTouch
   Assert.Equal() Failure: Values differ
   Expected: 201
   Actual:   null

TheEnvironmentIsRegisteredUnderBothInterfaces
   System.InvalidOperationException : No service for type
   'DependencyModules.Runtime.Interfaces.IModuleEnvironment' has been registered.
```

`AuthorizationConventionTests` had eight cases, every one about the requirement and none about anything else — which is why this shipped.

**5,204 tests pass, 0 fail**, across 30 projects. The public API baseline is updated for the one added extension method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX