### PR TITLE
Report scopes named on a scheme that cannot carry them, and drive the attribute guarantee

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/AttributeAuthorizationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/AttributeAuthorizationTests.cs
@@ -1,0 +1,53 @@
+namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
+
+/// <summary>
+/// An <c>[AuthorizeGrants]</c> written on a contract-first handler, over a real request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>described-authorization.md</c> promises this: a described requirement arrives as one more
+/// entry in the handler's metadata <em>alongside anything the implementation declared</em>, so a
+/// contract may narrow a route and can never widen one. <c>security: []</c> does not strip an
+/// attribute somebody wrote on the handler.
+/// </para>
+/// <para>
+/// The guarantee was reported as broken in contract-first mode - the claim being that no path
+/// existed from a C# attribute into the generated <c>_metadata</c>, so the attribute compiled, read
+/// as protective in review, and enforced nothing. The path does exist. What did not exist was a
+/// test: every existing case guarded a route <em>from</em> the description, and
+/// <c>SecuredServiceImpl</c> says in its own remarks that neither of its handlers carries an
+/// authorization attribute. Nothing in the suite would have contradicted the claim.
+/// </para>
+/// <para>
+/// Driven over HTTP rather than asserted against the generated source, because the generated source
+/// having the right characters in it is not the thing promised. What is promised is that the
+/// request is refused.
+/// </para>
+/// </remarks>
+public class AttributeAuthorizationTests {
+
+    /// <summary>
+    /// The attribute guards the route, even though the description declares it public.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnAttributeOnTheHandlerGuardsADescribedPublicRoute(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/guarded/by-attribute");
+
+        Assert.Equal(401, response.StatusCode);
+    }
+
+    /// <summary>
+    /// And the neighbouring route, which the description also declares public and which carries no
+    /// attribute, still answers.
+    /// </summary>
+    /// <remarks>
+    /// The control. Without it a test above would pass just as well if this application had turned
+    /// default-deny on, which would make it a test of the posture rather than of the attribute.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ADescribedPublicRouteWithNoAttributeStillAnswers(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/stores");
+
+        response.Assert.Ok();
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/GuardedServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/GuardedServiceImpl.cs
@@ -1,0 +1,33 @@
+using Hardened.IntegrationTests.OpenApi.SUT.Services;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Runtime.Authorization;
+
+namespace Hardened.IntegrationTests.OpenApi.SUT;
+
+/// <summary>
+/// A handler guarded by an attribute the implementation wrote, on an operation the description
+/// declares public.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The opposite direction from <see cref="SecuredServiceImpl"/>, and the one nothing was driving.
+/// <c>described-authorization.md</c> states that a described requirement arrives as one more entry
+/// in the handler's metadata alongside anything the implementation declared, so a contract may
+/// narrow a route and can never widen one - <c>security: []</c> does not strip an
+/// <c>[AuthorizeGrants]</c> somebody wrote here.
+/// </para>
+/// <para>
+/// That guarantee was reported as not holding in contract-first mode, on the grounds that no path
+/// existed from a C# attribute into the generated metadata. The path exists:
+/// <c>HandlerSelector</c> collects every attribute on a <c>[Handler]</c> class,
+/// <c>RequestModelBuilder.EnrichWithHandlerFilters</c> appends them to the model the description
+/// produced, and <c>IExecutionRequestHandlerInfo.RequirementFrom</c> conjoins every
+/// <c>IAuthorizeAttribute</c> it finds. What was missing was a test, which is why the claim was
+/// credible.
+/// </para>
+/// </remarks>
+[Handler]
+[AuthorizeGrants("guarded:enter")]
+public class GuardedServiceImpl : IGuardedService {
+    public Task<string> GuardedByAttribute() => Task.FromResult("reached");
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -94,6 +94,22 @@ paths:
             application/json:
               schema:
                 type: string
+  # Declared public, and guarded anyway by an [AuthorizeGrants] on the implementation. This is the
+  # documented rule in described-authorization.md - "a contract can never widen one" - and nothing
+  # was driving it, which is how it came to be reported as broken.
+  /guarded/by-attribute:
+    get:
+      tags:
+        - Guarded
+      operationId: guardedByAttribute
+      security: []
+      responses:
+        '200':
+          description: Allowed.
+          content:
+            application/json:
+              schema:
+                type: string
   /secured/either:
     get:
       tags:

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SecurityScopeDiagnosticTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SecurityScopeDiagnosticTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// Scopes named on a security scheme that has nowhere to put them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// OpenAPI gives the scope array a meaning only under <c>oauth2</c> and <c>openIdConnect</c>. Name
+/// permissions beside any other scheme and they are read by nothing - so the operation keeps "be
+/// authenticated" and loses the permission it asked for. Every caller who can log in passes a check
+/// the document says needs a grant: a 403 becomes a 200, and the build is clean.
+/// </para>
+/// <para>
+/// <c>type: http, scheme: bearer</c> is what a real bearer API declares, which is what makes this
+/// worth a diagnostic rather than a footnote. It is not an exotic mistake; it is the shape somebody
+/// writes when they expect the obvious reading.
+/// </para>
+/// <para>
+/// Reported rather than honoured. Reading the array under <c>http</c> would make Hardened enforce a
+/// requirement no other tool in the ecosystem sees, so a document that passed review here would mean
+/// something different everywhere else.
+/// </para>
+/// </remarks>
+public class SecurityScopeDiagnosticTests {
+
+    private static string Document(string schemeDeclaration, string requirement) => $$"""
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            get:
+              operationId: listProducts
+              security:
+                {{requirement}}
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema:
+                        type: string
+        components:
+          securitySchemes:
+            {{schemeDeclaration}}
+        """;
+
+    private const string Bearer = """
+        depotAuth:
+              type: http
+              scheme: bearer
+        """;
+
+    private const string ApiKey = """
+        depotAuth:
+              type: apiKey
+              name: X-Api-Key
+              in: header
+        """;
+
+    private const string OAuth = """
+        depotAuth:
+              type: oauth2
+              flows:
+                clientCredentials:
+                  tokenUrl: https://example.invalid/token
+                  scopes:
+                    "depot:read": Read.
+        """;
+
+    private const string NamesAScope = """
+        - depotAuth: ["depot:read"]
+        """;
+
+    private const string NamesNothing = """
+        - depotAuth: []
+        """;
+
+    private static (ServiceSpecModel Model, List<string> Diagnostics) Parse(
+        string scheme, string requirement) {
+        var diagnostics = new List<string>();
+
+        var model = OpenApiSpecParser.Parse(
+            Document(scheme, requirement), "depot", CancellationToken.None,
+            diagnostics: diagnostics);
+
+        Assert.NotNull(model);
+
+        return (model!, diagnostics);
+    }
+
+    private static OperationModel Operation(ServiceSpecModel model) =>
+        model.Services.SelectMany(service => service.Operations).Single();
+
+    [Fact]
+    public void ScopesOnABearerSchemeAreReported() {
+        var (_, diagnostics) = Parse(Bearer, NamesAScope);
+
+        Assert.Contains(diagnostics, d => d.Contains("'depot:read'") && d.Contains("cannot carry"));
+    }
+
+    [Fact]
+    public void ScopesOnAnApiKeySchemeAreReported() {
+        var (_, diagnostics) = Parse(ApiKey, NamesAScope);
+
+        Assert.Contains(diagnostics, d => d.Contains("cannot carry"));
+    }
+
+    /// <summary>
+    /// The message says what the document said, so the fix does not need a second look at the file.
+    /// </summary>
+    [Fact]
+    public void TheReportNamesTheOperationTheSchemeAndItsType() {
+        var (_, diagnostics) = Parse(Bearer, NamesAScope);
+
+        var reported = Assert.Single(diagnostics, d => d.Contains("cannot carry"));
+
+        Assert.Contains("listProducts", reported);
+        Assert.Contains("depotAuth", reported);
+        Assert.Contains("Http", reported);
+    }
+
+    /// <summary>
+    /// And the behaviour it is warning about is unchanged: the caller must still authenticate, and
+    /// the grant is still not required. A diagnostic that also changed the answer would be a
+    /// breaking change wearing a warning.
+    /// </summary>
+    [Fact]
+    public void TheOperationStillRequiresAuthenticationAndNoGrant() {
+        var (model, _) = Parse(Bearer, NamesAScope);
+
+        var branch = Assert.Single(Operation(model).AuthorizationBranches);
+
+        Assert.True(branch.RequiresAuthentication);
+        Assert.Empty(branch.Grants);
+    }
+
+    /// <summary>
+    /// A scheme that can carry scopes keeps them, and says nothing.
+    /// </summary>
+    [Fact]
+    public void ScopesOnAnOAuthSchemeAreKeptAndNotReported() {
+        var (model, diagnostics) = Parse(OAuth, NamesAScope);
+
+        Assert.DoesNotContain(diagnostics, d => d.Contains("cannot carry"));
+
+        var branch = Assert.Single(Operation(model).AuthorizationBranches);
+
+        Assert.Contains("depot:read", branch.Grants);
+    }
+
+    /// <summary>
+    /// An empty array on a scheme that cannot carry scopes is the correct way to write it, and must
+    /// stay silent - otherwise the diagnostic fires on every API-key API in existence.
+    /// </summary>
+    [Fact]
+    public void AnEmptyScopeArrayIsNotReported() {
+        var (_, diagnostics) = Parse(ApiKey, NamesNothing);
+
+        Assert.DoesNotContain(diagnostics, d => d.Contains("cannot carry"));
+    }
+
+    /// <summary>
+    /// A scheme the document never declared already has its own report - that the reference is
+    /// dangling - and must not also collect this one, which would name a type it does not have.
+    /// </summary>
+    [Fact]
+    public void AnUndeclaredSchemeIsReportedOnlyAsDangling() {
+        var diagnostics = new List<string>();
+
+        OpenApiSpecParser.Parse(
+            Document(Bearer, """
+                - missingAuth: ["depot:read"]
+                """),
+            "depot", CancellationToken.None, diagnostics: diagnostics);
+
+        Assert.Contains(diagnostics, d => d.Contains("does not declare"));
+        Assert.DoesNotContain(diagnostics, d => d.Contains("cannot carry"));
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -1557,6 +1557,28 @@ internal static class OpenApiSpecParser {
                         }
                     }
                 } else {
+                    // Naming permissions on a scheme that has nowhere to put them is a document
+                    // error, and a silent one in the worst direction: the operation keeps only
+                    // "be authenticated", so every caller who can log in passes a check the
+                    // document says needs a permission. A 403 becomes a 200 and the build is clean.
+                    //
+                    // `type: http, scheme: bearer` is what a real bearer API declares, so this is
+                    // not an exotic mistake - it is the shape somebody writes when they expect the
+                    // obvious reading. Reported rather than honoured because OpenAPI gives the
+                    // array no meaning outside oauth2 and openIdConnect, and inventing one here
+                    // would make Hardened enforce something no other tool reads.
+                    if (!string.IsNullOrEmpty(name) &&
+                        scopes is { Count: > 0 } &&
+                        Declares(schemes, name!)) {
+                        diagnostics?.Add(
+                            $"operation '{operationId}' names {DescribeScopes(scopes)} on security " +
+                            $"scheme '{name}', which is declared as " +
+                            $"'{TypeOf(schemes, name!)}' and cannot carry them. They were not read, " +
+                            "so the operation requires an authenticated caller and none of the " +
+                            "permissions it names. Declare the scheme as 'oauth2' or " +
+                            "'openIdConnect' to keep them, or move the check into the handler.");
+                    }
+
                     // Either a scheme that cannot carry scopes, or one that can and declared none.
                     // Both say the same thing about the caller.
                     branch.RequiresAuthentication = true;
@@ -1594,6 +1616,44 @@ internal static class OpenApiSpecParser {
     private static bool Declares(
         IDictionary<string, IOpenApiSecurityScheme>? schemes, string name) =>
         schemes != null && schemes.ContainsKey(name);
+
+    /// <summary>
+    /// How a declared scheme names its own type, for a message that quotes the document back.
+    /// </summary>
+    private static string TypeOf(
+        IDictionary<string, IOpenApiSecurityScheme>? schemes, string name) =>
+        schemes != null && schemes.TryGetValue(name, out var scheme)
+            ? scheme.Type?.ToString() ?? "unknown"
+            : "unknown";
+
+    /// <summary>
+    /// The dropped scopes, quoted, so the message names what was lost rather than counting it.
+    /// </summary>
+    /// <remarks>
+    /// Listed in full up to three and summarised past that. A document declaring a long scope list
+    /// on the wrong scheme has one mistake, not eight, and a message that prints all of them buries
+    /// the sentence explaining what happened.
+    /// </remarks>
+    private static string DescribeScopes(IList<string> scopes) {
+        var named = new List<string>();
+
+        foreach (var scope in scopes) {
+            if (!string.IsNullOrEmpty(scope)) {
+                named.Add("'" + scope + "'");
+            }
+        }
+
+        if (named.Count == 0) {
+            return "scopes";
+        }
+
+        if (named.Count <= 3) {
+            return (named.Count == 1 ? "scope " : "scopes ") + string.Join(", ", named.ToArray());
+        }
+
+        return "scopes " + string.Join(", ", named.GetRange(0, 3).ToArray()) +
+               $" and {named.Count - 3} more";
+    }
 
     private static void ParsePath(string path, IOpenApiPathItem pathItem,
         Dictionary<string, List<OperationModel>> operationsByTag, SchemaCollector collector,


### PR DESCRIPTION
Two authorization findings from the Atlas Matrix study. **R07 is real and is fixed. D4 does not reproduce**, and is now covered so it cannot be reported again.

## D4 does not reproduce

The study rated this *Critical · security-shaped* and called it "the most consequential item left on the list, because the guarantee it breaks is written down". It reported that an `[AuthorizeGrants]` on a contract-first handler "compiles, reads as protective in review, and enforces nothing", because `RequestModelBuilder.BuildHandler` populates filters entirely from the parsed contract.

The path from a C# attribute into `_metadata` exists:

| Step | Where |
|---|---|
| Collects **every** attribute on a `[Handler]` class and its methods | `HandlerSelector.Transform` |
| Appends them to the model the description produced | `RequestModelBuilder.EnrichWithHandlerFilters` |
| Conjoins every `IAuthorizeAttribute` found in metadata | `IExecutionRequestHandlerInfo.RequirementFrom` |

I checked before concluding, in both contract-first modes, by putting the attribute on a handler and driving the route:

```
OpenAPI — [AuthorizeGrants("stores:admin")] on StoreServiceImpl
  /stores is declared `security: []` and answered 200
  → ARouteDeclaredPublicIsNotGuarded   Actual: 401
  → ListStores_ReturnsListOfStores     Actual: 401

Smithy — [AuthorizeGrants("bank:admin")] on BankServiceImpl
  → GetBalance_SendsTheDeclaredErrorWithItsTypeDiscriminator   Actual: 401
  → GetBalance_ErrorStatusComesFromTheErrorTrait               Actual: 401
  → PathRoutedOperationsStillWorkAlongsideDispatch             Actual: 401
```

`Hardened.Smithy.SourceGenerator` contains no C# at all — both front ends feed the same `SpecSourceGenerator` spine — so the two modes share this mechanism rather than each having their own.

So the guarantee in `described-authorization.md` — *"A contract can never widen one. `security: []` does not strip an `[AuthorizeGrants]` somebody wrote on the implementation"* — holds exactly as written, and needs no correction.

**What was actually missing was a test.** Every existing case guarded a route *from* the description, and `SecuredServiceImpl` states in its own remarks that neither of its handlers carries an authorization attribute. Nothing in the suite would have contradicted the claim, which is why it was credible.

This adds an operation declared `security: []` whose handler carries `[AuthorizeGrants]`, driven over HTTP, with the neighbouring unguarded route as a control — so the test cannot pass merely because the application turned default-deny on.

## R07 is real

Naming scopes on a scheme that cannot carry them dropped them in silence. The operation kept "be authenticated" and lost the permission, so every caller who can log in passed a check the document says needs a grant — a 403 answering 200, on a clean build.

`type: http, scheme: bearer` is what a real bearer API declares, so this is the shape somebody writes expecting the obvious reading, not an exotic mistake.

Now reported, naming the operation, the scheme, and the type it was declared as. **Reported rather than honoured**: OpenAPI gives the scope array no meaning outside `oauth2` and `openIdConnect`, so reading it under `http` would make Hardened enforce a requirement no other tool in the ecosystem sees.

## HOAT006 is deliberately not promoted

The study asked for this on the grounds that "its only effect is to weaken authorization". That is true of the dangling-scheme message but not of the code: `readerDiagnostics` carries general OpenAPI reader complaints through the same channel and they are logged under the same code — which is shared with `HSMT006`, since both front ends derive it from `DiagnosticPrefix + "006"`. Promoting it would make any reader grumble fatal in both.

Separating the security-weakening messages onto their own code means threading a second diagnostic channel through a `Parse` signature shared with Smithy. That is its own change rather than a rider on this one.

## Verification

Three of the seven new parser tests were confirmed to fail without the fix. The other four assert that the behaviour being warned about is *unchanged* — a diagnostic that also changed the answer would be a breaking change wearing a warning — so they pass either way by design.

**5,215 tests pass, 0 fail**, across 30 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX