### PR TITLE
Rework the README around the reader, with the mark on the title line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # <picture><source media="(prefers-color-scheme: dark)" srcset="assets/hardened-mark-dark.svg"><img src="assets/hardened-mark.svg" alt="" width="34"></picture> Hardened.Framework
 
 A compile-time, source-generated .NET framework for web APIs and AWS Lambda. The dependency
-injection, request routing, parameter binding and configuration are written by source generators
-during the build rather than resolved by reflection at startup — what runs is ordinary C# you can
-open and read.
+injection, routing, parameter binding, configuration and request filters are written by source
+generators during the build, not resolved by reflection at startup. What runs is ordinary C# you
+can open and read.
 
 Full documentation: **[ipjohnson.github.io/Hardened.Docs](https://ipjohnson.github.io/Hardened.Docs)**
 
@@ -40,13 +40,13 @@ for the same project assembled by hand.
 
 ## The contract is yours to choose
 
-Hardened builds the same application from any of three contract styles — pick with
+Hardened builds the same application from any of three contract styles. Pick with
 `--contract code|openapi|smithy` on the template, or change your mind later.
 
 ### Code-first
 
-The C# is the contract. A route is an attribute on a method of a plain class — no base type, no
-interface, no registration — and the OpenAPI document is generated *from* your handlers:
+The C# is the contract. A route is an attribute on a method of a plain class: no base type, no
+interface, no registration. The OpenAPI document is generated *from* your handlers.
 
 ```csharp
 [BasePath("/greeting")]
@@ -69,32 +69,108 @@ public partial class Application;
 
 ### OpenAPI-first
 
-An OpenAPI document is the contract. The build generates the models, a service interface per tag,
-the routes and the validation its constraints describe — you implement the interface it wrote:
+An OpenAPI document is the contract. Add it to the project as an `AdditionalFiles` item and the
+build generates the models, a service interface per tag, the routes and the validation its
+constraints describe.
 
-```xml
-<ItemGroup>
-    <AdditionalFiles Include="contracts/todos.yaml" />
-</ItemGroup>
+```yaml
+# contracts/greeting.yaml
+paths:
+  /greeting/{name}:
+    get:
+      tags: [Greeting]
+      operationId: hello
+      parameters:
+        - { name: name, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Greeting' }
+```
+
+You implement the interface it wrote. `[Handler]` is the whole wiring; the verb and the path came
+from the document, so neither is restated in C#.
+
+```csharp
+[Handler]
+public class GreetingService : IGreetingService {
+    public Task<Greeting> Hello(string name) =>
+        Task.FromResult(new Greeting($"Hello, {name}!"));
+}
 ```
 
 There are no route attributes anywhere in the project. Add an operation to the contract and the
 build writes the model, the route and the validation, then stops compiling until your service
-implements the new method — the specification and the code cannot disagree.
+implements the new method. The specification and the code cannot disagree.
 
 ### Smithy-first
 
 The same generated output from a [Smithy](https://smithy.io) model instead of an OpenAPI document.
+
+```smithy
+service Greeter {
+    version: "2024-01-01"
+    operations: [Hello]
+}
+
+@http(method: "GET", uri: "/greeting/{name}")
+@readonly
+operation Hello {
+    input := {
+        @httpLabel
+        @required
+        name: String
+    }
+
+    output := {
+        @required
+        message: String
+    }
+}
+```
+
+The implementation side is identical: implement the generated interface, mark it `[Handler]`.
+Constraint traits like `@required` and `@length` become validation filters in front of the handler.
 Needs the Smithy CLI on `PATH`; the build names the version it expects if yours differs.
 
 ### Whichever you choose
 
-The application serves its OpenAPI document at `/openapi.json` and a reference page at `/docs` —
-generated from the routing table when the code is the contract, your contract embedded verbatim
-when the contract came first. Hardened does not generate clients; the document is the deliverable,
-and Kiota or NSwag pointed at it does the rest. See
+The application serves its OpenAPI document at `/openapi.json` and a reference page at `/docs`.
+Code-first, the document is generated from the routing table; contract-first, it is your contract
+embedded verbatim. Hardened does not generate clients. The document is the deliverable, and Kiota
+or NSwag pointed at it does the rest. See
 [the OpenAPI document](https://ipjohnson.github.io/Hardened.Docs/guide/openapi-document) and
 [generating from OpenAPI](https://ipjohnson.github.io/Hardened.Docs/guide/openapi).
+
+## Filters
+
+Every request runs through the same pipeline, whatever the transport: an HTTP call, a Lambda
+invocation, an SQS message. A pipeline is an ordered list of filters, and the handler you wrote is
+the last one. A filter does its work around `chain.Next()`; not calling it short-circuits
+everything after it, which is how authorization and caching return without reaching the handler.
+
+```csharp
+public class TimingFilter : IExecutionFilter {
+    public async Task Execute(IExecutionChain chain) {
+        var start = MachineTimestamp.Now;
+
+        try {
+            await chain.Next();
+        }
+        finally {
+            chain.Context.RequestMetrics.Record(
+                RequestMetrics.TotalRequestDuration, start.GetElapsedMilliseconds());
+        }
+    }
+}
+```
+
+Attach a filter to one handler with an attribute (`[Retry]` is the shipped example), or to every
+handler through `IGlobalFilterRegistry`. Serialization is itself a filter: the response carries the
+handler's return *value*, so a filter that changes the payload changes the value and never needs to
+know how it will be written. The ordering, the context and the shipped positions are in
+[the execution pipeline](https://ipjohnson.github.io/Hardened.Docs/guide/execution-pipeline).
 
 ## What else the build writes
 
@@ -112,9 +188,8 @@ The same generate-don't-reflect treatment runs through the rest of the framework
   says what it needs; the pipeline decides whether the caller has it.
 - **[Streaming responses](https://ipjohnson.github.io/Hardened.Docs/guide/streaming)** — return
   `IAsyncEnumerable<T>` and the response streams.
-- **[Content negotiation](https://ipjohnson.github.io/Hardened.Docs/guide/content-negotiation)**,
-  **[filters](https://ipjohnson.github.io/Hardened.Docs/guide/execution-pipeline)** and
-  **[System.Text.Json configuration](https://ipjohnson.github.io/Hardened.Docs/guide/json)**
+- **[Content negotiation](https://ipjohnson.github.io/Hardened.Docs/guide/content-negotiation)**
+  and **[System.Text.Json configuration](https://ipjohnson.github.io/Hardened.Docs/guide/json)**
   follow the same shape.
 
 Everything lands as readable source: `EmitCompilerGeneratedFiles` is on in the templates, so the
@@ -122,9 +197,30 @@ routing table, the handlers and the binding sit under `obj/<configuration>/<tfm>
 
 ## Testing
 
-A test method declares the services it wants as parameters and the framework boots the real
-application around it, substituting mocks where you ask. The pipeline under test is the pipeline
-that ships. See [testing](https://ipjohnson.github.io/Hardened.Docs/guide/testing) and
+A test method declares what it needs as parameters. The framework boots the real application around
+the test, injects them, and substitutes a mock wherever a parameter is marked `[Mock]`. There is no
+socket, port or running host: `ITestWebApp` sends the request through the actual pipeline, meaning
+routing, filters, binding, the handler and serialization.
+
+```csharp
+public class TodoTests {
+    [HardenedTest]
+    public async Task GetTodo_ReturnsTheTodo(ITestWebApp app) {
+        var response = await app.Get("/todos/1");
+
+        response.Assert.Ok();
+        Assert.Equal(1, response.Deserialize<TodoResponse>().Id);
+    }
+
+    [HardenedTest]
+    public async Task GetTodo_UnknownId_IsNotFound(ITestWebApp app) {
+        (await app.Get("/todos/9999")).Assert.NotFound();
+    }
+}
+```
+
+The pipeline under test is the pipeline that ships. See
+[testing](https://ipjohnson.github.io/Hardened.Docs/guide/testing) and
 [testing web apps](https://ipjohnson.github.io/Hardened.Docs/guide/testing-web).
 
 ## Packages

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # <picture><source media="(prefers-color-scheme: dark)" srcset="assets/hardened-mark-dark.svg"><img src="assets/hardened-mark.svg" alt="" width="34"></picture> Hardened.Framework
 
-A compile-time, source-generated .NET framework for web APIs and AWS Lambda. The dependency
-injection, routing, parameter binding, configuration and request filters are written by source
-generators during the build, not resolved by reflection at startup. What runs is ordinary C# you
-can open and read.
+A compile-time, source-generated .NET framework for web APIs and serverless functions. The
+dependency injection, routing, parameter binding, configuration and request filters are written by
+source generators during the build, not resolved by reflection at startup. What runs is ordinary
+C# you can open and read.
+
+The core is provider-agnostic: a handler never learns what host it runs on, and swapping the
+runtime module is the whole migration. AWS Lambda is the function compute supported today, through
+[Hardened.Amz](https://github.com/ipjohnson/Hardened.Amz).
 
 Full documentation: **[ipjohnson.github.io/Hardened.Docs](https://ipjohnson.github.io/Hardened.Docs)**
 
@@ -31,7 +35,7 @@ can be swapped without touching the code.
 | Template | What you get |
 |---|---|
 | `hardened-web` | An implementation library, a host, and tests. `--host kestrel\|aspnet\|aws-lambda`, `--contract code\|openapi\|smithy` |
-| `hardened-function` | An AWS Lambda function and tests. `--trigger invoke\|sqs` |
+| `hardened-function` | A serverless function and tests, on AWS Lambda today. `--trigger invoke\|sqs` |
 | `hardened-library` | A reusable module an application picks up with one attribute |
 
 See the [templates guide](https://ipjohnson.github.io/Hardened.Docs/guide/project-templates) for
@@ -199,8 +203,8 @@ public union TodoResult(Todo, NotFound);
 public TodoResult ById(ITodoStore store, int id) { /* same body */ }
 ```
 
-Unions need `net11.0` and `<LangVersion>preview</LangVersion>`, which rules out Lambda's `net8.0`
-managed runtime today. Hardened matches `Response` and `union` structurally, so moving between them
+Unions need `net11.0` and `<LangVersion>preview</LangVersion>`, which rules out AWS Lambda's
+`net8.0` managed runtime today. Hardened matches `Response` and `union` structurally, so moving between them
 rewrites no handler. Cases like `NotFound`, `Created<T>` and `RateLimited` are built-in records
 that carry their status; each has a `<T>` form for your own error body.
 
@@ -212,8 +216,8 @@ two success statuses, is in
 
 ## Filters
 
-Every request runs through the same pipeline, whatever the transport: an HTTP call, a Lambda
-invocation, an SQS message. A pipeline is an ordered list of filters, and the handler you wrote is
+Every request runs through the same pipeline, whatever the transport: an HTTP call, a function
+invocation, a queue message. A pipeline is an ordered list of filters, and the handler you wrote is
 the last one. A filter does its work around `chain.Next()`; not calling it short-circuits
 everything after it, which is how authorization and caching return without reaching the handler.
 
@@ -298,5 +302,5 @@ full list, and which project references what, is in the
 
 ## Related repositories
 
-- [Hardened.Amz](https://github.com/ipjohnson/Hardened.Amz) — AWS Lambda runtimes, test harnesses, DynamoDB client, CDK constructs
+- [Hardened.Amz](https://github.com/ipjohnson/Hardened.Amz) — the AWS provider: Lambda runtimes, test harnesses, DynamoDB client, CDK constructs
 - [Hardened.Docs](https://github.com/ipjohnson/Hardened.Docs) — the documentation site

--- a/README.md
+++ b/README.md
@@ -271,7 +271,14 @@ the test, injects them, and substitutes a mock wherever a parameter is marked `[
 socket, port or running host: `ITestWebApp` sends the request through the actual pipeline, meaning
 routing, filters, binding, the handler and serialization.
 
+Two assembly attributes are the whole wiring: the harness, and the module under test. The real
+module graph is applied and startup services run, so there is no separate test setup to keep in
+step with the application.
+
 ```csharp
+[assembly: WebTesting]
+[assembly: HardenedTestEntryPoint(typeof(TodoLibrary))]
+
 public class TodoTests {
     [HardenedTest]
     public async Task GetTodo_ReturnsTheTodo(ITestWebApp app) {

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/hardened-mark-dark.svg">
-  <img src="assets/hardened-mark.svg" alt="" width="72">
-</picture>
+# <picture><source media="(prefers-color-scheme: dark)" srcset="assets/hardened-mark-dark.svg"><img src="assets/hardened-mark.svg" alt="" width="34"></picture> Hardened.Framework
 
-# Hardened.Framework
+A compile-time, source-generated .NET framework for web APIs and AWS Lambda. The dependency
+injection, request routing, parameter binding and configuration are written by source generators
+during the build rather than resolved by reflection at startup — what runs is ordinary C# you can
+open and read.
 
-The core framework for the [Hardened](https://ipjohnson.github.io/Hardened.Docs) ecosystem — a compile-time, source-generated .NET framework for building web APIs and AWS Lambda functions.
-
-Hardened uses C# source generators to write dependency injection, request routing, parameter binding and configuration during the build, rather than resolving them by reflection at startup. What runs is ordinary C# you can open and read.
+Full documentation: **[ipjohnson.github.io/Hardened.Docs](https://ipjohnson.github.io/Hardened.Docs)**
 
 ## Start here
 
@@ -18,14 +16,17 @@ cd Greeter
 dotnet run --project src/Greeter.Host
 ```
 
-That is a working API with tests, on <http://localhost:5080>. It opens a reference page at `/docs` on first run.
+That is a working API with tests, on <http://localhost:5080>, with a reference page at `/docs`.
 
 ```console
 $ curl localhost:5080/greeting/world
 {"message":"Hello, world!"}
 ```
 
-The templates exist because the packages alone are easy to get wrong: the runtime packages carry no analyzers, so a project that references only them compiles to an application that answers 404 to everything. The templates wire the generators, pin every version in one place, and split the projects so the host can be swapped without touching the code.
+Start from a template rather than from bare packages: the runtime packages carry no analyzers, so a
+project that references only them compiles to an application that answers 404 to everything. The
+templates wire the generators, pin every version in one place, and split the projects so the host
+can be swapped without touching the code.
 
 | Template | What you get |
 |---|---|
@@ -33,13 +34,19 @@ The templates exist because the packages alone are easy to get wrong: the runtim
 | `hardened-function` | An AWS Lambda function and tests. `--trigger invoke\|sqs` |
 | `hardened-library` | A reusable module an application picks up with one attribute |
 
-Every combination builds, tests and serves before a release ships — that is what `scripts/verify-templates.sh` is.
+See the [templates guide](https://ipjohnson.github.io/Hardened.Docs/guide/project-templates) for
+every option, and [getting started](https://ipjohnson.github.io/Hardened.Docs/guide/getting-started)
+for the same project assembled by hand.
 
-See the [templates guide](https://ipjohnson.github.io/Hardened.Docs/guide/project-templates) for the full set of options, and [getting started](https://ipjohnson.github.io/Hardened.Docs/guide/getting-started) for the same project assembled by hand.
+## The contract is yours to choose
 
-## What the generated code looks like
+Hardened builds the same application from any of three contract styles — pick with
+`--contract code|openapi|smithy` on the template, or change your mind later.
 
-A route is an attribute on a method of a plain class. No base type, no interface, no registration:
+### Code-first
+
+The C# is the contract. A route is an attribute on a method of a plain class — no base type, no
+interface, no registration — and the OpenAPI document is generated *from* your handlers:
 
 ```csharp
 [BasePath("/greeting")]
@@ -51,7 +58,7 @@ public class GreetingController {
 }
 ```
 
-The application names its runtime and the libraries it composes:
+The application names its runtime and the libraries it composes, and that is the whole bootstrap:
 
 ```csharp
 [HardenedModule]
@@ -60,68 +67,75 @@ The application names its runtime and the libraries it composes:
 public partial class Application;
 ```
 
-`EmitCompilerGeneratedFiles` is on in the templates, so the routing table, the handler for each route and the parameter binding are all readable under `obj/<configuration>/<tfm>/generated/`.
+### OpenAPI-first
+
+An OpenAPI document is the contract. The build generates the models, a service interface per tag,
+the routes and the validation its constraints describe — you implement the interface it wrote:
+
+```xml
+<ItemGroup>
+    <AdditionalFiles Include="contracts/todos.yaml" />
+</ItemGroup>
+```
+
+There are no route attributes anywhere in the project. Add an operation to the contract and the
+build writes the model, the route and the validation, then stops compiling until your service
+implements the new method — the specification and the code cannot disagree.
+
+### Smithy-first
+
+The same generated output from a [Smithy](https://smithy.io) model instead of an OpenAPI document.
+Needs the Smithy CLI on `PATH`; the build names the version it expects if yours differs.
+
+### Whichever you choose
+
+The application serves its OpenAPI document at `/openapi.json` and a reference page at `/docs` —
+generated from the routing table when the code is the contract, your contract embedded verbatim
+when the contract came first. Hardened does not generate clients; the document is the deliverable,
+and Kiota or NSwag pointed at it does the rest. See
+[the OpenAPI document](https://ipjohnson.github.io/Hardened.Docs/guide/openapi-document) and
+[generating from OpenAPI](https://ipjohnson.github.io/Hardened.Docs/guide/openapi).
+
+## What else the build writes
+
+The same generate-don't-reflect treatment runs through the rest of the framework:
+
+- **[Parameter binding](https://ipjohnson.github.io/Hardened.Docs/guide/parameter-binding)** —
+  path, query, header, body and injected services bind through code emitted for each handler's
+  exact signature; a binding that cannot work is a build error.
+- **[Configuration](https://ipjohnson.github.io/Hardened.Docs/guide/configuration)** — a
+  configuration model is a partial class of private fields; the generator writes the interface,
+  the implementation and the environment-variable reads.
+- **[Declared responses](https://ipjohnson.github.io/Hardened.Docs/guide/responses)** — a handler
+  that can answer more than one way says so in its signature, and the document reflects it.
+- **[Authorization](https://ipjohnson.github.io/Hardened.Docs/guide/authorization)** — a handler
+  says what it needs; the pipeline decides whether the caller has it.
+- **[Streaming responses](https://ipjohnson.github.io/Hardened.Docs/guide/streaming)** — return
+  `IAsyncEnumerable<T>` and the response streams.
+- **[Content negotiation](https://ipjohnson.github.io/Hardened.Docs/guide/content-negotiation)**,
+  **[filters](https://ipjohnson.github.io/Hardened.Docs/guide/execution-pipeline)** and
+  **[System.Text.Json configuration](https://ipjohnson.github.io/Hardened.Docs/guide/json)**
+  follow the same shape.
+
+Everything lands as readable source: `EmitCompilerGeneratedFiles` is on in the templates, so the
+routing table, the handlers and the binding sit under `obj/<configuration>/<tfm>/generated/`.
+
+## Testing
+
+A test method declares the services it wants as parameters and the framework boots the real
+application around it, substituting mocks where you ask. The pipeline under test is the pipeline
+that ships. See [testing](https://ipjohnson.github.io/Hardened.Docs/guide/testing) and
+[testing web apps](https://ipjohnson.github.io/Hardened.Docs/guide/testing-web).
 
 ## Packages
 
-All published to nuget.org. The templates reference the right ones for you; this table is for assembling a project by hand.
+Everything ships to nuget.org as `Hardened.*`; the templates reference the right set for each
+project shape. One rule matters when assembling by hand: the source generators are not optional and
+do not flow transitively — the project that owns the application must reference them directly. The
+full list, and which project references what, is in the
+[package reference](https://ipjohnson.github.io/Hardened.Docs/reference/packages).
 
-**Runtime**
+## Related repositories
 
-| Package | Description |
-|---|---|
-| `Hardened.Shared.Runtime` | Core: `[HardenedModule]`, configuration, environment, application lifecycle |
-| `Hardened.Requests.Abstract` | Request/response abstractions, execution pipeline interfaces |
-| `Hardened.Requests.Runtime` | Execution pipeline implementation, filters |
-| `Hardened.Web.Runtime` | Web routing: `[Get]`, `[Post]`, `[Put]`, `[Delete]`, `[Patch]`, `[BasePath]` |
-| `Hardened.Web.Kestrel.Runtime` | Kestrel host, without the ASP.NET Core request pipeline. The default |
-| `Hardened.Web.AspNetCore.Runtime` | ASP.NET Core host, for its middleware, authentication and hosting diagnostics |
-| `Hardened.Web.StaticContent` | Static file serving and content compression |
-| `Hardened.Requests.Serializers.Newtonsoft` | Newtonsoft.Json serialization, instead of System.Text.Json |
-
-**Source generators.** Not optional, and not transitive — analyzers do not flow through a package reference, so these are referenced by the project that needs them.
-
-| Package | Description |
-|---|---|
-| `Hardened.Library.SourceGenerator` | Module wiring and DI. Without it `PopulateServiceCollection` does not exist |
-| `Hardened.Web.SourceGenerator` | Routing table and handlers from route attributes |
-| `Hardened.Function.SourceGenerator` | Handlers from `[HardenedFunction]` |
-| `Hardened.Validation.SourceGenerator` | Validators from constraint attributes |
-| `Hardened.OpenApi.SourceGenerator` | Front end for an OpenAPI document as the contract |
-| `Hardened.Smithy.SourceGenerator` | Front end for a Smithy model as the contract |
-| `Hardened.Idl.SourceGenerator` | Shared back end for both contract front ends |
-| `Hardened.SourceGenerator` | Shared generator source library, not referenced directly |
-
-**Testing**
-
-| Package | Description |
-|---|---|
-| `Hardened.Shared.Testing` | `[HardenedTest]`, `[Mock]`, `ITestContext`. xUnit v3 |
-| `Hardened.Web.Testing` | `ITestWebApp`, `TestWebRequest`, `TestWebResponse` |
-| `Hardened.Requests.Testing` | Request pipeline testing utilities |
-| `Hardened.SourceGeneration.Testing` | Harness for testing source generators |
-
-**Templates and views**
-
-| Package | Description |
-|---|---|
-| `Hardened.Templates` | The `dotnet new` templates above |
-| `Hardened.Templates.RazorBlade` | RazorBlade view rendering |
-
-## Documentation
-
-Full documentation is at **[ipjohnson.github.io/Hardened.Docs](https://ipjohnson.github.io/Hardened.Docs)**.
-
-- [Project templates](https://ipjohnson.github.io/Hardened.Docs/guide/project-templates) — the fastest correct start
-- [Getting started](https://ipjohnson.github.io/Hardened.Docs/guide/getting-started)
-- [Modules](https://ipjohnson.github.io/Hardened.Docs/guide/modules)
-- [Registering services](https://ipjohnson.github.io/Hardened.Docs/guide/services)
-- [Routing](https://ipjohnson.github.io/Hardened.Docs/guide/routing)
-- [Testing](https://ipjohnson.github.io/Hardened.Docs/guide/testing)
-- [OpenAPI](https://ipjohnson.github.io/Hardened.Docs/guide/openapi)
-
-## Related Repositories
-
-- [Hardened.Amz](https://github.com/ipjohnson/Hardened.Amz) — AWS Lambda runtimes, DynamoDB/SQS clients, CDK support
-- [Hardened.Canaries](https://github.com/ipjohnson/Hardened.Canaries) — Canary testing framework
-- [Hardened.Docs](https://github.com/ipjohnson/Hardened.Docs) — Documentation site
+- [Hardened.Amz](https://github.com/ipjohnson/Hardened.Amz) — AWS Lambda runtimes, test harnesses, DynamoDB client, CDK constructs
+- [Hardened.Docs](https://github.com/ipjohnson/Hardened.Docs) — the documentation site

--- a/README.md
+++ b/README.md
@@ -143,6 +143,73 @@ or NSwag pointed at it does the rest. See
 [the OpenAPI document](https://ipjohnson.github.io/Hardened.Docs/guide/openapi-document) and
 [generating from OpenAPI](https://ipjohnson.github.io/Hardened.Docs/guide/openapi).
 
+## Three return models
+
+A handler that can answer more than one way has to say so somewhere. There are three places to say
+it. The choice decides what the compiler checks and what the generated document describes, and all
+three work side by side.
+
+| | The handler says | Other statuses | Needs |
+|---|---|---|---|
+| **Standard** | one success type | thrown | any SDK |
+| **Response** | the whole set, as `Response<T1..Tn>` | in the return type | any SDK |
+| **Union** | the whole set, as a C# `union` | in the return type | .NET 11, `LangVersion` preview |
+
+**Standard** is the default, and not a legacy mode. The signature names the success type and every
+other status is thrown. Nothing in the signature says the route can answer a 404, so nothing checks
+that you handled it, and the document describes only the 200.
+
+```csharp
+[Get("/todos/{id}")]
+public Todo ById(ITodoStore store, int id) {
+    var todo = store.Find(id);
+
+    if (todo is null) {
+        throw new NotFound("todo", $"No todo has id {id}.").AsException();
+    }
+
+    return todo;
+}
+```
+
+**Response** puts the whole set in the return type. `Response<T1..Tn>` is an ordinary struct with
+an implicit conversion per case, so the handler returns payloads and never names the wrapper. The
+compiler knows the set, the document describes all of it, and it compiles on any SDK.
+
+```csharp
+[Get("/todos/{id}")]
+public Response<Todo, NotFound> ById(ITodoStore store, int id) {
+    var todo = store.Find(id);
+
+    if (todo is null) {
+        return new NotFound("todo", $"No todo has id {id}.");
+    }
+
+    return todo;
+}
+```
+
+**Union** declares the same set as a C# language union, which adds exhaustiveness wherever you
+pattern-match on the result. The handler body is identical to the `Response` version.
+
+```csharp
+public union TodoResult(Todo, NotFound);
+
+[Get("/todos/{id}")]
+public TodoResult ById(ITodoStore store, int id) { /* same body */ }
+```
+
+Unions need `net11.0` and `<LangVersion>preview</LangVersion>`, which rules out Lambda's `net8.0`
+managed runtime today. Hardened matches `Response` and `union` structurally, so moving between them
+rewrites no handler. Cases like `NotFound`, `Created<T>` and `RateLimited` are built-in records
+that carry their status; each has a `<T>` form for your own error body.
+
+The return type alone decides, code-first. Contract-first, the statuses come from the contract and
+`<HardenedResponseModel>Standard|Response|Union</HardenedResponseModel>` decides the generated
+interface's shape. The full story, including declared 404s as nullable returns and operations with
+two success statuses, is in
+[declared responses](https://ipjohnson.github.io/Hardened.Docs/guide/responses).
+
 ## Filters
 
 Every request runs through the same pipeline, whatever the transport: an HTTP call, a Lambda
@@ -182,8 +249,6 @@ The same generate-don't-reflect treatment runs through the rest of the framework
 - **[Configuration](https://ipjohnson.github.io/Hardened.Docs/guide/configuration)** — a
   configuration model is a partial class of private fields; the generator writes the interface,
   the implementation and the environment-variable reads.
-- **[Declared responses](https://ipjohnson.github.io/Hardened.Docs/guide/responses)** — a handler
-  that can answer more than one way says so in its signature, and the document reflects it.
 - **[Authorization](https://ipjohnson.github.io/Hardened.Docs/guide/authorization)** — a handler
   says what it needs; the pipeline decides whether the caller has it.
 - **[Streaming responses](https://ipjohnson.github.io/Hardened.Docs/guide/streaming)** — return


### PR DESCRIPTION
Follow-up to #199, per review feedback.

- **One-line masthead**: the Plate mark sits inline with the H1. Verified against GitHub's own `/markdown` rendering (Primer CSS, light and dark) rather than eyeballed source.
- **The contract choice is the centrepiece**: code-first, OpenAPI-first and Smithy-first each get a short section, ending with what they share — the served document at `/openapi.json`, the `/docs` reference page, clients via Kiota/NSwag.
- **Package tables are gone** (22 packages before any feature): replaced by one paragraph — including the analyzers-don't-flow-transitively trap — and a link to the docs package reference.
- Feature bullets link the guide pages that exist today; the dead Hardened.Canaries link is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsGfMnw58VNjhuoLpd5gKV