### PR TITLE
Add GET /todos to the web template, and fix the Smithy list payload it needs

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -228,6 +228,11 @@ for COMBO in "${COMBOS[@]}"; do
         # indistinguishable from having no declared set at all, which is the thing worth proving
         # here - and the sample's 404 and 409 are the two statuses every mode has to answer the
         # same way, whether it reaches them by returning a case or by throwing.
+        # The list route, and asserted as an array rather than as 200. A Smithy @httpPayload list
+        # generated an empty record and answered {} - a 200 with nothing in it, which every check
+        # phrased as a status code passes.
+        LISTED=$(curl -s --max-time 5 "http://localhost:$PORT/todos" || true)
+
         MISSING=$(status_of "http://localhost:$PORT/todos/9999")
         DUPLICATE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
             -X POST -H 'Content-Type: application/json' \
@@ -278,6 +283,14 @@ for COMBO in "${COMBOS[@]}"; do
             echo "   FAILED: expected 404 and 409, got $MISSING and $DUPLICATE"
             FAILED=1
         fi
+
+        case "$LISTED" in
+            \[*\]) echo "   list: $LISTED" ;;
+            *)
+                echo "   FAILED: GET /todos should answer a JSON array, got '$LISTED'"
+                FAILED=1
+                ;;
+        esac
 
         if [ "$CREATED" != "$EXPECT_CREATED" ]; then
             echo "   FAILED: $CONTRACT/$MODEL should create at $EXPECT_CREATED, got $CREATED"

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/Fixtures/payload-shapes.json
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/Fixtures/payload-shapes.json
@@ -1,0 +1,148 @@
+{
+  "smithy": "2.0",
+  "shapes": {
+    "com.example.test#Depot": {
+      "type": "service",
+      "version": "1.0",
+      "operations": [
+        { "target": "com.example.test#ListPets" },
+        { "target": "com.example.test#ListNames" },
+        { "target": "com.example.test#GetPet" },
+        { "target": "com.example.test#GetName" },
+        { "target": "com.example.test#GetTags" }
+      ]
+    },
+
+    "com.example.test#Pet": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#Integer",
+          "traits": { "smithy.api#required": {} }
+        },
+        "name": { "target": "smithy.api#String" }
+      }
+    },
+
+    "com.example.test#PetList": {
+      "type": "list",
+      "member": { "target": "com.example.test#Pet" }
+    },
+
+    "com.example.test#NameList": {
+      "type": "list",
+      "member": { "target": "smithy.api#String" }
+    },
+
+    "com.example.test#TagMap": {
+      "type": "map",
+      "key": { "target": "smithy.api#String" },
+      "value": { "target": "smithy.api#String" }
+    },
+
+    "com.example.test#ListPets": {
+      "type": "operation",
+      "output": { "target": "com.example.test#ListPetsOutput" },
+      "traits": {
+        "smithy.api#http": { "method": "GET", "uri": "/pets", "code": 200 },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.example.test#ListPetsOutput": {
+      "type": "structure",
+      "members": {
+        "pets": {
+          "target": "com.example.test#PetList",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpPayload": {}
+          }
+        }
+      }
+    },
+
+    "com.example.test#ListNames": {
+      "type": "operation",
+      "output": { "target": "com.example.test#ListNamesOutput" },
+      "traits": {
+        "smithy.api#http": { "method": "GET", "uri": "/names", "code": 200 },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.example.test#ListNamesOutput": {
+      "type": "structure",
+      "members": {
+        "names": {
+          "target": "com.example.test#NameList",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpPayload": {}
+          }
+        }
+      }
+    },
+
+    "com.example.test#GetPet": {
+      "type": "operation",
+      "output": { "target": "com.example.test#GetPetOutput" },
+      "traits": {
+        "smithy.api#http": { "method": "GET", "uri": "/pets/one", "code": 200 },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.example.test#GetPetOutput": {
+      "type": "structure",
+      "members": {
+        "pet": {
+          "target": "com.example.test#Pet",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpPayload": {}
+          }
+        }
+      }
+    },
+
+    "com.example.test#GetName": {
+      "type": "operation",
+      "output": { "target": "com.example.test#GetNameOutput" },
+      "traits": {
+        "smithy.api#http": { "method": "GET", "uri": "/name", "code": 200 },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.example.test#GetNameOutput": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpPayload": {}
+          }
+        }
+      }
+    },
+
+    "com.example.test#GetTags": {
+      "type": "operation",
+      "output": { "target": "com.example.test#GetTagsOutput" },
+      "traits": {
+        "smithy.api#http": { "method": "GET", "uri": "/tags", "code": 200 },
+        "smithy.api#readonly": {}
+      }
+    },
+    "com.example.test#GetTagsOutput": {
+      "type": "structure",
+      "members": {
+        "tags": {
+          "target": "com.example.test#TagMap",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#httpPayload": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyPayloadShapeTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyPayloadShapeTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Hardened.Generation.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// What an <c>@httpPayload</c> member's target becomes, which used to depend on nothing but the
+/// shape id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ParseOutput</c> resolved the target with <c>ReferenceTo</c>, which builds a schema for a shape
+/// id and is right only for the kinds that get a C# type of their own. <c>Describe</c> is the
+/// function that decides which those are, and its own remarks state the rule: structures, unions and
+/// enums become references, and everything else is inlined at the use site - "a named <c>list</c> is
+/// a <c>List&lt;T&gt;</c>".
+/// </para>
+/// <para>
+/// So a list target reached <c>BuildSchema</c>, whose default arm assumes an object and reads a
+/// <c>members</c> map. A list shape carries a singular <c>member</c> and no map at all, so the loop
+/// ran zero times and <c>list PetList { member: Pet }</c> became <c>record PetList;</c> with no
+/// members - a service interface asking for a type there was no way to fill. The same shape read as
+/// a structure member has always inlined to <c>List&lt;Pet&gt;</c>, so one build emitted both.
+/// </para>
+/// <para>
+/// Nothing reported it. That arm has no diagnostic for a shape kind it does not model, which is why
+/// the map case below asserts one now.
+/// </para>
+/// </remarks>
+public class SmithyPayloadShapeTests {
+
+    private static string Fixture() =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "payload-shapes.json"));
+
+    private static ServiceSpecModel Model(List<string> diagnostics) {
+        var model = SmithySpecParser.Parse(Fixture(), "payload-shapes", diagnostics);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static OperationModel Operation(string operationId) =>
+        Model(new List<string>()).Services
+            .SelectMany(service => service.Operations)
+            .Single(operation => operation.OperationId == operationId);
+
+    /// <summary>
+    /// A list of a structure is an array of that structure, not a type named after the list.
+    /// </summary>
+    [Fact]
+    public void AListPayloadIsAnArrayOfItsMember() {
+        var operation = Operation("ListPets");
+
+        Assert.True(operation.ResponseIsArray);
+        Assert.Equal("#/components/schemas/Pet", operation.ResponseArrayItemsRef);
+        Assert.Null(operation.ResponseRef);
+    }
+
+    /// <summary>
+    /// And no schema is written for the list shape itself.
+    /// </summary>
+    /// <remarks>
+    /// The assertion that pins the defect rather than its symptom. <c>PetList</c> used to be emitted
+    /// as an object schema with no properties, so a build produced both <c>record PetList;</c> and,
+    /// from the same shape used as a structure member, <c>List&lt;Pet&gt;</c>.
+    /// </remarks>
+    [Fact]
+    public void AListPayloadWritesNoSchemaOfItsOwn() {
+        Assert.DoesNotContain(
+            Model(new List<string>()).Schemas, schema => schema.Name == "PetList");
+    }
+
+    /// <summary>
+    /// A list of a prelude type names the type rather than a reference, which is what
+    /// <c>List&lt;string&gt;</c> is generated from.
+    /// </summary>
+    [Fact]
+    public void AListPayloadOfPrimitivesNamesTheItemType() {
+        var operation = Operation("ListNames");
+
+        Assert.True(operation.ResponseIsArray);
+        Assert.Equal("string", operation.ResponseArrayItemsType);
+        Assert.Null(operation.ResponseArrayItemsRef);
+    }
+
+    /// <summary>
+    /// A structure payload is unchanged, which is the case that always worked and the reason the
+    /// defect went unnoticed.
+    /// </summary>
+    [Fact]
+    public void AStructurePayloadIsStillAReference() {
+        var operation = Operation("GetPet");
+
+        Assert.Equal("#/components/schemas/Pet", operation.ResponseRef);
+        Assert.False(operation.ResponseIsArray);
+    }
+
+    /// <summary>
+    /// A prelude target is the type it maps to.
+    /// </summary>
+    /// <remarks>
+    /// Worse than the list case before this. <c>ReferenceTo</c> found no shape for
+    /// <c>smithy.api#String</c>, so <c>BuildSchema</c> added nothing and the operation was left
+    /// holding a reference to a type that was never written.
+    /// </remarks>
+    [Fact]
+    public void APreludePayloadIsTheTypeItMapsTo() {
+        var operation = Operation("GetName");
+
+        Assert.Equal("string", operation.ResponseType);
+        Assert.Null(operation.ResponseRef);
+    }
+
+    /// <summary>
+    /// A map payload has nowhere to land, and says so.
+    /// </summary>
+    /// <remarks>
+    /// The shared model carries <c>ResponseIsArray</c> and its item type and nothing equivalent for
+    /// a dictionary, so the emitters fall back to a <c>Task</c> with no result. That is not what a
+    /// model declaring a payload asked for, and the whole lesson of the list case is that this arm
+    /// used to be silent.
+    /// </remarks>
+    [Fact]
+    public void AMapPayloadIsReported() {
+        var diagnostics = new List<string>();
+
+        Model(diagnostics);
+
+        Assert.Contains(
+            diagnostics,
+            diagnostic => diagnostic.Contains("GetTags") && diagnostic.Contains("@httpPayload"));
+    }
+
+    /// <summary>And leaves nothing behind that would name a body it cannot describe.</summary>
+    [Fact]
+    public void AMapPayloadNamesNoResponseShape() {
+        var operation = Operation("GetTags");
+
+        Assert.Null(operation.ResponseRef);
+        Assert.Null(operation.ResponseType);
+        Assert.False(operation.ResponseIsArray);
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -568,7 +568,7 @@ internal static class SmithySpecParser {
             var target = SmithyAst.Target(member.Value);
 
             if (target != null) {
-                model.ResponseRef = ReferenceTo(context, target);
+                DescribePayload(context, model, target, operationName);
 
                 return headers;
             }
@@ -582,6 +582,65 @@ internal static class SmithySpecParser {
         MarkHeaderBound(context, outputId, boundOut);
 
         return headers;
+    }
+
+    /// <summary>
+    /// An <c>@httpPayload</c> target, as whatever it means: a reference, an array, or an inlined
+    /// primitive.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Through <see cref="Describe"/> rather than <see cref="ReferenceTo"/>, and that is the whole
+    /// of it. <c>ReferenceTo</c> builds a schema for a shape id, which is right only for the kinds
+    /// that get a C# type of their own - and <c>Describe</c> is the function that decides which
+    /// those are. Calling it directly asserted the answer instead of asking for it.
+    /// </para>
+    /// <para>
+    /// A list target went to <see cref="BuildSchema"/>, whose default arm reads a <c>members</c> map
+    /// that a list shape does not have - it carries a singular <c>member</c> - so
+    /// <c>list PetList { member: Pet }</c> became <c>record PetList;</c> with no members at all, and
+    /// the service interface asked for a type there was no way to fill. The same shape read as a
+    /// structure member has always inlined to <c>List&lt;Pet&gt;</c>, so one build emitted both.
+    /// Nothing reported it, because that arm has no diagnostic for a kind it does not model.
+    /// </para>
+    /// <para>
+    /// A named simple shape was wrong the same way and a prelude one worse: <c>ReferenceTo</c> found
+    /// no shape for <c>smithy.api#String</c>, added no schema, and returned a reference to a type
+    /// that was never written.
+    /// </para>
+    /// </remarks>
+    private static void DescribePayload(
+        ParseContext context, OperationModel model, string target, string operationName) {
+        Describe(context, target, out var type, out var format, out var reference, out var facts);
+
+        if (reference != null) {
+            model.ResponseRef = reference;
+
+            return;
+        }
+
+        if (facts.IsArray) {
+            model.ResponseIsArray = true;
+            model.ResponseArrayItemsRef = facts.ItemRef;
+            model.ResponseArrayItemsType = facts.ItemType;
+
+            return;
+        }
+
+        // A map has no response field to land in - the shared model carries ResponseIsArray and its
+        // item type, and nothing equivalent for a dictionary - so the emitters fall back to a Task
+        // with no result. Reported rather than left silent, since answering with no body is not what
+        // a model declaring a payload asked for.
+        if (facts.IsDictionary) {
+            context.Diagnostics.Add(
+                $"operation '{operationName}' declares a map as its @httpPayload, which has no " +
+                "declared response shape; it answers with no body.");
+
+            return;
+        }
+
+        model.ResponseType = type;
+        model.ResponseFormat = format;
     }
 
     /// <summary>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -12,17 +12,18 @@ dotnet test
 dotnet run --project src/Hardened1.Host
 ```
 
-It prints its address and listens on **5080**. Set `PORT` to change it.
+It listens on **5080** and prints its address. Set `PORT` to change it.
 
 ```bash
-curl localhost:5080/todos/1
-{"id":1,"title":"Read the generated code","done":true}
+curl localhost:5080/todos
+[{"id":1,"title":"Read the generated code","done":true},{"id":2,"title":"Add an endpoint","done":false}]
 ```
 
-Three routes, and every one of them declares more than one answer:
+Four routes. `GET /todos` has one answer; the other three each declare more than one:
 
 | | success | and |
 |---|---|---|
+| `GET /todos` | 200 | |
 | `GET /todos/{id}` | 200 | 404 when no todo has that id |
 | `POST /todos` | #if (standardMode)#if (codeFirst)200#endif#if (specFirst)201#endif#endif#if (declaredMode)201 with a `Location`#endif | 409 when the title is taken |
 | `DELETE /todos/{id}` | #if (standardMode)200#endif#if (declaredMode)204#endif | 404 when no todo has that id |
@@ -34,7 +35,8 @@ curl -i -X POST localhost:5080/todos -H 'Content-Type: application/json' \
 
 #if (OpenApiUi)
 There is a reference page at <http://localhost:5080/docs> and the document behind it at
-`/openapi.json`. The page is served in the `development` environment only.
+`/openapi.json`. The page is served in the `development` environment only, and the address is
+printed on startup so it does not have to be remembered.
 
 Visual Studio and Rider open it on F5 — pick the **Hardened1.Host (+Browser)** configuration, which
 comes from `src/Hardened1.Host/Properties/launchSettings.json`. That profile names no environment

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Harness/Program.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Harness/Program.cs
@@ -3,6 +3,11 @@ using Hardened.Shared.Runtime.Application;
 using Hardened1.Host;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+// WaitForShutdownAsync is an IHost extension rather than a WebApplication member.
+using Microsoft.Extensions.Hosting;
+#if (OpenApiUi)
+using Microsoft.Extensions.Logging;
+#endif
 
 // Listens on 5080. Override with PORT.
 var port = int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var configured) ? configured : 5080;
@@ -20,4 +25,17 @@ var app = builder.Build();
 
 app.UseLambdaApplication();
 
-app.Run($"http://localhost:{port}");
+app.Urls.Add($"http://localhost:{port}");
+
+// Started rather than run, so anything printed below comes after the server is actually listening.
+await app.StartAsync();
+#if (OpenApiUi)
+
+// Gated on the environment because the reference page is: printing a URL that answers 404 is worse
+// than printing nothing.
+if (app.Services.GetRequiredService<IHardenedEnvironment>().Matches("development")) {
+    app.Logger.LogInformation("Browse http://localhost:{Port}/docs to access your API.", port);
+}
+#endif
+
+await app.WaitForShutdownAsync();

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 // WaitForShutdownAsync is an IHost extension rather than a WebApplication member.
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 #endif
 
 // Listens on 5080. Override with PORT.
@@ -39,9 +40,18 @@ await using var app = HardenedKestrelApplication.Create(
 await app.StartAsync();
 
 // Printed, so the address is read rather than guessed. The ASP.NET host does this for you.
-app.Services.GetRequiredService<ILoggerFactory>()
-    .CreateLogger("Hardened1.Host")
-    .LogInformation("Listening on http://localhost:{Port}", port);
+var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Hardened1.Host");
+
+logger.LogInformation("Listening on http://localhost:{Port}", port);
+#if (OpenApiUi)
+
+// Where to start, rather than an address and a guess about what is under it. Gated on the
+// environment because the reference page is: printing a URL that answers 404 is worse than
+// printing nothing.
+if (environment.Matches("development")) {
+    logger.LogInformation("Browse http://localhost:{Port}/docs to access your API.", port);
+}
+#endif
 
 await app.RunAsync();
 #endif
@@ -66,6 +76,14 @@ await ApplicationLogic.Start(app.Services, null);
 app.Urls.Add($"http://localhost:{port}");
 
 await app.StartAsync();
+#if (OpenApiUi)
+
+// ASP.NET prints the address itself, so this adds only the part it cannot know about. Gated on the
+// environment because the reference page is.
+if (environment.Matches("development")) {
+    app.Logger.LogInformation("Browse http://localhost:{Port}/docs to access your API.", port);
+}
+#endif
 
 await app.WaitForShutdownAsync();
 #endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
@@ -31,5 +31,9 @@ namespace Hardened1;
 [JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
 [JsonSerializable(typeof(Todo))]
 [JsonSerializable(typeof(NewTodo))]
+// List<Todo> rather than the IReadOnlyList<Todo> the handler declares. The response value reaches
+// the serializer as object, so System.Text.Json resolves the runtime type - and it is the runtime
+// type that needs a JsonTypeInfo here.
+[JsonSerializable(typeof(List<Todo>))]
 public partial class TemplateModuleNameJsonContext : JsonSerializerContext;
 #endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
@@ -33,6 +33,15 @@ public union RemovedTodoResult(NoContent, NotFound);
 /// </remarks>
 public class TodoController {
 
+    /// <summary>Every todo.</summary>
+    /// <remarks>
+    /// The one route here with a single outcome, so it reads the same under every response model -
+    /// there is nothing to declare beside the success type. The collection becomes an array in the
+    /// generated document without anything here describing it.
+    /// </remarks>
+    [Get("/")]
+    public IReadOnlyList<Todo> All(ITodoStore store) => store.All();
+
 #if (standardMode)
     /// <summary>One todo, or 404.</summary>
     /// <remarks>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
@@ -43,6 +43,17 @@ public class TodoService : ITodosService {
     private static TodoTitleTaken ConflictBody(string message) => new(message);
 #endif
 
+    /// <summary>
+    /// Every todo, as the array the contract declares.
+    /// </summary>
+    /// <remarks>
+    /// Outside the response-model split below, because this operation declares one status and there
+    /// is nothing for a declared set to hold. A named list is not a C# type of its own in either
+    /// contract language, so both generate List&lt;Todo&gt; and this method is written once.
+    /// </remarks>
+    public Task<List<Todo>> ListTodos() =>
+        Task.FromResult(_store.All().ToList());
+
 #if (standardMode)
     /// <summary>
     /// Null is the 404.

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoStore.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoStore.cs
@@ -30,6 +30,8 @@ public record NewTodo(string Title);
 /// </remarks>
 public interface ITodoStore {
 
+    IReadOnlyList<Todo> All();
+
     Todo? Find(int id);
 
     bool TitleExists(string title);
@@ -61,6 +63,8 @@ public class TodoStore : ITodoStore {
     };
 
     private int _nextId = 3;
+
+    public IReadOnlyList<Todo> All() => _todos.Values.ToList();
 
     public Todo? Find(int id) => _todos.TryGetValue(id, out var todo) ? todo : null;
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/contracts/todos.smithy
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/contracts/todos.smithy
@@ -12,7 +12,7 @@ namespace com.example.hardened1
 @title("Hardened1 API")
 service Todos {
     version: "2024-01-01"
-    operations: [GetTodo, CreateTodo, RemoveTodo]
+    operations: [ListTodos, GetTodo, CreateTodo, RemoveTodo]
 }
 
 /// What a client sends to create one. Named rather than inline, so the generated model is called
@@ -37,6 +37,17 @@ structure Todo {
     done: Boolean
 }
 
+// A named list, which does not become a C# type of its own - the generated signature is
+// List<Todo>. @httpPayload on the member below is what makes the list the whole response body
+// rather than a member of an object wrapping it, so this answers the same array the OpenAPI
+// contract does.
+//
+// // rather than ///, because /// becomes @documentation and then a C# XML comment, where the
+// angle brackets would not be well-formed.
+list TodoList {
+    member: Todo
+}
+
 /// The shape of an error body. @error is what makes it a declared failure rather than an output.
 @error("client")
 @httpError(404)
@@ -50,6 +61,17 @@ structure TodoNotFound {
 structure TodoTitleTaken {
     @required
     message: String
+}
+
+@documentation("Every todo.")
+@http(method: "GET", uri: "/todos", code: 200)
+@readonly
+operation ListTodos {
+    output := {
+        @required
+        @httpPayload
+        todos: TodoList
+    }
 }
 
 @documentation("One todo by id.")

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/contracts/todos.yaml
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/contracts/todos.yaml
@@ -63,6 +63,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/Problem'
   /todos:
+    get:
+      tags:
+        - Todos
+      operationId: listTodos
+      summary: Every todo.
+      responses:
+        '200':
+          description: The todos.
+          content:
+            application/json:
+              schema:
+                # An array response, so the generated signature is List<Todo> rather than a wrapper
+                # type. The only operation here that declares one status, which is why it is the
+                # same in every response model.
+                type: array
+                items:
+                  $ref: '#/components/schemas/Todo'
     post:
       tags:
         - Todos

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
@@ -21,6 +21,16 @@ public class TodoTests {
     private record NewTodoRequest(string Title);
 
     [HardenedTest]
+    public async Task ListTodos_ReturnsEveryTodo(ITestWebApp app) {
+        var response = await app.Get("/todos");
+
+        response.Assert.Ok();
+
+        Assert.Equal(
+            [1, 2], response.Deserialize<List<TodoResponse>>().Select(todo => todo.Id));
+    }
+
+    [HardenedTest]
     public async Task GetTodo_ReturnsTheTodo(ITestWebApp app) {
         var response = await app.Get("/todos/1");
 


### PR DESCRIPTION
The documented quickstart called `/greeting/world`, a route `hardened-web` has never generated. Adding the list route it should have called turned up a defect in the Smithy front end, so this is two commits.

## The parser

`ParseOutput` resolved an `@httpPayload` target with `ReferenceTo`, which builds a schema for a shape id. That is right only for the kinds that get a C# type of their own. `Describe` is the function that decides which those are, and its own remarks already state the rule: structures, unions and enums become references, everything else is inlined at the use site, and "a named `list` is a `List<T>`".

A list target therefore reached `BuildSchema`, whose `default:` arm assumes an object and reads a `members` map. A list shape carries a singular `member` and no map at all, so the loop ran zero times. One build emitted both of these from the same `PetList` shape:

```csharp
// PetList as a structure member
public sealed partial record ListPetsOutput(... List<Pet> Pets, ...);

// the same PetList through @httpPayload
public sealed partial record PetList;
```

The service interface asked for `Task<PetList>`, a type with nowhere to put pets. Whatever an implementation constructed serialized as `{}`.

A prelude target was worse. `ReferenceTo` found no shape for `smithy.api#String`, added no schema, and returned a reference to a type that was never written.

Nothing reported any of it, because that arm has no diagnostic for a shape kind it does not model. A map payload still has no response field to land in, so it now reports rather than falling through silently.

Seven tests over a new fixture. Six fail against the old parser. `AStructurePayloadIsStillAReference` guards the case that always worked.

## The template

`GET /todos` in all three contract variants, and all six shipped combinations answer the same array. Verified over a real socket:

```
kestrel:code      list: [{"id":1,...,"done":true},{"id":2,...,"done":false}]
kestrel:openapi   list: [{"id":1,...,"done":true},{"id":2,...,"done":false}]
kestrel:smithy    list: [{"id":1,...,"done":true},{"id":2,...,"done":false}]
```

Code-first returns `IReadOnlyList<Todo>` from a route outside the response-model conditionals, because one outcome reads the same in every mode. The JSON context registers `List<Todo>`, which is the runtime type the serializer resolves.

`verify-templates.sh` asserts the route answers a JSON array rather than a status code. A Smithy list payload used to answer `{}`, which every check phrased as a status code passes.

## The console

All three hosts now name the reference page:

```
info: Sample.Host[0] Listening on http://localhost:5422
info: Sample.Host[0] Browse http://localhost:5422/docs to access your API.
```

`http` rather than `https`, because that is what the template serves. Gated on `environment.Matches("development")`, because the page is. Confirmed present in the development run log and absent from the production one. The Lambda harness needed `app.Run` split into `StartAsync` and `WaitForShutdownAsync` to have somewhere to print after the server is up.

## Verification

All nine template combinations pass `verify-templates.sh`. The solution builds and all 30 test assemblies pass. The Release build with `ContinuousIntegrationBuild=true` is clean, with the pinned Smithy CLI 1.73.0 on `PATH`.

## Not fixed

`ShapeFacts` carries no format for a list's item type, so a `list of Long` generates `List<int>`. That predates this change and affects array properties and parameters the same way, so I left it consistent rather than fixing one of the three sites.

## Follows

`ipjohnson/Hardened.Docs` branch `template-todos-listing-docs` updates the quickstarts to match. It is pushed and unopened, and should land after this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F8CoxcUDqi8K7y1CbkuAi