### PR TITLE
Re-mean [Authorize<T>]: the type parameter is the scheme, the policy rides second

### DIFF
--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -26,7 +26,15 @@ serving the source verbatim where that is wanted.
   `components.securitySchemes` and the effective `security` per operation. Smithy: from the
   service's auth trait (`@httpBearerAuth`, `@httpBasicAuth`, `@httpDigestAuth`,
   `@httpApiKeyAuth`), minus operations opting out with `@auth([])`; sigv4 has no OpenAPI spelling
-  and stays unpublished. Code-first has no way to declare a scheme yet.
+  and stays unpublished. Code-first declares a scheme as a type - a class implementing
+  `IAuthenticationScheme`, shaped by `[HttpAuthenticationScheme]`, `[ApiKeyAuthenticationScheme]`
+  or `[OAuth2AuthenticationScheme]` - and using it anywhere is declaring it:
+  `[Authorize<BearerAuth>]` requires an authenticated caller and puts the scheme in the document,
+  `[Authorize<BearerAuth, CanManagePets>]` conjoins a policy, and `[AuthorizeGrants]` beside
+  either becomes the requirement's scope list where the scheme kind carries scopes (OAuth2), and
+  "authenticated via this scheme" where it cannot - the same rule the OpenAPI reader applies in
+  the other direction. A derived grants attribute or an `IGrantProvider` computes its grants at
+  run time, so those operations publish the scheme requirement without scopes.
 - **Parameters** - the declared wire type, format, bounds, pattern, item counts, enum vocabulary
   and default, from the contract. A parameter carrying a default publishes `required: false`,
   because the binder answers an absent value with the default. A code-first enum parameter
@@ -60,6 +68,8 @@ serving the source verbatim where that is wanted.
 | `[Throws<T>(status)]` | handler | a thrown status, into the document |
 | `SuccessStatus = 201` | verb attribute | the success status, code-first Standard mode |
 | `[JsonEnumNaming(...)]` | assembly or enum | the wire vocabulary: converters, binder, document |
+| `IAuthenticationScheme` + shape attribute | scheme class | a security scheme, declared by being used |
+| `[Authorize<TAuth>]` / `[Authorize<TAuth, TPolicy>]` | handler or controller | the requirement, enforced and published |
 | `ValidationModules.Constraints.*` | model properties | validation, and the schema facets |
 
 ## What holds it true
@@ -72,7 +82,7 @@ Strict parsing is part of the assertion: `System.Text.Json` refuses raw control 
 multi-line description that stopped being escaped fails these suites rather than the reference
 page.
 
-Known gaps, stated rather than implied: code-first cannot declare a security scheme or express a
+Known gaps, stated rather than implied: code-first cannot express a
 constraint on a query, header or path parameter (`HRDV001` names the ways out); a `Nullable`
 scalar parameter whose type argument did not survive the syntax transform still publishes as a
 string; and `@timestampFormat` is read for nullability and otherwise inert.

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -82,6 +82,20 @@ namespace Hardened.Requests.Abstract.Authorization
         public string? Subject { get; }
         public bool TryGetClaim(string name, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out string value) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class ApiKeyAuthenticationSchemeAttribute : System.Attribute
+    {
+        public ApiKeyAuthenticationSchemeAttribute(string name, Hardened.Requests.Abstract.Authorization.ApiKeyLocation location) { }
+        public string? Description { get; set; }
+        public Hardened.Requests.Abstract.Authorization.ApiKeyLocation Location { get; }
+        public string Name { get; }
+    }
+    public enum ApiKeyLocation
+    {
+        Header = 0,
+        Query = 1,
+        Cookie = 2,
+    }
     public sealed class AuthorizationChallenge
     {
         public const string BearerScheme = "Bearer";
@@ -149,6 +163,14 @@ namespace Hardened.Requests.Abstract.Authorization
         public static Hardened.Requests.Abstract.Authorization.GrantResolution Granting(params string[] granted) { }
         public static Hardened.Requests.Abstract.Authorization.GrantResolution Refusing(Hardened.Requests.Abstract.Authorization.AuthorizationDecision decision) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class HttpAuthenticationSchemeAttribute : System.Attribute
+    {
+        public HttpAuthenticationSchemeAttribute(string scheme) { }
+        public string? BearerFormat { get; set; }
+        public string? Description { get; set; }
+        public string Scheme { get; }
+    }
     public interface IActivityAuthorizationHandler
     {
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.GrantResolution> Resolve(Hardened.Requests.Abstract.Execution.IExecutionContext context, System.Collections.Generic.IReadOnlyList<string> grants);
@@ -158,6 +180,7 @@ namespace Hardened.Requests.Abstract.Authorization
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.AuthorizationDecision> Authorize(Hardened.Requests.Abstract.Execution.IExecutionContext context, params string[] grants);
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.GrantResolution> Resolve(Hardened.Requests.Abstract.Execution.IExecutionContext context, System.Collections.Generic.IReadOnlyList<string> grants);
     }
+    public interface IAuthenticationScheme { }
     public interface IAuthorizationConvention
     {
         Hardened.Requests.Abstract.Authorization.Requirement? Apply(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo);
@@ -178,6 +201,23 @@ namespace Hardened.Requests.Abstract.Authorization
         string? Issuer { get; }
         string? Subject { get; }
         bool TryGetClaim(string name, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out string value);
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class OAuth2AuthenticationSchemeAttribute : System.Attribute
+    {
+        public OAuth2AuthenticationSchemeAttribute(Hardened.Requests.Abstract.Authorization.OAuth2Flow flow) { }
+        public string? AuthorizationUrl { get; set; }
+        public string? Description { get; set; }
+        public Hardened.Requests.Abstract.Authorization.OAuth2Flow Flow { get; }
+        public string? RefreshUrl { get; set; }
+        public string? TokenUrl { get; set; }
+    }
+    public enum OAuth2Flow
+    {
+        AuthorizationCode = 0,
+        ClientCredentials = 1,
+        Implicit = 2,
+        Password = 3,
     }
     public abstract class Requirement
     {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -49,7 +49,15 @@ namespace Hardened.Requests.Runtime.Authorization
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection RequireAuthorization(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
-    public sealed class AuthorizeAttribute<TPolicy> : System.Attribute, Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute
+    public sealed class AuthorizeAttribute<TAuth> : System.Attribute, Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute
+        where TAuth : Hardened.Requests.Abstract.Authorization.IAuthenticationScheme
+    {
+        public AuthorizeAttribute() { }
+        public Hardened.Requests.Abstract.Authorization.Requirement Requirement { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
+    public sealed class AuthorizeAttribute<TAuth, TPolicy> : System.Attribute, Hardened.Requests.Abstract.Authorization.IAuthorizeAttribute
+        where TAuth : Hardened.Requests.Abstract.Authorization.IAuthenticationScheme
         where TPolicy : Hardened.Requests.Abstract.Authorization.IAuthorizationPolicy, new ()
     {
         public AuthorizeAttribute() { }

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Authorization/AuthenticationSchemeAttributeTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Authorization/AuthenticationSchemeAttributeTests.cs
@@ -1,0 +1,50 @@
+using Hardened.Requests.Abstract.Authorization;
+using Xunit;
+
+namespace Hardened.Requests.Abstract.Tests.Authorization;
+
+/// <summary>
+/// The scheme-shape attributes carry what was declared. The generator reads them as symbols;
+/// these pin the runtime surface an application or a tool reading the metadata sees.
+/// </summary>
+public class AuthenticationSchemeAttributeTests {
+
+    [Fact]
+    public void HttpSchemeCarriesItsShape() {
+        var attribute = new HttpAuthenticationSchemeAttribute("bearer") {
+            BearerFormat = "JWT",
+            Description = "The bearer."
+        };
+
+        Assert.Equal("bearer", attribute.Scheme);
+        Assert.Equal("JWT", attribute.BearerFormat);
+        Assert.Equal("The bearer.", attribute.Description);
+    }
+
+    [Fact]
+    public void ApiKeySchemeCarriesItsShape() {
+        var attribute = new ApiKeyAuthenticationSchemeAttribute("X-Api-Key", ApiKeyLocation.Header) {
+            Description = "The key."
+        };
+
+        Assert.Equal("X-Api-Key", attribute.Name);
+        Assert.Equal(ApiKeyLocation.Header, attribute.Location);
+        Assert.Equal("The key.", attribute.Description);
+    }
+
+    [Fact]
+    public void OAuth2SchemeCarriesItsShape() {
+        var attribute = new OAuth2AuthenticationSchemeAttribute(OAuth2Flow.ClientCredentials) {
+            TokenUrl = "https://id.example/token",
+            AuthorizationUrl = "https://id.example/authorize",
+            RefreshUrl = "https://id.example/refresh",
+            Description = "The flow."
+        };
+
+        Assert.Equal(OAuth2Flow.ClientCredentials, attribute.Flow);
+        Assert.Equal("https://id.example/token", attribute.TokenUrl);
+        Assert.Equal("https://id.example/authorize", attribute.AuthorizationUrl);
+        Assert.Equal("https://id.example/refresh", attribute.RefreshUrl);
+        Assert.Equal("The flow.", attribute.Description);
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/AuthenticationSchemeAttributes.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/AuthenticationSchemeAttributes.cs
@@ -1,0 +1,84 @@
+namespace Hardened.Requests.Abstract.Authorization;
+
+/// <summary>Where an API key travels.</summary>
+public enum ApiKeyLocation {
+    Header,
+    Query,
+    Cookie
+}
+
+/// <summary>The OAuth2 flow a scheme declares.</summary>
+public enum OAuth2Flow {
+    AuthorizationCode,
+    ClientCredentials,
+    Implicit,
+    Password
+}
+
+/// <summary>
+/// Declares an <see cref="IAuthenticationScheme"/> type as an HTTP authentication scheme -
+/// <c>bearer</c>, <c>basic</c>, <c>digest</c>.
+/// </summary>
+/// <remarks>
+/// The arguments become the scheme's <c>components.securitySchemes</c> entry, keyed by the
+/// declaring type's name. An HTTP scheme cannot carry scopes, so grants required beside it reach
+/// the document as "authenticated via this scheme" and nothing more - the same rule the OpenAPI
+/// reader applies in the other direction.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class HttpAuthenticationSchemeAttribute : Attribute {
+    public HttpAuthenticationSchemeAttribute(string scheme) {
+        Scheme = scheme;
+    }
+
+    /// <summary>The RFC 9110 auth-scheme token: <c>bearer</c>, <c>basic</c>, <c>digest</c>.</summary>
+    public string Scheme { get; }
+
+    /// <summary>A hint for documentation - <c>JWT</c>, typically.</summary>
+    public string? BearerFormat { get; set; }
+
+    public string? Description { get; set; }
+}
+
+/// <summary>
+/// Declares an <see cref="IAuthenticationScheme"/> type as an API-key scheme.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class ApiKeyAuthenticationSchemeAttribute : Attribute {
+    public ApiKeyAuthenticationSchemeAttribute(string name, ApiKeyLocation location) {
+        Name = name;
+        Location = location;
+    }
+
+    /// <summary>The header, query or cookie name the key travels in.</summary>
+    public string Name { get; }
+
+    public ApiKeyLocation Location { get; }
+
+    public string? Description { get; set; }
+}
+
+/// <summary>
+/// Declares an <see cref="IAuthenticationScheme"/> type as an OAuth2 scheme with one flow.
+/// </summary>
+/// <remarks>
+/// OAuth2 is the scheme kind that carries scopes, so grants required beside it become the
+/// requirement's scope list in the published document. The flow's scope catalogue is emitted
+/// empty for now; the scopes an operation actually requires appear on the operation.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class OAuth2AuthenticationSchemeAttribute : Attribute {
+    public OAuth2AuthenticationSchemeAttribute(OAuth2Flow flow) {
+        Flow = flow;
+    }
+
+    public OAuth2Flow Flow { get; }
+
+    public string? AuthorizationUrl { get; set; }
+
+    public string? TokenUrl { get; set; }
+
+    public string? RefreshUrl { get; set; }
+
+    public string? Description { get; set; }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/IAuthenticationScheme.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/IAuthenticationScheme.cs
@@ -1,0 +1,23 @@
+namespace Hardened.Requests.Abstract.Authorization;
+
+/// <summary>
+/// A way a caller is established, named as a type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A marker, deliberately. The scheme's document shape rides an attribute on the implementing
+/// type - <see cref="HttpAuthenticationSchemeAttribute"/> and friends - because the source
+/// generator reads attributes and cannot execute members. The type itself is the identity:
+/// <c>[Authorize&lt;BearerAuth&gt;]</c> names it, "find references" finds every operation that
+/// requires it, and the published document's <c>securitySchemes</c> entry is keyed by the type's
+/// name. Declaring a scheme is therefore just declaring the type; using it anywhere puts it in
+/// the document.
+/// </para>
+/// <para>
+/// The scheme says how a caller is established, and nothing about what they may do. Grants stay
+/// scheme-less on purpose - <c>IActivityAuthorizationService</c>'s contributors may resolve them
+/// from the credential or from a store - so the same grant can be satisfiable under two schemes,
+/// and two callers on one scheme can hold different grants.
+/// </para>
+/// </remarks>
+public interface IAuthenticationScheme;

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
@@ -20,6 +20,9 @@ namespace Hardened.Requests.Runtime.Tests.Authorization;
 /// </summary>
 public class AuthorizationFilterProviderTests {
 
+    [HttpAuthenticationScheme("bearer")]
+    private sealed class BearerAuth : IAuthenticationScheme;
+
     private class CanManagePets : AuthorizationPolicy {
         protected override Requirement Define() => Grant("pets:manage");
     }
@@ -118,7 +121,7 @@ public class AuthorizationFilterProviderTests {
 
     [Fact]
     public void APolicyAttributeProducesAFilter() {
-        Assert.NotNull(Filter(false, new AuthorizeAttribute<CanManagePets>()));
+        Assert.NotNull(Filter(false, new AuthorizeAttribute<BearerAuth, CanManagePets>()));
     }
 
     /// <summary>
@@ -128,7 +131,7 @@ public class AuthorizationFilterProviderTests {
     /// </summary>
     [Fact]
     public void AllowAnonymousWinsOverARequirementOnTheSameHandler() {
-        Assert.Null(Filter(false, new AuthorizeAttribute<CanManagePets>(), new AllowAnonymousAttribute()));
+        Assert.Null(Filter(false, new AuthorizeAttribute<BearerAuth, CanManagePets>(), new AllowAnonymousAttribute()));
     }
 
     /// <summary>
@@ -216,7 +219,7 @@ public class AuthorizationFilterProviderTests {
         object[] metadata = [
             new AuthorizeGrantsAttribute("tenant:member"),
             new AuthorizeGrantsAttribute<PetsReadWrite>(),
-            new AuthorizeAttribute<CanManagePets>(),
+            new AuthorizeAttribute<BearerAuth, CanManagePets>(),
         ];
 
         Assert.True(await Admits(
@@ -283,7 +286,7 @@ public class AuthorizationFilterProviderTests {
     [Fact]
     public async Task APolicyAndAGrantAttributeMustBothHold() {
         object[] metadata = [
-            new AuthorizeAttribute<CanManagePets>(),
+            new AuthorizeAttribute<BearerAuth, CanManagePets>(),
             new AuthorizeGrantsAttribute("pets:read"),
         ];
 
@@ -313,7 +316,7 @@ public class AuthorizationFilterProviderTests {
     /// </summary>
     [Fact]
     public void ARequirementOverTheRequestRunsAfterParametersAreBound() {
-        var filter = Filter(false, new AuthorizeAttribute<MustOwnTheResource>())!;
+        var filter = Filter(false, new AuthorizeAttribute<BearerAuth, MustOwnTheResource>())!;
 
         Assert.Equal(FilterOrder.Authorization, filter.Order);
         Assert.True(filter.Order > FilterOrder.Validation);
@@ -329,7 +332,7 @@ public class AuthorizationFilterProviderTests {
         var filter = Filter(
             false,
             new AuthorizeGrantsAttribute("pets:read"),
-            new AuthorizeAttribute<MustOwnTheResource>())!;
+            new AuthorizeAttribute<BearerAuth, MustOwnTheResource>())!;
 
         Assert.Equal(FilterOrder.Authorization, filter.Order);
     }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizeAttributeTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizeAttributeTests.cs
@@ -28,26 +28,47 @@ public class AuthorizeAttributeTests {
     private static ICallerPrincipal Holding(params string[] grants) =>
         new CallerPrincipal("bearer", grants);
 
-    #region the typed form
+    /// <summary>The scheme the typed forms name. The shape attribute is the document's business.</summary>
+    [HttpAuthenticationScheme("bearer")]
+    private sealed class BearerAuth : IAuthenticationScheme;
 
+    #region the typed forms
+
+    /// <summary>
+    /// The single type parameter is the scheme, and the requirement is "an authenticated
+    /// caller" - the spelling that had none before the slot was re-meant.
+    /// </summary>
     [Fact]
-    public void Authorize_YieldsThePolicysRequirement() {
-        var requirement = new AuthorizeAttribute<CanManagePets>().Requirement;
+    public void AuthorizeScheme_RequiresAnAuthenticatedCaller() {
+        var requirement = new AuthorizeAttribute<BearerAuth>().Requirement;
+
+        Assert.True(requirement.IsSatisfiedBy(Holding(), Context));
+        Assert.False(requirement.IsSatisfiedBy(AnonymousCallerPrincipal.Instance, Context));
+    }
+
+    /// <summary>
+    /// The policy rides second and its tree still decides, conjoined with authenticated - so a
+    /// context-only policy cannot admit an anonymous caller by accident.
+    /// </summary>
+    [Fact]
+    public void AuthorizeSchemeAndPolicy_YieldsThePolicysRequirement() {
+        var requirement = new AuthorizeAttribute<BearerAuth, CanManagePets>().Requirement;
 
         Assert.True(requirement.IsSatisfiedBy(Holding("pets:read", "pets:write"), Context));
         Assert.True(requirement.IsSatisfiedBy(Holding("admin:*"), Context));
         Assert.False(requirement.IsSatisfiedBy(Holding("pets:read"), Context));
+        Assert.False(requirement.IsSatisfiedBy(AnonymousCallerPrincipal.Instance, Context));
     }
 
     /// <summary>
-    /// One policy instance per closed type, however many handlers carry the attribute. Writing
-    /// <c>[Authorize&lt;CanManagePets&gt;]</c> on a hundred handlers costs one tree.
+    /// One requirement per closed type, however many handlers carry the attribute. Writing
+    /// <c>[Authorize&lt;BearerAuth, CanManagePets&gt;]</c> on a hundred handlers costs one tree.
     /// </summary>
     [Fact]
     public void Authorize_SharesOneRequirementAcrossEveryInstance() {
         Assert.Same(
-            new AuthorizeAttribute<CanManagePets>().Requirement,
-            new AuthorizeAttribute<CanManagePets>().Requirement);
+            new AuthorizeAttribute<BearerAuth, CanManagePets>().Requirement,
+            new AuthorizeAttribute<BearerAuth, CanManagePets>().Requirement);
     }
 
     #endregion
@@ -116,14 +137,15 @@ public class AuthorizeAttributeTests {
     [Fact]
     public void BothFormsAreFoundThroughOneInterface() {
         object[] metadata = [
-            new AuthorizeAttribute<CanManagePets>(),
+            new AuthorizeAttribute<BearerAuth>(),
+            new AuthorizeAttribute<BearerAuth, CanManagePets>(),
             new AuthorizeGrantsAttribute("pets:read"),
             "something else entirely",
         ];
 
         var requirements = metadata.OfType<IAuthorizeAttribute>().Select(a => a.Requirement).ToArray();
 
-        Assert.Equal(2, requirements.Length);
+        Assert.Equal(3, requirements.Length);
         Assert.All(requirements, Assert.NotNull);
     }
 
@@ -138,7 +160,8 @@ public class AuthorizeAttributeTests {
     }
 
     [Theory]
-    [InlineData(typeof(AuthorizeAttribute<CanManagePets>))]
+    [InlineData(typeof(AuthorizeAttribute<BearerAuth>))]
+    [InlineData(typeof(AuthorizeAttribute<BearerAuth, CanManagePets>))]
     [InlineData(typeof(AuthorizeGrantsAttribute))]
     [InlineData(typeof(AllowAnonymousAttribute))]
     public void EveryFormAppliesToAMethodOrAClass(Type attributeType) {

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizeAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizeAttribute.cs
@@ -3,31 +3,76 @@ using Hardened.Requests.Abstract.Authorization;
 namespace Hardened.Requests.Runtime.Authorization;
 
 /// <summary>
-/// Requires the caller to satisfy <typeparamref name="TPolicy"/>.
+/// Requires a caller established via <typeparamref name="TAuth"/>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The hand-authored form: typed, findable by "go to references", and renamed by a refactor along
-/// with the policy it names. The composition lives inside the policy, so this attribute never needs
-/// a variant per permutation of grants - <c>[AuthorizeAny&lt;A, B, C&gt;]</c> was the wrong shape.
+/// The single type parameter is the authentication scheme, not the policy. It used to be the
+/// policy; the policy now rides second, in <see cref="AuthorizeAttribute{TAuth,TPolicy}"/>,
+/// because an operation's scheme is the fact every secured operation has and most only have -
+/// "an authenticated caller" needed no spelling at all before this - and because the published
+/// document needs the scheme named to declare anything. A policy type written here fails the
+/// constraint at the call site, which names <see cref="IAuthenticationScheme"/> and is the
+/// migration message: move the policy to the second position.
 /// </para>
 /// <example>
 /// <code>
-/// [Authorize&lt;CanManagePets&gt;]
+/// [HttpAuthenticationScheme("bearer")]
+/// public sealed class BearerAuth : IAuthenticationScheme;
+///
+/// [Authorize&lt;BearerAuth&gt;]
+/// [Post("/pets")]
+/// public Task&lt;Pet&gt; CreatePet(CreatePetRequest body) =&gt; ...;
+/// </code>
+/// </example>
+/// <para>
+/// Using a scheme anywhere is what declares it: the generator collects every
+/// <typeparamref name="TAuth"/> the handlers name into <c>components.securitySchemes</c>, and
+/// the operation carries its requirement. Enforcement is
+/// <see cref="Requirement.Authenticated"/> - which issuer and token shape the scheme means is
+/// the application's authentication middleware's business, exactly as it was.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class AuthorizeAttribute<TAuth> : Attribute, IAuthorizeAttribute
+    where TAuth : IAuthenticationScheme {
+
+    public Requirement Requirement => Requirement.Authenticated();
+}
+
+/// <summary>
+/// Requires a caller established via <typeparamref name="TAuth"/> who satisfies
+/// <typeparamref name="TPolicy"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hand-authored composition form: typed, findable by "go to references", and renamed by a
+/// refactor along with the policy it names. The composition lives inside the policy, so this
+/// attribute never needs a variant per permutation of grants -
+/// <c>[AuthorizeAny&lt;A, B, C&gt;]</c> was the wrong shape.
+/// </para>
+/// <example>
+/// <code>
+/// [Authorize&lt;BearerAuth, CanManagePets&gt;]
 /// [Get("/pets/{petId}")]
 /// public Task&lt;Pet&gt; GetPet(string petId) =&gt; ...;
 /// </code>
 /// </example>
 /// <para>
 /// The policy is constructed once per closed type and its requirement built once, so writing this
-/// on a hundred handlers costs one instance and one tree.
+/// on a hundred handlers costs one instance and one tree. The requirement conjoins
+/// <see cref="Requirement.Authenticated"/> with the policy's own, which is what the pipeline
+/// would do anyway for a policy over grants and makes a context-only policy still demand a
+/// caller.
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-public sealed class AuthorizeAttribute<TPolicy> : Attribute, IAuthorizeAttribute
+public sealed class AuthorizeAttribute<TAuth, TPolicy> : Attribute, IAuthorizeAttribute
+    where TAuth : IAuthenticationScheme
     where TPolicy : IAuthorizationPolicy, new() {
 
-    private static readonly TPolicy _policy = new();
+    private static readonly Requirement _requirement =
+        Requirement.Authenticated() & new TPolicy().Requirement;
 
-    public Requirement Requirement => _policy.Requirement;
+    public Requirement Requirement => _requirement;
 }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
@@ -90,6 +90,7 @@ internal static class RequestModelBuilder {
                     ResponseSchemas = model.ResponseSchemas,
                     DeclaredResponsesAreComplete = model.DeclaredResponsesAreComplete,
                     SecurityRequirements = model.SecurityRequirements,
+                    DeclaredSecuritySchemes = model.DeclaredSecuritySchemes,
                     HasGeneratedValidation = model.HasGeneratedValidation,
                 });
             } else {

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
@@ -421,4 +421,104 @@ public class OpenApiDocumentEmissionTests {
     }
 
     #endregion
+
+    #region what [Authorize<TAuth>] declares for the document
+
+    /// <summary>
+    /// Schemes as types, used where they are enforced. Using one is declaring it: the writer
+    /// collects every TAuth the handlers name into components.securitySchemes.
+    /// </summary>
+    private const string SecuredControllers = """
+        [Hardened.Requests.Abstract.Authorization.HttpAuthenticationScheme("bearer", BearerFormat = "JWT")]
+        public sealed class BearerAuth : Hardened.Requests.Abstract.Authorization.IAuthenticationScheme;
+
+        [Hardened.Requests.Abstract.Authorization.OAuth2AuthenticationScheme(
+            Hardened.Requests.Abstract.Authorization.OAuth2Flow.ClientCredentials, TokenUrl = "https://id.example/token")]
+        public sealed class PetsOAuth : Hardened.Requests.Abstract.Authorization.IAuthenticationScheme;
+
+        public record Pet(string Id);
+
+        public class PetController {
+            [Get("/pets/{id}")]
+            [Hardened.Requests.Runtime.Authorization.Authorize<BearerAuth>]
+            public Task<Pet> Get(string id) => Task.FromResult(new Pet(id));
+
+            [Post("/pets")]
+            [Hardened.Requests.Runtime.Authorization.Authorize<PetsOAuth>]
+            [Hardened.Requests.Runtime.Authorization.AuthorizeGrants("pets:write", "pets:admin")]
+            public Task<Pet> Create() => Task.FromResult(new Pet("1"));
+
+            [Delete("/pets/{id}")]
+            [Hardened.Requests.Runtime.Authorization.Authorize<BearerAuth>]
+            [Hardened.Requests.Runtime.Authorization.AuthorizeGrants("pets:admin")]
+            public Task Remove(string id) => Task.CompletedTask;
+
+            [Get("/pets")]
+            public Task<List<Pet>> List() => Task.FromResult(new List<Pet>());
+        }
+        """;
+
+    private static JsonElement SecuredDocument() =>
+        JsonDocument.Parse(Extract(
+            RequestGeneratorHarness
+                .Generate(Application(SecuredControllers, Enable))
+                .AssertNoErrors()
+                .SourceContaining("OpenApiDocument"))).RootElement;
+
+    /// <summary>
+    /// Every scheme the handlers name, keyed by its type's name, shaped by its type's attribute.
+    /// Code-first published no securitySchemes at all before this.
+    /// </summary>
+    [Fact]
+    public void UsedSchemesAreDeclaredInComponents() {
+        var schemes = SecuredDocument().GetProperty("components").GetProperty("securitySchemes");
+
+        var bearer = schemes.GetProperty("BearerAuth");
+
+        Assert.Equal("http", bearer.GetProperty("type").GetString());
+        Assert.Equal("bearer", bearer.GetProperty("scheme").GetString());
+        Assert.Equal("JWT", bearer.GetProperty("bearerFormat").GetString());
+
+        var oauth = schemes.GetProperty("PetsOAuth");
+
+        Assert.Equal("oauth2", oauth.GetProperty("type").GetString());
+        Assert.Equal(
+            "https://id.example/token",
+            oauth.GetProperty("flows").GetProperty("clientCredentials")
+                .GetProperty("tokenUrl").GetString());
+    }
+
+    /// <summary>
+    /// Grants become the requirement's scopes only where the scheme kind can carry them - OAuth2 -
+    /// mirroring the rule the OpenAPI reader applies in the other direction. On an http scheme the
+    /// operation still says "authenticated via this scheme", and the enforcement of the grants is
+    /// unchanged either way.
+    /// </summary>
+    [Fact]
+    public void GrantsBecomeScopesOnlyWhereTheSchemeCarriesThem() {
+        var paths = SecuredDocument().GetProperty("paths");
+
+        var create = paths.GetProperty("/pets").GetProperty("post");
+        var oauthRequirement = Assert.Single(create.GetProperty("security").EnumerateArray());
+
+        Assert.Equal(
+            new[] { "pets:write", "pets:admin" },
+            oauthRequirement.GetProperty("PetsOAuth").EnumerateArray()
+                .Select(scope => scope.GetString()));
+
+        var remove = paths.GetProperty("/pets/{id}").GetProperty("delete");
+        var bearerRequirement = Assert.Single(remove.GetProperty("security").EnumerateArray());
+
+        Assert.Equal(0, bearerRequirement.GetProperty("BearerAuth").GetArrayLength());
+    }
+
+    /// <summary>An operation naming no scheme declares no security, exactly as before.</summary>
+    [Fact]
+    public void AnUnsecuredOperationDeclaresNothing() {
+        var list = SecuredDocument().GetProperty("paths").GetProperty("/pets").GetProperty("get");
+
+        Assert.False(list.TryGetProperty("security", out _));
+    }
+
+    #endregion
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -62,6 +62,7 @@ public class RequestHandlerModel {
             // field left out here is a field the document loses only when the application has
             // [Handler] filters, which is the worst kind of sometimes.
             SecurityRequirements = SecurityRequirements,
+            DeclaredSecuritySchemes = DeclaredSecuritySchemes,
             HasGeneratedValidation = HasGeneratedValidation
         };
 
@@ -204,6 +205,14 @@ public class RequestHandlerModel {
     public IReadOnlyList<string> SecurityRequirements { get; set; } =
         System.Array.Empty<string>();
 
+    /// <summary>
+    /// The schemes this handler's attributes declare by using them, for
+    /// <c>components.securitySchemes</c>. Empty for described handlers, whose schemes travel on
+    /// the document identity instead.
+    /// </summary>
+    public IReadOnlyList<SecuritySchemeDeclaration> DeclaredSecuritySchemes { get; set; } =
+        System.Array.Empty<SecuritySchemeDeclaration>();
+
     public override bool Equals(object obj) {
         if (obj is not RequestHandlerModel requestHandlerModel) {
             return false;
@@ -284,6 +293,16 @@ public class RequestHandlerModel {
             if (!string.Equals(
                     SecurityRequirements[i], requestHandlerModel.SecurityRequirements[i],
                     StringComparison.Ordinal)) {
+                return false;
+            }
+        }
+
+        if (DeclaredSecuritySchemes.Count != requestHandlerModel.DeclaredSecuritySchemes.Count) {
+            return false;
+        }
+
+        for (var i = 0; i < DeclaredSecuritySchemes.Count; i++) {
+            if (!DeclaredSecuritySchemes[i].Equals(requestHandlerModel.DeclaredSecuritySchemes[i])) {
                 return false;
             }
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/SecuritySchemeDeclaration.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/SecuritySchemeDeclaration.cs
@@ -1,0 +1,39 @@
+namespace Hardened.SourceGenerator.Models.Request;
+
+/// <summary>
+/// A security scheme a handler's attributes declare: its component name, its OpenAPI JSON, and
+/// whether its kind can carry scopes.
+/// </summary>
+/// <remarks>
+/// Value-equal because it rides <c>RequestHandlerModel</c>'s equality, which is an incremental
+/// cache key - editing a scheme type's attribute must invalidate the document that repeats it.
+/// </remarks>
+public sealed class SecuritySchemeDeclaration : System.IEquatable<SecuritySchemeDeclaration> {
+
+    public SecuritySchemeDeclaration(string name, string json, bool carriesScopes) {
+        Name = name;
+        Json = json;
+        CarriesScopes = carriesScopes;
+    }
+
+    /// <summary>The <c>components.securitySchemes</c> key: the scheme type's name.</summary>
+    public string Name { get; }
+
+    /// <summary>The scheme object, as complete OpenAPI JSON.</summary>
+    public string Json { get; }
+
+    /// <summary>Whether requirements against this scheme may list scopes - OAuth2's privilege.</summary>
+    public bool CarriesScopes { get; }
+
+    public bool Equals(SecuritySchemeDeclaration? other) =>
+        other is not null &&
+        Name == other.Name && Json == other.Json && CarriesScopes == other.CarriesScopes;
+
+    public override bool Equals(object? obj) => Equals(obj as SecuritySchemeDeclaration);
+
+    public override int GetHashCode() {
+        unchecked {
+            return (Name.GetHashCode() * 397) ^ Json.GetHashCode();
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -121,9 +121,24 @@ public static class OpenApiDocumentGenerator {
 
         builder.Append('}');
 
-        var securitySchemes = identity?.SecuritySchemes;
+        // The identity's schemes (a contract's declarations) unioned with the ones handlers
+        // declare by naming them - [Authorize<TAuth>]'s whole premise is that usage is
+        // declaration. Identity wins a name collision, because a contract's spelling is the one
+        // reviewed.
+        var securitySchemes = new List<(string Name, string Json)>(
+            identity?.SecuritySchemes ?? (IReadOnlyList<(string, string)>)System.Array.Empty<(string, string)>());
 
-        if (components.Count > 0 || securitySchemes is { Count: > 0 }) {
+        foreach (var handler in handlers) {
+            foreach (var declared in handler.DeclaredSecuritySchemes) {
+                if (!securitySchemes.Exists(existing => existing.Name == declared.Name)) {
+                    securitySchemes.Add((declared.Name, declared.Json));
+                }
+            }
+        }
+
+        securitySchemes.Sort((left, right) => string.CompareOrdinal(left.Name, right.Name));
+
+        if (components.Count > 0 || securitySchemes.Count > 0) {
             builder.Append(",\"components\":{");
 
             if (components.Count > 0) {
@@ -145,7 +160,7 @@ public static class OpenApiDocumentGenerator {
                 builder.Append('}');
             }
 
-            if (securitySchemes is { Count: > 0 }) {
+            if (securitySchemes.Count > 0) {
                 if (components.Count > 0) {
                     builder.Append(',');
                 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -33,7 +33,7 @@ public abstract class BaseRequestModelGenerator {
             response.ThrowsDiagnostic = string.Join(",", unresolved);
         }
 
-        return Compose(
+        var model = Compose(
             nameModel,
             controllerType,
             methodName,
@@ -52,6 +52,12 @@ public abstract class BaseRequestModelGenerator {
             // leaves the success to the return type.
             response.UnionCases != null || thrown.Count == 0,
             BodySchema(context, methodDeclaration, parameters));
+
+        // After Compose, because it is a fact about the handler rather than an input to
+        // assembling it: what the attributes declare for the published document.
+        SecurityDeclarationSelector.Apply(context, methodDeclaration, model, cancellationToken);
+
+        return model;
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/SecurityDeclarationSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/SecurityDeclarationSelector.cs
@@ -1,0 +1,256 @@
+using System.Collections.Generic;
+using System.Threading;
+using Hardened.SourceGenerator.Models.Request;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Hardened.SourceGenerator.Requests;
+
+/// <summary>
+/// What a handler's authorization attributes declare, for the published document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Enforcement never reads this. The pipeline honours <c>IAuthorizeAttribute</c> instances at run
+/// time, attribute bodies and all; the document is written at compile time and can read only what
+/// is literally in the source - a scheme named as <c>[Authorize&lt;TAuth&gt;]</c>'s type argument,
+/// grants named as <c>[AuthorizeGrants("...")]</c>'s literal arguments. A derived grants
+/// attribute or an <c>IGrantProvider</c> computes its grants in a constructor the generator
+/// cannot execute, so those operations publish "authenticated via the scheme" and nothing more -
+/// the same boundary <c>[Throws&lt;T&gt;]</c> lives with, stated rather than guessed at.
+/// </para>
+/// <para>
+/// Using a scheme is declaring it: every distinct <c>TAuth</c> found on a handler or its
+/// controller reaches <c>components.securitySchemes</c>, keyed by the type's name, with its
+/// shape read from the scheme type's own attribute. Grants become the requirement's scope list
+/// only when the scheme kind can carry one - OAuth2 - mirroring the rule the OpenAPI reader
+/// applies in the other direction. Grants with no scheme in sight publish nothing, because a
+/// requirement must reference a declared scheme.
+/// </para>
+/// </remarks>
+internal static class SecurityDeclarationSelector {
+
+    private const string AuthorizeAttributeName =
+        "Hardened.Requests.Runtime.Authorization.AuthorizeAttribute";
+
+    private const string GrantsAttributeName =
+        "Hardened.Requests.Runtime.Authorization.AuthorizeGrantsAttribute";
+
+    private const string SchemeInterface =
+        "Hardened.Requests.Abstract.Authorization.IAuthenticationScheme";
+
+    /// <summary>
+    /// Reads the method's and its controller's attributes and writes what they declare onto the
+    /// model.
+    /// </summary>
+    public static void Apply(
+        GeneratorSyntaxContext context,
+        MethodDeclarationSyntax method,
+        RequestHandlerModel model,
+        CancellationToken cancellationToken) {
+        var schemes = new List<SecuritySchemeDeclaration>();
+        var grants = new List<string>();
+
+        Read(context, method.AttributeLists, schemes, grants, cancellationToken);
+
+        if (method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault()
+            is { } controller) {
+            Read(context, controller.AttributeLists, schemes, grants, cancellationToken);
+        }
+
+        if (schemes.Count == 0) {
+            return;
+        }
+
+        var requirements = new List<string>();
+
+        foreach (var scheme in schemes) {
+            requirements.Add(RequirementJson(scheme, grants));
+        }
+
+        model.DeclaredSecuritySchemes = schemes;
+        model.SecurityRequirements = requirements;
+    }
+
+    private static void Read(
+        GeneratorSyntaxContext context,
+        SyntaxList<AttributeListSyntax> attributeLists,
+        List<SecuritySchemeDeclaration> schemes,
+        List<string> grants,
+        CancellationToken cancellationToken) {
+        foreach (var attributeList in attributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (context.SemanticModel.GetTypeInfo(attribute, cancellationToken).Type
+                    is not INamedTypeSymbol type) {
+                    continue;
+                }
+
+                var definition = type.OriginalDefinition.ToDisplayString();
+
+                if (definition.StartsWith(AuthorizeAttributeName + "<", System.StringComparison.Ordinal) &&
+                    type.TypeArguments.Length >= 1 &&
+                    type.TypeArguments[0] is INamedTypeSymbol schemeType &&
+                    ImplementsScheme(schemeType)) {
+                    var declaration = Declare(schemeType);
+
+                    if (declaration != null &&
+                        !schemes.Exists(existing => existing.Name == declaration.Name)) {
+                        schemes.Add(declaration);
+                    }
+                } else if (definition == GrantsAttributeName) {
+                    // The literal form only. The generic form computes its grants in a provider
+                    // the generator cannot run.
+                    LiteralGrants(attribute, context, grants, cancellationToken);
+                }
+            }
+        }
+    }
+
+    private static bool ImplementsScheme(INamedTypeSymbol type) {
+        foreach (var contract in type.AllInterfaces) {
+            if (contract.ToDisplayString() == SchemeInterface) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>The literal arguments of <c>[AuthorizeGrants("a", "b")]</c>, from the syntax.</summary>
+    private static void LiteralGrants(
+        AttributeSyntax attribute, GeneratorSyntaxContext context, List<string> grants,
+        CancellationToken cancellationToken) {
+        if (attribute.ArgumentList == null) {
+            return;
+        }
+
+        foreach (var argument in attribute.ArgumentList.Arguments) {
+            var value = context.SemanticModel.GetConstantValue(argument.Expression, cancellationToken);
+
+            if (value is { HasValue: true, Value: string grant } &&
+                grant.Length > 0 && !grants.Contains(grant)) {
+                grants.Add(grant);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The scheme type's declared shape as its <c>securitySchemes</c> entry, or null when the
+    /// type carries no shape attribute - a scheme with no declarable shape is enforced and not
+    /// published.
+    /// </summary>
+    private static SecuritySchemeDeclaration? Declare(INamedTypeSymbol schemeType) {
+        foreach (var attribute in schemeType.GetAttributes()) {
+            switch (attribute.AttributeClass?.Name) {
+                case "HttpAuthenticationSchemeAttribute": {
+                    var scheme = Argument(attribute, 0) ?? "bearer";
+                    var json = "{\"type\":\"http\",\"scheme\":\"" + Escape(scheme) + "\"";
+
+                    if (Named(attribute, "BearerFormat") is { } format) {
+                        json += ",\"bearerFormat\":\"" + Escape(format) + "\"";
+                    }
+
+                    json += Description(attribute) + "}";
+
+                    return new SecuritySchemeDeclaration(schemeType.Name, json, carriesScopes: false);
+                }
+
+                case "ApiKeyAuthenticationSchemeAttribute": {
+                    var name = Argument(attribute, 0) ?? "";
+                    var location = attribute.ConstructorArguments.Length > 1
+                        ? attribute.ConstructorArguments[1].Value switch {
+                            1 => "query",
+                            2 => "cookie",
+                            _ => "header"
+                        }
+                        : "header";
+
+                    var json = "{\"type\":\"apiKey\",\"name\":\"" + Escape(name) +
+                               "\",\"in\":\"" + location + "\"" + Description(attribute) + "}";
+
+                    return new SecuritySchemeDeclaration(schemeType.Name, json, carriesScopes: false);
+                }
+
+                case "OAuth2AuthenticationSchemeAttribute": {
+                    var flow = attribute.ConstructorArguments.Length > 0
+                        ? attribute.ConstructorArguments[0].Value switch {
+                            1 => "clientCredentials",
+                            2 => "implicit",
+                            3 => "password",
+                            _ => "authorizationCode"
+                        }
+                        : "authorizationCode";
+
+                    var json = "{\"type\":\"oauth2\",\"flows\":{\"" + flow + "\":{";
+                    var first = true;
+
+                    if (Named(attribute, "AuthorizationUrl") is { } authorization) {
+                        json += "\"authorizationUrl\":\"" + Escape(authorization) + "\"";
+                        first = false;
+                    }
+
+                    if (Named(attribute, "TokenUrl") is { } token) {
+                        json += (first ? "" : ",") + "\"tokenUrl\":\"" + Escape(token) + "\"";
+                        first = false;
+                    }
+
+                    if (Named(attribute, "RefreshUrl") is { } refresh) {
+                        json += (first ? "" : ",") + "\"refreshUrl\":\"" + Escape(refresh) + "\"";
+                        first = false;
+                    }
+
+                    json += (first ? "" : ",") + "\"scopes\":{}}}" + Description(attribute) + "}";
+
+                    return new SecuritySchemeDeclaration(schemeType.Name, json, carriesScopes: true);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string RequirementJson(
+        SecuritySchemeDeclaration scheme, IReadOnlyList<string> grants) {
+        if (!scheme.CarriesScopes || grants.Count == 0) {
+            return "{\"" + Escape(scheme.Name) + "\":[]}";
+        }
+
+        var builder = new System.Text.StringBuilder("{\"")
+            .Append(Escape(scheme.Name)).Append("\":[");
+
+        for (var i = 0; i < grants.Count; i++) {
+            if (i > 0) {
+                builder.Append(',');
+            }
+
+            builder.Append('"').Append(Escape(grants[i])).Append('"');
+        }
+
+        return builder.Append("]}").ToString();
+    }
+
+    private static string? Argument(AttributeData attribute, int index) =>
+        attribute.ConstructorArguments.Length > index
+            ? attribute.ConstructorArguments[index].Value as string
+            : null;
+
+    private static string? Named(AttributeData attribute, string name) {
+        foreach (var argument in attribute.NamedArguments) {
+            if (argument.Key == name && argument.Value.Value is string value && value.Length > 0) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static string Description(AttributeData attribute) =>
+        Named(attribute, "Description") is { } description
+            ? ",\"description\":\"" + Escape(description) + "\""
+            : "";
+
+    private static string Escape(string value) =>
+        OpenApiDocument.JsonSchemaWriter.Escape(value);
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Authorization/RequireAuthorizationDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Authorization/RequireAuthorizationDiagnostics.cs
@@ -56,7 +56,7 @@ public static class RequireAuthorizationDiagnostics {
         title: "Handler carries no authorization attribute",
         messageFormat:
         "'{0}' carries neither an authorization attribute nor [AllowAnonymous], and this application " +
-        "requires one, so the handler will refuse every request at run time. Write [Authorize<T>] or " +
+        "requires one, so the handler will refuse every request at run time. Write [Authorize<TAuth>], [Authorize<TAuth, TPolicy>] or " +
         "[AuthorizeGrants] to say what it needs, or [AllowAnonymous] to say it is public on purpose.",
         category: "Hardened.Authorization",
         defaultSeverity: DiagnosticSeverity.Warning,

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OpenApiRoundTripTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OpenApiRoundTripTests.cs
@@ -52,6 +52,14 @@ public class OpenApiRoundTripTests {
 
         public enum Priority { Standard, Express, NextDay }
 
+        [Hardened.Requests.Abstract.Authorization.HttpAuthenticationScheme("bearer", BearerFormat = "JWT")]
+        public sealed class BearerAuth : Hardened.Requests.Abstract.Authorization.IAuthenticationScheme;
+
+        [Hardened.Requests.Abstract.Authorization.OAuth2AuthenticationScheme(
+            Hardened.Requests.Abstract.Authorization.OAuth2Flow.ClientCredentials,
+            TokenUrl = "https://id.example/token")]
+        public sealed class OrdersOAuth : Hardened.Requests.Abstract.Authorization.IAuthenticationScheme;
+
         public class Order {
             [StringLength(3, 12)]
             [Pattern("^[A-Z0-9-]+$")]
@@ -93,10 +101,13 @@ public class OpenApiRoundTripTests {
                 [FromQueryString] int limit = 20) => new();
 
             [Post("/")]
+            [Hardened.Requests.Runtime.Authorization.Authorize<OrdersOAuth>]
+            [Hardened.Requests.Runtime.Authorization.AuthorizeGrants("orders:write")]
             public OrderSummary Create(Order order) => new();
 
             [Obsolete("Cancel the order instead.")]
             [Delete("/{id}")]
+            [Hardened.Requests.Runtime.Authorization.Authorize<BearerAuth>]
             public void Delete(string id) { }
 
             /// <summary>Every scalar a value parsed from text can be declared as.</summary>
@@ -574,6 +585,38 @@ public class OpenApiRoundTripTests {
         Assert.Equal(
             new[] { "standard", "express", "nextDay" },
             priority.Enum!.Select(value => value.GetValue<string>()));
+    }
+
+
+    /// <summary>
+    /// A scheme used is a scheme declared, read back through a real OpenAPI parser: the shape
+    /// from the type's attribute in components, the requirement on the operation, and grants as
+    /// scopes only where the scheme kind carries them.
+    /// </summary>
+    [Fact]
+    public void UsedSchemesRoundTripWithTheirRequirements() {
+        var document = RoundTrip();
+
+        var bearer = document.Components!.SecuritySchemes!["BearerAuth"];
+
+        Assert.Equal(SecuritySchemeType.Http, bearer.Type);
+        Assert.Equal("bearer", bearer.Scheme);
+        Assert.Equal("JWT", bearer.BearerFormat);
+
+        var oauth = document.Components!.SecuritySchemes!["OrdersOAuth"];
+
+        Assert.Equal(SecuritySchemeType.OAuth2, oauth.Type);
+
+        var create = Operation(document, "/orders", HttpMethod.Post);
+        var requirement = Assert.Single(create.Security!);
+        var scopes = Assert.Single(requirement.Values);
+
+        Assert.Equal("orders:write", Assert.Single(scopes));
+
+        var delete = Operation(document, "/orders/{id}", HttpMethod.Delete);
+        var bearerRequirement = Assert.Single(delete.Security!);
+
+        Assert.Empty(Assert.Single(bearerRequirement.Values));
     }
 
 }


### PR DESCRIPTION
Stacked on #204, whose document plumbing this builds on (`DocumentIdentity`, `SecurityRequirements`, the writer's `securitySchemes` emission).

`[Authorize<TAuth>]` requires a caller established via `TAuth`; `[Authorize<TAuth, TPolicy>]` conjoins the policy. The single type parameter used to be the policy. It is now the scheme, because the scheme is the fact every secured operation has and most only have ("an authenticated caller" previously had no spelling at all), and because the published document needs the scheme named before it can declare anything. A policy written in the old position fails the generic constraint at the call site, and the CS0311 names `IAuthenticationScheme`, which is the migration message.

A scheme is a type: a class implementing the `IAuthenticationScheme` marker, shaped by `[HttpAuthenticationScheme("bearer", BearerFormat = "JWT")]`, `[ApiKeyAuthenticationScheme("X-Api-Key", ApiKeyLocation.Header)]` or `[OAuth2AuthenticationScheme(OAuth2Flow.ClientCredentials, TokenUrl = ...)]`. Using a scheme is declaring it: the generator collects every `TAuth` the handlers name into `components.securitySchemes`, keyed by the type's name, and each operation carries its requirement. `[AuthorizeGrants]`'s literal grants become the requirement's scope list where the scheme kind carries scopes (OAuth2) and "authenticated via this scheme" where it cannot, mirroring the rule the OpenAPI reader applies on the way in. Grants computed at run time (a derived attribute, an `IGrantProvider`) publish the scheme without scopes; that is the same information boundary `[Throws<T>]` lives with, stated in the selector's remarks.

Enforcement is unchanged in mechanism: both forms implement `IAuthorizeAttribute` and conjoin as before. The two-argument form conjoins `Requirement.Authenticated()` with the policy's tree, so a context-only policy still demands a caller. This closes the one document gap all three arms of the front-end trial shared: code-first enforced authentication and published no `securitySchemes`, so a generated client sent every request anonymous.

## Verification

Full sweep green: 2,252 generator tests and 332 integration tests across twelve suites, including the migrated `AuthorizeAttributeTests` (which now pin the authenticated-conjunction semantics) and new emission tests asserting scheme declaration by use, scopes on OAuth2 requirements, empty requirements on bearer, and nothing on unsecured operations. PublicApi baselines updated for `Hardened.Requests.Abstract` and `Hardened.Requests.Runtime`.

## Reviewer notes

- Breaking: any existing `[Authorize<SomePolicy>]` fails compilation with CS0311 naming `IAuthenticationScheme`; the fix is `[Authorize<TAuth, SomePolicy>]`. The repo's only usages were in `AuthorizeAttributeTests` and `AuthorizationFilterProviderTests`, both migrated here.
- The OAuth2 flow's `scopes` catalogue is emitted empty for now; the scopes an operation requires appear on the operation. Synthesizing the catalogue from the grants in use is a possible follow-up.
- Scheme-specific runtime enforcement (rejecting a basic credential where bearer is required) remains the authentication middleware's business; a scheme type carrying credential-to-principal behavior is the natural next step and is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaUs7mMTVVSd8stcFxwYDV
