### PR TITLE
Build the document and health chains through ExecutionHelper, so they can be guarded

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
@@ -234,7 +234,14 @@ namespace Hardened.Web.Runtime.Health
         public bool IncludeDetail { get; set; }
         public string LivePath { get; set; }
         public string ReadyPath { get; set; }
+        public Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; set; }
         public System.TimeSpan TotalTimeout { get; set; }
+    }
+    public class HealthCheckController
+    {
+        public HealthCheckController(System.IServiceProvider rootProvider, Hardened.Web.Runtime.Health.HealthCheckConfiguration config) { }
+        public System.Threading.Tasks.Task Live(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.Task Ready(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }
     public class HealthCheckProvider : Hardened.Web.Runtime.Handlers.IWebExecutionRequestHandlerProvider
     {
@@ -307,6 +314,11 @@ namespace Hardened.Web.Runtime.OpenApi
         string ScriptUrl { get; }
         string Title { get; }
     }
+    public class OpenApiDocumentController
+    {
+        public OpenApiDocumentController() { }
+        public System.Threading.Tasks.Task Write(Hardened.Requests.Abstract.Execution.IExecutionContext context, byte[] gzipDocument, string contentType) { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
     public class OpenApiDocumentPathAttribute : System.Attribute
     {
@@ -315,8 +327,8 @@ namespace Hardened.Web.Runtime.OpenApi
     }
     public class OpenApiDocumentProvider : Hardened.Web.Runtime.Handlers.IWebExecutionRequestHandlerProvider
     {
-        public OpenApiDocumentProvider(System.ReadOnlySpan<byte> gzipDocument, string path = "/openapi.json", string contentType = "application/json") { }
-        public OpenApiDocumentProvider(string document, string path = "/openapi.json", string contentType = "application/json") { }
+        public OpenApiDocumentProvider(System.IServiceProvider serviceProvider, System.ReadOnlySpan<byte> gzipDocument, string path = "/openapi.json", string contentType = "application/json", Hardened.Requests.Abstract.Authorization.Requirement? requirement = null) { }
+        public OpenApiDocumentProvider(System.IServiceProvider serviceProvider, string document, string path = "/openapi.json", string contentType = "application/json", Hardened.Requests.Abstract.Authorization.Requirement? requirement = null) { }
         public Hardened.Web.Runtime.Handlers.RequestHandlerInfo? GetExecutionRequestHandler(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }
     [Hardened.Web.Runtime.OpenApi.OpenApiDocumentPath("/openapi.json")]

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
@@ -204,7 +204,11 @@ internal static class SpecRoutingTableGenerator {
             if (registration.SourceUrl.Length > 0) {
                 statements.Add(new CodeOutputComponent(
                     $"serviceCollection.AddSingleton<{Global(KnownTypes.Web.IWebExecutionRequestHandlerProvider)}>(" +
-                    "new global::Hardened.Web.Runtime.OpenApi.OpenApiDocumentProvider(global::" +
+                    // A factory rather than an instance. The provider builds its chain through
+                    // ExecutionHelper - which is where conventions are applied and the global filter
+                    // registry is asked for this handler's guard - and that needs the container.
+                    "serviceProvider => new global::Hardened.Web.Runtime.OpenApi.OpenApiDocumentProvider(" +
+                    "serviceProvider, global::" +
                     registration.SpecificationTypeName + ".DocumentGZip, " +
                     Quote(registration.SourceUrl) + ", global::" +
                     registration.SpecificationTypeName + ".ContentType))"));
@@ -220,7 +224,8 @@ internal static class SpecRoutingTableGenerator {
             // named openapi.json.
             statements.Add(new CodeOutputComponent(
                 $"serviceCollection.AddSingleton<{Global(KnownTypes.Web.IWebExecutionRequestHandlerProvider)}>(" +
-                "new global::Hardened.Web.Runtime.OpenApi.OpenApiDocumentProvider(global::" +
+                "serviceProvider => new global::Hardened.Web.Runtime.OpenApi.OpenApiDocumentProvider(" +
+                "serviceProvider, global::" +
                 appModel.EntryPointType.Namespace + "." + appModel.EntryPointType.Name + "." +
                 OpenApiDocumentSource.DocumentPropertyName + ", " +
                 Quote(registration.PublishUrl) + "))"));

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -390,7 +390,11 @@ public static class RoutingTableGenerator {
                 "AddSingleton",
                 new[] { KnownTypes.Web.IWebExecutionRequestHandlerProvider },
                 CodeOutputComponent.Get(
-                    "new global::Hardened.Web.Runtime.OpenApi.OpenApiDocumentProvider(" +
+                    // A factory rather than an instance. The provider builds its chain through
+                    // ExecutionHelper - which is where conventions are applied and the global filter
+                    // registry is asked for this handler's guard - and that needs the container.
+                    "serviceProvider => new global::Hardened.Web.Runtime.OpenApi.OpenApiDocumentProvider(" +
+                    "serviceProvider, " +
                     classDefinition.Name + "." + OpenApiDocumentSource.DocumentPropertyName +
                     ", \"" + path.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\")")));
     }

--- a/src/Web/Hardened.Web.Runtime.Tests/Health/HealthCheckProviderTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Health/HealthCheckProviderTests.cs
@@ -1,7 +1,10 @@
 using System.Text;
 using System.Text.Json;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Filters;
 using Hardened.Requests.Runtime.QueryString;
 using Hardened.Requests.Testing;
 using Hardened.Web.Runtime.Health;
@@ -41,29 +44,74 @@ public class HealthCheckProviderTests {
         }
     }
 
-    private static (HealthCheckProvider Provider, HealthCheckConfiguration Config) Build(
-        params IHealthCheck[] checks) =>
+    private static (HealthCheckProvider Provider, HealthCheckConfiguration Config,
+        ServiceProvider Services) Build(params IHealthCheck[] checks) =>
         Build(new HealthCheckConfiguration(), checks);
 
-    private static (HealthCheckProvider, HealthCheckConfiguration) Build(
-        HealthCheckConfiguration config, params IHealthCheck[] checks) {
+    /// <summary>
+    /// A pass-through, standing in for the serialization filter.
+    /// </summary>
+    /// <remarks>
+    /// A probe sets <c>ShouldSerialize = false</c> and writes its own body, so the real filter has
+    /// nothing to do here - and constructing one would drag a serializer and a content negotiator
+    /// into tests about liveness.
+    /// </remarks>
+    private sealed class PassThrough : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    /// <summary>
+    /// The services <c>ExecutionHelper</c> resolves while assembling a chain.
+    /// </summary>
+    /// <remarks>
+    /// The probes build their chains through the helper now, rather than hand-rolling one, which is
+    /// what puts conventions and <c>IGlobalFilterRegistry</c> in front of them. The cost here is
+    /// that these tests need the container a real application has.
+    /// </remarks>
+    private static ServiceProvider Services(
+        HealthCheckConfiguration config, IHealthCheck[] checks,
+        Action<IServiceCollection>? configure = null) {
         var services = new ServiceCollection();
 
         foreach (var check in checks) {
             services.AddSingleton(check);
         }
 
-        var provider = services.BuildServiceProvider();
+        var ioProvider = Substitute.For<IIOFilterProvider>();
+        ioProvider.ProvideFilter(
+                Arg.Any<IExecutionRequestHandlerInfo>(),
+                Arg.Any<Func<IExecutionContext, Task<IExecutionRequestParameters>>>())
+            .Returns(new PassThrough());
 
-        return (new HealthCheckProvider(config, provider), config);
+        services.AddSingleton(ioProvider);
+        services.AddSingleton<IInstanceFilterProvider, InstanceFilterProvider>();
+        services.AddSingleton<IGlobalFilterRegistry>(
+            new GlobalFilterRegistry(Array.Empty<IRequestFilterProvider>()));
+        services.AddSingleton(config);
+        services.AddSingleton<HealthCheckController>();
+
+        configure?.Invoke(services);
+
+        return services.BuildServiceProvider();
     }
 
-    private static IExecutionContext Context(string path, string method = "GET") {
+    private static (HealthCheckProvider, HealthCheckConfiguration, ServiceProvider) Build(
+        HealthCheckConfiguration config, params IHealthCheck[] checks) {
+        var services = Services(config, checks);
+
+        // The same container for the provider and the context. The controller is resolved from the
+        // context and reads its checks from the container it was constructed with, so two would
+        // mean the probe ran a different set of checks from the one the test registered.
+        return (new HealthCheckProvider(config, services), config, services);
+    }
+
+    private static IExecutionContext Context(
+        string path, string method = "GET", IServiceProvider? services = null) {
         var request = new TestExecutionRequest(
             method, path, "application/json",
             new SimpleQueryStringCollection(new Dictionary<string, string>()));
 
-        var services = new ServiceCollection().BuildServiceProvider();
+        services ??= Services(new HealthCheckConfiguration(), Array.Empty<IHealthCheck>());
 
         return new TestExecutionContext(
             services, services, Substitute.For<IKnownServices>(), request,
@@ -71,8 +119,9 @@ public class HealthCheckProviderTests {
     }
 
     private static async Task<(int? Status, JsonElement Body)> Probe(
-        HealthCheckProvider provider, string path, string method = "GET") {
-        var context = Context(path, method);
+        HealthCheckProvider provider, IServiceProvider services, string path,
+        string method = "GET") {
+        var context = Context(path, method, services);
         var match = provider.GetExecutionRequestHandler(context);
 
         Assert.NotNull(match);
@@ -85,6 +134,77 @@ public class HealthCheckProviderTests {
         return (context.Response.Status, JsonDocument.Parse(json).RootElement);
     }
 
+    // ------------------------------------------------------- governable at last
+
+    /// <summary>Requires a grant of everything under a path prefix.</summary>
+    private sealed class PrefixConvention : IAuthorizationConvention {
+        public Requirement? Apply(IExecutionRequestHandlerInfo handlerInfo) =>
+            handlerInfo.Path.StartsWith("/health", StringComparison.Ordinal)
+                ? Requirement.Grant("ops:probe")
+                : null;
+    }
+
+    private static IExecutionRequestHandlerInfo HandlerInfoFor(
+        HealthCheckProvider provider, IServiceProvider services, string path) {
+        var match = provider.GetExecutionRequestHandler(Context(path, services: services));
+
+        Assert.NotNull(match);
+
+        return match!.Handler!.HandlerInfo;
+    }
+
+    /// <summary>
+    /// A convention reaches both probes.
+    /// </summary>
+    /// <remarks>
+    /// It did not. Each probe built its own one-filter chain, and <c>IGlobalFilterRegistry</c> -
+    /// where <c>AuthorizationFilterProvider</c> lives - is only consulted inside
+    /// <c>ExecutionHelper.CreateFilterArray</c>, so neither endpoint was reachable by any
+    /// authorization mechanism at all.
+    /// </remarks>
+    [Theory]
+    [InlineData("/health/live")]
+    [InlineData("/health/ready")]
+    public void AConventionReachesAProbe(string path) {
+        var config = new HealthCheckConfiguration();
+        var services = Services(config, Array.Empty<IHealthCheck>(),
+            collection => collection.AddSingleton<IAuthorizationConvention>(new PrefixConvention()));
+
+        var handlerInfo = HandlerInfoFor(
+            new HealthCheckProvider(config, services), services, path);
+
+        Assert.Contains("ops:probe", handlerInfo.Requirement!.RequiredGrants);
+    }
+
+    /// <summary>
+    /// A deployment that wants its probes guarded states it on the configuration.
+    /// </summary>
+    [Fact]
+    public void ADeclaredRequirementReachesAProbe() {
+        var config = new HealthCheckConfiguration { Requirement = Requirement.Grant("ops:probe") };
+        var services = Services(config, Array.Empty<IHealthCheck>());
+
+        var handlerInfo = HandlerInfoFor(
+            new HealthCheckProvider(config, services), services, "/health/ready");
+
+        Assert.Contains("ops:probe", handlerInfo.Requirement!.RequiredGrants);
+    }
+
+    /// <summary>
+    /// And the default is unchanged: no requirement, so a probe inherits the application's posture
+    /// rather than overriding it. A liveness probe that has to authenticate reports unhealthy when
+    /// the identity provider is down, which is the opposite of what it is for.
+    /// </summary>
+    [Fact]
+    public void NothingConfiguredLeavesAProbeUnguarded() {
+        var config = new HealthCheckConfiguration();
+        var services = Services(config, Array.Empty<IHealthCheck>());
+
+        Assert.Null(
+            HandlerInfoFor(new HealthCheckProvider(config, services), services, "/health/live")
+                .Requirement);
+    }
+
     // ------------------------------------------------------------- liveness
 
     /// <summary>
@@ -95,9 +215,9 @@ public class HealthCheckProviderTests {
     [Fact]
     public async Task Live_AnswersHealthyWithoutRunningAnyCheck() {
         var unhealthy = new Stub("db", HealthCheckResult.Unhealthy("down"));
-        var (provider, _) = Build(unhealthy);
+        var (provider, _, services) = Build(unhealthy);
 
-        var (status, body) = await Probe(provider, "/health/live");
+        var (status, body) = await Probe(provider, services, "/health/live");
 
         Assert.Equal(200, status);
         Assert.Equal("Healthy", body.GetProperty("status").GetString());
@@ -112,9 +232,9 @@ public class HealthCheckProviderTests {
     /// </summary>
     [Fact]
     public async Task Ready_AnswersHealthyWhenNoChecksAreRegistered() {
-        var (provider, _) = Build();
+        var (provider, _, services) = Build();
 
-        var (status, body) = await Probe(provider, "/health/ready");
+        var (status, body) = await Probe(provider, services, "/health/ready");
 
         Assert.Equal(200, status);
         Assert.Equal("Healthy", body.GetProperty("status").GetString());
@@ -125,9 +245,9 @@ public class HealthCheckProviderTests {
         var first = new Stub("a", HealthCheckResult.Healthy());
         var second = new Stub("b", HealthCheckResult.Healthy());
 
-        var (provider, _) = Build(first, second);
+        var (provider, _, services) = Build(first, second);
 
-        await Probe(provider, "/health/ready");
+        await Probe(provider, services, "/health/ready");
 
         Assert.Equal(1, first.Calls);
         Assert.Equal(1, second.Calls);
@@ -143,9 +263,9 @@ public class HealthCheckProviderTests {
     [InlineData(HealthStatus.Degraded, 200)]
     [InlineData(HealthStatus.Unhealthy, 503)]
     public async Task Ready_MapsStatusToCode(HealthStatus status, int expected) {
-        var (provider, _) = Build(new Stub("only", new HealthCheckResult(status)));
+        var (provider, _, services) = Build(new Stub("only", new HealthCheckResult(status)));
 
-        var (code, body) = await Probe(provider, "/health/ready");
+        var (code, body) = await Probe(provider, services, "/health/ready");
 
         Assert.Equal(expected, code);
         Assert.Equal(status.ToString(), body.GetProperty("status").GetString());
@@ -154,12 +274,12 @@ public class HealthCheckProviderTests {
     /// <summary>The worst check decides the overall answer.</summary>
     [Fact]
     public async Task Ready_ReportsTheWorstOfTheChecks() {
-        var (provider, _) = Build(
+        var (provider, _, services) = Build(
             new Stub("fine", HealthCheckResult.Healthy()),
             new Stub("slow", HealthCheckResult.Degraded()),
             new Stub("down", HealthCheckResult.Unhealthy()));
 
-        var (status, body) = await Probe(provider, "/health/ready");
+        var (status, body) = await Probe(provider, services, "/health/ready");
 
         Assert.Equal(503, status);
         Assert.Equal("Unhealthy", body.GetProperty("status").GetString());
@@ -172,10 +292,10 @@ public class HealthCheckProviderTests {
     /// </summary>
     [Fact]
     public async Task Ready_TreatsAThrowingCheckAsUnhealthyRatherThanFailing() {
-        var (provider, _) = Build(
+        var (provider, _, services) = Build(
             new Stub("explodes", _ => throw new InvalidOperationException("boom")));
 
-        var (status, body) = await Probe(provider, "/health/ready");
+        var (status, body) = await Probe(provider, services, "/health/ready");
 
         Assert.Equal(503, status);
         Assert.Equal("Unhealthy", body.GetProperty("status").GetString());
@@ -193,7 +313,7 @@ public class HealthCheckProviderTests {
             TotalTimeout = TimeSpan.FromSeconds(5)
         };
 
-        var (provider, _) = Build(
+        var (provider, _, services) = Build(
             config,
             new Stub("hangs", async token => {
                 await Task.Delay(TimeSpan.FromSeconds(30), token);
@@ -201,7 +321,7 @@ public class HealthCheckProviderTests {
                 return HealthCheckResult.Healthy();
             }));
 
-        var (status, _) = await Probe(provider, "/health/ready");
+        var (status, _) = await Probe(provider, services, "/health/ready");
 
         Assert.Equal(503, status);
     }
@@ -212,7 +332,7 @@ public class HealthCheckProviderTests {
         var config = new HealthCheckConfiguration { CheckTimeout = TimeSpan.FromMilliseconds(50) };
         var observed = CancellationToken.None;
 
-        var (provider, _) = Build(
+        var (provider, _, services) = Build(
             config,
             new Stub("watches", token => {
                 observed = token;
@@ -220,7 +340,7 @@ public class HealthCheckProviderTests {
                 return Task.FromResult(HealthCheckResult.Healthy());
             }));
 
-        await Probe(provider, "/health/ready");
+        await Probe(provider, services, "/health/ready");
 
         Assert.True(observed.CanBeCanceled);
     }
@@ -233,10 +353,10 @@ public class HealthCheckProviderTests {
     /// </summary>
     [Fact]
     public async Task Ready_ReportsNoDetailByDefault() {
-        var (provider, _) = Build(
+        var (provider, _, services) = Build(
             new Stub("internal-billing-db", HealthCheckResult.Unhealthy("connection refused")));
 
-        var (_, body) = await Probe(provider, "/health/ready");
+        var (_, body) = await Probe(provider, services, "/health/ready");
 
         Assert.False(body.TryGetProperty("checks", out _));
     }
@@ -245,12 +365,12 @@ public class HealthCheckProviderTests {
     public async Task Ready_ReportsPerCheckDetailWhenAsked() {
         var config = new HealthCheckConfiguration { IncludeDetail = true };
 
-        var (provider, _) = Build(
+        var (provider, _, services) = Build(
             config,
             new Stub("db", HealthCheckResult.Unhealthy("connection refused")),
             new Stub("cache", HealthCheckResult.Healthy()));
 
-        var (_, body) = await Probe(provider, "/health/ready");
+        var (_, body) = await Probe(provider, services, "/health/ready");
 
         var checks = body.GetProperty("checks");
 
@@ -266,7 +386,7 @@ public class HealthCheckProviderTests {
     [InlineData("/health/live")]
     [InlineData("/health/ready")]
     public void GetExecutionRequestHandler_AnswersBothPaths(string path) {
-        var (provider, _) = Build();
+        var (provider, _, services) = Build();
 
         Assert.NotNull(provider.GetExecutionRequestHandler(Context(path)));
     }
@@ -274,7 +394,7 @@ public class HealthCheckProviderTests {
     /// <summary>A probe issuing HEAD is asking the same question.</summary>
     [Fact]
     public void GetExecutionRequestHandler_AnswersHeadAsWellAsGet() {
-        var (provider, _) = Build();
+        var (provider, _, services) = Build();
 
         Assert.NotNull(provider.GetExecutionRequestHandler(Context("/health/live", "HEAD")));
     }
@@ -287,14 +407,14 @@ public class HealthCheckProviderTests {
     [InlineData("POST")]
     [InlineData("DELETE")]
     public void GetExecutionRequestHandler_DeclinesWriteVerbs(string method) {
-        var (provider, _) = Build();
+        var (provider, _, services) = Build();
 
         Assert.Null(provider.GetExecutionRequestHandler(Context("/health/live", method)));
     }
 
     [Fact]
     public void GetExecutionRequestHandler_DeclinesEverythingElse() {
-        var (provider, _) = Build();
+        var (provider, _, services) = Build();
 
         Assert.Null(provider.GetExecutionRequestHandler(Context("/orders")));
         Assert.Null(provider.GetExecutionRequestHandler(Context("/health")));
@@ -306,7 +426,7 @@ public class HealthCheckProviderTests {
             LivePath = "/_alive", ReadyPath = "/_ready"
         };
 
-        var (provider, _) = Build(config);
+        var (provider, _, services) = Build(config);
 
         Assert.NotNull(provider.GetExecutionRequestHandler(Context("/_alive")));
         Assert.NotNull(provider.GetExecutionRequestHandler(Context("/_ready")));
@@ -321,7 +441,7 @@ public class HealthCheckProviderTests {
     /// </summary>
     [Fact]
     public async Task Ready_IsNotCacheable() {
-        var (provider, _) = Build();
+        var (provider, _, services) = Build();
         var context = Context("/health/ready");
 
         var match = provider.GetExecutionRequestHandler(context);
@@ -338,7 +458,7 @@ public class HealthCheckProviderTests {
     /// </summary>
     [Fact]
     public async Task Ready_DoesNotGoThroughSerialization() {
-        var (provider, _) = Build();
+        var (provider, _, services) = Build();
         var context = Context("/health/ready");
 
         var match = provider.GetExecutionRequestHandler(context);

--- a/src/Web/Hardened.Web.Runtime.Tests/OpenApi/OpenApiDocumentProviderTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/OpenApi/OpenApiDocumentProviderTests.cs
@@ -1,7 +1,11 @@
 using System.IO.Compression;
 using System.Text;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.Filters;
 using Hardened.Requests.Runtime.QueryString;
 using Hardened.Requests.Testing;
 using Hardened.Web.Runtime.OpenApi;
@@ -20,8 +24,49 @@ public class OpenApiDocumentProviderTests {
 
     private const string Document = """{"openapi":"3.1.0","info":{"title":"t","version":"1"},"paths":{}}""";
 
+    /// <summary>
+    /// A pass-through, standing in for the serialization filter.
+    /// </summary>
+    /// <remarks>
+    /// The document sets <c>ShouldSerialize = false</c> and writes its own bytes, so the real
+    /// filter has nothing to do here - and constructing one would drag a serializer and a content
+    /// negotiator into tests about gzip.
+    /// </remarks>
+    private sealed class PassThrough : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    /// <summary>
+    /// The services <c>ExecutionHelper</c> resolves while assembling a chain.
+    /// </summary>
+    /// <remarks>
+    /// The provider builds its chain through the helper now, rather than hand-rolling one, which is
+    /// what puts conventions and <c>IGlobalFilterRegistry</c> in front of the published document.
+    /// The cost here is that these tests need the container a real application has.
+    /// </remarks>
+    private static ServiceProvider Services(Action<IServiceCollection>? configure = null) {
+        var collection = new ServiceCollection();
+
+        var ioProvider = Substitute.For<IIOFilterProvider>();
+        ioProvider.ProvideFilter(
+                Arg.Any<IExecutionRequestHandlerInfo>(),
+                Arg.Any<Func<IExecutionContext, Task<IExecutionRequestParameters>>>())
+            .Returns(new PassThrough());
+
+        collection.AddSingleton(ioProvider);
+        collection.AddSingleton<IInstanceFilterProvider, InstanceFilterProvider>();
+        collection.AddSingleton<IGlobalFilterRegistry>(
+            new GlobalFilterRegistry(Array.Empty<IRequestFilterProvider>()));
+        collection.AddSingleton<OpenApiDocumentController>();
+
+        configure?.Invoke(collection);
+
+        return collection.BuildServiceProvider();
+    }
+
     private static IExecutionContext Context(
-        string path = "/openapi.json", string method = "GET", string? acceptEncoding = "gzip") {
+        string path = "/openapi.json", string method = "GET", string? acceptEncoding = "gzip",
+        IServiceProvider? services = null) {
         var request = new TestExecutionRequest(
             method, path, "application/json",
             new SimpleQueryStringCollection(new Dictionary<string, string>()));
@@ -30,7 +75,7 @@ public class OpenApiDocumentProviderTests {
             request.Headers[KnownHeaders.AcceptEncoding] = acceptEncoding;
         }
 
-        var services = new ServiceCollection().BuildServiceProvider();
+        services ??= Services();
 
         return new TestExecutionContext(
             services, services, Substitute.For<IKnownServices>(), request,
@@ -66,7 +111,7 @@ public class OpenApiDocumentProviderTests {
 
     [Fact]
     public async Task Handle_ServesGZipToAClientThatAcceptsIt() {
-        var context = await Serve(new OpenApiDocumentProvider(Document), Context());
+        var context = await Serve(new OpenApiDocumentProvider(Services(), Document), Context());
 
         Assert.Equal(200, context.Response.Status);
         Assert.Equal("application/json", context.Response.ContentType);
@@ -78,7 +123,7 @@ public class OpenApiDocumentProviderTests {
     [Fact]
     public async Task Handle_InflatesForAClientThatDoesNotAcceptGZip() {
         var context = await Serve(
-            new OpenApiDocumentProvider(Document), Context(acceptEncoding: "identity"));
+            new OpenApiDocumentProvider(Services(), Document), Context(acceptEncoding: "identity"));
 
         Assert.False(context.Response.Headers.ContainsKey(KnownHeaders.ContentEncoding));
         Assert.Equal(Document, Encoding.UTF8.GetString(BodyBytes(context)));
@@ -87,7 +132,7 @@ public class OpenApiDocumentProviderTests {
     [Fact]
     public async Task Handle_InflatesWhenNoAcceptEncodingIsSentAtAll() {
         var context = await Serve(
-            new OpenApiDocumentProvider(Document), Context(acceptEncoding: null));
+            new OpenApiDocumentProvider(Services(), Document), Context(acceptEncoding: null));
 
         Assert.Equal(Document, Encoding.UTF8.GetString(BodyBytes(context)));
     }
@@ -105,7 +150,7 @@ public class OpenApiDocumentProviderTests {
     [InlineData("gzip;q=1.0, identity;q=0.5")]
     public async Task Handle_RecognisesGZipAnywhereInTheAcceptEncodingValue(string accepted) {
         var context = await Serve(
-            new OpenApiDocumentProvider(Document), Context(acceptEncoding: accepted));
+            new OpenApiDocumentProvider(Services(), Document), Context(acceptEncoding: accepted));
 
         Assert.Equal(
             KnownEncoding.GZip, context.Response.Headers[KnownHeaders.ContentEncoding].ToString());
@@ -123,7 +168,7 @@ public class OpenApiDocumentProviderTests {
     [InlineData("")]
     public async Task Handle_DoesNotTreatAPartialTokenAsGZip(string accepted) {
         var context = await Serve(
-            new OpenApiDocumentProvider(Document), Context(acceptEncoding: accepted));
+            new OpenApiDocumentProvider(Services(), Document), Context(acceptEncoding: accepted));
 
         Assert.False(context.Response.Headers.ContainsKey(KnownHeaders.ContentEncoding));
         Assert.Equal(Document, Encoding.UTF8.GetString(BodyBytes(context)));
@@ -131,7 +176,7 @@ public class OpenApiDocumentProviderTests {
 
     [Fact]
     public async Task Handle_SetsContentLengthToWhatWasWritten() {
-        var context = await Serve(new OpenApiDocumentProvider(Document), Context());
+        var context = await Serve(new OpenApiDocumentProvider(Services(), Document), Context());
 
         Assert.Equal(
             BodyBytes(context).Length.ToString(),
@@ -140,7 +185,7 @@ public class OpenApiDocumentProviderTests {
 
     [Fact]
     public async Task Handle_SendsNoCacheSoAStaleDocumentIsNotServedAfterADeploy() {
-        var context = await Serve(new OpenApiDocumentProvider(Document), Context());
+        var context = await Serve(new OpenApiDocumentProvider(Services(), Document), Context());
 
         Assert.Equal("no-cache", context.Response.Headers[KnownHeaders.CacheControl].ToString());
     }
@@ -151,7 +196,7 @@ public class OpenApiDocumentProviderTests {
     /// </summary>
     [Fact]
     public async Task Handle_DoesNotSerializeTheDocument() {
-        var context = await Serve(new OpenApiDocumentProvider(Document), Context());
+        var context = await Serve(new OpenApiDocumentProvider(Services(), Document), Context());
 
         Assert.False(context.Response.ShouldSerialize);
     }
@@ -163,7 +208,7 @@ public class OpenApiDocumentProviderTests {
     /// </summary>
     [Fact]
     public void GetExecutionRequestHandler_MatchesHead() {
-        var provider = new OpenApiDocumentProvider(Document);
+        var provider = new OpenApiDocumentProvider(Services(), Document);
 
         Assert.NotNull(provider.GetExecutionRequestHandler(Context(method: "HEAD")));
         Assert.NotNull(provider.GetExecutionRequestHandler(Context(method: "head")));
@@ -178,7 +223,7 @@ public class OpenApiDocumentProviderTests {
     [InlineData("PUT")]
     [InlineData("DELETE")]
     public void GetExecutionRequestHandler_ReportsWhatIsAllowedForEveryOtherVerb(string method) {
-        var provider = new OpenApiDocumentProvider(Document);
+        var provider = new OpenApiDocumentProvider(Services(), Document);
 
         var match = provider.GetExecutionRequestHandler(Context(method: method));
 
@@ -189,7 +234,7 @@ public class OpenApiDocumentProviderTests {
 
     [Fact]
     public void GetExecutionRequestHandler_IgnoresAnotherPath() {
-        var provider = new OpenApiDocumentProvider(Document);
+        var provider = new OpenApiDocumentProvider(Services(), Document);
 
         Assert.Null(provider.GetExecutionRequestHandler(Context("/openapi.yaml")));
         Assert.Null(provider.GetExecutionRequestHandler(Context("/openapi.json/")));
@@ -202,7 +247,7 @@ public class OpenApiDocumentProviderTests {
     [Fact]
     public async Task Handle_KeepsTheContentTypeItWasGiven() {
         var provider = new OpenApiDocumentProvider(
-            "openapi: 3.1.0", "/openapi.yaml", "application/yaml");
+            Services(), "openapi: 3.1.0", "/openapi.yaml", "application/yaml");
 
         var context = await Serve(provider, Context("/openapi.yaml"));
 
@@ -218,9 +263,113 @@ public class OpenApiDocumentProviderTests {
         var compressed = Deflate(Document);
 
         var context = await Serve(
-            new OpenApiDocumentProvider(new ReadOnlySpan<byte>(compressed)), Context());
+            new OpenApiDocumentProvider(Services(), new ReadOnlySpan<byte>(compressed)), Context());
 
         Assert.Equal(compressed, BodyBytes(context));
+    }
+
+    // ---------------------------------------------------- governable at last
+
+    /// <summary>Requires a grant of everything under a path prefix.</summary>
+    private sealed class PrefixConvention : IAuthorizationConvention {
+        private readonly string _prefix;
+
+        public PrefixConvention(string prefix) {
+            _prefix = prefix;
+        }
+
+        public Requirement? Apply(IExecutionRequestHandlerInfo handlerInfo) =>
+            handlerInfo.Path.StartsWith(_prefix, StringComparison.Ordinal)
+                ? Requirement.Grant("docs:read")
+                : null;
+    }
+
+    private static IExecutionRequestHandlerInfo HandlerInfoFor(
+        OpenApiDocumentProvider provider, IServiceProvider services) {
+        var match = provider.GetExecutionRequestHandler(
+            Context(services: services));
+
+        Assert.NotNull(match);
+
+        return match!.Handler!.HandlerInfo;
+    }
+
+    /// <summary>
+    /// A convention reaches the published document.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It did not. The provider built its own one-filter chain, and <c>IGlobalFilterRegistry</c> -
+    /// where <c>AuthorizationFilterProvider</c> lives - is only consulted inside
+    /// <c>ExecutionHelper.CreateFilterArray</c>. So an application on default-deny, whose entire
+    /// premise is that an unannotated handler is denied rather than public, published its whole API
+    /// description anonymously and got no diagnostic saying so.
+    /// </para>
+    /// <para>
+    /// The reference page at <c>/docs</c> was gate-able the whole time, because
+    /// <c>OpenApiUiProvider</c> already went through the helper. Guarding the page while publishing
+    /// the document is the inversion this closes.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void AConventionReachesTheDocument() {
+        var services = Services(collection =>
+            collection.AddSingleton<IAuthorizationConvention>(new PrefixConvention("/openapi")));
+
+        var handlerInfo = HandlerInfoFor(
+            new OpenApiDocumentProvider(services, Document), services);
+
+        Assert.NotNull(handlerInfo.Requirement);
+        Assert.Contains("docs:read", handlerInfo.Requirement!.RequiredGrants);
+    }
+
+    /// <summary>
+    /// A document that wants a policy of its own states it directly, which is what
+    /// <c>IExecutionRequestHandlerInfo</c> documents as the supported way for a handler registered
+    /// by hand to say what it needs.
+    /// </summary>
+    [Fact]
+    public void ADeclaredRequirementReachesTheDocument() {
+        var services = Services();
+
+        var handlerInfo = HandlerInfoFor(
+            new OpenApiDocumentProvider(
+                services, Document, requirement: Requirement.Grant("docs:read")),
+            services);
+
+        Assert.Contains("docs:read", handlerInfo.Requirement!.RequiredGrants);
+    }
+
+    /// <summary>
+    /// And the two conjoin rather than one replacing the other, so a convention can narrow a
+    /// document that already declared something and can never open one.
+    /// </summary>
+    [Fact]
+    public void ADeclaredRequirementAndAConventionBothApply() {
+        var services = Services(collection =>
+            collection.AddSingleton<IAuthorizationConvention>(new PrefixConvention("/openapi")));
+
+        var handlerInfo = HandlerInfoFor(
+            new OpenApiDocumentProvider(
+                services, Document, requirement: Requirement.Grant("docs:internal")),
+            services);
+
+        var grants = handlerInfo.Requirement!.RequiredGrants.ToArray();
+
+        Assert.Contains("docs:internal", grants);
+        Assert.Contains("docs:read", grants);
+    }
+
+    /// <summary>
+    /// Nothing configured leaves the document as it was: no requirement of its own, inheriting the
+    /// application's posture rather than overriding it.
+    /// </summary>
+    [Fact]
+    public void NothingConfiguredLeavesTheDocumentUnguarded() {
+        var services = Services();
+
+        Assert.Null(
+            HandlerInfoFor(new OpenApiDocumentProvider(services, Document), services).Requirement);
     }
 
     private static byte[] Deflate(string value) {

--- a/src/Web/Hardened.Web.Runtime/DependencyInjection/HardenedWebModule.cs
+++ b/src/Web/Hardened.Web.Runtime/DependencyInjection/HardenedWebModule.cs
@@ -7,6 +7,7 @@ using Hardened.Web.Runtime.Configuration;
 using Hardened.Web.Runtime.Cors;
 using Hardened.Web.Runtime.Handlers;
 using Hardened.Web.Runtime.Health;
+using Hardened.Web.Runtime.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -37,6 +38,13 @@ public partial class HardenedWebModule : IServiceCollectionConfiguration {
         services.AddSingleton<IStartupService, CorsStartupService>();
 
         services.TryAddSingleton<HealthCheckConfiguration>();
+
+        // The controllers the framework's own endpoints invoke through. Registered here rather than
+        // beside each provider because InstanceFilter resolves a controller with GetRequiredService,
+        // and OpenApiDocumentProvider is constructed by generated code with no module of its own to
+        // register from.
+        services.TryAddSingleton<OpenApiDocumentController>();
+        services.TryAddSingleton<HealthCheckController>();
 
         // Registered ahead of anything an application adds, because providers are consulted in
         // reverse registration order - so an application declaring its own route at either health

--- a/src/Web/Hardened.Web.Runtime/Health/HealthCheckConfiguration.cs
+++ b/src/Web/Hardened.Web.Runtime/Health/HealthCheckConfiguration.cs
@@ -1,3 +1,4 @@
+using Hardened.Requests.Abstract.Authorization;
 namespace Hardened.Web.Runtime.Health;
 
 /// <summary>
@@ -45,4 +46,29 @@ public class HealthCheckConfiguration {
     /// behind a private listener, or when the endpoint is not routable from outside.
     /// </remarks>
     public bool IncludeDetail { get; set; }
+
+    /// <summary>
+    /// What a caller must satisfy to read either health endpoint.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Null, which inherits the application's posture rather than overriding it: public where no
+    /// authorization is configured, denied under default-deny, and gate-able by convention
+    /// everywhere else. That is the same choice <c>HardenedOpenApiUi</c> made for the reference
+    /// page, and the reason neither carries an <c>[AllowAnonymous]</c> - it is the one thing a
+    /// convention cannot narrow.
+    /// </para>
+    /// <para>
+    /// Stating one here is the supported way for a handler registered by hand to say what it needs,
+    /// per <c>IExecutionRequestHandlerInfo.Requirement</c>. It conjoins with anything a convention
+    /// adds rather than replacing it, so a requirement set here can only ever narrow.
+    /// </para>
+    /// <para>
+    /// Most deployments should leave this alone. A liveness probe that has to authenticate is a
+    /// liveness probe that reports unhealthy when the identity provider is down, which is the
+    /// opposite of what it is for. Set it when the endpoints are routable from outside and
+    /// <see cref="IncludeDetail"/> is on.
+    /// </para>
+    /// </remarks>
+    public Requirement? Requirement { get; set; }
 }

--- a/src/Web/Hardened.Web.Runtime/Health/HealthCheckController.cs
+++ b/src/Web/Hardened.Web.Runtime/Health/HealthCheckController.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Web.Runtime.Health;
+
+/// <summary>
+/// Answers the two probes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A controller rather than the provider answering inline, so a probe has the same shape as any
+/// other handler - which is what <c>ExecutionHelper</c> is built to run, and what makes the filter
+/// chain, conventions and authorization apply to it unchanged. The same reason
+/// <c>OpenApiUiController</c>, <c>OpenApiDocumentController</c> and <c>StaticContentController</c>
+/// exist.
+/// </para>
+/// <para>
+/// Stateless per request and a singleton for that reason. The checks are resolved per probe rather
+/// than held, so one registered as scoped or transient behaves as its registration says rather than
+/// being pinned to the first probe.
+/// </para>
+/// </remarks>
+public class HealthCheckController {
+    private readonly IServiceProvider _rootProvider;
+    private readonly HealthCheckConfiguration _config;
+
+    public HealthCheckController(IServiceProvider rootProvider, HealthCheckConfiguration config) {
+        _rootProvider = rootProvider;
+        _config = config;
+    }
+
+    /// <summary>
+    /// Alive if this code is running. No dependency is consulted, on purpose.
+    /// </summary>
+    public Task Live(IExecutionContext context) {
+        Write(context, 200, HealthStatus.Healthy, Array.Empty<(string, HealthCheckResult)>());
+
+        return Task.CompletedTask;
+    }
+
+    public async Task Ready(IExecutionContext context) {
+        // Resolved per probe rather than held, so a check registered as scoped or transient behaves
+        // as its registration says rather than being pinned to the first probe.
+        var checks = _rootProvider.GetServices<IHealthCheck>().ToArray();
+
+        if (checks.Length == 0) {
+            // No checks is ready. An application that registered none has not said it is unhealthy;
+            // it has said it has nothing to verify.
+            Write(context, 200, HealthStatus.Healthy, Array.Empty<(string, HealthCheckResult)>());
+
+            return;
+        }
+
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+
+        budget.CancelAfter(_config.TotalTimeout);
+
+        var results = await Task.WhenAll(checks.Select(check => Run(check, budget.Token)));
+
+        var worst = results.Aggregate(
+            HealthStatus.Healthy, (current, result) => Max(current, result.Item2.Status));
+
+        Write(context, worst == HealthStatus.Unhealthy ? 503 : 200, worst, results);
+    }
+
+    /// <summary>
+    /// One check, bounded, with a failure of its own turned into a verdict rather than an exception.
+    /// </summary>
+    /// <remarks>
+    /// A check that throws is unhealthy - that is what "I could not reach it" looks like from
+    /// inside - and a check that overruns its timeout is unhealthy for the same reason. Neither is
+    /// allowed to fail the probe itself, because a 500 from a readiness endpoint is far less
+    /// actionable than a 503.
+    /// </remarks>
+    private async Task<(string, HealthCheckResult)> Run(IHealthCheck check, CancellationToken budget) {
+        using var perCheck = CancellationTokenSource.CreateLinkedTokenSource(budget);
+
+        perCheck.CancelAfter(_config.CheckTimeout);
+
+        try {
+            return (check.Name, await check.Check(perCheck.Token));
+        }
+        catch (OperationCanceledException) {
+            return (check.Name, HealthCheckResult.Unhealthy("timed out"));
+        }
+        catch (Exception exception) {
+            return (check.Name, HealthCheckResult.Unhealthy(exception.GetType().Name));
+        }
+    }
+
+    private static HealthStatus Max(HealthStatus left, HealthStatus right) =>
+        left > right ? left : right;
+
+    /// <summary>
+    /// Writes the body directly rather than going through serialization.
+    /// </summary>
+    /// <remarks>
+    /// The same reason <c>OpenApiDocumentController</c> does: there is nothing to negotiate, and
+    /// leaving <c>ShouldSerialize</c> on would have the locator pick a serializer from whatever the
+    /// prober happened to send in <c>Accept</c>. It also keeps the endpoint answerable when the
+    /// serialization stack is itself the thing that is broken.
+    /// </remarks>
+    private void Write(
+        IExecutionContext context,
+        int status,
+        HealthStatus overall,
+        IReadOnlyCollection<(string Name, HealthCheckResult Result)> results) {
+        var response = context.Response;
+
+        response.Status = status;
+        response.ContentType = "application/json";
+        response.ShouldSerialize = false;
+        response.Headers[KnownHeaders.CacheControl] = new StringValues("no-store");
+
+        using var writer = new Utf8JsonWriter(response.Body);
+
+        writer.WriteStartObject();
+        writer.WriteString("status", overall.ToString());
+
+        if (_config.IncludeDetail && results.Count > 0) {
+            writer.WriteStartObject("checks");
+
+            foreach (var (name, result) in results) {
+                writer.WriteStartObject(name);
+                writer.WriteString("status", result.Status.ToString());
+
+                if (result.Description != null) {
+                    writer.WriteString("description", result.Description);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndObject();
+        writer.Flush();
+    }
+}

--- a/src/Web/Hardened.Web.Runtime/Health/HealthCheckProvider.cs
+++ b/src/Web/Hardened.Web.Runtime/Health/HealthCheckProvider.cs
@@ -1,11 +1,8 @@
-using System.Text.Json;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
-using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.PathTokens;
 using Hardened.Web.Runtime.Handlers;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Primitives;
 
 namespace Hardened.Web.Runtime.Health;
 
@@ -35,15 +32,13 @@ namespace Hardened.Web.Runtime.Health;
 public class HealthCheckProvider : IWebExecutionRequestHandlerProvider {
     private readonly HealthCheckConfiguration _config;
     private readonly IServiceProvider _rootProvider;
-    private readonly IExecutionRequestHandler _live;
-    private readonly IExecutionRequestHandler _ready;
+
+    private IExecutionRequestHandler? _live;
+    private IExecutionRequestHandler? _ready;
 
     public HealthCheckProvider(HealthCheckConfiguration config, IServiceProvider rootProvider) {
         _config = config;
         _rootProvider = rootProvider;
-
-        _live = new Handler(_config.LivePath, Live);
-        _ready = new Handler(_config.ReadyPath, Ready);
     }
 
     public RequestHandlerInfo? GetExecutionRequestHandler(IExecutionContext context) {
@@ -58,154 +53,55 @@ public class HealthCheckProvider : IWebExecutionRequestHandlerProvider {
 
         var path = context.Request.Path;
 
+        // Built once, lazily, rather than per request - conventions are asked per handler
+        // construction, which is the contract they are written against.
         if (string.Equals(path, _config.LivePath, StringComparison.Ordinal)) {
-            return new RequestHandlerInfo(_live, PathTokenCollection.Empty);
+            return new RequestHandlerInfo(
+                _live ??= Handler.For(
+                    _rootProvider, _config, _config.LivePath,
+                    nameof(HealthCheckController.Live),
+                    static (controller, context) => controller.Live(context)),
+                PathTokenCollection.Empty);
         }
 
         if (string.Equals(path, _config.ReadyPath, StringComparison.Ordinal)) {
-            return new RequestHandlerInfo(_ready, PathTokenCollection.Empty);
+            return new RequestHandlerInfo(
+                _ready ??= Handler.For(
+                    _rootProvider, _config, _config.ReadyPath,
+                    nameof(HealthCheckController.Ready),
+                    static (controller, context) => controller.Ready(context)),
+                PathTokenCollection.Empty);
         }
 
         return null;
     }
 
     /// <summary>
-    /// Alive if this code is running. No dependency is consulted, on purpose.
+    /// A probe, run as an ordinary handler.
     /// </summary>
-    private Task Live(IExecutionContext context) {
-        Write(context, 200, HealthStatus.Healthy, Array.Empty<(string, HealthCheckResult)>());
+    private sealed class Handler : BaseExecutionHandler<HealthCheckController> {
 
-        return Task.CompletedTask;
-    }
+        /// <summary>
+        /// Empty, and load bearing. There is deliberately no <c>[AllowAnonymous]</c>: that is the one
+        /// thing a convention cannot narrow, and without it a probe inherits the application's
+        /// posture rather than overriding it.
+        /// </summary>
+        private static readonly object[] Metadata = [];
 
-    private async Task Ready(IExecutionContext context) {
-        // Resolved per probe rather than held, so a check registered as scoped or transient behaves
-        // as its registration says rather than being pinned to the first probe.
-        var checks = _rootProvider.GetServices<IHealthCheck>().ToArray();
+        private Handler(ExecutionHandlerSetup setup) : base(setup) { }
 
-        if (checks.Length == 0) {
-            // No checks is ready. An application that registered none has not said it is unhealthy;
-            // it has said it has nothing to verify.
-            Write(context, 200, HealthStatus.Healthy, Array.Empty<(string, HealthCheckResult)>());
-
-            return;
-        }
-
-        using var budget = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
-
-        budget.CancelAfter(_config.TotalTimeout);
-
-        var results = await Task.WhenAll(checks.Select(check => Run(check, budget.Token)));
-
-        var worst = results.Aggregate(
-            HealthStatus.Healthy, (current, result) => Max(current, result.Item2.Status));
-
-        Write(context, worst == HealthStatus.Unhealthy ? 503 : 200, worst, results);
-    }
-
-    /// <summary>
-    /// One check, bounded, with a failure of its own turned into a verdict rather than an exception.
-    /// </summary>
-    /// <remarks>
-    /// A check that throws is unhealthy - that is what "I could not reach it" looks like from
-    /// inside - and a check that overruns its timeout is unhealthy for the same reason. Neither is
-    /// allowed to fail the probe itself, because a 500 from a readiness endpoint is far less
-    /// actionable than a 503.
-    /// </remarks>
-    private async Task<(string, HealthCheckResult)> Run(IHealthCheck check, CancellationToken budget) {
-        using var perCheck = CancellationTokenSource.CreateLinkedTokenSource(budget);
-
-        perCheck.CancelAfter(_config.CheckTimeout);
-
-        try {
-            return (check.Name, await check.Check(perCheck.Token));
-        }
-        catch (OperationCanceledException) {
-            return (check.Name, HealthCheckResult.Unhealthy("timed out"));
-        }
-        catch (Exception exception) {
-            return (check.Name, HealthCheckResult.Unhealthy(exception.GetType().Name));
-        }
-    }
-
-    private static HealthStatus Max(HealthStatus left, HealthStatus right) =>
-        left > right ? left : right;
-
-    /// <summary>
-    /// Writes the body directly rather than going through serialization.
-    /// </summary>
-    /// <remarks>
-    /// The same reason <c>OpenApiDocumentProvider</c> does: there is nothing to negotiate, and
-    /// leaving <c>ShouldSerialize</c> on would have the locator pick a serializer from whatever the
-    /// prober happened to send in <c>Accept</c>. It also keeps the endpoint answerable when the
-    /// serialization stack is itself the thing that is broken.
-    /// </remarks>
-    private void Write(
-        IExecutionContext context,
-        int status,
-        HealthStatus overall,
-        IReadOnlyCollection<(string Name, HealthCheckResult Result)> results) {
-        var response = context.Response;
-
-        response.Status = status;
-        response.ContentType = "application/json";
-        response.ShouldSerialize = false;
-        response.Headers[KnownHeaders.CacheControl] = new StringValues("no-store");
-
-        using var writer = new Utf8JsonWriter(response.Body);
-
-        writer.WriteStartObject();
-        writer.WriteString("status", overall.ToString());
-
-        if (_config.IncludeDetail && results.Count > 0) {
-            writer.WriteStartObject("checks");
-
-            foreach (var (name, result) in results) {
-                writer.WriteStartObject(name);
-                writer.WriteString("status", result.Status.ToString());
-
-                if (result.Description != null) {
-                    writer.WriteString("description", result.Description);
-                }
-
-                writer.WriteEndObject();
-            }
-
-            writer.WriteEndObject();
-        }
-
-        writer.WriteEndObject();
-        writer.Flush();
-    }
-
-    /// <summary>
-    /// A handler whose chain is one filter: the thing that answers.
-    /// </summary>
-    private sealed class Handler : IExecutionRequestHandler {
-        private readonly Func<IExecutionContext, Task> _answer;
-
-        public Handler(string path, Func<IExecutionContext, Task> answer) {
-            _answer = answer;
-
-            HandlerInfo = new ExecutionRequestHandlerInfo(
-                path, "GET", typeof(HealthCheckProvider), nameof(GetExecutionRequestHandler));
-        }
-
-        public IExecutionRequestHandlerInfo HandlerInfo { get; }
-
-        public IExecutionChain GetExecutionChain(IExecutionContext context) =>
-            new ExecutionChain(
-                new Func<IExecutionContext, IExecutionFilter>[] { _ => new AnswerFilter(_answer) },
-                context);
-    }
-
-    private sealed class AnswerFilter : IExecutionFilter {
-        private readonly Func<IExecutionContext, Task> _answer;
-
-        public AnswerFilter(Func<IExecutionContext, Task> answer) {
-            _answer = answer;
-        }
-
-        public Task Execute(IExecutionChain chain) => _answer(chain.Context);
+        public static Handler For(
+            IServiceProvider serviceProvider,
+            HealthCheckConfiguration config,
+            string path,
+            string methodName,
+            Func<HealthCheckController, IExecutionContext, Task> answer) =>
+            new(ExecutionHelper.AsyncStandardFilterEmptyParameters<HealthCheckController>(
+                serviceProvider,
+                new ExecutionRequestHandlerInfo(
+                    path, "GET", typeof(HealthCheckController), methodName, [], Metadata,
+                    config.Requirement),
+                (context, controller) => answer(controller, context),
+                ExecutionHelper.GetFilterInfo(Metadata)));
     }
 }

--- a/src/Web/Hardened.Web.Runtime/OpenApi/HardenedOpenApiUi.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/HardenedOpenApiUi.cs
@@ -40,8 +40,9 @@ namespace Hardened.Web.Runtime.OpenApi;
 /// <b>Conventions apply to it.</b> The page has no generated route - a route path is a compile-time
 /// constant and this one is configuration - but <see cref="OpenApiUiProvider"/> builds its chain
 /// through <c>ExecutionHelper</c> rather than hand-rolling one, which is where authorization
-/// conventions are applied. The health endpoints and <see cref="OpenApiDocumentProvider"/> hand-roll
-/// theirs and are invisible to a convention; this is not.
+/// conventions are applied. <see cref="OpenApiDocumentProvider"/> and the health endpoints hand-rolled
+/// theirs and were invisible to a convention, so the page was gate-able and the document it renders
+/// was not; both go through the helper now.
 /// </para>
 ///
 /// <para>

--- a/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiDocumentController.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiDocumentController.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.IO.Compression;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Web.Runtime.OpenApi;
+
+/// <summary>
+/// Writes one published document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A controller rather than the provider writing the response inline, so the document has the same
+/// shape as any other handler - which is what <c>ExecutionHelper</c> is built to run, and what makes
+/// the filter chain, conventions and authorization apply to it unchanged. The same reason
+/// <see cref="OpenApiUiController"/> and <c>StaticContentController</c> exist.
+/// </para>
+/// <para>
+/// Stateless, and a singleton for that reason. What varies between two published documents - the
+/// bytes, the content type - is closed over by the lambda <see cref="OpenApiDocumentProvider"/>
+/// hands to <c>ExecutionHelper</c>, not held here.
+/// </para>
+/// </remarks>
+public class OpenApiDocumentController {
+
+    /// <summary>
+    /// Writes the bytes directly rather than going through serialization: the document is already
+    /// JSON or YAML, and handing it to a serializer would encode it a second time as a string.
+    /// </summary>
+    public async Task Write(IExecutionContext context, byte[] gzipDocument, string contentType) {
+        var response = context.Response;
+
+        response.Status = 200;
+        response.ContentType = contentType;
+        response.ShouldSerialize = false;
+        response.Headers[KnownHeaders.CacheControl] = new StringValues("no-cache");
+
+        if (AcceptsGZip(context)) {
+            response.IsBinary = true;
+            response.Headers[KnownHeaders.ContentEncoding] = KnownEncoding.GZipStringValues;
+            response.Headers[KnownHeaders.ContentLength] =
+                gzipDocument.Length.ToString(CultureInfo.InvariantCulture);
+
+            await response.Body.WriteAsync(gzipDocument, 0, gzipDocument.Length);
+
+            return;
+        }
+
+        using var source = new MemoryStream(gzipDocument, writable: false);
+        await using var gzip = new GZipStream(source, CompressionMode.Decompress);
+
+        await gzip.CopyToAsync(response.Body);
+    }
+
+    /// <summary>
+    /// Whether the client said it takes gzip.
+    /// </summary>
+    /// <remarks>
+    /// The bounded token search this used to spell out inline now lives in
+    /// <see cref="AcceptEncodingHeader"/>, unchanged. It was the only correct reading of
+    /// <c>Accept-Encoding</c> in the codebase and it was private to one file, while
+    /// <c>StaticContentHandler</c> a few directories away asked the question with
+    /// <c>StringValues.Contains</c> and got the wrong answer for every browser.
+    /// </remarks>
+    private static bool AcceptsGZip(IExecutionContext context) =>
+        context.Request.Headers.TryGetValue(KnownHeaders.AcceptEncoding, out var accepted) &&
+        AcceptEncodingHeader.Accepts(accepted, KnownEncoding.GZip);
+}

--- a/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiDocumentProvider.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiDocumentProvider.cs
@@ -1,13 +1,11 @@
-using System.Globalization;
 using System.IO.Compression;
 using System.Text;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
-using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.PathTokens;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.PathTokens;
 using Hardened.Web.Runtime.Handlers;
-using Microsoft.Extensions.Primitives;
 
 namespace Hardened.Web.Runtime.OpenApi;
 
@@ -19,6 +17,22 @@ namespace Hardened.Web.Runtime.OpenApi;
 /// Registered as one more <c>IWebExecutionRequestHandlerProvider</c>, which is how the routing
 /// tables themselves are registered - the pipeline asks each in turn, so this needs no route
 /// attribute and no entry in any generated table.
+/// </para>
+/// <para>
+/// <b>Its chain is built by <see cref="ExecutionHelper"/>.</b> It used to build its own, holding one
+/// filter that wrote the bytes - so nothing that hangs off a handler reached the published document:
+/// no filters, no conventions, no authorization. <c>IGlobalFilterRegistry</c>, which is where
+/// <c>AuthorizationFilterProvider</c> lives, is only consulted inside
+/// <c>ExecutionHelper.CreateFilterArray</c>, so an application on default-deny - whose entire
+/// premise is that an unannotated handler is denied rather than public - served its whole API
+/// description anonymously and got no diagnostic saying so. The reference page at <c>/docs</c> was
+/// gate-able and the document it renders was not.
+/// </para>
+/// <para>
+/// The same move <see cref="OpenApiUiProvider"/> and <c>StaticContentMountProvider</c> already made,
+/// for the same reason. A document that wants a policy of its own states it as its
+/// <c>requirement</c>, which <see cref="IExecutionRequestHandlerInfo"/> documents as the
+/// supported way for a handler registered by hand to say what it needs.
 /// </para>
 /// <para>
 /// The providers are consulted in reverse registration order, so an application that declares its
@@ -35,7 +49,12 @@ namespace Hardened.Web.Runtime.OpenApi;
 /// </remarks>
 public class OpenApiDocumentProvider : IWebExecutionRequestHandlerProvider {
     private readonly string _path;
-    private readonly OpenApiDocumentHandler _handler;
+    private readonly byte[] _gzipDocument;
+    private readonly string _contentType;
+    private readonly Requirement? _requirement;
+    private readonly IServiceProvider _serviceProvider;
+
+    private IExecutionRequestHandler? _handler;
 
     /// <summary>
     /// Serves the generated document, which arrives gzip-compressed.
@@ -45,12 +64,17 @@ public class OpenApiDocumentProvider : IWebExecutionRequestHandlerProvider {
     /// <c>ReadOnlySpan&lt;byte&gt;</c> over a metadata blob, with nothing allocated to hold it - and
     /// copied once here, since a span cannot be stored in a field or cross an await.
     /// </param>
+    /// <param name="requirement">
+    /// What a caller must satisfy to read the document. Null inherits the application's posture,
+    /// which is the same three behaviours <c>HardenedOpenApiUi</c> chose for the page: public where
+    /// no authorization is configured, denied under default-deny, and gate-able by convention
+    /// everywhere else.
+    /// </param>
     public OpenApiDocumentProvider(
+        IServiceProvider serviceProvider,
         ReadOnlySpan<byte> gzipDocument, string path = "/openapi.json",
-        string contentType = "application/json") {
-        _path = path;
-        _handler = new OpenApiDocumentHandler(gzipDocument.ToArray(), path, contentType);
-    }
+        string contentType = "application/json", Requirement? requirement = null)
+        : this(serviceProvider, gzipDocument.ToArray(), path, contentType, requirement) { }
 
     /// <summary>
     /// Serves <paramref name="document"/> at <paramref name="path"/>.
@@ -68,9 +92,19 @@ public class OpenApiDocumentProvider : IWebExecutionRequestHandlerProvider {
     /// same size a generated one does.
     /// </remarks>
     public OpenApiDocumentProvider(
-        string document, string path = "/openapi.json", string contentType = "application/json") {
+        IServiceProvider serviceProvider,
+        string document, string path = "/openapi.json",
+        string contentType = "application/json", Requirement? requirement = null)
+        : this(serviceProvider, Compress(document), path, contentType, requirement) { }
+
+    private OpenApiDocumentProvider(
+        IServiceProvider serviceProvider,
+        byte[] gzipDocument, string path, string contentType, Requirement? requirement) {
+        _serviceProvider = serviceProvider;
+        _gzipDocument = gzipDocument;
         _path = path;
-        _handler = new OpenApiDocumentHandler(Compress(document), path, contentType);
+        _contentType = contentType;
+        _requirement = requirement;
     }
 
     /// <summary>What a request to this path may do, when it did something else.</summary>
@@ -81,9 +115,8 @@ public class OpenApiDocumentProvider : IWebExecutionRequestHandlerProvider {
             return null;
         }
 
-        // HEAD as well as GET. The table's usual HEAD-to-GET redirection does not reach a provider
-        // serving its own chain, but WebExecutionHandlerService.Dispatch still drops the body and
-        // reports the length for one - so accepting it here is all that was missing.
+        // HEAD as well as GET. WebExecutionHandlerService.Dispatch drops the body and reports the
+        // length for one, so accepting it here is all that is needed.
         var method = context.Request.Method;
 
         if (!string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase) &&
@@ -93,7 +126,12 @@ public class OpenApiDocumentProvider : IWebExecutionRequestHandlerProvider {
             return RequestHandlerInfo.MethodNotAllowed(Allow);
         }
 
-        return new RequestHandlerInfo(_handler, PathTokenCollection.Empty);
+        // Built once, lazily, rather than per request - conventions are asked per handler
+        // construction, which is the contract they are written against.
+        return new RequestHandlerInfo(
+            _handler ??= new Handler(
+                _serviceProvider, _gzipDocument, _path, _contentType, _requirement),
+            PathTokenCollection.Empty);
     }
 
     private static byte[] Compress(string document) {
@@ -110,79 +148,26 @@ public class OpenApiDocumentProvider : IWebExecutionRequestHandlerProvider {
         return output.ToArray();
     }
 
-    private class OpenApiDocumentHandler : IExecutionRequestHandler {
-        private readonly byte[] _gzipDocument;
-        private readonly string _contentType;
-
-        public OpenApiDocumentHandler(byte[] gzipDocument, string path, string contentType) {
-            _gzipDocument = gzipDocument;
-            _contentType = contentType;
-
-            HandlerInfo = new ExecutionRequestHandlerInfo(
-                path, "GET", typeof(OpenApiDocumentProvider), nameof(GetExecutionChain));
-        }
-
-        public IExecutionRequestHandlerInfo HandlerInfo { get; }
-
-        public IExecutionChain GetExecutionChain(IExecutionContext context) =>
-            new ExecutionChain(
-                new Func<IExecutionContext, IExecutionFilter>[] {
-                    _ => new WriteFilter(_gzipDocument, _contentType)
-                },
-                context);
-    }
-
-    /// <summary>
-    /// Writes the bytes directly rather than going through serialization: the document is already
-    /// JSON, and handing it to a serializer would encode it a second time as a string.
-    /// </summary>
-    private class WriteFilter : IExecutionFilter {
-        private readonly byte[] _gzipDocument;
-        private readonly string _contentType;
-
-        public WriteFilter(byte[] gzipDocument, string contentType) {
-            _gzipDocument = gzipDocument;
-            _contentType = contentType;
-        }
-
-        public async Task Execute(IExecutionChain chain) {
-            var context = chain.Context;
-            var response = context.Response;
-
-            response.Status = 200;
-            response.ContentType = _contentType;
-            response.ShouldSerialize = false;
-            response.Headers[KnownHeaders.CacheControl] = new StringValues("no-cache");
-
-            if (AcceptsGZip(context)) {
-                response.IsBinary = true;
-                response.Headers[KnownHeaders.ContentEncoding] = KnownEncoding.GZipStringValues;
-                response.Headers[KnownHeaders.ContentLength] =
-                    _gzipDocument.Length.ToString(CultureInfo.InvariantCulture);
-
-                await response.Body.WriteAsync(_gzipDocument, 0, _gzipDocument.Length);
-
-                return;
-            }
-
-            using var source = new MemoryStream(_gzipDocument, writable: false);
-            await using var gzip = new GZipStream(source, CompressionMode.Decompress);
-
-            await gzip.CopyToAsync(response.Body);
-        }
+    private sealed class Handler : BaseExecutionHandler<OpenApiDocumentController> {
 
         /// <summary>
-        /// Whether the client said it takes gzip.
+        /// Empty, and load bearing. There is deliberately no <c>[AllowAnonymous]</c>: that is the one
+        /// thing a convention cannot narrow, and without it the document inherits the application's
+        /// posture rather than overriding it.
         /// </summary>
-        /// <remarks>
-        /// The bounded token search this used to spell out inline now lives in
-        /// <see cref="AcceptEncodingHeader"/>, unchanged. It was the only correct reading of
-        /// <c>Accept-Encoding</c> in the codebase and it was private to this file, while
-        /// <c>StaticContentHandler</c> a few directories away asked the question with
-        /// <c>StringValues.Contains</c> and got the wrong answer for every browser.
-        /// </remarks>
-        private static bool AcceptsGZip(IExecutionContext context) =>
-            context.Request.Headers.TryGetValue(KnownHeaders.AcceptEncoding, out var accepted) &&
-            AcceptEncodingHeader.Accepts(accepted, KnownEncoding.GZip);
+        private static readonly object[] Metadata = [];
+
+        public Handler(
+            IServiceProvider serviceProvider,
+            byte[] gzipDocument, string path, string contentType, Requirement? requirement)
+            : base(ExecutionHelper.AsyncStandardFilterEmptyParameters<OpenApiDocumentController>(
+                serviceProvider,
+                new ExecutionRequestHandlerInfo(
+                    path, "GET", typeof(OpenApiDocumentController),
+                    nameof(OpenApiDocumentController.Write), [], Metadata, requirement),
+                // A lambda rather than a static method, because what varies between two published
+                // documents is exactly what it closes over.
+                (context, controller) => controller.Write(context, gzipDocument, contentType),
+                ExecutionHelper.GetFilterInfo(Metadata))) { }
     }
 }

--- a/src/Web/Hardened.Web.StaticContent/StaticContentMountProvider.cs
+++ b/src/Web/Hardened.Web.StaticContent/StaticContentMountProvider.cs
@@ -25,7 +25,8 @@ namespace Hardened.Web.StaticContent;
 /// adds no authorization code: <c>CreateFilterArray</c> applies conventions and then asks
 /// <c>IGlobalFilterRegistry</c>, which is where <c>AuthorizationFilterProvider</c> lives. The same
 /// move <c>OpenApiUiProvider</c> made for a page whose path is configuration rather than a
-/// compile-time constant, which is exactly this situation.
+/// compile-time constant, and the one <c>OpenApiDocumentProvider</c> and <c>HealthCheckProvider</c>
+/// have since made for the same reason.
 /// </para>
 /// <para>
 /// <b>There is deliberately no <c>[AllowAnonymous]</c> in the metadata.</b> That is the one thing a


### PR DESCRIPTION
Closes **D5** from the Atlas Matrix study, with the scope correction that it covers the health endpoints too.

## What was wrong

Neither `/openapi.json` nor `/health/*` could be guarded by **any** mechanism — not a convention, not an attribute, not configuration.

Both hand-rolled their own `ExecutionChain` holding one filter. `IGlobalFilterRegistry` — where `AuthorizationFilterProvider` lives — is consulted in exactly one place:

```
ExecutionHelper.cs:216   serviceProvider.GetRequiredService<IGlobalFilterRegistry>().GetFilters(handlerInfo)
```

`WebExecutionHandlerService.Dispatch` just calls `match.Handler.GetExecutionChain(context)` and runs whatever comes back. So an application on default-deny — whose entire premise is that an unannotated handler is denied rather than public — published its whole API description and both probes anonymously, with no diagnostic.

`/docs` was gate-able the whole time, because `OpenApiUiProvider` already went through the helper. **The page was governable and the document it renders was not.**

## Fixed the way the framework already fixed it twice

`StaticContentMountProvider` had this exact defect, and its remarks describe it in the past tense:

> Static content used to be a fall through … so nothing that hangs off a handler reached it — no filters, no conventions, no authorization, no HEAD handling, no 405, no `RequestMapped`. An application that adopted `[RequireAuthorization]` … still served everything under its content root anonymously and got no diagnostic saying so.

Both offenders now make the same move. `OpenApiDocumentController` and `HealthCheckController` carry what the providers used to do inline, so each endpoint has the shape `ExecutionHelper` is built to run — the same reason `OpenApiUiController` and `StaticContentController` exist. Both are registered in `HardenedWebModule`, because `InstanceFilter` resolves a controller with `GetRequiredService` and `OpenApiDocumentProvider` is constructed by generated code with no module of its own.

## The declaration site already existed

Not invented here. `IExecutionRequestHandlerInfo` documents `Requirement` as how *"a handler registered by hand can state one without inventing an attribute to carry it"*, and `IStaticContentConfiguration.Requirement` is the shipped precedent.

- `OpenApiDocumentProvider` takes an optional `requirement`
- `HealthCheckConfiguration` gains one

Both conjoin with whatever a convention adds rather than replacing it, so either can only narrow.

Neither carries `[AllowAnonymous]`, deliberately — that is the one thing a convention cannot narrow. Without it each inherits the application's posture: public where no authorization is configured, denied under default-deny, gate-able by convention everywhere else.

## ⚠️ Breaking

`OpenApiDocumentProvider`'s constructors take an `IServiceProvider` first:

```diff
-public OpenApiDocumentProvider(ReadOnlySpan<byte> gzipDocument, string path = …, string contentType = …)
+public OpenApiDocumentProvider(IServiceProvider serviceProvider, ReadOnlySpan<byte> gzipDocument, string path = …, string contentType = …, Requirement? requirement = null)
```

It is constructed by generated code, so a consumer who rebuilds is unaffected; one who constructs it by hand is not. Both routing table generators emit a factory rather than an instance now, since building the chain needs the container.

## Also picked up, free

Going through the helper gives both endpoints the filter chain, HEAD handling, 405 and `RequestMapped` — the same list static content got.

## Verification

Eight new tests, covering both endpoints: a convention reaches them, a declared requirement reaches them, the two conjoin, and nothing configured still leaves them inheriting the application's posture rather than overriding it.

**5,223 tests pass, 0 fail**, across 30 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX