### PR TITLE
Add AGENTS.md, and trim the READMEs' rationale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ error above it. Capture to a file and test `$?`.
 version — so a machine with only the .NET 11 SDK compiles everything and then starts no test host
 at all. Install both.
 
-The preview is named exactly rather than as `11.0.x`. A floating preview moved the SDK mid-session
-once.
+The preview is named exactly rather than as `11.0.x`. Keep it that way — a floating preview moves
+the SDK underneath a session.
 
 ## Generators
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# Hardened.Framework
+
+Invariants and traps for anyone editing this repository. `README.md` covers what the framework is
+and how an application consumes it; this file does not repeat that.
+
+## Layout
+
+The solution is `src/Hardened.Framework.sln`. There is none at the repository root.
+
+| Path | Contents |
+|---|---|
+| `src/Shared` | Module entry points, configuration, environment, metrics, the test framework |
+| `src/Requests` | The execution pipeline and its abstractions |
+| `src/Web` | Routing, the Kestrel and ASP.NET Core hosts, static content, the web test client |
+| `src/Templates` | The `dotnet new` templates, and RazorBlade view rendering |
+| `src/SourceGenerators` | Every generator and build task, and the shared library they build on |
+| `src/IntegrationTests` | Working applications driven through the real pipeline |
+| `src/PublicApi` | The approved public surface of every shipped assembly |
+| `src/Benchmarks` | The figures in the Kestrel host's README |
+
+## Commands
+
+```bash
+dotnet build src/Hardened.Framework.sln
+dotnet test  src/Hardened.Framework.sln
+```
+
+Before opening a pull request, build the way CI does:
+
+```bash
+dotnet build src/Hardened.Framework.sln --configuration Release -p:ContinuousIntegrationBuild=true
+```
+
+`ContinuousIntegrationBuild` sets `TreatWarningsAsErrors` (`src/Directory.Build.props`). Local
+builds deliberately do not, so a build that is green locally can still fail CI on a warning.
+
+**Check the exit code, not the tail of the output.** A restore that resolves an assembly two ways
+prints MSB3277 conflict lines by the hundred, which fills a `head -N` window and hides the real
+error above it. Capture to a file and test `$?`.
+
+## Two SDKs, and both are load-bearing
+
+`src/global.json` pins the build to a .NET 11 preview, which is the compiler that can read a C# 15
+`union`. Every project targets `net8.0` and every test assembly is framework-dependent on
+`Microsoft.NETCore.App` 8.0.0 with no `rollForward`, and the default policy does not cross a major
+version — so a machine with only the .NET 11 SDK compiles everything and then starts no test host
+at all. Install both.
+
+The preview is named exactly rather than as `11.0.x`. A floating preview moved the SDK mid-session
+once.
+
+## Generators
+
+**Emitted C# is written with CSharpAuthor.** `StringBuilder` is for ordinary string work, not for
+building C#. New emitters use CSharpAuthor; the remaining `StringBuilder` emitters are legacy to
+convert.
+
+**CSharpAuthor and ValidationModules.Impl are compiled from source, not referenced.**
+`src/SourceGenerators/CSharpAuthor.props` and `ValidationModulesImpl.props` do this, because an
+analyzer is loaded by the compiler with no probing path of its own and a sibling DLL is a
+`FileNotFoundException` at initialization. Both switch to a sibling checkout when one exists —
+`~/CSharpAuthor`, `~/ValidationModules` — which is why a coverage baseline written locally is not
+reproducible in CI.
+
+**`CS8785` is an error here, locally as well as in CI.** A generator that throws mid-run has emitted
+some of its output and none of the rest, and Roslyn reports that as a warning.
+
+**Verify an analyzer actually reaches the compiler.** `project.assets.json` and
+`-getItem:Analyzer` both report a package that never reaches `csc`. Grep the real command line:
+
+```bash
+dotnet build -v:d 2>&1 | grep -o '/analyzer:[^ ]*' | sort -u
+```
+
+**A build task in this repository is built by the same build that consumes it.** The OpenAPI and
+Smithy targets run their tasks through `TaskHostFactory` for that reason. If you opt into
+`HardenedOpenApiInProcessTask=true` or `HardenedSmithyInProcessTask=true`, the assembly stays
+locked and a stale one runs — build with `-nr:false`.
+
+**Generated sources under `obj/**/generated/` are not cleaned by a rename.** A generator that
+changes name leaves its old directory behind, and Rider compiles both. Debug and Release have
+separate directories, so an IDE reading one while you build the other reports errors `dotnet build`
+does not. Delete `obj/` when the IDE and the CLI disagree.
+
+## Smithy needs the CLI
+
+The integration fixture compiles `.smithy` sources with the Smithy CLI, pinned by
+`$(HardenedSmithyCliVersion)` in `Hardened.Smithy.SourceGenerator.targets` — **1.73.0** today. The
+build enforces the pin rather than trusting it: a mismatch is `HSMT011`, an error under
+`ContinuousIntegrationBuild` and a warning otherwise.
+
+`scripts/verify-templates.sh` **skips the smithy combinations silently** when the CLI is absent.
+Install it before trusting a green run from that script.
+
+## The approved public surface
+
+`src/PublicApi` checks in the public surface of every shipped assembly and compares it on every run.
+A diff there means the shipped contract changed: review it as an API change, then re-approve
+deliberately.
+
+```bash
+APPROVE_PUBLIC_API=1 dotnet test src/PublicApi/Hardened.PublicApi.Tests
+```
+
+Never set that in CI.
+
+## The coverage gate
+
+`scripts/coverage-gate.py` holds each assembly at the coverage it already had. Raising a floor is a
+deliberate commit.
+
+**Never write a baseline from a local run.** The generator assemblies compile their dependencies
+from source, and a sibling checkout changes what is in them. Take the summary from CI:
+
+```bash
+gh run download <run-id> -n coverage-report -D /tmp/cicov
+python3 scripts/coverage-gate.py --summary /tmp/cicov/Summary.json --update
+```
+
+**A baseline entry no run reported is fatal; an assembly the run reported and the baseline does not
+is only printed.** So moving code between assemblies means renaming the baseline entry in the same
+commit, and an assembly that never reaches the report is never gated —
+`Hardened.Smithy.BuildTask` is in that state under `ContinuousIntegrationBuild`, which is
+unmeasured rather than untested.
+
+## Releasing
+
+A `v*` tag drives `release.yaml`, and the tag is the source of truth for the version. The current
+line is `0.15.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
+
+**The pack list in `release.yaml` is hand-maintained and has drifted four times.** A new packable
+project has to be added to it *and* to `EXPECTED`, which is a literal on purpose. Adding it to the
+solution alone ships a release missing that package.
+
+`0.8.0-rc1000` was a bad release — three unusable packages, superseded by `0.9.0-rc1000`. Never
+recommend it.
+
+Dry-run a release before tagging: pack at the real version into a local folder feed and restore a
+generated project against it, with `NUGET_PACKAGES` redirected so the global cache is not poisoned.
+
+## Things that will catch you out
+
+**Editing `.sln` through `dotnet sln`.** `dotnet sln remove` followed by `dotnet sln add
+--solution-folder` silently drops projects and exits 0. Edit the solution file directly and check
+the diff.
+
+**An optional `CancellationToken` on a shared test helper.** Every call site that omits it trips
+`xUnit1051`, which is a warning locally and an error under `ContinuousIntegrationBuild` — so the
+failure is CI-only and lands at dozens of call sites at once.
+
+**Check `main` is synced before branching.** An unpushed local commit gets absorbed into your pull
+request's squash merge.
+
+**`Hardened.SourceGenerator` ships source, not an assembly.** Green CI here says nothing about
+whether that source compiles in a consumer. Validate a change to it against Hardened.Amz.
+
+**Placement between `Abstract` and `Runtime`.** The contract stays in `Hardened.Requests.Abstract`;
+behaviour moves. A type a function handler needs cannot move to `Hardened.Web.Runtime` — the Lambda
+function runtimes do not reference it.
+
+## Where the rest is written down
+
+- `docs/testing-conventions.md` — what to assert, and what not to
+- `docs/generator-diagnostics.md` — every diagnostic the generators raise
+- `docs/described-authorization.md` — what a contract's `security` becomes
+- `docs/validation-usage.md` — constraints, custom validators, the error response
+- Full user documentation: <https://ipjohnson.github.io/Hardened.Docs>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ curl localhost:5080/greeting/world
 {"message":"Hello, world!"}
 ```
 
-Start from a template rather than from bare packages: the runtime packages carry no analyzers, so a
+Start from a template rather than from bare packages. The runtime packages carry no analyzers, so a
 project that references only them compiles to an application that answers 404 to everything. The
 templates wire the generators, pin every version in one place, and split the projects so the host
 can be swapped without touching the code.
@@ -106,7 +106,8 @@ public class GreetingService : IGreetingService {
 
 There are no route attributes anywhere in the project. Add an operation to the contract and the
 build writes the model, the route and the validation, then stops compiling until your service
-implements the new method. The specification and the code cannot disagree.
+implements the new method. See
+[generating from OpenAPI](https://ipjohnson.github.io/Hardened.Docs/guide/openapi).
 
 ### Smithy-first
 
@@ -135,17 +136,26 @@ operation Hello {
 ```
 
 The implementation side is identical: implement the generated interface, mark it `[Handler]`.
+
+```csharp
+[Handler]
+public class GreeterService : IGreeterService {
+    public Task<HelloOutput> Hello(string name) =>
+        Task.FromResult(new HelloOutput($"Hello, {name}!"));
+}
+```
+
 Constraint traits like `@required` and `@length` become validation filters in front of the handler.
-Needs the Smithy CLI on `PATH`; the build names the version it expects if yours differs.
+Needs the Smithy CLI on `PATH`; the build names the version it expects if yours differs. See
+[generating from Smithy](https://ipjohnson.github.io/Hardened.Docs/guide/smithy).
 
 ### Whichever you choose
 
 The application serves its OpenAPI document at `/openapi.json` and a reference page at `/docs`.
 Code-first, the document is generated from the routing table; contract-first, it is your contract
-embedded verbatim. Hardened does not generate clients. The document is the deliverable, and Kiota
+embedded verbatim. Hardened does not generate clients — the document is the deliverable, and Kiota
 or NSwag pointed at it does the rest. See
-[the OpenAPI document](https://ipjohnson.github.io/Hardened.Docs/guide/openapi-document) and
-[generating from OpenAPI](https://ipjohnson.github.io/Hardened.Docs/guide/openapi).
+[the OpenAPI document](https://ipjohnson.github.io/Hardened.Docs/guide/openapi-document).
 
 ## Three return models
 
@@ -159,9 +169,9 @@ three work side by side.
 | **Response** | the whole set, as `Response<T1..Tn>` | in the return type | any SDK |
 | **Union** | the whole set, as a C# `union` | in the return type | .NET 11, `LangVersion` preview |
 
-**Standard** is the default, and not a legacy mode. The signature names the success type and every
-other status is thrown. Nothing in the signature says the route can answer a 404, so nothing checks
-that you handled it, and the document describes only the 200.
+**Standard** is the default. The signature names the success type and every other status is thrown.
+Nothing in the signature says the route can answer a 404, so nothing checks that you handled it, and
+the document describes only the 200.
 
 ```csharp
 [Get("/todos/{id}")]
@@ -176,9 +186,9 @@ public Todo ById(ITodoStore store, int id) {
 }
 ```
 
-**Response** puts the whole set in the return type. `Response<T1..Tn>` is an ordinary struct with
-an implicit conversion per case, so the handler returns payloads and never names the wrapper. The
-compiler knows the set, the document describes all of it, and it compiles on any SDK.
+**Response** puts the whole set in the return type. `Response<T1..Tn>` is an ordinary struct with an
+implicit conversion per case, so the handler returns payloads and never names the wrapper. The
+compiler knows the set and the document describes all of it.
 
 ```csharp
 [Get("/todos/{id}")]
@@ -204,15 +214,14 @@ public TodoResult ById(ITodoStore store, int id) { /* same body */ }
 ```
 
 Unions need `net11.0` and `<LangVersion>preview</LangVersion>`, which rules out AWS Lambda's
-`net8.0` managed runtime today. Hardened matches `Response` and `union` structurally, so moving between them
-rewrites no handler. Cases like `NotFound`, `Created<T>` and `RateLimited` are built-in records
-that carry their status; each has a `<T>` form for your own error body.
+`net8.0` managed runtime today. Hardened matches `Response` and `union` structurally, so moving
+between them rewrites no handler. Cases like `NotFound`, `Created<T>` and `RateLimited` are built-in
+records that carry their status; each has a `<T>` form for your own error body.
 
-The return type alone decides, code-first. Contract-first, the statuses come from the contract and
+Code-first, the return type alone decides. Contract-first, the statuses come from the contract and
 `<HardenedResponseModel>Standard|Response|Union</HardenedResponseModel>` decides the generated
-interface's shape. The full story, including declared 404s as nullable returns and operations with
-two success statuses, is in
-[declared responses](https://ipjohnson.github.io/Hardened.Docs/guide/responses).
+interface's shape. Declared 404s as nullable returns, and operations with two success statuses, are
+in [declared responses](https://ipjohnson.github.io/Hardened.Docs/guide/responses).
 
 ## Filters
 
@@ -239,8 +248,8 @@ public class TimingFilter : IExecutionFilter {
 
 Attach a filter to one handler with an attribute (`[Retry]` is the shipped example), or to every
 handler through `IGlobalFilterRegistry`. Serialization is itself a filter: the response carries the
-handler's return *value*, so a filter that changes the payload changes the value and never needs to
-know how it will be written. The ordering, the context and the shipped positions are in
+handler's return *value*, so a filter that changes the payload changes the value rather than the
+bytes. The ordering, the context and the shipped positions are in
 [the execution pipeline](https://ipjohnson.github.io/Hardened.Docs/guide/execution-pipeline).
 
 ## What else the build writes
@@ -268,12 +277,10 @@ routing table, the handlers and the binding sit under `obj/<configuration>/<tfm>
 
 A test method declares what it needs as parameters. The framework boots the real application around
 the test, injects them, and substitutes a mock wherever a parameter is marked `[Mock]`. There is no
-socket, port or running host: `ITestWebApp` sends the request through the actual pipeline, meaning
-routing, filters, binding, the handler and serialization.
+socket, port or running host: `ITestWebApp` sends the request through the actual pipeline — routing,
+filters, binding, the handler and serialization.
 
-Two assembly attributes are the whole wiring: the harness, and the module under test. The real
-module graph is applied and startup services run, so there is no separate test setup to keep in
-step with the application.
+Two assembly attributes are the whole wiring: the harness, and the module under test.
 
 ```csharp
 [assembly: WebTesting]
@@ -295,17 +302,15 @@ public class TodoTests {
 }
 ```
 
-The pipeline under test is the pipeline that ships. See
-[testing](https://ipjohnson.github.io/Hardened.Docs/guide/testing) and
+See [testing](https://ipjohnson.github.io/Hardened.Docs/guide/testing) and
 [testing web apps](https://ipjohnson.github.io/Hardened.Docs/guide/testing-web).
 
 ## Packages
 
-Everything ships to nuget.org as `Hardened.*`; the templates reference the right set for each
-project shape. One rule matters when assembling by hand: the source generators are not optional and
-do not flow transitively — the project that owns the application must reference them directly. The
-full list, and which project references what, is in the
-[package reference](https://ipjohnson.github.io/Hardened.Docs/reference/packages).
+Everything ships to nuget.org as `Hardened.*`, and the templates reference the right set for each
+project shape. Assembling by hand, the source generators are not optional and do not flow
+transitively: the project that owns the application references them directly. The full list is in
+the [package reference](https://ipjohnson.github.io/Hardened.Docs/reference/packages).
 
 ## Related repositories
 

--- a/docs/described-authorization.md
+++ b/docs/described-authorization.md
@@ -6,13 +6,9 @@ What a description says an operation requires of its caller, and what Hardened d
 
 A description carries **authorization**. It does not carry **authentication**.
 
-Which scheme a caller proves themselves with — which issuer, which token format, which JWKS
-endpoint — is configuration this application already owns, and a description cannot know it. Which
-*permissions* an operation needs is a fact about the operation, belongs beside it, and maps onto
-`Requirement` without an intermediary.
-
-So Hardened reads **scopes and ignores schemes**. The scheme decides only one thing: whether the
-entry carries scopes at all.
+Hardened reads **scopes and ignores schemes**. The scheme decides one thing: whether the entry
+carries scopes at all. Which issuer, token format or JWKS endpoint a caller proves themselves
+against stays application configuration.
 
 ## What is read
 
@@ -29,21 +25,16 @@ entry carries scopes at all.
 Only `oauth2` and `openIdConnect` may carry scopes. The specification requires every other type to
 declare an empty array, so those say "be someone" and nothing more.
 
-A scope name is read as a grant name, unchanged. No prefixing, no namespacing: prefixing would
-impose a naming convention on every application to solve a collision almost none of them have.
+A scope name is read as a grant name, unchanged. No prefixing and no namespacing.
 
 ### An empty array means two different things
-
-They are opposites and conflating them would be a bad defect.
 
 - **`{ oauth2: [] }`** — an empty *scope* array. The caller must be authenticated and needs no
   particular permission.
 - **`security: []`** — an empty *security* array. The specification's way of opting one operation
   out of a document-level default. It derives **nothing**.
 
-### Why an unscoped entry is a requirement, not the absence of one
-
-This is the load-bearing rule.
+### An unscoped entry is a requirement, not the absence of one
 
 ```yaml
 security:
@@ -51,9 +42,9 @@ security:
   - apiKey: []
 ```
 
-Read the second entry as "requires nothing" and the OR is satisfied by everybody — a document that
-reads as protective would generate a requirement **weaker than declaring none at all**. It becomes
-`Authenticated()`, which is a real requirement, so the alternative stays an alternative.
+The second entry becomes `Authenticated()`, so the alternative stays an alternative. Reading it as
+"requires nothing" would satisfy the OR for everybody, making a document that reads as protective
+weaker than declaring none at all.
 
 ## It narrows, and can never open
 
@@ -67,20 +58,14 @@ implementation declared. `IExecutionRequestHandlerInfo.RequirementFrom` conjoins
 - `[AllowAnonymous]` remains the single thing that cancels it — the same rule an attribute or a
   convention is held to.
 
-This is why `security: []` derives nothing rather than deriving `[AllowAnonymous]`. An author who
-wants a route anonymous says so in code, where it is visible to whoever reads the handler.
-
-It is also why the requirement is metadata rather than the `requirement` parameter on
-`ExecutionRequestHandlerInfo`: that reads `requirement ?? RequirementFrom(Metadata)`, so passing it
-there would have **silenced** an attribute on the implementation instead of composing with it.
+`security: []` therefore derives nothing rather than `[AllowAnonymous]`. An author who wants a route
+anonymous says so in code, where whoever reads the handler can see it.
 
 ## Enforcement needs no opt-in
 
 `AuthorizationFilterProvider`'s `requireAuthorization` flag decides what happens to a handler that
-declares **nothing**. A handler that declares something is guarded either way.
-
-So a contract that names a scope protects its route on the next build, rather than on the next time
-somebody remembers to turn a posture on.
+declares **nothing**. A handler that declares something is guarded either way, so a contract that
+names a scope protects its route on the next build.
 
 > **This makes adding `security` to an existing contract a breaking change for its callers.** An
 > operation that answered 200 to an anonymous request answers 401 once the description says it needs
@@ -99,29 +84,21 @@ cannot say what they must hold.
 | `@auth([])` on the operation or the service | nothing |
 | service declares no scheme | nothing |
 
-The auth traits were previously classified `Ignorable`, on the grounds that "authentication is
-Hardened's own story rather than the IDL's". That is right about the *scheme* and wrong about
-whether an operation needs one at all, which is a fact about the operation.
-
-Making a stock Smithy model carry permissions would need a custom trait — `@grants(["pets:read"])`.
-Smithy's trait system is built for that and it would be small, but it puts a Hardened-specific
-extension in a model whose portability is usually the reason Smithy was chosen. Not done; nothing
-about the design forecloses it.
+To require particular grants on a Smithy-generated route, put `[AuthorizeGrants]` on the
+implementation. A contract can narrow a route and never widen one, so that composes.
 
 ## Diagnostics
 
-A `security` entry naming a scheme that `components.securitySchemes` does not declare is reported.
-The reference is dangling — the document's own error — and reading its scope list would invent
-authorization out of a name that resolves to nothing. The operation falls back to requiring an
-authenticated caller and **none of the permissions it names**, which is a downgrade nobody asked
-for, so it is a build message rather than a discovery in production.
+A `security` entry naming a scheme that `components.securitySchemes` does not declare is reported at
+build time. The operation falls back to requiring an authenticated caller and **none of the
+permissions it names**.
 
 ---
 
-# Not built: publishing security into a generated document
+# Design note: publishing security into a generated document
 
-Code-first does not emit `security` into the document it generates. This is the other half of the
-gap and it is **deliberately unbuilt**, with the design settled.
+Not user documentation. Code-first does not emit `security` into the document it generates, and this
+records why and what the shape would be.
 
 ## It must be opt-in
 

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -3,8 +3,8 @@
 Every diagnostic the Hardened source generators raise, what causes it, and how to satisfy it.
 
 Warnings become errors under `ContinuousIntegrationBuild`, so anything left unaddressed locally
-fails CI. That is deliberate — the alternative is a warning nobody reads. Each entry below names the
-`NoWarn` for the cases where the warning is describing something you meant to do.
+fails CI. Each entry below names the `NoWarn` for the cases where the warning is describing
+something you meant to do.
 
 ## Handler binding
 
@@ -27,10 +27,10 @@ without implementations:
 </PropertyGroup>
 ```
 
-That is a supported target — a package carrying the contract for a client to consume, or one project
-describing a service that another implements. It is a warning rather than an error for exactly that
-reason. The `NoWarn` has to be written down rather than inferred, so that the ordinary case of
-forgetting to write a handler is still reported.
+That is a supported target: a package carrying the contract for a client to consume, or one project
+describing a service that another implements. It is a warning rather than an error for that reason,
+and the `NoWarn` has to be written down so the ordinary case of forgetting to write a handler is
+still reported.
 
 ### HOAG031 — handler implements no described service
 
@@ -51,10 +51,8 @@ Note what this is *not*. A handler declaring a base class is fine:
 public class CatalogHandler : HandlerBase, ICatalogService { }
 ```
 
-C# requires the base class to come first, and the generator used to read the first base-list entry
-and call it the service interface — so this registered `HandlerBase`, left `ICatalogService`
-unimplemented, built clean, and every route on the service was dead. The base list is searched by
-name now. HOAG031 fires only when *no* entry matches.
+C# requires the base class to come first, and the base list is searched by name, so HOAG031 fires
+only when *no* entry matches a described service.
 
 ## Other diagnostics
 
@@ -91,11 +89,7 @@ x-hardened-content-negotiation: lenient   # at the document root
 `Strict` is the default and answers 406 with a body naming what the operation produces. `Lenient`
 serializes with the default serializer anyway, which is what the framework did before this existed.
 
-It is deliberately not per operation. A policy each operation restates is one that ends up applied
-unevenly, and the operation that quietly differs is invisible. Nor is it derived from the document:
-a 406 is the transport telling a client its `Accept` named nothing that exists, and unlike a 404 —
-which is a domain outcome an operation may or may not report — there is nothing about it for an API
-author to decide.
+It is one setting for the whole service, not per operation, and it is not derived from the document.
 
-An operation that declares nothing negotiates exactly as it did before: every registered serializer
-is a candidate.
+An operation that declares nothing negotiates as before: every registered serializer is a
+candidate.

--- a/docs/validation-usage.md
+++ b/docs/validation-usage.md
@@ -118,7 +118,7 @@ When validation fails, the filter returns HTTP 400 with a structured response:
     {
       "field": "age",
       "code": "range",
-      "message": "age must be between 0 and 150."
+      "message": "age must be between 0 and 30."
     }
   ]
 }

--- a/src/Templates/Hardened.Templates.RazorBlade/README.md
+++ b/src/Templates/Hardened.Templates.RazorBlade/README.md
@@ -1,10 +1,10 @@
 # Hardened.Templates.RazorBlade
 
-Renders Razor views for handlers annotated with `[Template<T>]`.
+Renders Razor views for handlers annotated with `[Output<T>]`.
 
 RazorBlade compiles `.cshtml` to C# at build time and has no dependency on ASP.NET Core — no
-`Microsoft.AspNetCore.App` framework reference, no MVC types in the generated code. That is what
-makes it usable from the Lambda runtimes, which are plain `Microsoft.NET.Sdk` projects.
+`Microsoft.AspNetCore.App` framework reference, no MVC types in the generated code. The same views
+work under Kestrel, ASP.NET Core and the Lambda runtimes.
 
 ## Wiring
 
@@ -14,15 +14,15 @@ Turn it on by naming the marker, which is what references the package:
 [HardenedModule]
 [HardenedWebModule]
 [KestrelRuntime]
-[Enable<HardenedRazorTemplate>]
+[Enable<HardenedRazorTemplates>]
 public partial class Application { }
 ```
 
-That generates `ApplicationRazorTemplate<TModel>` — the entry point's name plus the marker's — for
+That generates `ApplicationRazorTemplates<TModel>` — the entry point's name plus the marker's — for
 views to inherit:
 
 ```razor
-@inherits Application.ApplicationRazorTemplate<FortunePage>
+@inherits Application.ApplicationRazorTemplates<FortunePage>
 <table>@foreach (var fortune in Model.Fortunes) { <tr><td>@fortune.Message</td></tr> }</table>
 ```
 
@@ -30,61 +30,50 @@ and a handler names the view by type:
 
 ```csharp
 [Get("/fortunes")]
-[Template<Views.Fortunes>]
+[Output<Views.Fortunes>]
 public FortunePage GetFortunes() => _repository.Load();
 ```
 
-There is nothing to register. The generated handler puts a factory on the response,
-`TemplateResponseSerializer` builds the view, hands it the model and asks it to render. A template
-renders itself — there is no engine, and no name resolved through a dictionary.
+There is nothing to register. The generated handler puts a factory on the response, the
+serialization filter builds the view, hands it the model and asks it to render.
 
 ## What the compiler checks, and where
 
-The boundary is not where it looks.
-
-**On the attribute.** `TemplateAttribute<T>` constrains `T` to `IHardenedTemplate, new()`, and the
-attribute is applied in your own assembly, where RazorBlade's output exists. A type that is not a
-template, or has no parameterless constructor, is an error on the attribute — naming the template.
-
-This is also why the view is named by type rather than by string: because the attribute is in your
-assembly, RazorBlade's `internal` generated classes are nameable there. A registry of named
-descriptors existed to work around exactly that.
+**On the attribute.** `OutputAttribute<T>` constrains `T` to `IHardenedResponseOutput, new()`, and
+the attribute is applied in your own assembly, where RazorBlade's output exists. A type that is not
+an output, or has no parameterless constructor, is an error on the attribute, naming the type. It is
+also why the view is named by type rather than by string: RazorBlade's `internal` generated classes
+are nameable from your assembly.
 
 **In generated code.** That the view's model matches the handler's return type cannot be expressed
-on the attribute — it does not know the return type — and the generator cannot check it, because
-the view is another generator's output and invisible to it. So the generator emits an assignment
-the compiler has to bind:
+on the attribute, and the generator cannot check it because the view is another generator's output.
+So the generator emits an assignment the compiler has to bind:
 
 ```csharp
-private static readonly IHardenedTemplate<FortunePage> _templateCheck_GetFortunes = new Views.Fortunes();
+private static readonly IHardenedResponseOutput<FortunePage> _outputCheck_GetFortunes = new Views.Fortunes();
 ```
 
-A mismatch reads "cannot convert Views.Fortunes to IHardenedTemplate<FortunePage>", naming both
-types. That is the one mechanism that works across a generator boundary: another generator's output
-cannot be inspected, but code can be emitted that the compiler binds against it.
+A mismatch reads "cannot convert Views.Fortunes to IHardenedResponseOutput<FortunePage>", naming
+both types.
 
 ## Choosing a view per request
 
-The response carries a factory, assigned before the handler runs, so a handler or filter can
-replace it — a different view for mobile than for desktop, an A/B test, an error view:
+The response carries a factory, assigned before the handler runs, so a handler or filter can replace
+it — a different view for mobile than for desktop, an A/B test, an error view:
 
 ```csharp
-context.Response.TemplateFactory = static _ => new Views.FortunesMobile();
+context.Response.OutputFactory = static _ => new Views.FortunesMobile();
 ```
 
-One construction shape only. C# has `where T : new()` but no constraint for "has a constructor
-taking `TModel`", so a second shape could not be compile-checked and would not deliver the guarantee
-that makes this worth having. The model is attached after construction.
+One construction shape only: the view is constructed with no arguments and the model attached
+afterwards.
 
 ## Specification-first
 
 The same attribute works on the implementation of a spec-generated service interface. The document
-declares the contract — that the operation answers with `text/html` — and the attribute names the
-view that produces it, so changing engines or views does not edit the API description.
-
-There is no spec extension for this. Which server-side view renders a response is not part of an
-HTTP contract: clients, gateways and documentation tooling have no views, and a second
-implementation of the same specification in another language has nothing to do with the value.
+declares that the operation answers with `text/html`, and the attribute names the view that produces
+it, so changing engines or views does not edit the API description. There is no spec extension for
+this.
 
 ## Content type
 
@@ -92,21 +81,19 @@ From the marker, which is to say from the base class:
 
 | Marker | Base | Content type |
 |---|---|---|
-| `HardenedRazorTemplate` | `HardenedHtmlTemplate<T>` | `text/html; charset=utf-8` |
+| `HardenedRazorTemplates` | `HardenedHtmlTemplate<T>` | `text/html; charset=utf-8` |
 
 A handler that sets `Response.ContentType` itself keeps it — rendering only fills in a blank.
 
 Another engine ships its own marker with its own `[TemplateBase]` and `[TemplateContentType]` and
-needs no change to Hardened: the generator resolves whichever marker was named and reads those two
-attributes. Two markers on one module produce two bases, so multi-engine is the same mechanism
-rather than a retrofit.
+needs no change to Hardened. Two markers on one module produce two bases.
 
 ## Two things that will catch you out
 
 **Reference `RazorBlade` directly in the application.** RazorBlade ships `build/` but no
 `buildTransitive/`, and MSBuild props do not flow transitively. Referencing only
 `Hardened.Templates.RazorBlade` means the `.props` that globs `**/*.cshtml` never reaches your
-project, and your templates compile to nothing with no error.
+project, and your views compile to nothing with no error.
 
 ```xml
 <PackageReference Include="RazorBlade" Version="1.0.0" />
@@ -115,23 +102,20 @@ project, and your templates compile to nothing with no error.
 
 **Kestrel and ASP.NET Core hosts need one Razor generator, not two.** RazorBlade emits warning
 RB0006 when `UsingMicrosoftNETSdkRazor` is true, because its generator and the SDK's would both
-process the same `.cshtml`. Set `EnableDefaultRazorBladeItems=false` and list templates explicitly,
-or keep views out of the Razor SDK's default globs.
+process the same `.cshtml`. Set `EnableDefaultRazorBladeItems=false` and list views explicitly, or
+keep them out of the Razor SDK's default globs.
 
 ## Naming
 
 If your own assembly's namespace ends in `RazorBlade`, qualify the base type in `.cshtml` with
 `global::`. Without it the name binds to the enclosing namespace and fails to resolve.
 
-## Why the base is what it is
+## Writing a base of your own
 
 `HardenedHtmlTemplate<TModel>` inherits RazorBlade's **non-generic** `HtmlTemplate` and declares its
-own `Model`. Both of the natural alternatives were tried and neither works:
+own `Model`. Both of the natural alternatives fail:
 
 - `RazorBlade.HtmlTemplate<TModel>.Model` is read-only (`CS0200`), so a model cannot be attached
-  after construction — and attaching after construction is the whole shape of this design.
+  after construction.
 - RazorBlade emits the `(TModel model) : base(model)` constructor **only for its own base types**, so
   a custom generic base gets parameterless construction and fails with `CS7036`.
-
-Inheriting the non-generic base sidesteps both: parameterless construction is correct, and there is
-no constructor for anyone to generate.

--- a/src/Web/Hardened.Web.Kestrel.Runtime/README.md
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/README.md
@@ -27,12 +27,12 @@ public partial class Application { }
 Nothing else changes. Controllers, filters, binding and the generated routing table are identical
 to an ASP.NET-hosted Hardened application.
 
-## What this actually does
+## What this does
 
 `IServer.StartAsync` takes an `IHttpApplication<TContext>`, not a `RequestDelegate`.
 `HostingApplication` — the piece that builds an `HttpContext`, opens the DI scope and raises the
-hosting diagnostics — is only the default implementation of that interface, and nothing about
-Kestrel requires it. This package supplies Hardened's own:
+hosting diagnostics — is only the default implementation of that interface. This package supplies
+Hardened's own:
 
 ```
 Kestrel → HostingApplication → HttpContext → ASP.NET middleware
@@ -58,37 +58,32 @@ each driven from an identical feature collection with no server underneath:
 | `GET /binding/{id}` | 1176 ns | **1000 ns** | 14.9% | 1101 ns | 3721 ns |
 | `POST /sum` | 1548 ns | **1469 ns** | 5.1% | 1623 ns | 4507 ns |
 
-Routes carrying a query string save the most. `AspNetExecutionRequest.QueryString` reads
-`HttpRequest.Query` — already parsed by ASP.NET — and then materialises a second `Dictionary` from
-it with a `ToString()` per value. Here the raw query string is parsed once, directly.
+Routes carrying a query string save the most: this host parses the raw query string once, where
+`AspNetExecutionRequest.QueryString` reads the already-parsed `HttpRequest.Query` and materialises a
+second `Dictionary` from it.
 
-Two things to keep in mind when reading the table. This host calls `IRequestLogger` on begin and
-end and records `TotalRequestDuration`, matching the Lambda runtime; `AspNetCoreRequestHandler`
-does none of that, so the ASP.NET column is doing slightly less work than the Kestrel one. And
-none of these figures include sockets, HTTP parsing or framing, which Kestrel adds equally to
-every hosted option — see `src/Benchmarks/README.md` for why that boundary was chosen.
+Two caveats. This host calls `IRequestLogger` on begin and end and records
+`TotalRequestDuration`, matching the Lambda runtime, and `AspNetCoreRequestHandler` does none of
+that, so the ASP.NET column is doing slightly less work. And none of these figures include sockets,
+HTTP parsing or framing, which Kestrel adds equally to every hosted option — see
+`src/Benchmarks/README.md`.
 
 ## What you give up
 
-This is additive. `Hardened.Web.AspNetCore.Runtime` remains the right choice when any of the
-following matter — and the first one matters more often than teams expect.
+`Hardened.Web.AspNetCore.Runtime` is the right choice when any of the following matter.
 
 - **ASP.NET's own hosting diagnostics.** The `Microsoft.AspNetCore.Hosting` `DiagnosticSource` and
   `EventSource` events are not raised, so instrumentation packages that subscribe to *those names*
   see nothing.
 
-  Tracing itself does work, and has since the request pipeline began reporting spans. Hardened
-  publishes its own `ActivitySource` and `Meter`, both named `Hardened.Requests` — a server span per
-  request, parented on an inbound `traceparent`, tagged with route and status, plus a correlation id
-  on every response. Point a collector at that name rather than at the ASP.NET one:
+  Tracing itself works. Hardened publishes its own `ActivitySource` and `Meter`, both named
+  `Hardened.Requests` — a server span per request, parented on an inbound `traceparent`, tagged with
+  route and status, plus a correlation id on every response. Point a collector at that name rather
+  than at the ASP.NET one:
 
   ```csharp
   builder.AddSource("Hardened.Requests");   // and .AddMeter("Hardened.Requests")
   ```
-
-  This bullet used to say distributed tracing did not work at all. It was written before the spans
-  existed and outlived them, which is worth knowing because it sends people to
-  `Hardened.Web.AspNetCore.Runtime` for a reason that no longer holds.
 - **ASP.NET authentication and authorization** middleware.
 - **General response compression.** Hardened's `GZipStaticContentCompressor` covers static content
   only, so dynamic responses have no equivalent.
@@ -96,10 +91,8 @@ following matter — and the first one matters more often than teams expect.
   middleware ecosystem generally.
 - `IHttpContextAccessor`, and anything in application code that depends on `HttpContext`.
 
-Hardened supplies its own CORS and filter pipeline, so those particular overlaps are covered.
-Static files are covered by `Hardened.Web.StaticContent`, which is a separate package rather than
-part of the runtime: most services serve none, and a DI registration is exactly what a trimmer
-cannot remove, so carrying it unconditionally cost every application about 20 KB it could not drop.
+Hardened supplies its own CORS and filter pipeline, so those overlaps are covered. Static files are
+covered by `Hardened.Web.StaticContent`, a separate package.
 
 ## Hosting inside a generic host
 
@@ -111,9 +104,8 @@ start. To keep configuration binding, logging setup and coordinated shutdown fro
 builder.Services.AddHardenedKestrel(kestrel => kestrel.ListenAnyIP(5080));
 ```
 
-That keeps `Microsoft.Extensions.Hosting` and drops only `Microsoft.AspNetCore.Hosting`. Using
-`ConfigureWebHostDefaults` would bring back `GenericWebHostService` and `HostingApplication` — the
-things this package exists to avoid.
+That keeps `Microsoft.Extensions.Hosting` and drops only `Microsoft.AspNetCore.Hosting`. Do not use
+`ConfigureWebHostDefaults`: it brings back `GenericWebHostService` and `HostingApplication`.
 
 ## Notes for anyone changing this
 


### PR DESCRIPTION
## What changed

**`AGENTS.md`** — new. The repository had no agent instructions of its own; the three `AGENTS.md`
files under `src/Templates` are template content, written into a generated project rather than
describing this one. It records the traps that are green locally and red in CI: the
`ContinuousIntegrationBuild` warning gate, the two-SDK requirement, the coverage baseline that
cannot be written from a local run, the hand-maintained pack list, the approved public surface, and
`verify-templates.sh` skipping smithy in silence when the CLI is absent.

**`README.md`** — trimmed the rationale clauses. The Smithy section was the only contract style that
stopped at the contract; it now shows the implementation the other two do, and all three link to
their guide page.

**`src/Templates/Hardened.Templates.RazorBlade/README.md`** — pointed at the shipped API. It
documented `[Template<T>]`, `[Enable<HardenedRazorTemplate>]`, `IHardenedTemplate` and
`Response.TemplateFactory`. The shipped names are `[Output<T>]`, `[Enable<HardenedRazorTemplates>]`,
`IHardenedResponseOutput` and `Response.OutputFactory`, so every snippet on the nuget.org package
page fails to compile.

**`src/Web/Hardened.Web.Kestrel.Runtime/README.md`**, **`docs/described-authorization.md`**,
**`docs/generator-diagnostics.md`** — same trim. `described-authorization.md`'s second half is a
design record for unbuilt work, now labelled as one rather than reading as documentation.

**`docs/validation-usage.md`** — the error-response example said "between 0 and 150" against a
schema declaring `maximum: 30`.

## What is not touched

`docs/DOCS-PLAN.md`, `TEMPLATE-PLAN.md`, `TESTING-PLAN.md`, `ENVIRONMENT-SPLIT.md` and
`validation-system.md` are planning and architecture records, not user documentation.

## Noted, not fixed

`RELEASE_LINE: 0.4.0` in `build-package.yaml` has not moved in eleven release lines. Previews still
sort below `0.15.0-rc1000` so nothing is shadowed, but the continuous feed's version no longer names
the line the code belongs to. Bumping it changes what gets published, so it is left out of a
documentation change.

Companion changes: ipjohnson/Hardened.Docs#17 and ipjohnson/Hardened.Amz#80.

Markdown only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3A1dLXmXc8bnteNZmfDHp
