### PR TITLE
Ship the repository README in every package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# <picture><source media="(prefers-color-scheme: dark)" srcset="assets/hardened-mark-dark.svg"><img src="assets/hardened-mark.svg" alt="" width="34"></picture> Hardened.Framework
+![Hardened](https://raw.githubusercontent.com/ipjohnson/Hardened.Framework/main/assets/hardened-icon-128.png)
+
+# Hardened.Framework
 
 A compile-time, source-generated .NET framework for web APIs and serverless functions. The
 dependency injection, routing, parameter binding, configuration and request filters are written by

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,15 +22,26 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
         <PackageIcon>hardened-icon-128.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <!--
-      PackageIcon names a file inside the nupkg, so the icon has to be packed into every
-      package alongside declaring it - a declaration without the file is NU5046 at pack time.
-      One icon for the whole Hardened.* family, from assets/ at the repository root.
+      PackageIcon and PackageReadmeFile both name a file inside the nupkg, so each has to be
+      packed alongside being declared - a declaration without the file is NU5046 for the icon
+      and NU5039 for the readme, both at pack time.
+
+      One icon and one readme for every package in the repository, from the repository root.
+      Every package showing the same readme is deliberate: the packages are one framework, and
+      a per-package readme is a second place for the story to drift out of date.
+
+      Note that nuget.org renders the readme through Markdig with inline HTML disabled, so raw
+      HTML in README.md is displayed as escaped text rather than rendered. That is why the
+      title carries a Markdown image and not the theme-aware <picture> element GitHub supports.
     -->
     <ItemGroup>
         <None Include="$(MSBuildThisFileDirectory)../assets/hardened-icon-128.png"
+              Pack="true" PackagePath="/" Visible="false" />
+        <None Include="$(MSBuildThisFileDirectory)../README.md"
               Pack="true" PackagePath="/" Visible="false" />
     </ItemGroup>
 


### PR DESCRIPTION
No Hardened package has ever carried a readme. `Hardened.Shared.Runtime.0.15.0-rc1000.nupkg` contains the nuspec, the icon, the assembly and the signature. Its metadata has `<icon>` and no `<readme>`, so nuget.org renders the description field and stops. Every package in both repositories is the same.

`PackageReadmeFile` names a path inside the nupkg, so the file has to be packed as well as declared. That is the arrangement `PackageIcon` already had, and the readme simply never got it.

## The title had to change

nuget.org renders readmes through Markdig with `.DisableHtml()` and then sanitizes the output. Raw HTML is escaped rather than rendered. Rendering the current README through that pipeline turns the whole `<picture>` element into visible text:

```
<h1 id="picturesource-mediaprefers-color-scheme-dark-srcset...">&lt;picture&gt;&lt;source media="(prefers-color-scheme: dark)" ... &lt;/picture&gt; Hardened.Framework</h1>
```

Relative image paths are dropped as well, so `assets/hardened-mark.svg` would not have loaded even as plain Markdown.

The mark is now a Markdown image pointing at `hardened-icon-128.png` on raw.githubusercontent.com, which is on nuget.org's allowlist. This costs the dark-mode variant. Markdown cannot switch on `prefers-color-scheme`, and neither mark SVG works alone: `hardened-mark.svg` is `#1B242E` and disappears on dark, `hardened-mark-dark.svg` is `#EBEFF3` and disappears on light. The icon tile carries its own gunmetal background and reads on either.

## Verification

Both READMEs rendered through nuget.org's pipeline, replicating `MarkdownService.cs` against the same pinned `Markdig.Signed 0.37.0` and `HtmlSanitizer 9.0.892`:

```
--- first rendered block:
    <p><img src="https://raw.githubusercontent.com/.../hardened-icon-128.png" class="img-fluid" alt="Hardened"></p>
--- <img> tags: 1
--- empty hrefs (dead links): 0
```

All 22 packages packed locally. Each nuspec carries `<readme>README.md</readme>` and each archive contains the file. `NU5128`/`NU5129` appear in the pack logs and are unchanged from main, where the same generator projects produce them.

Build and tests: 5357 passed, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pDzGPkansX9JYnMUH1Qti