### PR TITLE
Show the same route in all three contract sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ That is a working todo API with tests, on <http://localhost:5080>, with a refere
 `/docs`.
 
 ```console
-$ curl localhost:5080/todos
-[{"id":1,"title":"Read the generated code","done":true},{"id":2,"title":"Add an endpoint","done":false}]
+$ curl localhost:5080/todos/1
+{"id":1,"title":"Read the generated code","done":true}
 ```
 
 Four routes. `GET /todos` has one answer. `GET /todos/{id}`, `POST /todos` and
@@ -59,18 +59,23 @@ interface, no registration. The OpenAPI document is generated *from* your handle
 ```csharp
 [HardenedModule]
 [HardenedWebModule]
-[BasePath("/todos")]               // this assembly's URL space
+[BasePath("/todos")]               // every route below is relative to this
 public partial class TodosLibrary;
 
 public class TodoController {
-    [Get("/")]
-    public IReadOnlyList<Todo> All(ITodoStore store) => store.All();
+    [Get("/{id}")]
+    public Todo ById(ITodoStore store, int id) =>
+        store.Find(id) ?? throw new NotFound("todo", $"No todo has id {id}.").AsException();
 }
 ```
 
-Services arrive as method parameters, alongside the route and body values. Anything the container
-knows about can be asked for that way, and nothing has to be stored on the class. A parameter typed
-as a concrete class is bound from the request body instead.
+That is the `GET /todos/1` from the quickstart. Services arrive as method parameters, alongside
+the route and body values, so anything the container knows about can be asked for that way and
+nothing has to be stored on the class. A parameter typed as a concrete class is bound from the
+request body instead.
+
+The 404 is thrown here because the return type names only the success case. Putting it in the
+signature instead is what the [three return models](#three-return-models) below are about.
 
 The application names its runtime and the libraries it composes, and that is the whole bootstrap:
 


### PR DESCRIPTION
Follow-up to #207. Code-first showed the collection (`All`) while OpenAPI-first and Smithy-first both showed `getTodo`, so the section that exists to compare three ways of writing one contract was comparing three different operations. All three are now `GET /todos/{id}`.

The quickstart `curl` fetches that route too, so the first thing a reader runs is the route the rest of the README dissects. It also shortens the response line — the array was wide enough to scroll inside nuget.org's code block.

```diff
-$ curl localhost:5080/todos
-[{"id":1,"title":"Read the generated code","done":true},{"id":2,"title":"Add an endpoint","done":false}]
+$ curl localhost:5080/todos/1
+{"id":1,"title":"Read the generated code","done":true}
```

## On the handler shown

It is the template's `ById` in expression-bodied form:

```csharp
[Get("/{id}")]
public Todo ById(ITodoStore store, int id) =>
    store.Find(id) ?? throw new NotFound("todo", $"No todo has id {id}.").AsException();
```

Not copied from the template verbatim, and deliberately. The statement-bodied version `hardened-web` ships is shown as-is under **Three return models**, which is the section about response handling. Repeating those nine lines here would have put the same block in the document twice, so this section gets the compact form and the route, the signature and the 404 body are identical either way.

Checked rather than eyeballed: patched into the generated project, built with `-p:ContinuousIntegrationBuild=true` (0 warnings, 0 errors), and run. `GET /todos/1` answers 200 with the body quoted above, `GET /todos/9999` answers 404.

Two small additions so the throw is not left cold at the top of the contract story: a sentence tying the snippet back to the quickstart call, and a pointer to the return-models section for putting the 404 in the signature instead. The `#three-return-models` anchor survives nuget.org's pipeline — it demotes headings but derives ids from the text, and internal `#` links are explicitly allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
