### PR TITLE
Negotiate an error body like an error, not like the operation's success

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/PlainTextErrorResponseTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/PlainTextErrorResponseTests.cs
@@ -1,0 +1,76 @@
+namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
+
+/// <summary>
+/// Errors on an operation whose success is not JSON.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The declared set was collected from the 2xx responses alone, so
+/// <c>/pets/{petId}/label</c> declared <c>text/plain</c> and nothing else - a set no error model
+/// can travel as. Its declared 404 and the framework's own binding 400 both failed to find a
+/// serializer, and the locator's refusal reached the caller as an empty 500. The error
+/// representations are in the set now, after the success ones, so an error is negotiated like an
+/// error while a client with no preference still gets the text the document leads with.
+/// </para>
+/// </remarks>
+public class PlainTextErrorResponseTests {
+
+    /// <summary>
+    /// The ordering half of the fix: the success representation still leads the declared set, so
+    /// a client with no preference gets the text, not the JSON the errors added.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheSuccessStillLeadsTheDeclaredSet(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/pets/7/label");
+
+        response.Assert.Ok();
+
+        Assert.Equal("text/plain", response.Headers["Content-Type"]);
+        Assert.Equal("Pet 7", await Body(response));
+    }
+
+    [HardenedTest]
+    public async Task TheDeclaredNotFoundAnswersAsJson(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/pets/missing/label");
+
+        Assert.Equal(404, response.StatusCode);
+        Assert.Equal("application/json", response.Headers["Content-Type"]);
+
+        var problem = response.Deserialize<Problem>();
+
+        Assert.NotNull(problem);
+        Assert.Equal(404, problem!.Status);
+        Assert.Equal("Not Found", problem.Title);
+    }
+
+    /// <summary>
+    /// The framework's own refusal takes the same route as a declared error: a query value that
+    /// does not parse answers the standard 400 envelope, in JSON, on an operation that produces
+    /// text.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABindingFailureAnswersTheValidationEnvelopeAsJson(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/pets/7/label?copies=abc");
+
+        response.Assert.BadRequest();
+
+        Assert.Equal("application/json", response.Headers["Content-Type"]);
+
+        var error = response.Deserialize<ValidationShape>();
+
+        Assert.Equal("ValidationError", error!.Type);
+        Assert.Equal("copies", Assert.Single(error.Errors).Field);
+    }
+
+    private record ValidationShape(string Type, string Message, List<FieldShape> Errors);
+
+    private record FieldShape(string Field, string Code, string Message);
+
+    private static async Task<string> Body(TestWebResponse response) {
+        response.Body.Position = 0;
+
+        using var reader = new StreamReader(response.Body, leaveOpen: true);
+
+        return await reader.ReadToEndAsync();
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/PetServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/PetServiceImpl.cs
@@ -115,4 +115,21 @@ public class PetServiceImpl : IPetService {
     public Task<string> PetsAsPlainText() {
         return Task.FromResult(string.Join("\n", Pets.Select(pet => $"{pet.Id}: {pet.Name}")));
     }
+
+    /// <summary>
+    /// A scalar <c>text/plain</c> success beside a declared JSON 404, which is the shape whose
+    /// errors could not answer at all while the declared set was collected from the successes
+    /// alone. The 404 is thrown rather than returned: a scalar success stays non-nullable, so the
+    /// generated exception is the one route to this operation's declared error.
+    /// </summary>
+    public Task<string> GetPetLabel(string petId, int? copies) {
+        if (petId == "missing") {
+            throw new GetPetLabelNotFoundException(
+                new Problem { Status = 404, Title = "Not Found" });
+        }
+
+        var line = $"Pet {petId}";
+
+        return Task.FromResult(string.Join("\n", Enumerable.Repeat(line, copies ?? 1)));
+    }
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -304,6 +304,40 @@ paths:
             text/plain:
               schema:
                 type: string
+  # A scalar text/plain success beside a JSON error. The declared set used to be collected from
+  # the 2xx responses alone, so this operation's set was text/plain and nothing else - a set no
+  # error model can travel as - and the 404 below, like the framework's own binding 400, reached
+  # the caller as an empty 500.
+  /pets/{petId}/label:
+    get:
+      tags:
+        - Pet
+      operationId: getPetLabel
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: copies
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: The pet's cage label, one line per copy
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: No pet with that id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /stores:
     get:
       tags:

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ErrorHandlingTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ErrorHandlingTests.cs
@@ -157,4 +157,36 @@ public class ErrorHandlingTests {
 
     private record ConflictShape(string Code, string Message);
 
+    // ------------------------------------------------------------- a committed content type
+
+    /// <summary>
+    /// [RawResponse] commits the content type before the handler runs, so it is still on the
+    /// response when the handler throws - and the raw writer cannot carry an error model. The
+    /// error is recommitted to JSON instead of the locator's refusal escaping as an empty 500.
+    /// </summary>
+    [HardenedTest]
+    public async Task ARawResponseHandlerThatThrowsStillAnswersItsDeclaredStatus(
+        ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/raw-declared-status");
+
+        Assert.Equal(409, response.StatusCode);
+        Assert.Equal("application/json", response.Headers["Content-Type"]);
+
+        var body = response.Deserialize<ConflictShape>();
+
+        Assert.Equal("locked", body!.Code);
+    }
+
+    /// <summary>The same rescue for an unclassified fault: a 500 with a body, in JSON.</summary>
+    [HardenedTest]
+    public async Task ARawResponseHandlerThatFaultsAnswersAJsonServerError(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/raw-server-error");
+
+        Assert.Equal(500, response.StatusCode);
+        Assert.Equal("application/json", response.Headers["Content-Type"]);
+
+        var error = response.Deserialize<ErrorModel>();
+
+        Assert.Equal("ServerError", error.Type);
+    }
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ErrorController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ErrorController.cs
@@ -1,3 +1,4 @@
+using Hardened.Requests.Abstract.Attributes;
 using Hardened.Requests.Runtime.Errors;
 using Hardened.Web.Runtime.Attributes;
 
@@ -57,6 +58,23 @@ public class ErrorController {
     public string DeclaredBody() =>
         throw new Hardened.Requests.Abstract.Errors.StatusCodeException(
             409, new ConflictBody("locked", "held by another writer"));
+
+    /// <summary>
+    /// A committed content type plus a thrown declared status. The commitment happens before the
+    /// handler runs, so it is on the response when the error is serialized - and the raw writer
+    /// takes only strings, bytes and streams, never an error model.
+    /// </summary>
+    [RawResponse]
+    [Get("/raw-declared-status")]
+    public string RawDeclaredStatus() =>
+        throw new Hardened.Requests.Abstract.Errors.StatusCodeException(
+            409, new ConflictBody("locked", "held by another writer"));
+
+    /// <summary>The same commitment against an unclassified fault.</summary>
+    [RawResponse("image/png")]
+    [Get("/raw-server-error")]
+    public byte[] RawServerError() =>
+        throw new InvalidOperationException("the image was not ready");
 
     public record ConflictBody(string Code, string Message);
 

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -1107,6 +1107,10 @@ namespace Hardened.Requests.Abstract.Serializer
         public ContentNegotiationPolicy(Hardened.Requests.Abstract.Serializer.ContentNegotiationMode mode = 0) { }
         public Hardened.Requests.Abstract.Serializer.ContentNegotiationMode Mode { get; }
     }
+    public class ContentTypeNotProducibleException : System.Exception
+    {
+        public ContentTypeNotProducibleException(string message) { }
+    }
     public sealed class DelegatingStringConverter<TValue> : Hardened.Requests.Abstract.Serializer.IStringConverter
     {
         public DelegatingStringConverter(Hardened.Requests.Abstract.Serializer.DelegatingStringConverter<TValue>.TryParse tryParse, string? typeName = null) { }

--- a/src/Requests/Hardened.Requests.Abstract/Serializer/ContentTypeNotProducibleException.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Serializer/ContentTypeNotProducibleException.cs
@@ -1,0 +1,21 @@
+namespace Hardened.Requests.Abstract.Serializer;
+
+/// <summary>
+/// The response promised a representation no registered serializer can write.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A configuration fault, not a client one, which is why it is not a
+/// <see cref="Hardened.Requests.Abstract.Errors.StatusCodeException"/>: a service that commits to
+/// <c>application/pdf</c> with no PDF serializer registered is broken however the client asked, and
+/// answering 406 would make that look like the client's mistake.
+/// </para>
+/// <para>
+/// Typed so the error path can tell this refusal apart from everything else the locator throws.
+/// An error response that cannot travel as the operation's own representation is re-committed to
+/// JSON and sent; a success response that cannot travel as what it promised stays a fault.
+/// </para>
+/// </remarks>
+public class ContentTypeNotProducibleException : Exception {
+    public ContentTypeNotProducibleException(string message) : base(message) { }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/DeclaredContentTypeNegotiationTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/DeclaredContentTypeNegotiationTests.cs
@@ -156,10 +156,9 @@ public class DeclaredContentTypeNegotiationTests {
         var locator = Locator(
             ContentNegotiationMode.Strict, Serializer("application/json", isDefault: true));
 
-        var failure = Assert.Throws<Exception>(
+        var failure = Assert.Throws<ContentTypeNotProducibleException>(
             () => locator.FindResponseSerializer(Context("text/html", "application/pdf")));
 
-        Assert.IsNotType<NotAcceptableException>(failure);
         Assert.Contains("application/pdf", failure.Message);
     }
 

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ExceptionResponseSerializerTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ExceptionResponseSerializerTests.cs
@@ -1,5 +1,6 @@
 using Hardened.Requests.Abstract.Errors;
 using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Logging;
 using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Errors;
@@ -108,6 +109,79 @@ public class ExceptionResponseSerializerTests {
         await fixture.Subject.Handle(context, failure);
 
         fixture.Converter.Received(1).ConvertExceptionToModel(context, failure);
+    }
+
+    // ------------------------------------------------------------------- a committed content type
+
+    /// <summary>
+    /// A committed content type the error model cannot travel as is recommitted to JSON rather
+    /// than escaping as the locator's configuration fault. This is <c>[RawResponse]</c> plus a
+    /// thrown exception, which used to reach the caller as an empty 500.
+    /// </summary>
+    [Fact]
+    public async Task ACommittedTypeThatCannotCarryTheErrorIsRecommittedToJson() {
+        var fixture = new Fixture();
+        var context = Pipeline.Context();
+
+        context.Response.ContentType = "image/png";
+
+        fixture.Converter.ConvertExceptionToModel(context, Arg.Any<Exception>())
+            .Returns((500, new ErrorModel()));
+
+        fixture.Locator.FindResponseSerializer(Arg.Any<IExecutionContext>())
+            .Returns(_ => {
+                if (context.Response.ContentType != KnownContentType.Json) {
+                    throw new ContentTypeNotProducibleException(
+                        "Response committed to content type 'image/png' but no registered " +
+                        "serializer can produce it.");
+                }
+
+                return fixture.Serializer;
+            });
+
+        await fixture.Subject.Handle(context, new InvalidOperationException("failed"));
+
+        Assert.Equal(KnownContentType.Json, context.Response.ContentType);
+        await fixture.Serializer.Received(1).SerializeResponse(context);
+    }
+
+    /// <summary>
+    /// A committed type the error can travel as is honoured. Recommitting is a rescue, not a
+    /// default: a caller of an XML operation still gets its errors in XML.
+    /// </summary>
+    [Fact]
+    public async Task AProducibleCommittedTypeKeepsTheError() {
+        var fixture = new Fixture();
+        var context = Pipeline.Context();
+
+        context.Response.ContentType = "application/xml";
+
+        fixture.Converter.ConvertExceptionToModel(context, Arg.Any<Exception>())
+            .Returns((500, new ErrorModel()));
+
+        await fixture.Subject.Handle(context, new InvalidOperationException("failed"));
+
+        Assert.Equal("application/xml", context.Response.ContentType);
+        await fixture.Serializer.Received(1).SerializeResponse(context);
+    }
+
+    /// <summary>
+    /// A client asking for representations the operation does not have is a different refusal, and
+    /// it keeps travelling to the 406 path rather than being flattened into a JSON error here.
+    /// </summary>
+    [Fact]
+    public async Task ANotAcceptableRefusalIsNotFlattenedToJson() {
+        var fixture = new Fixture();
+        var context = Pipeline.Context();
+
+        fixture.Converter.ConvertExceptionToModel(context, Arg.Any<Exception>())
+            .Returns((400, new ErrorModel()));
+
+        fixture.Locator.FindResponseSerializer(Arg.Any<IExecutionContext>())
+            .Returns(_ => throw new NotAcceptableException(new[] { "text/plain" }));
+
+        await Assert.ThrowsAsync<NotAcceptableException>(
+            () => fixture.Subject.Handle(context, new Exception("failed")));
     }
 
     // ------------------------------------------------------------------------------ logging

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/SerializationLocatorServiceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/SerializationLocatorServiceTests.cs
@@ -229,7 +229,8 @@ public class SerializationLocatorServiceTests {
 
         var locator = Locator(serializers: new[] { json });
 
-        var exception = Assert.Throws<Exception>(() => locator.FindResponseSerializer(context));
+        var exception = Assert.Throws<ContentTypeNotProducibleException>(
+            () => locator.FindResponseSerializer(context));
 
         Assert.Contains("application/pdf", exception.Message);
     }

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/ExceptionResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/ExceptionResponseSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Errors;
 using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Logging;
 using Hardened.Requests.Abstract.Serializer;
 
@@ -48,6 +49,33 @@ public class ExceptionResponseSerializer : IExceptionResponseSerializer {
 
         _requestLogger.RequestFailed(context, exp);
 
-        return _serializationLocatorService.FindResponseSerializer(context).SerializeResponse(context);
+        return FindErrorSerializer(context).SerializeResponse(context);
+    }
+
+    /// <summary>
+    /// The serializer for the error model, negotiated like an error rather than like the
+    /// operation's success.
+    /// </summary>
+    /// <remarks>
+    /// The operation's own representations get first refusal, so a caller of a JSON operation
+    /// still gets JSON errors and an XML one XML. But those representations were declared for the
+    /// success body, and an error model often is not writable as any of them - a
+    /// <c>[RawResponse]</c> handler's committed <c>image/png</c>, or a <c>text/plain</c> operation
+    /// whose raw writer takes only strings. That refusal used to escape as the locator's
+    /// configuration fault and reach the caller as an empty 500. The content type is committed to
+    /// JSON instead - the same move the 406 path makes, and committing rather than clearing is what
+    /// keeps the second pass out of the declared-set tier that just refused - and located again.
+    /// A <see cref="NotAcceptableException"/> is not caught: the client's stated preference is a
+    /// different question, answered where it always was.
+    /// </remarks>
+    private IResponseSerializer FindErrorSerializer(IExecutionContext context) {
+        try {
+            return _serializationLocatorService.FindResponseSerializer(context);
+        }
+        catch (ContentTypeNotProducibleException) {
+            context.Response.ContentType = KnownContentType.Json;
+
+            return _serializationLocatorService.FindResponseSerializer(context);
+        }
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/SerializationLocatorService.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/SerializationLocatorService.cs
@@ -95,7 +95,7 @@ public class SerializationLocatorService : ISerializationLocatorService {
             // Falling through to JSON here would answer a request for application/pdf with a JSON
             // document and no indication anything went wrong. Nothing registered can write what this
             // response promised, which is a configuration problem rather than a client one.
-            throw new Exception(
+            throw new ContentTypeNotProducibleException(
                 $"Response committed to content type '{committedContentType}' but no registered " +
                 "serializer can produce it.");
         }
@@ -187,7 +187,7 @@ public class SerializationLocatorService : ISerializationLocatorService {
         }
 
         if (!producible) {
-            throw new Exception(
+            throw new ContentTypeNotProducibleException(
                 $"This operation declares {string.Join(", ", declared)} and no registered " +
                 "serializer can produce any of them.");
         }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ProducedContentTypesTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ProducedContentTypesTests.cs
@@ -1,0 +1,100 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The set an operation's responses are negotiated against, collected from every declared
+/// response rather than the successes alone.
+/// </summary>
+/// <remarks>
+/// Collected from the 2xx loop only, a <c>text/plain</c> operation declared a set no error model
+/// could travel as, so its declared 404 and the framework's own 400 reached the caller as an
+/// empty 500. The error representations belong in the set - after the success ones, because the
+/// set is negotiated first-match for a client that states no preference and the success
+/// representation must stay the one such a client gets.
+/// </remarks>
+public class ProducedContentTypesTests {
+
+    private const string PlainTextWithErrors = """
+        openapi: 3.0.0
+        info: { title: Labels, version: 1.0.0 }
+        paths:
+          /labels/{id}:
+            get:
+              operationId: getLabel
+              parameters:
+                - { name: id, in: path, required: true, schema: { type: string } }
+              responses:
+                '200':
+                  description: The label
+                  content: { text/plain: { schema: { type: string } } }
+                '404':
+                  description: No such label
+                  content: { application/json: { schema: { $ref: '#/components/schemas/Problem' } } }
+                '429':
+                  description: Slow down
+                  content: { application/json: { schema: { $ref: '#/components/schemas/Problem' } } }
+          /labels/{id}/status:
+            get:
+              operationId: getLabelStatus
+              parameters:
+                - { name: id, in: path, required: true, schema: { type: string } }
+              responses:
+                '200':
+                  description: The status
+                  content: { application/json: { schema: { $ref: '#/components/schemas/Problem' } } }
+                '404':
+                  description: No such label, no body declared for it
+          /labels/{id}/archive:
+            post:
+              operationId: archiveLabel
+              parameters:
+                - { name: id, in: path, required: true, schema: { type: string } }
+              responses:
+                '204': { description: Archived }
+                '404':
+                  description: No such label
+                  content: { application/json: { schema: { $ref: '#/components/schemas/Problem' } } }
+        components:
+          schemas:
+            Problem: { type: object, properties: { detail: { type: string } } }
+        """;
+
+    private static OperationModel Operation(string operationId) {
+        var model = OpenApiSpecParser.Parse(PlainTextWithErrors, "labels", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!.Services.SelectMany(service => service.Operations)
+            .Single(operation => operation.OperationId == operationId);
+    }
+
+    [Fact]
+    public void TheErrorRepresentationsFollowTheSuccessOnes() {
+        Assert.Equal(
+            new[] { "text/plain", "application/json" },
+            Operation("getLabel").ProducedContentTypes);
+    }
+
+    [Fact]
+    public void ARepresentationSharedBySuccessAndErrorAppearsOnce() {
+        Assert.Equal(
+            new[] { "application/json" },
+            Operation("getLabelStatus").ProducedContentTypes);
+    }
+
+    /// <summary>
+    /// A bodiless success contributes nothing, so the set is the error representations alone -
+    /// which are the only bodies this operation ever writes.
+    /// </summary>
+    [Fact]
+    public void ABodilessSuccessLeavesTheErrorRepresentations() {
+        Assert.Equal(
+            new[] { "application/json" },
+            Operation("archiveLabel").ProducedContentTypes);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -2035,6 +2035,8 @@ internal static class OpenApiSpecParser {
             }
 
             if (operation.Responses != null) {
+                var errorContentTypes = new List<string>();
+
                 // Everything the specification says the operation can answer with, other than the
                 // success case. All of it used to be discarded, so a document could describe a 404
                 // and its payload in detail and generate no trace of either.
@@ -2043,6 +2045,14 @@ internal static class OpenApiSpecParser {
                              .OrderBy(r => r.Key, StringComparer.Ordinal)) {
                     if (!int.TryParse(respKvp.Key, out var errorStatus)) {
                         continue;
+                    }
+
+                    if (respKvp.Value?.Content != null) {
+                        foreach (var declared in respKvp.Value.Content.Keys) {
+                            if (!errorContentTypes.Contains(declared)) {
+                                errorContentTypes.Add(declared);
+                            }
+                        }
                     }
 
                     var errorContent = respKvp.Value?.Content != null
@@ -2148,6 +2158,19 @@ internal static class OpenApiSpecParser {
 
                     opModel.SuccessResponses.Add(success);
                     isPrimarySuccess = false;
+                }
+
+                // The error representations, after the loop above on purpose: the declared set is
+                // negotiated first-match for a client that states no preference, so the success
+                // representations must lead and the error ones follow. This entry is what lets an
+                // error answer at all on an operation whose success is not JSON - collected from
+                // the 2xx responses alone, a text/plain operation declared a set no error model
+                // could travel as, and every declared 404 and framework 400 on it reached the
+                // caller as an empty 500.
+                foreach (var errorContentType in errorContentTypes) {
+                    if (!opModel.ProducedContentTypes.Contains(errorContentType)) {
+                        opModel.ProducedContentTypes.Add(errorContentType);
+                    }
                 }
             }
 

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyProducedContentTypesTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyProducedContentTypesTests.cs
@@ -1,0 +1,106 @@
+using Hardened.Generation.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// The set a REST operation's responses are negotiated against, mirroring what the OpenAPI parser
+/// collects from a content map.
+/// </summary>
+/// <remarks>
+/// This front end used to declare no set at all, which left every response negotiated against
+/// every registered serializer - so an <c>@httpPayload</c> string under
+/// <c>@mediaType("text/plain")</c> went out as a quoted JSON string for a client that stated no
+/// preference. The error entry is always <c>application/json</c>, after the success entry because
+/// the set is negotiated first-match; it is what lets a declared error answer on an operation
+/// whose success is not JSON.
+/// </remarks>
+public class SmithyProducedContentTypesTests {
+
+    private const string Model =
+        """
+        { "smithy": "2.0", "shapes": {
+            "com.example#Svc": {
+              "type": "service", "version": "1",
+              "operations": [
+                { "target": "com.example#GetLabel" },
+                { "target": "com.example#GetStatus" } ] },
+            "com.example#GetLabel": {
+              "type": "operation",
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/labels/{id}", "code": 200 } },
+              "input": { "target": "com.example#GetLabelInput" },
+              "output": { "target": "com.example#GetLabelOutput" },
+              "errors": [ { "target": "com.example#NotFoundError" } ] },
+            "com.example#GetLabelInput": {
+              "type": "structure",
+              "members": {
+                "id": { "target": "smithy.api#String",
+                        "traits": { "smithy.api#httpLabel": {}, "smithy.api#required": {} } } } },
+            "com.example#GetLabelOutput": {
+              "type": "structure",
+              "members": {
+                "label": { "target": "com.example#LabelText",
+                           "traits": { "smithy.api#httpPayload": {} } } } },
+            "com.example#LabelText": {
+              "type": "string",
+              "traits": { "smithy.api#mediaType": "text/plain" } },
+            "com.example#GetStatus": {
+              "type": "operation",
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/status", "code": 200 } },
+              "output": { "target": "com.example#GetStatusOutput" },
+              "errors": [ { "target": "com.example#NotFoundError" } ] },
+            "com.example#GetStatusOutput": {
+              "type": "structure",
+              "members": {
+                "state": { "target": "smithy.api#String" } } },
+            "com.example#NotFoundError": {
+              "type": "structure",
+              "traits": { "smithy.api#error": "client", "smithy.api#httpError": 404 },
+              "members": {
+                "message": { "target": "smithy.api#String" } } } } }
+        """;
+
+    private static OperationModel Operation(string operationId) {
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(Model, "labels", diagnostics);
+
+        Assert.NotNull(model);
+
+        return Assert.Single(
+            Assert.Single(model!.Services).Operations, o => o.OperationId == operationId);
+    }
+
+    [Fact]
+    public void ThePayloadMediaTypeLeadsAndTheErrorRepresentationFollows() {
+        Assert.Equal(
+            new[] { "text/plain", "application/json" },
+            Operation("GetLabel").ProducedContentTypes);
+    }
+
+    [Fact]
+    public void AJsonOperationWithJsonErrorsDeclaresItOnce() {
+        Assert.Equal(
+            new[] { "application/json" },
+            Operation("GetStatus").ProducedContentTypes);
+    }
+
+    /// <summary>
+    /// A dispatch protocol names one content type for everything and negotiation has no say, so
+    /// its operations declare no set.
+    /// </summary>
+    [Fact]
+    public void ADispatchOperationDeclaresNoSet() {
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(
+            File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "bank-awsjson.json")),
+            "bank",
+            diagnostics);
+
+        Assert.NotNull(model);
+
+        Assert.All(
+            model!.Services[0].Operations,
+            operation => Assert.Empty(operation.ProducedContentTypes));
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -477,6 +477,25 @@ internal static class SmithySpecParser {
 
         ParseErrors(context, operation, model, protocol);
 
+        // The set the response is negotiated against, mirroring what the OpenAPI parser collects
+        // from a content map. Success first and errors after, because the set is negotiated
+        // first-match for a client that states no preference. The error entry is always
+        // application/json - a REST protocol's error bodies are JSON whatever the success is - and
+        // it is what lets a declared error answer on an operation whose success is not. Dispatch
+        // protocols stay out: the protocol names one content type for everything and negotiation
+        // has no say.
+        if (!protocol.Dispatches) {
+            if (model.ResponseContentType != null &&
+                !model.ProducedContentTypes.Contains(model.ResponseContentType)) {
+                model.ProducedContentTypes.Add(model.ResponseContentType);
+            }
+
+            if (model.ErrorResponses.Count > 0 &&
+                !model.ProducedContentTypes.Contains("application/json")) {
+                model.ProducedContentTypes.Add("application/json");
+            }
+        }
+
         return model;
     }
 


### PR DESCRIPTION
F1 from the Forty-Four Fixes plan. Fixes D-A-02 and D-B-04, two of the trial's five blockers.

## The two mechanisms

**A committed content type survives into the error response.** `[RawResponse]` commits `Response.ContentType` before the handler runs. When the handler throws, `ExceptionResponseSerializer` sets the error model and re-enters the locator, whose committed tier finds that the raw writer takes only strings, bytes and streams. Its refusal escaped as an unhandled exception and the caller saw an empty 500.

**The declared set was collected from the success responses alone.** Both spec parsers filled `ProducedContentTypes` from the 2xx content maps only. A `text/plain` operation therefore declared a set no error model can travel as, and every declared 404 and framework 400 on it failed the same way.

## The fixes

- `ExceptionResponseSerializer.Handle` recommits the response to JSON when the committed or declared representations cannot carry the error model, then locates again. This is the same move the 406 path already makes in `ContextSerializationService.WriteNotAcceptable`. A `NotAcceptableException` is not caught; the client's stated preference still travels to the 406 path.
- The locator's two configuration refusals are now typed as `ContentTypeNotProducibleException` (new public type in `Hardened.Requests.Abstract.Serializer`, approved-api file updated), so the rescue catches exactly them.
- `OpenApiSpecParser` collects error-response content types into `ProducedContentTypes`, appended after the success types so a client with no preference still gets the representation the document leads with.
- `SmithySpecParser` gets the matching change. It previously populated no declared set at all, so a `@mediaType("text/plain")` payload went out JSON-quoted for a client with no preference. REST operations now declare the payload media type plus `application/json` when errors are declared. Dispatch protocols (awsJson) deliberately stay out of negotiation.

## Tests

- `petstore.yaml` gains `GET /pets/{petId}/label`: scalar `text/plain` 200 beside a declared JSON 404, the trial's exact blocker shape. New `PlainTextErrorResponseTests` drives the thrown declared 404 and a query-binding 400 to JSON answers, and pins the ordering (no `Accept` still answers `text/plain`).
- `ErrorController` gains two `[RawResponse]` handlers that throw; `ErrorHandlingTests` asserts the declared 409 with its declared body, and a JSON 500 for an unclassified fault.
- Parser unit tests for both front ends, including dispatch staying out and dedup of shared types.
- Unit tests on the recommit itself: rescue on unproducible commitment, no rescue when the committed type can carry the error, `NotAcceptableException` passes through.

Full suite green, Debug and Release, and the Release build was run CI-style with `ContinuousIntegrationBuild=true` and the pinned Smithy CLI 1.73.0.

## Behaviour notes

- The generated interface for a scalar success with a declared 404 stays non-nullable (`Task<string>`), so the fixture answers its 404 by throwing the generated `GetPetLabelNotFoundException`. The nullable-return route exists only for reference successes.
- With error representations in the declared set, a client sending `Accept: application/json` to the label operation is answered with the string as JSON rather than 406. `/pets/plain` declares no errors and keeps its strict 406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)