### PR TITLE
Report constraints written on an array's inline item schema

### DIFF
--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ArrayItemConstraintTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ArrayItemConstraintTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// Constraints written on an array's inline item schema, which are read by nothing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An array property keeps three things from its <c>items</c>: the reference, the type and the
+/// format. Every constraint beside them was dropped without a word - so
+/// <c>items: { type: string, minLength: 3 }</c> declared a rule, generated
+/// <c>List&lt;string&gt;</c>, and accepted the empty string at runtime.
+/// </para>
+/// <para>
+/// This is not the nested-array case the previous review closed. An <c>items</c> naming a schema
+/// gets its properties walked and constrained as any other model's are; what was dropped is a
+/// constraint on the element <em>itself</em> - the shape somebody writes for an array of primitives,
+/// and the shape with nowhere else to put the rule.
+/// </para>
+/// </remarks>
+public class ArrayItemConstraintTests {
+
+    private static string Document(string itemSchema) => $$"""
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /orders:
+            post:
+              operationId: placeOrder
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/Order'
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema:
+                        type: string
+        components:
+          schemas:
+            Order:
+              type: object
+              properties:
+                skus:
+                  type: array
+                  items:
+                    {{itemSchema}}
+            Part:
+              type: object
+              properties:
+                sku:
+                  type: string
+                  minLength: 3
+        """;
+
+    private static ServiceSpecModel Parse(string yaml) {
+        var model = OpenApiSpecParser.Parse(yaml, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static UnmappedKeywordModel[] Unmapped(string itemSchema) =>
+        Parse(Document(itemSchema)).UnmappedKeywords.ToArray();
+
+    [Theory]
+    [InlineData("{ type: string, minLength: 3 }", "minLength")]
+    [InlineData("{ type: string, maxLength: 32 }", "maxLength")]
+    [InlineData("{ type: string, pattern: '^[A-Z]+$' }", "pattern")]
+    [InlineData("{ type: integer, minimum: 1 }", "minimum")]
+    [InlineData("{ type: integer, maximum: 99 }", "maximum")]
+    [InlineData("{ type: integer, multipleOf: 5 }", "multipleOf")]
+    public void AConstraintOnAnInlineItemIsRecordedAsUnmapped(string itemSchema, string keyword) {
+        Assert.Contains(Unmapped(itemSchema), u => u.Keyword == keyword);
+    }
+
+    /// <summary>
+    /// The location names the member and marks it as the element rather than the array, because
+    /// "minLength is not enforced" against a property that is a list reads as a rule about the list.
+    /// </summary>
+    /// <remarks>
+    /// Asserted over every entry rather than a single one. A schema reachable both as a component
+    /// and through an operation's body is walked once for each, so one declaration is recorded at
+    /// two locations - which is how every keyword here has always behaved, and what
+    /// <c>SpecDiagnostics</c> collapses into "at X and 1 other place" when it reports.
+    /// </remarks>
+    [Fact]
+    public void TheLocationNamesTheElementNotTheArray() {
+        var located = Unmapped("{ type: string, minLength: 3 }")
+            .Where(u => u.Keyword == "minLength")
+            .ToArray();
+
+        Assert.NotEmpty(located);
+        Assert.All(located, u => Assert.EndsWith("skus[]", u.Location));
+    }
+
+    /// <summary>
+    /// Every dropped keyword on one element is reported, not just the first - a document declaring
+    /// three rules has lost three.
+    /// </summary>
+    [Fact]
+    public void EveryDroppedKeywordOnOneElementIsReported() {
+        var keywords = Unmapped("{ type: string, minLength: 3, maxLength: 32, pattern: '^[A-Z]+$' }")
+            .Select(u => u.Keyword)
+            .ToArray();
+
+        Assert.Contains("minLength", keywords);
+        Assert.Contains("maxLength", keywords);
+        Assert.Contains("pattern", keywords);
+    }
+
+    /// <summary>
+    /// An item naming a schema is generated as a type and constrained through its own properties, so
+    /// nothing is lost and reporting it would be a false positive on the arrangement that works.
+    /// </summary>
+    [Fact]
+    public void AReferencedItemSchemaIsNotReported() {
+        Assert.Empty(Unmapped("$ref: '#/components/schemas/Part'"));
+    }
+
+    /// <summary>
+    /// An array of plain primitives declares no rule and must stay silent, or the diagnostic fires
+    /// on every string list in existence.
+    /// </summary>
+    [Fact]
+    public void AnUnconstrainedItemIsNotReported() {
+        Assert.Empty(Unmapped("{ type: string }"));
+    }
+
+    /// <summary>
+    /// The constraint the parser <em>does</em> read is still read. This reports what is dropped; it
+    /// does not stop anything being honoured.
+    /// </summary>
+    [Fact]
+    public void ConstraintsOnAnOrdinaryPropertyAreStillCompiled() {
+        var part = Parse(Document("{ type: string }")).Schemas
+            .Single(schema => schema.Name == "Part");
+
+        var sku = part.Properties.Single(property => property.Name == "sku");
+
+        Assert.Equal(3, sku.MinLength);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -1226,6 +1226,72 @@ internal static class OpenApiSpecParser {
         if (schema.Not != null) {
             unmapped.Add(new UnmappedKeywordModel("not", location));
         }
+
+        NoteUnmappedItemConstraints(schema, location, unmapped);
+    }
+
+    /// <summary>
+    /// Constraints written on an array's inline item schema, which are read by nothing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An array property keeps three things from its <c>items</c>: the reference, the type and the
+    /// format. Every constraint beside them is dropped - so
+    /// <c>items: { type: string, minLength: 3 }</c> declares a rule, generates
+    /// <c>List&lt;string&gt;</c>, and accepts the empty string at runtime.
+    /// </para>
+    /// <para>
+    /// This is not the nested-array case that was already closed. An <c>items</c> naming a schema
+    /// gets its properties walked and constrained as any other model's are; what is dropped is a
+    /// constraint on the element <em>itself</em>, which is the shape somebody writes for an array of
+    /// primitives - a list of SKUs, of codes, of identifiers - and the shape with nowhere else to
+    /// put the rule.
+    /// </para>
+    /// <para>
+    /// Reported rather than honoured. Honouring means compiling a per-element rule for a primitive,
+    /// which is a validator vocabulary question rather than a parser one, and answering it here
+    /// would put a second constraint compiler beside the one ValidationModules owns. Until then the
+    /// document says the rule and the build says it is not applied, which is the whole point of
+    /// <c>HOAT013</c>.
+    /// </para>
+    /// </remarks>
+    private static void NoteUnmappedItemConstraints(
+        IOpenApiSchema schema, string location, ICollection<UnmappedKeywordModel> unmapped) {
+        if (SchemaType(schema) != "array" || schema.Items is not { } items) {
+            return;
+        }
+
+        // A referenced item schema is generated as a type and constrained through its own
+        // properties, so nothing is lost there and reporting it would be a false positive.
+        if (GetNonPrimitiveRef(items) != null) {
+            return;
+        }
+
+        var at = location + "[]";
+
+        if (items.MinLength.HasValue) {
+            unmapped.Add(new UnmappedKeywordModel("minLength", at));
+        }
+
+        if (items.MaxLength.HasValue) {
+            unmapped.Add(new UnmappedKeywordModel("maxLength", at));
+        }
+
+        if (!string.IsNullOrEmpty(items.Pattern)) {
+            unmapped.Add(new UnmappedKeywordModel("pattern", at));
+        }
+
+        if (Bound(items.Minimum) is not null || Bound(items.ExclusiveMinimum) is not null) {
+            unmapped.Add(new UnmappedKeywordModel("minimum", at));
+        }
+
+        if (Bound(items.Maximum) is not null || Bound(items.ExclusiveMaximum) is not null) {
+            unmapped.Add(new UnmappedKeywordModel("maximum", at));
+        }
+
+        if (items.MultipleOf.HasValue) {
+            unmapped.Add(new UnmappedKeywordModel("multipleOf", at));
+        }
     }
 
     private static void ExtractValidationConstraints(IOpenApiSchema schema, PropertyModel model) {


### PR DESCRIPTION
Recommendation **05** from the Atlas Matrix study — *"point `HOAT013` at every unenforced declaration"*, which the study called the highest ratio in the list.

One of the four extensions it named is a real gap and is implemented. Two are not defects. The fourth is real but narrower than stated, and needs a different mechanism.

## The real one: constraints on an inline array item

An array property kept three things from its `items` — the reference, the type and the format. Every constraint beside them was dropped without a word:

```yaml
skus:
  type: array
  items: { type: string, minLength: 3, pattern: '^[A-Z]+$' }
```

Two rules declared, `List<string>` generated, the empty string accepted at runtime, clean build.

This is **not** the nested-array case the previous review closed. An `items` naming a schema gets its properties walked and constrained as any other model's are — that arrangement works, and is deliberately not reported, or the diagnostic would fire on the thing that already functions. What was dropped is a constraint on the **element itself**: the shape somebody writes for an array of primitives, and the shape with nowhere else to put the rule.

Reported rather than honoured. Honouring means compiling a per-element rule for a primitive, which is a validator vocabulary question rather than a parser one — answering it here would put a second constraint compiler beside the one ValidationModules owns.

## Two that turned out not to be defects

| Asked for | Actually |
|---|---|
| `responses.*.headers` | **Honoured since `0ef403d`** — no longer an unenforced declaration |
| `minProperties` | **Mapped**, at `OpenApiSpecParser.cs:1260`, onto `MinItems`/`MaxItems` — what bounds a free-form object's member count is what bounds a list's length |

## One that is real but narrower

The study asked for *"a declared `4xx` whose body the framework overrides"*. A declared `4xx` body is **not** overridden in general — `ExceptionToModelConverter` uses `StatusCodeException.Value` when there is one, and its own comment says so: *"which keeps a declared payload working exactly as it did."*

What **is** overridden is a declared `400` when the failure is a validation failure, because the converter returns `RequestValidationError` before it ever looks at a declared value. So a document declaring `400: { schema: MyError }` gets `RequestValidationError` on the wire.

Detecting that means comparing the declared schema against `RequestValidationError`, not checking for a keyword — a different mechanism from `HOAT013`'s, so it's left as its own change rather than half-done here.

## Verification

Eight of the ten new tests were confirmed to fail without the fix. The other two are the negative controls — a referenced item schema and an unconstrained one — and pass either way by design.

One thing the tests surfaced and pin: a schema reachable both as a component and through an operation's body is walked once for each, so one declaration is recorded at two locations. That is how every keyword here has always behaved, and `SpecDiagnostics` already collapses it into *"at X and 1 other place"*.

**5,234 tests pass, 0 fail**, across 30 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX