### PR TITLE
Seal generated models that nothing derives from

### DIFF
--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
@@ -70,6 +70,19 @@ internal static class SchemaEmitter {
 
         record.TypeKeyword = ClassKeyword.Record;
         record.Modifiers |= ComponentModifier.Public | ComponentModifier.Partial;
+
+        // Sealed unless the document says something derives from it. A validator for a sealed type
+        // needs no rules for a type that might inherit it, which is the whole of the win - and a
+        // request or response model is the case where nothing does inherit it.
+        //
+        // Sealed and partial answer different questions, which is why both are set. Sealed forbids
+        // deriving; partial permits extending in place, which is how an application adds an
+        // interface or a computed member to a type it did not write. The response case types have
+        // been emitted this way since headers landed.
+        if (IsLeaf(schema, allSchemas)) {
+            record.Modifiers |= ComponentModifier.Sealed;
+        }
+
         record.Comment = DocComment.Format(schema.Description);
 
         if (schema.IsDeprecated) {
@@ -295,6 +308,47 @@ internal static class SchemaEmitter {
     /// first.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Whether nothing in the document derives from <paramref name="schema"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two ways a schema is a base, and both disqualify it. Another schema names it as its
+    /// <c>BaseRef</c> - an <c>allOf</c> that composes it - or it declares a discriminator, which
+    /// makes it a polymorphic base whether or not this slice of the document happens to contain
+    /// anything mapped to it.
+    /// </para>
+    /// <para>
+    /// <b>Unknown means unsealed.</b> <paramref name="allSchemas"/> is optional, and a caller that
+    /// passes nothing is not saying the schema is a leaf - it is saying it does not know. Sealing on
+    /// no evidence would emit a type a later slice cannot derive from, and the failure would land in
+    /// the consumer's build rather than here.
+    /// </para>
+    /// <para>
+    /// Compared on the pascal-cased name, the same way <see cref="SchemaShape.Base"/> resolves one,
+    /// so the two agree about what a reference points at rather than agreeing by inspection.
+    /// </para>
+    /// </remarks>
+    private static bool IsLeaf(SchemaModel schema, IReadOnlyList<SchemaModel>? allSchemas) {
+        if (allSchemas == null || schema.IsPolymorphicBase) {
+            return false;
+        }
+
+        var name = NamingHelper.ToPascalCase(schema.Name);
+
+        foreach (var candidate in allSchemas) {
+            if (candidate.BaseRef == null) {
+                continue;
+            }
+
+            if (NamingHelper.ToPascalCase(TypeMapper.GetRefName(candidate.BaseRef)) == name) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static void EmitBaseType(
         ClassDefinition record, SchemaModel schema, string modelsNamespace,
         IReadOnlyList<SchemaModel>? allSchemas) {

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SealedLeafModelTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SealedLeafModelTests.cs
@@ -1,0 +1,195 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// A model nothing derives from is sealed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For the validator, not for the reader. A validator for a sealed type needs no rules for a type
+/// that might inherit it - it knows the members it can be handed are the members it can see - and a
+/// request or response model is exactly the case where nothing does inherit it.
+/// </para>
+/// <para>
+/// Sealed and partial answer different questions and both are set. Sealed forbids deriving; partial
+/// permits extending in place, which is how an application adds an interface or a computed member to
+/// a type it did not write. Sealing to make the validator's job smaller never required refusing
+/// that, and the response case types have been emitted this way since headers landed.
+/// </para>
+/// </remarks>
+public class SealedLeafModelTests {
+
+    /// <summary>
+    /// Emits every schema the document declares, each against the full list.
+    /// </summary>
+    /// <remarks>
+    /// The two-argument harness overload, because that is what the real emitter is handed -
+    /// <c>SpecFileEmitter</c> passes <c>model.Schemas</c>. Whether a schema is a leaf cannot be
+    /// answered from the schema alone, so the one-argument overload could only ever say "unknown".
+    /// </remarks>
+    private static string Emit(string schemas) {
+        var document = $$"""
+            openapi: 3.0.0
+            info: { title: Depot, version: '1.0' }
+            paths:
+              /parts:
+                get:
+                  operationId: listParts
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: string
+            components:
+              schemas:
+            {{schemas}}
+            """;
+
+        var model = OpenApiSpecParser.Parse(document, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        var all = model!.Schemas.ToList();
+
+        return string.Join("\n", all.Select(schema => EmitterHarness.Schema(schema, all)));
+    }
+
+    /// <summary>
+    /// The ordinary case, and the one the whole change is for.
+    /// </summary>
+    [Fact]
+    public void AModelNothingDerivesFromIsSealed() {
+        var emitted = Emit("""
+                Part:
+                  type: object
+                  properties:
+                    sku: { type: string }
+            """);
+
+        Assert.Contains("public sealed partial record Part(", emitted);
+    }
+
+    /// <summary>
+    /// A schema something genuinely derives from is a base, and sealing it would make the document
+    /// unrepresentable.
+    /// </summary>
+    /// <remarks>
+    /// Discriminated, because that is the only arrangement that produces inheritance here.
+    /// <c>OpenApiSpecParser</c> sets <c>BaseRef</c> only when an <c>allOf</c> branch references a
+    /// schema carrying a discriminator; a plain <c>allOf</c> is flattened into the deriving schema
+    /// instead. So a document without discriminators is all leaves, and all of it seals.
+    /// </remarks>
+    [Fact]
+    public void AModelSomethingDerivesFromIsNotSealed() {
+        var emitted = Emit("""
+                Part:
+                  type: object
+                  required: [kind]
+                  properties:
+                    kind: { type: string }
+                    sku: { type: string }
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      motor: '#/components/schemas/MotorPart'
+                MotorPart:
+                  allOf:
+                    - $ref: '#/components/schemas/Part'
+                    - type: object
+                      properties:
+                        voltage: { type: integer }
+            """);
+
+        Assert.Contains("public partial record Part(", emitted);
+        Assert.DoesNotContain("public sealed partial record Part(", emitted);
+    }
+
+    /// <summary>
+    /// And the derived end of that pair is itself a leaf, so it seals.
+    /// </summary>
+    [Fact]
+    public void TheDerivedEndOfAHierarchyIsStillSealed() {
+        var emitted = Emit("""
+                Part:
+                  type: object
+                  required: [kind]
+                  properties:
+                    kind: { type: string }
+                    sku: { type: string }
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      motor: '#/components/schemas/MotorPart'
+                MotorPart:
+                  allOf:
+                    - $ref: '#/components/schemas/Part'
+                    - type: object
+                      properties:
+                        voltage: { type: integer }
+            """);
+
+        Assert.Contains("public sealed partial record MotorPart(", emitted);
+    }
+
+    /// <summary>
+    /// A schema declaring a discriminator is a polymorphic base whether or not this slice of the
+    /// document happens to contain anything mapped to it.
+    /// </summary>
+    [Fact]
+    public void APolymorphicBaseIsNotSealed() {
+        var emitted = Emit("""
+                Part:
+                  type: object
+                  required: [kind]
+                  properties:
+                    kind: { type: string }
+                  discriminator:
+                    propertyName: kind
+            """);
+
+        Assert.DoesNotContain("public sealed partial record Part", emitted);
+    }
+
+    /// <summary>
+    /// Every model is still partial, sealed or not. That is what lets an application extend a type
+    /// it did not write, and it is a separate question from whether anything may derive from it.
+    /// </summary>
+    [Fact]
+    public void EveryModelIsStillPartial() {
+        var emitted = Emit("""
+                Part:
+                  type: object
+                  required: [kind]
+                  properties:
+                    kind: { type: string }
+                    sku: { type: string }
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      motor: '#/components/schemas/MotorPart'
+                MotorPart:
+                  allOf:
+                    - $ref: '#/components/schemas/Part'
+                    - type: object
+                      properties:
+                        voltage: { type: integer }
+            """);
+
+        var declarations = emitted
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.Contains(" record ") && line.StartsWith("public", System.StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.NotEmpty(declarations);
+        Assert.All(declarations, line => Assert.Contains("partial record", line));
+    }
+
+}

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/GeneratedCodeCompilesTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/GeneratedCodeCompilesTests.cs
@@ -44,7 +44,7 @@ public class GeneratedCodeCompilesTests {
 
         var record = result.SourceContaining("petstore.g.cs");
 
-        Assert.Contains("public partial record Widget(", record);
+        Assert.Contains("public sealed partial record Widget(", record);
         Assert.Contains("global::System.Collections.Generic.List<global::TestNamespace.Models.Part>? Parts = default", record);
         Assert.Contains("global::System.Collections.Generic.Dictionary<string,string>? Labels = default", record);
     }
@@ -428,7 +428,7 @@ public class GeneratedCodeCompilesTests {
                     id: { type: string }
             """).AssertNoErrors();
 
-        Assert.Contains("public partial record Orphan(", result.SourceContaining("petstore.g.cs"));
+        Assert.Contains("public sealed partial record Orphan(", result.SourceContaining("petstore.g.cs"));
     }
 
     /// <summary>
@@ -449,7 +449,7 @@ public class GeneratedCodeCompilesTests {
                   type: object
             """).AssertNoErrors();
 
-        Assert.Contains("public partial record Empty;", result.SourceContaining("petstore.g.cs"));
+        Assert.Contains("public sealed partial record Empty;", result.SourceContaining("petstore.g.cs"));
     }
 
     /// <summary>
@@ -505,7 +505,7 @@ public class GeneratedCodeCompilesTests {
                     tracking_number: { type: string }
             """).AssertNoErrors();
 
-        Assert.Contains("public partial record ShippingLabel(", result.SourceContaining("petstore.g.cs"));
+        Assert.Contains("public sealed partial record ShippingLabel(", result.SourceContaining("petstore.g.cs"));
         Assert.Contains("public partial interface IShippingLabelService", result.SourceContaining("petstore.g.cs"));
         Assert.Contains("ListShippingLabels(", result.SourceContaining("petstore.g.cs"));
     }
@@ -634,7 +634,7 @@ public class GeneratedCodeCompilesTests {
                 "namespace TestNamespace; public class NotAModule { }")
             .AssertNoErrors();
 
-        Assert.Contains("public partial record Pet", result.GeneratedSources["petstore.g.cs"]);
+        Assert.Contains("public sealed partial record Pet", result.GeneratedSources["petstore.g.cs"]);
         Assert.DoesNotContain(result.GeneratedSources.Keys, key => key.Contains("SpecRouting"));
     }
 
@@ -733,16 +733,25 @@ public class GeneratedCodeCompilesTests {
         var generated = Undent(OpenApiGenerator.Run(Specs.DiscriminatedHierarchy).AssertNoErrors());
 
         // The base declares the shared properties; each derived record forwards them.
+        //
+        // Pet is deliberately not sealed. It is the one shape in the emitter that something derives
+        // from, so it is the one that keeps the door open - every leaf beside it seals.
         Assert.Contains("public partial record Pet(", generated);
+        Assert.DoesNotContain("public sealed partial record Pet(", generated);
         Assert.Contains(") : global::TestNamespace.Models.Pet(PetType, Name, Nickname);", generated);
         Assert.Contains("record Dog(", generated);
         Assert.Contains("record Cat(", generated);
+
+        // And the derived ends are leaves, so they do seal.
+        Assert.Contains("public sealed partial record Dog(", generated);
+        Assert.Contains("public sealed partial record Cat(", generated);
 
         // The whole point: the branches are typed, not an untyped blob. Checked on the record
         // declarations rather than the file, because the resolver always carries a JsonElement
         // entry among its primitives whatever the spec says.
         foreach (var line in generated.Split('\n')) {
-            if (line.StartsWith("public partial record ")) {
+            if (line.StartsWith("public partial record ") ||
+                line.StartsWith("public sealed partial record ")) {
                 Assert.DoesNotContain("JsonElement", line);
             }
         }

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/InlineObjectTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/InlineObjectTests.cs
@@ -63,12 +63,12 @@ public class InlineObjectTests {
         var generated = OpenApiGenerator.Run(Specs.InlineObjects).AssertNoErrors()
             .SourceContaining("petstore.g.cs");
 
-        Assert.Contains("public partial record PetAddress(", generated);
-        Assert.Contains("public partial record PetAddressGeo(", generated);
+        Assert.Contains("public sealed partial record PetAddress(", generated);
+        Assert.Contains("public sealed partial record PetAddressGeo(", generated);
         Assert.Contains("PetAddress Address", generated);
 
         foreach (var line in generated.Split('\n')) {
-            if (line.TrimStart().StartsWith("public partial record ")) {
+            if (line.TrimStart().StartsWith("public sealed partial record ")) {
                 Assert.DoesNotContain("JsonElement", line);
             }
         }


### PR DESCRIPTION
A validator for a sealed type needs no rules for a type that might inherit it — it knows the members it can be handed are the members it can see. A request or response model is exactly the case where nothing does inherit it.

```csharp
public sealed partial record GetBalanceOutput(long BalanceCents, string? Currency = default);
```

## What counts as a leaf

Sealed unless the document says otherwise, and it says so two ways:

- another schema names this one as its `BaseRef`, or
- this one declares a discriminator, making it a polymorphic base whether or not the current slice contains anything mapped to it

Both disqualify. Everything else seals.

## In practice that is nearly everything

`OpenApiSpecParser` sets `BaseRef` **only** when an `allOf` branch references a schema carrying a discriminator:

```csharp
if (SchemaRef(branch) != null && branch.Discriminator != null) {
    model.BaseRef = SchemaRef(branch);
}
```

A plain `allOf` is *flattened* into the deriving schema instead — it produces no inheritance at all. So a document without discriminators is all leaves. Across the integration suites: **26 models sealed, none left open.**

## Sealed and partial answer different questions

Both are set. Sealed forbids deriving; partial permits extending in place, which is how an application adds an interface or a computed member to a type it did not write. The response case types have been emitted this way since headers landed, so the combination is established in the tree.

Extending a generated model across files is safe as of #191 — before that it took the validation generator down and emitted no validators at all, on a green build.

## Unknown means unsealed

`allSchemas` is optional, and a caller that passes nothing is not saying the schema is a leaf — it is saying it does not know. Sealing on no evidence would emit a type a later slice cannot derive from, and that failure would land in the consumer's build rather than here.

The two `SchemaRecordEmitter` tests using the one-argument harness overload therefore still expect an unsealed record. That is the rule working, not an exception to it.

## Test changes

`ADiscriminatedHierarchyBecomesRecordInheritance` now asserts the distinction directly rather than incidentally: `Pet` stays open because `Dog` and `Cat` derive from it, and `Dog` and `Cat` seal because nothing derives from them.

The remaining edits are text assertions moving from `public partial record` to `public sealed partial record`. No generated code stopped compiling.

**5,290 tests pass, 0 fail**, across 30 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUvKJpJDxdWauvrqYdHuEX