### PR TITLE
Raise twelve coverage floors to what the tests added for the study measured

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
   "Hardened.Idl.SourceGenerator": {
-    "line": 59.5,
-    "branch": 48.0
+    "line": 60.7,
+    "branch": 49.0
   },
   "Hardened.Library.SourceGenerator": {
     "line": 34.2,
@@ -9,11 +9,11 @@
   },
   "Hardened.OpenApi.BuildTask": {
     "line": 45.0,
-    "branch": 33.5
+    "branch": 36.3
   },
   "Hardened.Requests.Abstract": {
-    "line": 93.8,
-    "branch": 96.4
+    "line": 95.4,
+    "branch": 100.0
   },
   "Hardened.Requests.Runtime": {
     "line": 97.2,
@@ -28,7 +28,7 @@
     "branch": 100.0
   },
   "Hardened.Shared.Runtime": {
-    "line": 96.6,
+    "line": 97.3,
     "branch": 99.3
   },
   "Hardened.Shared.Testing": {
@@ -36,8 +36,8 @@
     "branch": 83.8
   },
   "Hardened.Smithy.BuildTask": {
-    "line": 67.3,
-    "branch": 43.7
+    "line": 69.4,
+    "branch": 45.8
   },
   "Hardened.SourceGeneration.Testing": {
     "line": 84.6,
@@ -45,15 +45,15 @@
   },
   "Hardened.SourceGenerator": {
     "line": 68.3,
-    "branch": 49.7
+    "branch": 50.3
   },
   "Hardened.Templates.RazorBlade": {
     "line": 100.0,
     "branch": 100.0
   },
   "Hardened.Validation.SourceGenerator": {
-    "line": 20.2,
-    "branch": 12.4
+    "line": 25.4,
+    "branch": 15.4
   },
   "Hardened.Web.AspNetCore.Runtime": {
     "line": 97.1,
@@ -69,7 +69,7 @@
   },
   "Hardened.Web.SourceGenerator": {
     "line": 66.1,
-    "branch": 49.0
+    "branch": 49.7
   },
   "Hardened.Web.StaticContent": {
     "line": 96.6,

--- a/scripts/coverage-gate.py
+++ b/scripts/coverage-gate.py
@@ -72,6 +72,17 @@ import sys
 # run fails. Hardened.Shared.Runtime's branch coverage moves between 85.2 and 85.8 - wider than
 # this tolerance - and was briefly pinned at 85.8 that way. Where an assembly is known to wobble,
 # the baseline belongs at the bottom of the range rather than at the reading in front of you.
+#
+# Two more are now measured, from a pull request's run and the run of the same code after it
+# merged:
+#
+#   Hardened.Requests.Runtime branch   94.3 then 93.7   0.6 - wider than the tolerance
+#   Hardened.Shared.Testing   branch   84.7 then 84.2   0.5 - exactly the tolerance
+#
+# Pinning the first at 94.3 would have failed the next ordinary run, which is how that pair came
+# to be measured rather than assumed. Neither was raised. Take the summary from a run of main
+# rather than of the branch proposing the raise: they are not the same reading, and the branch's
+# is the one with no run after it to check against.
 TOLERANCE = 0.5
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent


### PR DESCRIPTION
The Atlas Matrix study's closing finding: *"The runtime is close to exhaustively tested. The generators are not — and Hardened's entire value proposition is that the wiring is written during the build. The generators are the product, and they are the least-covered assemblies in the repository."*

Six pull requests of emit-path tests later, the floors move to match.

| Assembly | Line | Branch |
|---|---|---|
| `Hardened.Validation.SourceGenerator` | 20.2 → **25.4** | 12.4 → **15.4** |
| `Hardened.Smithy.BuildTask` | 67.3 → **69.4** | 43.7 → **45.8** |
| `Hardened.OpenApi.BuildTask` | — | 33.5 → **36.3** |
| `Hardened.Idl.SourceGenerator` | 59.5 → **60.7** | 48.0 → **49.0** |
| `Hardened.SourceGenerator` | — | 49.7 → **50.3** |
| `Hardened.Web.SourceGenerator` | — | 49.0 → **49.7** |
| `Hardened.Requests.Abstract` | 93.8 → **95.4** | 96.4 → **100.0** |
| `Hardened.Shared.Runtime` | 96.6 → **97.3** | — |

`Hardened.Validation.SourceGenerator` moved most. It was the worst-covered assembly in the report *and* where the silent validator-dropping defect lived — which is the thesis landing rather than a coincidence.

## Taken from main, not from this branch

Deliberate, and it turned out to matter rather than being procedural. The same code measured on a pull request's run and on main after it merged:

```
Hardened.Requests.Runtime branch   94.3 on the PR run,   93.7 after merge   (0.6 apart)
Hardened.Shared.Testing   branch   84.7 on the PR run,   84.2 after merge   (0.5 apart)
```

The first is **wider than the gate's 0.5 tolerance**, so pinning it from the PR's reading would have failed the next ordinary run — exactly the failure `coverage-gate.py`'s own header warns about. Neither is raised here, and both readings are now recorded in that header beside the one wobbling assembly it already documented.

## Raised by hand, not with `--update`

Two reasons.

**`--update` writes a floor down.** It records whatever the run measured, including a reading that dipped inside the tolerance band. `Hardened.Web.Runtime` line reads 98.4 against a 98.5 floor — not a regression, but `--update` would lower the floor to 98.4 anyway. A ratchet that moves backwards is not one, so that floor is held.

**It also re-serialises the file**, reordering every entry's keys and burying twelve real changes in a whole-file diff. This edits the text in place, so the diff is 12 lines.

## Result

**Twelve raised, one held, none lowered.** The gate passes against both the main run this was taken from and the pull request run it was cross-checked against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX