### PR TITLE
Add the three response types every application in the study had to invent

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -649,6 +649,24 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(400)]
+    public sealed class BadRequest : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadRequest>
+    {
+        public BadRequest(string? Detail = null) { }
+        public string? Detail { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(400)]
+    public sealed class BadRequest<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadRequest<T>>
+    {
+        public BadRequest(T Body) { }
+        public T Body { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
     [Hardened.Requests.Abstract.Responses.HttpStatus(409)]
     public sealed class Conflict : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Conflict>
     {
@@ -757,6 +775,16 @@ namespace Hardened.Requests.Abstract.Responses
         public string Title { get; }
         public string Type { get; }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(200)]
+    public sealed class Ok<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Ok<T>>
+    {
+        public Ok(T Value, System.Collections.Generic.IReadOnlyDictionary<string, string>? Headers = null) { }
+        public Ok(T value, string headerName, string headerValue) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string>? Headers { get; init; }
+        public int Status { get; }
+        public T Value { get; init; }
+        public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+    }
     [Hardened.Requests.Abstract.Responses.HttpStatus(412)]
     public sealed class PreconditionFailed : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed>
     {
@@ -775,13 +803,33 @@ namespace Hardened.Requests.Abstract.Responses
         public string Title { get; }
         public string Type { get; }
     }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(428)]
+    public sealed class PreconditionRequired : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionRequired>
+    {
+        public PreconditionRequired(string? Detail = null) { }
+        public string? Detail { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
+    [Hardened.Requests.Abstract.Responses.HttpStatus(428)]
+    public sealed class PreconditionRequired<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionRequired<T>>
+    {
+        public PreconditionRequired(T Body) { }
+        public T Body { get; init; }
+        public int Status { get; }
+        public string Title { get; }
+        public string Type { get; }
+    }
     public static class ProblemTypes
     {
+        public const string BadRequest = "urn:hardened:problem:bad-request";
         public const string Conflict = "urn:hardened:problem:conflict";
         public const string Forbidden = "urn:hardened:problem:forbidden";
         public const string Gone = "urn:hardened:problem:gone";
         public const string NotFound = "urn:hardened:problem:not-found";
         public const string PreconditionFailed = "urn:hardened:problem:precondition-failed";
+        public const string PreconditionRequired = "urn:hardened:problem:precondition-required";
         public const string Prefix = "urn:hardened:problem:";
         public const string RateLimited = "urn:hardened:problem:rate-limited";
         public const string ServiceUnavailable = "urn:hardened:problem:service-unavailable";

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/AddedResponseTypeTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/AddedResponseTypeTests.cs
@@ -1,0 +1,171 @@
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Responses;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Tests.Responses;
+
+/// <summary>
+/// The three gaps nine independent applications each worked around.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>BuiltInResponseTypeTests</c> already covers status agreement, sealing and the interface for
+/// every type by reflection, so nothing here restates those. What is asserted is the behaviour each
+/// of these was added for.
+/// </para>
+/// <para>
+/// The absences were measured rather than assumed. Every application in the study invented its own
+/// 400 shape; every optimistic-concurrency route answered one of its two conditional cases with a
+/// status it had to choose itself; and every route that needed a header on a 200 hand-wrote a filter
+/// to put one there.
+/// </para>
+/// </remarks>
+public class AddedResponseTypeTests {
+
+    private sealed record Part(string Sku);
+
+    #region Ok<T> - a 200 whose headers are part of the answer
+
+    /// <summary>
+    /// The case this exists for: an <c>ETag</c> on a read, set by the handler that computed it
+    /// rather than by a filter re-deriving it from the payload afterwards.
+    /// </summary>
+    [Fact]
+    public void Ok_AppliesTheHeadersItWasGiven() {
+        var headers = new Dictionary<string, StringValues>();
+
+        new Ok<Part>(new Part("A1"), KnownHeaders.ETag, "\"v1\"").ApplyHeaders(headers);
+
+        Assert.Equal("\"v1\"", headers[KnownHeaders.ETag]);
+    }
+
+    [Fact]
+    public void Ok_AppliesEveryHeaderInTheDictionary() {
+        var headers = new Dictionary<string, StringValues>();
+
+        new Ok<Part>(new Part("A1"), new Dictionary<string, string> {
+            [KnownHeaders.ETag] = "\"v1\"",
+            [KnownHeaders.CacheControl] = "no-cache"
+        }).ApplyHeaders(headers);
+
+        Assert.Equal("\"v1\"", headers[KnownHeaders.ETag]);
+        Assert.Equal("no-cache", headers[KnownHeaders.CacheControl]);
+    }
+
+    /// <summary>
+    /// Headers are optional, so the plain form stays a plain 200 rather than a null dereference.
+    /// </summary>
+    [Fact]
+    public void Ok_WithNoHeadersAppliesNone() {
+        var headers = new Dictionary<string, StringValues>();
+
+        new Ok<Part>(new Part("A1")).ApplyHeaders(headers);
+
+        Assert.Empty(headers);
+    }
+
+    /// <summary>
+    /// Assigns rather than appends, which is the contract <c>IProvidesResponseHeaders</c> states: a
+    /// retried or forked request producing the same response twice must not send the header twice.
+    /// </summary>
+    [Fact]
+    public void Ok_AssignsRatherThanAppends() {
+        var headers = new Dictionary<string, StringValues>();
+        var response = new Ok<Part>(new Part("A1"), KnownHeaders.ETag, "\"v1\"");
+
+        response.ApplyHeaders(headers);
+        response.ApplyHeaders(headers);
+
+        Assert.Equal("\"v1\"", headers[KnownHeaders.ETag]);
+    }
+
+    /// <summary>
+    /// The body is the value, not the wrapper - the same rule <c>Created&lt;T&gt;</c> follows.
+    /// Serializing the record would put the caller's resource under a <c>value</c> member and the
+    /// headers in the body as well as on the response.
+    /// </summary>
+    [Fact]
+    public void Ok_SendsTheValueAsTheBodyRatherThanItself() {
+        var part = new Part("A1");
+
+        Assert.Same(part, ((ICarriesResponseBody)new Ok<Part>(part)).Body);
+    }
+
+    #endregion
+
+    #region the conditional-request pair
+
+    /// <summary>
+    /// 428 is the half that was missing, and it is the half that loses updates: a validator that was
+    /// never sent, rather than one that is stale.
+    /// </summary>
+    [Fact]
+    public void PreconditionRequired_Is428AndPairsWith412() {
+        Assert.Equal(428, new PreconditionRequired().Status);
+        Assert.Equal(412, new PreconditionFailed().Status);
+    }
+
+    [Fact]
+    public void PreconditionRequired_CarriesItsOwnProblemType() {
+        Assert.Equal(ProblemTypes.PreconditionRequired, new PreconditionRequired().Type);
+        Assert.NotEqual(new PreconditionFailed().Type, new PreconditionRequired().Type);
+    }
+
+    [Fact]
+    public void PreconditionRequiredOfT_SendsTheSuppliedBody() {
+        var part = new Part("A1");
+
+        Assert.Same(part, ((ICarriesResponseBody)new PreconditionRequired<Part>(part)).Body);
+    }
+
+    /// <summary>
+    /// The generic and non-generic forms are one problem kind, so they share a <c>type</c> URI. RFC
+    /// 9457 makes <c>type</c> the identity of what went wrong, not of what shape the body is.
+    /// </summary>
+    [Fact]
+    public void PreconditionRequired_BothFormsShareOneProblemType() {
+        Assert.Equal(
+            new PreconditionRequired().Type,
+            new PreconditionRequired<Part>(new Part("A1")).Type);
+    }
+
+    #endregion
+
+    #region BadRequest
+
+    [Fact]
+    public void BadRequest_Is400WithItsOwnProblemType() {
+        Assert.Equal(400, new BadRequest().Status);
+        Assert.Equal(ProblemTypes.BadRequest, new BadRequest().Type);
+    }
+
+    [Fact]
+    public void BadRequest_BothFormsShareOneProblemType() {
+        Assert.Equal(new BadRequest().Type, new BadRequest<Part>(new Part("A1")).Type);
+    }
+
+    [Fact]
+    public void BadRequestOfT_SendsTheSuppliedBody() {
+        var part = new Part("A1");
+
+        Assert.Same(part, ((ICarriesResponseBody)new BadRequest<Part>(part)).Body);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Every built-in problem type is a distinct URI. A duplicate would make two different problems
+    /// indistinguishable to a client matching on <c>type</c>, which is the member RFC 9457 asks it to
+    /// match on.
+    /// </summary>
+    [Fact]
+    public void EveryProblemTypeUriIsDistinct() {
+        var uris = typeof(ProblemTypes)
+            .GetFields()
+            .Where(field => field.IsLiteral && field.Name != nameof(ProblemTypes.Prefix))
+            .Select(field => (string)field.GetRawConstantValue()!)
+            .ToArray();
+
+        Assert.Equal(uris.Length, uris.Distinct().Count());
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadRequest.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadRequest.cs
@@ -1,0 +1,28 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// The request was not one this service can act on - 400.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The gap this closes was measured rather than assumed: nine applications built against this
+/// framework each invented their own 400 shape, because there was no built-in one and 400 is the
+/// most-answered client error there is.
+/// </para>
+/// <para>
+/// <b>Not what a validation failure returns.</b> A failed constraint answers 400 with
+/// <c>RequestValidationError</c>, which carries the field-level list a caller needs to fix the
+/// payload. This is for the 400s that are not field-level - a parameter combination that cannot be
+/// satisfied, a state the request does not fit - where "which field" is the wrong question and a
+/// list of none would be noise.
+/// </para>
+/// </remarks>
+[HttpStatus(400)]
+public sealed record BadRequest(string? Detail = null) : IHttpStatusResponse {
+
+    public string Type => ProblemTypes.BadRequest;
+
+    public string Title => "Bad Request";
+
+    public int Status => 400;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadRequestOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadRequestOfT.cs
@@ -1,0 +1,29 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 400 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generic form of <see cref="BadRequest"/>, for a caller who already has a payload type and does
+/// not want a Hardened-shaped problem document. Both are the same problem kind and carry the same
+/// <c>type</c> URI - that identifies what went wrong, not what shape the body is.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Body"/>, not this record.</b> It implements
+/// <see cref="ICarriesResponseBody"/>, so the generated dispatch sends the payload rather than a
+/// wrapper with the payload nested inside it.
+/// </para>
+/// </remarks>
+[HttpStatus(400)]
+public sealed record BadRequest<T>(T Body)
+    : IHttpStatusResponse, ICarriesResponseBody {
+
+    public string Type => ProblemTypes.BadRequest;
+
+    public string Title => "Bad Request";
+
+    public int Status => 400;
+
+    object? ICarriesResponseBody.Body => Body;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/OkOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/OkOfT.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 200 carrying a body and headers the handler chooses.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The partner to <see cref="Created{T}"/>, and the one the study found missing on every route that
+/// needed it. A handler returning <c>T</c> answers 200 and sets no headers, which is right almost
+/// always - but an <c>ETag</c> on a read, a <c>Cache-Control</c> on a computed document, a
+/// <c>RateLimit-Remaining</c> on a metered one, are all 200s whose headers are part of the answer.
+/// Without this, each of those meant hand-writing a filter to put a header on a response the handler
+/// had already produced, re-deriving from the payload what the handler knew when it returned.
+/// </para>
+/// <para>
+/// <b>Headers are supplied rather than fixed.</b> <see cref="Created{T}"/> can hard-code
+/// <c>Location</c> because a 201 has exactly one header that matters. A 200 does not, so this takes
+/// what to set - which also means it does not need a variant per header.
+/// </para>
+/// <para>
+/// <b>The body is <see cref="Value"/>, not this record</b>, through
+/// <see cref="ICarriesResponseBody"/> - the same reason <see cref="Created{T}"/> does it.
+/// Serializing the wrapper would put the caller's resource under a <c>value</c> member and the
+/// headers in the body as well as on the response.
+/// </para>
+/// <para>
+/// No non-generic <c>Ok</c>. A 200 with no body is 204, which <see cref="NoContent"/> already is,
+/// and offering both would make "no body" a choice between two spellings that mean different things
+/// on the wire.
+/// </para>
+/// </remarks>
+[HttpStatus(200)]
+public sealed record Ok<T>(T Value, IReadOnlyDictionary<string, string>? Headers = null)
+    : IHttpStatusResponse, IProvidesResponseHeaders, ICarriesResponseBody {
+
+    /// <summary>
+    /// A 200 carrying one header, which is the common case - an <c>ETag</c>.
+    /// </summary>
+    public Ok(T value, string headerName, string headerValue)
+        : this(value, new Dictionary<string, string> { [headerName] = headerValue }) { }
+
+    public int Status => 200;
+
+    object? ICarriesResponseBody.Body => Value;
+
+    public void ApplyHeaders(IDictionary<string, StringValues> headers) {
+        if (Headers == null) {
+            return;
+        }
+
+        foreach (var header in Headers) {
+            headers[header.Key] = header.Value;
+        }
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequired.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequired.cs
@@ -1,0 +1,27 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A conditional request that arrived without its condition - 428.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The other half of the conditional-request pair. <see cref="PreconditionFailed"/> answers a
+/// validator that is stale; this answers one that was never sent, which is the case that actually
+/// loses an update: two clients read, both write unconditionally, and the second silently overwrites
+/// the first. RFC 6585 defines 428 for exactly this, and its stated purpose is to let a server
+/// require the conditional request rather than hope for one.
+/// </para>
+/// <para>
+/// Shipping only the 412 half made every optimistic-concurrency route in the study answer one of its
+/// two cases with an invented status.
+/// </para>
+/// </remarks>
+[HttpStatus(428)]
+public sealed record PreconditionRequired(string? Detail = null) : IHttpStatusResponse {
+
+    public string Type => ProblemTypes.PreconditionRequired;
+
+    public string Title => "Precondition Required";
+
+    public int Status => 428;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequiredOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequiredOfT.cs
@@ -1,0 +1,23 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A 428 carrying a body the caller supplies.
+/// </summary>
+/// <remarks>
+/// The generic form of <see cref="PreconditionRequired"/>, for a caller who already has a payload
+/// type and does not want a Hardened-shaped problem document. Both are the same problem kind and
+/// carry the same <c>type</c> URI. The body is <see cref="Body"/> rather than this record, through
+/// <see cref="ICarriesResponseBody"/>.
+/// </remarks>
+[HttpStatus(428)]
+public sealed record PreconditionRequired<T>(T Body)
+    : IHttpStatusResponse, ICarriesResponseBody {
+
+    public string Type => ProblemTypes.PreconditionRequired;
+
+    public string Title => "Precondition Required";
+
+    public int Status => 428;
+
+    object? ICarriesResponseBody.Body => Body;
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ProblemTypes.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ProblemTypes.cs
@@ -25,6 +25,8 @@ public static class ProblemTypes {
     /// <summary>The namespace every built-in problem type is qualified by.</summary>
     public const string Prefix = "urn:hardened:problem:";
 
+    public const string BadRequest = Prefix + "bad-request";
+
     public const string Unauthorized = Prefix + "unauthorized";
 
     public const string Forbidden = Prefix + "forbidden";
@@ -36,6 +38,8 @@ public static class ProblemTypes {
     public const string Gone = Prefix + "gone";
 
     public const string PreconditionFailed = Prefix + "precondition-failed";
+
+    public const string PreconditionRequired = Prefix + "precondition-required";
 
     public const string RateLimited = Prefix + "rate-limited";
 


### PR DESCRIPTION
Recommendation from the Atlas Matrix study's response-vocabulary finding. **Measured absences, not guessed ones** — nine applications built against this framework each worked around the same three gaps.

## `BadRequest` / `BadRequest<T>`

There was no 400, which is the most-answered client error there is, so every application in the study invented its own shape for it.

Deliberately **not** what a validation failure returns. A failed constraint answers 400 with `RequestValidationError` and its field-level list. This is for the 400s that are not field-level — a parameter combination that cannot be satisfied, a state the request does not fit — where "which field" is the wrong question and a list of none would be noise.

## `PreconditionRequired` / `PreconditionRequired<T>` — 428

The other half of the conditional-request pair. `PreconditionFailed` answers a validator that is **stale**; this answers one that was **never sent** — which is the case that actually loses an update: two clients read, both write unconditionally, and the second silently overwrites the first. RFC 6585 defines 428 for exactly this.

Shipping only the 412 half made every optimistic-concurrency route in the study answer one of its two cases with a status it had to choose itself.

## `Ok<T>`

The 200-with-headers partner to `Created<T>`. An `ETag` on a read, a `Cache-Control` on a computed document, a `RateLimit-Remaining` on a metered one are all 200s whose headers are part of the answer — and each one meant hand-writing a filter to put a header on a response the handler had already produced, re-deriving from the payload what the handler knew when it returned.

```csharp
return new Ok<Part>(part, KnownHeaders.ETag, version);
```

Headers are **supplied rather than fixed**: `Created<T>` can hard-code `Location` because a 201 has exactly one header that matters, and a 200 does not — which also means no variant per header.

**No non-generic `Ok`.** A 200 with no body is 204, which `NoContent` already is, and offering both would make "no body" a choice between two spellings that mean different things on the wire.

## Thirty test cases came for free

`BuiltInResponseTypeTests` finds types by reflection rather than from a list, so status agreement, sealing and `IHttpStatusResponse` are asserted for these without anyone adding them anywhere — which is what that design is for. The tests written by hand cover only what each type was added to do.

## Public API

Purely additive. No existing signature changed.

## What is deliberately not here

Extending `[JsonRequired]` to hand-written models — the other half of that finding — cannot be done by emitting an attribute onto user code. It needs a diagnostic: a `[Required]` on a non-nullable value-type member carrying neither `required` nor `[JsonRequired]` cannot be enforced at deserialization, because an omitted `int` is `0` and `0` is not null. That is a generator change rather than a vocabulary one, and is left as its own.

**5,277 tests pass, 0 fail**, across 30 projects, rebased onto #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX