### PR TITLE
Report a required member of a value type whose absence nothing can detect

### DIFF
--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
@@ -287,6 +287,166 @@ public class ValidationGeneratorTests {
 
     #endregion
 
+    // ---------------------------------------- required members of a value type
+
+    private const string RequiredValueType = """
+        using ValidationModules.Constraints;
+
+        namespace TestApp.Models;
+
+        public class Part {
+            [Required]
+            public int Category { get; set; }
+        }
+        """;
+
+    private static Diagnostic[] Warnings(GeneratorResult result, string id) =>
+        result.GeneratorDiagnostics.Where(d => d.Id == id).ToArray();
+
+    /// <summary>
+    /// A required member of a value type whose absence nothing can detect.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>[Required]</c> compiles to a null check and a value type is never null, so an omitted
+    /// <c>int</c> arrives as <c>0</c>, the check passes, and the API answers 201 carrying a value
+    /// the caller never sent. An omitted enum is worse - it becomes whichever member was declared
+    /// first, so the record reads as a deliberate choice rather than an absence.
+    /// </para>
+    /// <para>
+    /// The study found this fixed in contract-first and still live in code-first, by two agents in
+    /// the same run. It was fixed there because <c>SchemaEmitter</c> writes <c>[JsonRequired]</c>
+    /// onto exactly this shape; a generator cannot write an attribute onto a member somebody else
+    /// wrote, so for a hand-written model the only thing available is to say so.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ARequiredValueTypeMemberIsReported() {
+        var result = Run(("Entry.cs", EntryPoint), ("Part.cs", RequiredValueType));
+
+        var warning = Assert.Single(Warnings(result, "HRDV003"));
+
+        Assert.Contains("Category", warning.GetMessage());
+        Assert.Contains("int", warning.GetMessage());
+    }
+
+    /// <summary>
+    /// An enum is the case worth naming separately: the default is a real member, so the invented
+    /// value is indistinguishable from a chosen one.
+    /// </summary>
+    [Fact]
+    public void ARequiredEnumMemberIsReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Part.cs", """
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public enum Category { Electrical, Hydraulic }
+
+                public class Part {
+                    [Required]
+                    public Category Category { get; set; }
+                }
+                """));
+
+        Assert.Single(Warnings(result, "HRDV003"));
+    }
+
+    /// <summary>
+    /// Both remedies silence it, because both make the deserializer reject the absence.
+    /// </summary>
+    [Theory]
+    [InlineData("[Required]\n    public required int Category { get; set; }")]
+    [InlineData("[Required]\n    [System.Text.Json.Serialization.JsonRequired]\n    public int Category { get; set; }")]
+    public void AMemberTheDeserializerCanRejectIsNotReported(string declaration) {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Part.cs", $$"""
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class Part {
+                    {{declaration}}
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV003"));
+    }
+
+    /// <summary>
+    /// A reference type is what the null check was written for, and a nullable value type has
+    /// somewhere to put "absent". Neither is at risk, and reporting either would train people to
+    /// ignore this.
+    /// </summary>
+    [Theory]
+    [InlineData("public string Sku { get; set; } = \"\";")]
+    [InlineData("public int? Category { get; set; }")]
+    public void AMemberThatCanBeNullIsNotReported(string declaration) {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Part.cs", $$"""
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class Part {
+                    [Required]
+                    {{declaration}}
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV003"));
+    }
+
+    /// <summary>
+    /// An unconstrained value type says nothing about being required, so there is nothing to warn
+    /// about.
+    /// </summary>
+    [Fact]
+    public void AnUnconstrainedValueTypeMemberIsNotReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Part.cs", """
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class Part {
+                    [StringLength(Min = 1, Max = 8)]
+                    public string Sku { get; set; } = "";
+
+                    public int Category { get; set; }
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV003"));
+    }
+
+    /// <summary>
+    /// The DataAnnotations spelling reaches the same place, because the front end reads both
+    /// vocabularies and this has to agree with it.
+    /// </summary>
+    [Fact]
+    public void TheDataAnnotationsSpellingIsReportedToo() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Part.cs", """
+                using System.ComponentModel.DataAnnotations;
+
+                namespace TestApp.Models;
+
+                public class Part {
+                    [Required]
+                    public int Category { get; set; }
+                }
+                """));
+
+        Assert.Single(Warnings(result, "HRDV003"));
+    }
+
     #region registration into the entry point
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator/HardenedValidationGenerator.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator/HardenedValidationGenerator.cs
@@ -175,7 +175,89 @@ public class HardenedValidationGenerator : IIncrementalGenerator {
 
         var model = frontEnd.Build(symbol, ValidationGeneratorOptions.ValidatorNameFor);
 
-        return new ModelResult(model, frontEnd.Diagnostics.ToImmutableArray());
+        var diagnostics = frontEnd.Diagnostics.ToList();
+
+        diagnostics.AddRange(RequiredValueTypesThatCannotBeMissed(symbol));
+
+        return new ModelResult(model, diagnostics.ToImmutableArray());
+    }
+
+    /// <summary>
+    /// Members declared required whose absence nothing can detect.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>[Required]</c> compiles to a null check and a value type is never null, so an omitted
+    /// <c>int</c> arrives as <c>0</c>, passes, and reaches the handler as a value the caller never
+    /// sent. Sited on the symbol rather than on the built model because what decides this is the
+    /// member's C# type and modifiers, which the validation IR has already abstracted away.
+    /// </para>
+    /// <para>
+    /// Spec-emitted models do not trip it: <c>SchemaEmitter</c> writes <c>[JsonRequired]</c> onto
+    /// exactly this shape, so the check reads that attribute and stays quiet. Nothing here needs to
+    /// know which front end produced the type - the presence of a remedy is the test.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<Diagnostic> RequiredValueTypesThatCannotBeMissed(
+        INamedTypeSymbol symbol) {
+        foreach (var member in symbol.GetMembers()) {
+            if (member is not IPropertySymbol property || property.IsStatic) {
+                continue;
+            }
+
+            // A nullable value type has somewhere to put "absent", and a reference type is what the
+            // null check was written for. Neither is at risk.
+            if (!property.Type.IsValueType ||
+                property.Type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T) {
+                continue;
+            }
+
+            if (!DeclaresRequired(property) || CanDetectAbsence(property)) {
+                continue;
+            }
+
+            yield return ValidationGeneratorDiagnostics.RequiredValueTypeCannotBeMissed(
+                symbol, property);
+        }
+    }
+
+    /// <summary>
+    /// Whether the member carries a required constraint, in either vocabulary the front end reads.
+    /// </summary>
+    private static bool DeclaresRequired(IPropertySymbol property) {
+        foreach (var attribute in property.GetAttributes()) {
+            var name = attribute.AttributeClass?.ToDisplayString();
+
+            if (name is "ValidationModules.Constraints.RequiredAttribute"
+                     or "System.ComponentModel.DataAnnotations.RequiredAttribute") {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether anything already makes the deserializer reject an omitted member.
+    /// </summary>
+    /// <remarks>
+    /// The <c>required</c> modifier is checked first because it is the better answer: the
+    /// reflection-based deserializer and the source-generated resolver both honour it, where
+    /// <c>[JsonRequired]</c> is read by the former alone.
+    /// </remarks>
+    private static bool CanDetectAbsence(IPropertySymbol property) {
+        if (property.IsRequired) {
+            return true;
+        }
+
+        foreach (var attribute in property.GetAttributes()) {
+            if (attribute.AttributeClass?.ToDisplayString()
+                == "System.Text.Json.Serialization.JsonRequiredAttribute") {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private sealed record ModelResult(ValidatedTypeModel? Model, ImmutableArray<Diagnostic> Diagnostics);

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator/ValidationGeneratorDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator/ValidationGeneratorDiagnostics.cs
@@ -38,6 +38,56 @@ public static class ValidationGeneratorDiagnostics {
         isEnabledByDefault: true);
 
     /// <summary>
+    /// A required member of a value type that nothing can find missing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>[Required]</c> compiles to a null check, and a value type is never null. So
+    /// <c>[Required] public int Category { get; set; }</c> deserializes an omitted member to
+    /// <c>0</c>, the check passes because <c>0</c> is not null, and the API answers 201 carrying a
+    /// value the caller never sent. An omitted enum is worse: it becomes whichever member was
+    /// declared first, so the record reads as a deliberate choice.
+    /// </para>
+    /// <para>
+    /// <b>Why this is a diagnostic and not a fix.</b> Spec-emitted models get <c>[JsonRequired]</c>
+    /// written onto them by <c>SchemaEmitter</c>, which is why the same defect was closed there and
+    /// not here. A generator cannot add an attribute to a member somebody else wrote, so the only
+    /// thing available for a hand-written model is to say so.
+    /// </para>
+    /// <para>
+    /// Both remedies it names are one word. <c>[JsonRequired]</c> is read by the reflection-based
+    /// deserializer and the <c>required</c> modifier is read by both it and the source-generated
+    /// resolver, which is why the modifier is named first.
+    /// </para>
+    /// </remarks>
+    public static readonly DiagnosticDescriptor RequiredValueTypeCannotBeMissedDescriptor = new(
+        "HRDV003",
+        "A required member of a value type cannot be found missing",
+        "'{0}.{1}' is required and is '{2}', which is a value type - so an omitted member " +
+        "deserializes to default({2}) and the required check passes, because default({2}) is not " +
+        "null. Declare it 'required', or add [JsonRequired], so the deserializer rejects the " +
+        "absence. Making it '{2}?' also works and changes the model's shape.",
+        "Hardened.Validation",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports <see cref="RequiredValueTypeCannotBeMissedDescriptor"/> against the member.
+    /// </summary>
+    /// <remarks>
+    /// Located on the member's own declaration rather than the type's, because the fix is one word
+    /// on one property and a diagnostic pointing at the class makes the reader find which.
+    /// </remarks>
+    public static Diagnostic RequiredValueTypeCannotBeMissed(
+        INamedTypeSymbol owner, IPropertySymbol property) =>
+        Diagnostic.Create(
+            RequiredValueTypeCannotBeMissedDescriptor,
+            property.Locations.Length > 0 ? property.Locations[0] : Location.None,
+            owner.Name,
+            property.Name,
+            property.Type.ToDisplayString());
+
+    /// <summary>
     /// Reports <see cref="DuplicateValidatorSourceDescriptor"/> against the type that collided.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
The other half of the Atlas Matrix study's required-value-type finding — the half that was **fixed in contract-first and still live in code-first**, verified by two agents in the same run.

## What happens

`[Required]` compiles to a null check, and a value type is never null:

```csharp
[Required] public int Category { get; set; }
```

An omitted member deserializes to `0`, the check passes because `0` is not null, and the API answers 201 carrying a value the caller never sent. The study's measurement:

```
code-first  POST /parts omitting "category" → 201 {"category":"electrical"}
            …a value the caller never sent. Published schema agrees: required: ["sku","name"]
```

An omitted **enum** is worse — it becomes whichever member was declared first, so the record reads as a deliberate choice rather than an absence.

## Why a diagnostic rather than the same fix

Contract-first was fixed because `SchemaEmitter` writes `[JsonRequired]` onto exactly this shape. A generator cannot write an attribute onto a member somebody else wrote, so for a hand-written model the only thing available is to say so.

`HRDV003` names the member, its type, and both one-word remedies. The `required` modifier is named first, because the reflection-based deserializer and the source-generated resolver both honour it — `[JsonRequired]` is read by the former alone.

## Where it lives

On the symbol in `BuildModel`, not on the built model: what decides this is the member's C# type and modifiers, and the validation IR has already abstracted those away. The generator already returns diagnostics from there, so nothing new had to be plumbed.

**Spec-emitted models do not trip it.** The check tests for the presence of a remedy, so the `[JsonRequired]` that `SchemaEmitter` already writes keeps them quiet — nothing here needs to know which front end produced the type.

## Verification

Eight new cases, including the four that must stay **silent**: a reference type (what the null check was written for), a nullable value type (it has somewhere to put "absent"), an unconstrained value type, and both remedies. The DataAnnotations spelling is covered too, since the front end reads both vocabularies and this has to agree with it.

The warning fires **nowhere in the existing tree** — the CI-mode build (`TreatWarningsAsErrors`) is clean, so this adds no work to unrelated projects.

**5,285 tests pass, 0 fail**, across 30 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX