### PR TITLE
Publish the constraints the spec-first schema writer was dropping

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/GeneratedDocumentTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/GeneratedDocumentTests.cs
@@ -91,6 +91,51 @@ public class GeneratedDocumentTests {
     }
 
     /// <summary>
+    /// The constraints the contract declares reach the published schemas.
+    /// </summary>
+    /// <remarks>
+    /// The model carried every one of these facts and the writer published none - only type,
+    /// format and description survived, while parameters travelled a function that always knew
+    /// the keywords. The trial's document-fidelity matrix found exactly that inversion: every
+    /// parameter constraint published, every body constraint dropped. These assertions are that
+    /// matrix, over the schemas this contract already declares.
+    /// </remarks>
+    [HardenedTest]
+    public async Task TheSchemasCarryTheConstraintsTheContractDeclared(ITestWebApp app) {
+        var schemas = (await Document(app)).GetProperty("components").GetProperty("schemas");
+
+        var create = schemas.GetProperty("CreatePetRequest").GetProperty("properties");
+
+        Assert.Equal(1, create.GetProperty("name").GetProperty("minLength").GetInt32());
+        Assert.Equal(100, create.GetProperty("name").GetProperty("maxLength").GetInt32());
+        Assert.Equal(
+            "^[a-zA-Z0-9-]*$", create.GetProperty("tag").GetProperty("pattern").GetString());
+
+        var rating = schemas.GetProperty("UpdatePetRequest").GetProperty("properties")
+            .GetProperty("rating");
+
+        Assert.Equal(1, rating.GetProperty("minimum").GetInt32());
+        Assert.Equal(5, rating.GetProperty("maximum").GetInt32());
+    }
+
+    /// <summary>
+    /// A property the contract marks nullable publishes the 2020-12 type array, the way the
+    /// code-first writer already does. The framework's own 404 body sends <c>detail</c> as null.
+    /// </summary>
+    [HardenedTest]
+    public async Task ANullablePropertyPublishesTheTypeArray(ITestWebApp app) {
+        var detail = (await Document(app)).GetProperty("components").GetProperty("schemas")
+            .GetProperty("Problem").GetProperty("properties").GetProperty("detail");
+
+        var type = detail.GetProperty("type");
+
+        Assert.Equal(JsonValueKind.Array, type.ValueKind);
+        Assert.Equal(
+            new[] { "string", "null" },
+            type.EnumerateArray().Select(entry => entry.GetString()).ToArray());
+    }
+
+    /// <summary>
     /// Every verb declared at one path reaches the document, including where they disagree about
     /// the token's constraint.
     /// </summary>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -523,5 +523,9 @@ components:
         status:
           type: integer
           format: int32
+        # Declared nullable, which the published document must repeat as the 2020-12 type array.
+        # The framework's own 404 body sends detail as null, so a document typing it plain string
+        # was describing a payload the service never sends.
         detail:
           type: string
+          nullable: true

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyServedDocumentTests.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyServedDocumentTests.cs
@@ -58,6 +58,51 @@ public class SmithyServedDocumentTests {
     }
 
     /// <summary>
+    /// The <c>@length</c> the model declares on a body member reaches the published schema. Both
+    /// spec front ends share the writer that dropped every body constraint, so this is the Smithy
+    /// half of the same fix the OpenAPI SUT asserts.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheBodySchemasCarryTheConstraintsTheModelDeclares(ITestWebApp app) {
+        var document = await Document(app);
+
+        var bodyRef = document.GetProperty("paths").GetProperty("/pets").GetProperty("post")
+            .GetProperty("requestBody").GetProperty("content").GetProperty("application/json")
+            .GetProperty("schema").GetProperty("$ref").GetString();
+
+        var name = document.GetProperty("components").GetProperty("schemas")
+            .GetProperty(bodyRef!.Substring("#/components/schemas/".Length))
+            .GetProperty("properties").GetProperty("name");
+
+        Assert.Equal(1, name.GetProperty("minLength").GetInt32());
+        Assert.Equal(64, name.GetProperty("maxLength").GetInt32());
+    }
+
+    /// <summary>
+    /// A member that is neither <c>@required</c> nor defaulted is nullable under Smithy's rules,
+    /// and the published schema says so with the 2020-12 type array.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOptionalMemberPublishesTheNullableTypeArray(ITestWebApp app) {
+        var document = await Document(app);
+
+        var responseRef = document.GetProperty("paths").GetProperty("/pets").GetProperty("get")
+            .GetProperty("responses").GetProperty("200").GetProperty("content")
+            .GetProperty("application/json").GetProperty("schema").GetProperty("$ref").GetString();
+
+        var nextToken = document.GetProperty("components").GetProperty("schemas")
+            .GetProperty(responseRef!.Substring("#/components/schemas/".Length))
+            .GetProperty("properties").GetProperty("nextToken");
+
+        var type = nextToken.GetProperty("type");
+
+        Assert.Equal(JsonValueKind.Array, type.ValueKind);
+        Assert.Equal(
+            new[] { "string", "null" },
+            type.EnumerateArray().Select(entry => entry.GetString()).ToArray());
+    }
+
+    /// <summary>
     /// And the status the model declares, rather than a guess.
     /// </summary>
     [HardenedTest]

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/IConstraintFacets.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/IConstraintFacets.cs
@@ -38,4 +38,7 @@ internal interface IConstraintFacets {
     int? MaxItems { get; }
 
     List<string>? EnumValues { get; }
+
+    /// <summary>The declared <c>default</c>, as written in the contract.</summary>
+    string? Default { get; }
 }

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/SchemaModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/SchemaModel.cs
@@ -62,6 +62,14 @@ internal class SchemaModel : IEquatable<SchemaModel> {
     public string? ArrayItemsRef { get; set; }
     public string? ArrayItemsType { get; set; }
     public string? ArrayItemsFormat { get; set; }
+
+    /// <summary>
+    /// The item-count bounds a named array schema declares on itself. A property's bounds live on
+    /// <see cref="PropertyModel"/>; these are for the schema a contract names at the top level,
+    /// whose bound previously had nowhere to land.
+    /// </summary>
+    public int? MinItems { get; set; }
+    public int? MaxItems { get; set; }
     public string? DictionaryValueType { get; set; }
     public string? DictionaryValueRef { get; set; }
     public string? Type { get; set; }
@@ -104,6 +112,8 @@ internal class SchemaModel : IEquatable<SchemaModel> {
                ArrayItemsRef == other.ArrayItemsRef &&
                ArrayItemsType == other.ArrayItemsType &&
                ArrayItemsFormat == other.ArrayItemsFormat &&
+               MinItems == other.MinItems &&
+               MaxItems == other.MaxItems &&
                DictionaryValueType == other.DictionaryValueType &&
                DictionaryValueRef == other.DictionaryValueRef &&
                DiscriminatorPropertyName == other.DiscriminatorPropertyName &&

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -340,6 +340,8 @@ internal static class SpecModelSerializer {
         record.Add("ArrayItemsRef", schema.ArrayItemsRef);
         record.Add("ArrayItemsType", schema.ArrayItemsType);
         record.Add("ArrayItemsFormat", schema.ArrayItemsFormat);
+        record.Add("MinItems", schema.MinItems);
+        record.Add("MaxItems", schema.MaxItems);
         record.Add("DictionaryValueType", schema.DictionaryValueType);
         record.Add("DictionaryValueRef", schema.DictionaryValueRef);
         record.WriteTo(builder);
@@ -427,6 +429,8 @@ internal static class SpecModelSerializer {
         ArrayItemsRef = record.String("ArrayItemsRef"),
         ArrayItemsType = record.String("ArrayItemsType"),
         ArrayItemsFormat = record.String("ArrayItemsFormat"),
+        MinItems = record.Int("MinItems"),
+        MaxItems = record.Int("MaxItems"),
         DictionaryValueType = record.String("DictionaryValueType"),
         DictionaryValueRef = record.String("DictionaryValueRef"),
     };

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/NamedArraySchemaBoundsTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/NamedArraySchemaBoundsTests.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// Item-count bounds on a schema the contract names at the top level.
+/// </summary>
+/// <remarks>
+/// A property's <c>minItems</c> lands on <c>PropertyModel</c> and always did. A named array
+/// schema's landed nowhere - <c>SchemaModel</c> had no field for it - so
+/// <c>Batch: { type: array, minItems: 1 }</c> parsed to an unbounded list and the published
+/// document said nothing either.
+/// </remarks>
+public class NamedArraySchemaBoundsTests {
+
+    private const string Document = """
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /batches:
+            post:
+              operationId: submitBatch
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/Batch'
+              responses:
+                '204': { description: Accepted }
+        components:
+          schemas:
+            Batch:
+              type: array
+              minItems: 1
+              maxItems: 100
+              items:
+                type: string
+        """;
+
+    [Fact]
+    public void TheBoundsLandOnTheSchemaModel() {
+        var model = OpenApiSpecParser.Parse(Document, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        var batch = model!.Schemas.Single(schema => schema.Name == "Batch");
+
+        Assert.Equal(SchemaKind.Array, batch.Kind);
+        Assert.Equal(1, batch.MinItems);
+        Assert.Equal(100, batch.MaxItems);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
@@ -374,6 +374,8 @@ public class SpecModelSerializerTests {
                     ArrayItemsRef = "#/components/schemas/Tag",
                     ArrayItemsType = "string",
                     ArrayItemsFormat = "uuid",
+                    MinItems = 1,
+                    MaxItems = 25,
                     DictionaryValueType = "string",
                     DictionaryValueRef = "#/components/schemas/Value",
                     Type = "object",

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -867,7 +867,9 @@ internal static class OpenApiSpecParser {
             Kind = SchemaKind.Array,
             ArrayItemsRef = GetNonPrimitiveRef(schema.Items),
             ArrayItemsType = SchemaType(schema.Items),
-            ArrayItemsFormat = schema.Items?.Format
+            ArrayItemsFormat = schema.Items?.Format,
+            MinItems = schema.MinItems,
+            MaxItems = schema.MaxItems
         };
     }
 

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecSchemaFacetTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecSchemaFacetTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Generation.Models;
+using Hardened.SourceGenerator.Requests;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// The constraint facets a specification-first body schema publishes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The model carried every one of these and the writer published none - only type, format and
+/// description survived. Parameters travelled a different function that always knew the keywords,
+/// which is how the trial's document-fidelity matrix came out inverted: every parameter constraint
+/// published, every body constraint dropped, on both spec front ends at once, because this writer
+/// is the one they share.
+/// </para>
+/// <para>
+/// The assertion list is that matrix: bounds and their exclusive forms, lengths, pattern, item
+/// counts, default, enum, and nullability as the 2020-12 type array.
+/// </para>
+/// </remarks>
+public class SpecSchemaFacetTests {
+
+    private static string Component(SchemaModel schema, params SchemaModel[] others) {
+        var schemas = new List<SchemaModel> { schema };
+
+        schemas.AddRange(others);
+
+        var handlerSchema = SpecSchemaWriter.ForRef(
+            "#/components/schemas/" + schema.Name, schemas);
+
+        Assert.NotNull(handlerSchema);
+
+        return handlerSchema!.Components.Single(c => c.Name == schema.Name).Json;
+    }
+
+    private static SchemaModel Thing(params PropertyModel[] properties) {
+        var schema = new SchemaModel { Name = "Thing", Kind = SchemaKind.Object };
+
+        schema.Properties.AddRange(properties);
+
+        return schema;
+    }
+
+    [Fact]
+    public void StringFacetsArePublished() {
+        var schema = Component(Thing(new PropertyModel {
+            Name = "code",
+            Type = "string",
+            MinLength = 1,
+            MaxLength = 12,
+            Pattern = "^[a-z]+$"
+        }));
+
+        Assert.Contains("\"minLength\":1", schema);
+        Assert.Contains("\"maxLength\":12", schema);
+        Assert.Contains("\"pattern\":\"^[a-z]+$\"", schema);
+    }
+
+    [Fact]
+    public void NumericBoundsArePublished() {
+        var schema = Component(Thing(new PropertyModel {
+            Name = "rating",
+            Type = "integer",
+            Minimum = 1,
+            Maximum = 5
+        }));
+
+        Assert.Contains("\"minimum\":1", schema);
+        Assert.Contains("\"maximum\":5", schema);
+    }
+
+    /// <summary>
+    /// The 2020-12 spelling, where the exclusive bound is itself the number - the same choice
+    /// <c>JsonSchemaWriter</c> and <c>SchemaConstraintWriter</c> already made, because the default
+    /// document is one this spelling is correct in.
+    /// </summary>
+    [Fact]
+    public void ExclusiveBoundsUseTheModernSpelling() {
+        var schema = Component(Thing(new PropertyModel {
+            Name = "ratio",
+            Type = "number",
+            Minimum = 0,
+            Maximum = 1,
+            ExclusiveMinimum = true,
+            ExclusiveMaximum = true
+        }));
+
+        Assert.Contains("\"exclusiveMinimum\":0", schema);
+        Assert.Contains("\"exclusiveMaximum\":1", schema);
+        Assert.DoesNotContain("\"exclusiveMinimum\":true", schema);
+        Assert.DoesNotContain("\"minimum\"", schema);
+    }
+
+    [Fact]
+    public void ADefaultAndAnInlineEnumArePublished() {
+        var schema = Component(Thing(new PropertyModel {
+            Name = "state",
+            Type = "string",
+            Default = "open",
+            EnumValues = new List<string> { "open", "closed" }
+        }));
+
+        Assert.Contains("\"default\":\"open\"", schema);
+        Assert.Contains("\"enum\":[\"open\",\"closed\"]", schema);
+    }
+
+    [Fact]
+    public void ANullablePropertyPublishesTheTypeArray() {
+        var schema = Component(Thing(new PropertyModel {
+            Name = "deliveredAt",
+            Type = "string",
+            Format = "date-time",
+            IsNullable = true
+        }));
+
+        Assert.Contains("\"deliveredAt\":{\"type\":[\"string\",\"null\"]", schema);
+    }
+
+    [Fact]
+    public void AnArrayPropertyPublishesItsItemBounds() {
+        var schema = Component(Thing(new PropertyModel {
+            Name = "lines",
+            Type = "array",
+            IsArray = true,
+            ArrayItemsType = "string",
+            MinItems = 1,
+            MaxItems = 10
+        }));
+
+        Assert.Contains("\"minItems\":1", schema);
+        Assert.Contains("\"maxItems\":10", schema);
+    }
+
+    [Fact]
+    public void ANamedArraySchemaPublishesItsOwnBounds() {
+        var array = new SchemaModel {
+            Name = "Batch",
+            Kind = SchemaKind.Array,
+            ArrayItemsType = "string",
+            MinItems = 1,
+            MaxItems = 100
+        };
+
+        var schema = Component(array);
+
+        Assert.Contains("\"type\":\"array\"", schema);
+        Assert.Contains("\"minItems\":1", schema);
+        Assert.Contains("\"maxItems\":100", schema);
+    }
+
+    /// <summary>A reference stays a bare reference; the component it names carries the facts.</summary>
+    [Fact]
+    public void AReferencePropertyIsLeftAlone() {
+        var owner = Thing(new PropertyModel {
+            Name = "address",
+            Ref = "#/components/schemas/Address",
+            IsNullable = true,
+            MinLength = 3
+        });
+
+        var address = new SchemaModel { Name = "Address", Kind = SchemaKind.Object };
+
+        var schema = Component(owner, address);
+
+        Assert.Contains("\"address\":{\"$ref\":\"#/components/schemas/Address\"}", schema);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -988,7 +988,7 @@ public static class OpenApiDocumentGenerator {
     /// document is the defect this replaces.
     /// </remarks>
     private static void AppendScalarFacets(
-        StringBuilder builder, string type, string? format, ParameterModel spec,
+        StringBuilder builder, string type, string? format, IConstraintFacets spec,
         OpenApiVersion version, bool openObject) {
         if (openObject) {
             builder.Append('{');
@@ -1000,6 +1000,24 @@ public static class OpenApiDocumentGenerator {
             builder.Append(",\"format\":\"").Append(JsonSchemaWriter.Escape(format!)).Append('"');
         }
 
+        AppendConstraintFacets(builder, type, spec, version);
+
+        if (openObject) {
+            builder.Append('}');
+        }
+    }
+
+    /// <summary>
+    /// The constraint keywords alone, appended to a schema object someone else opened.
+    /// </summary>
+    /// <remarks>
+    /// Shared with <c>SpecSchemaWriter</c>, which writes body schemas from the normalised model.
+    /// Parameters travelled through here from the start, which is why the trial found every
+    /// parameter constraint published and every body constraint dropped - two writers, one of
+    /// which never learned these keywords.
+    /// </remarks>
+    internal static void AppendConstraintFacets(
+        StringBuilder builder, string type, IConstraintFacets spec, OpenApiVersion version) {
         if (spec.EnumValues is { Count: > 0 }) {
             builder.Append(",\"enum\":[");
 
@@ -1050,10 +1068,6 @@ public static class OpenApiDocumentGenerator {
 
         if (!string.IsNullOrEmpty(spec.Default)) {
             builder.Append(",\"default\":").Append(DefaultLiteralJson(type, spec.Default!));
-        }
-
-        if (openObject) {
-            builder.Append('}');
         }
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecSchemaWriter.cs
@@ -156,8 +156,17 @@ internal static class SpecSchemaWriter {
                 Describe(builder, schema.Description);
                 builder.Append(",\"items\":")
                     .Append(Inline(schema.ArrayItemsRef, schema.ArrayItemsType, schema.ArrayItemsFormat,
-                        null, schemas, components, seen))
-                    .Append('}');
+                        null, null, false, schemas, components, seen));
+
+                if (schema.MinItems.HasValue) {
+                    builder.Append(",\"minItems\":").Append(schema.MinItems.Value);
+                }
+
+                if (schema.MaxItems.HasValue) {
+                    builder.Append(",\"maxItems\":").Append(schema.MaxItems.Value);
+                }
+
+                builder.Append('}');
 
                 break;
 
@@ -192,14 +201,25 @@ internal static class SpecSchemaWriter {
             builder.Append('"').Append(JsonSchemaWriter.Escape(property.Name)).Append("\":");
 
             if (property.IsArray) {
-                builder.Append("{\"type\":\"array\",\"items\":")
+                var array = new StringBuilder("{\"type\":\"array\",\"items\":")
                     .Append(Inline(property.ArrayItemsRef, property.ArrayItemsType,
-                        property.ArrayItemsFormat, null, schemas, components, seen))
-                    .Append('}');
+                        property.ArrayItemsFormat, null, null, false, schemas, components, seen));
+
+                if (property.MinItems.HasValue) {
+                    array.Append(",\"minItems\":").Append(property.MinItems.Value);
+                }
+
+                if (property.MaxItems.HasValue) {
+                    array.Append(",\"maxItems\":").Append(property.MaxItems.Value);
+                }
+
+                Describe(array, property.Description);
+
+                builder.Append(Nullable(array.Append('}').ToString(), property.IsNullable));
             }
             else {
                 builder.Append(Inline(property.Ref, property.Type, property.Format,
-                    property.Description, schemas, components, seen));
+                    property.Description, property, property.IsNullable, schemas, components, seen));
             }
         }
 
@@ -247,10 +267,13 @@ internal static class SpecSchemaWriter {
     /// <remarks>
     /// A <c>$ref</c> beside a description is not legal in OpenAPI 3.0 - the sibling keys are ignored
     /// - so a described reference is wrapped in <c>allOf</c>, which is the spelling every tool
-    /// reads. A described scalar carries the description directly.
+    /// reads. A described scalar carries the description directly, and its declared constraints
+    /// with it: the model held every one of them and this writer published none, which is how the
+    /// trial's document-fidelity matrix came out inverted - parameters constrained, bodies bare.
     /// </remarks>
     private static string Inline(
         string? schemaRef, string? type, string? format, string? description,
+        IConstraintFacets? facets, bool isNullable,
         IReadOnlyList<SchemaModel> schemas, Dictionary<string, string> components,
         HashSet<string> seen) {
         if (schemaRef != null) {
@@ -276,9 +299,45 @@ internal static class SpecSchemaWriter {
             builder.Append(",\"format\":\"").Append(JsonSchemaWriter.Escape(format!)).Append('"');
         }
 
+        if (facets != null) {
+            OpenApiDocumentGenerator.AppendConstraintFacets(
+                builder, type ?? "string", facets, OpenApiVersionFacts.Default);
+        }
+
         Describe(builder, description);
 
-        return builder.Append('}').ToString();
+        return Nullable(builder.Append('}').ToString(), isNullable);
+    }
+
+    /// <summary>
+    /// The schema with <c>"null"</c> added to its type when the contract marks the member
+    /// nullable.
+    /// </summary>
+    /// <remarks>
+    /// The 2020-12 spelling - a type array - ported from <c>JsonSchemaWriter.Nullable</c> and
+    /// correct here for the same reason it gives: the default document is one this spelling is
+    /// valid in. A <c>$ref</c> is left alone; the referenced schema describes the type.
+    /// </remarks>
+    private static string Nullable(string schema, bool isNullable) {
+        if (!isNullable) {
+            return schema;
+        }
+
+        const string prefix = "{\"type\":\"";
+
+        if (!schema.StartsWith(prefix, System.StringComparison.Ordinal)) {
+            return schema;
+        }
+
+        var close = schema.IndexOf('"', prefix.Length);
+
+        if (close < 0) {
+            return schema;
+        }
+
+        var name = schema.Substring(prefix.Length, close - prefix.Length);
+
+        return "{\"type\":[\"" + name + "\",\"null\"]" + schema.Substring(close + 1);
     }
 
     private static void Describe(StringBuilder builder, string? description) {


### PR DESCRIPTION
F3 from the Forty-Four Fixes plan. Fixes D-B-08, D-C-01, D-B-09, D-C-08, and the spec half of D-A-10.

## The defect

Both spec front ends share `SpecSchemaWriter`, and it emitted `type`, `format` and `description` and nothing else. `PropertyModel` implements `IConstraintFacets` and carried every declared fact - which is why the normalised-model dumps in the trial showed nothing lost on the way in. Parameters travelled `AppendScalarFacets`, a function the schema writer never called. That is the whole of the trial's document-fidelity inversion: every parameter constraint published, every body constraint dropped, on both spec front ends at once.

## The fix

- The constraint tail of `AppendScalarFacets` is extracted as `AppendConstraintFacets` over `IConstraintFacets` (which gains `Default`), and `SpecSchemaWriter.Inline` calls it - bodies and parameters publish through one function, so they cannot drift again.
- Nullability is the ported `JsonSchemaWriter.Nullable` surgery keyed on `PropertyModel.IsNullable`, in the 2020-12 type-array spelling that writer already chose for the same reason: the version is not known where schemas are built and the default document is one the spelling is correct in.
- `SchemaModel` gains `MinItems`/`MaxItems` so a named top-level array schema's bound has somewhere to land; the OpenAPI parser fills them, `SpecModelSerializer` round-trips them, and the writer emits them. The Smithy parser never builds named array schemas, so it needs no change.
- Array properties publish their bounds and their descriptions, which were also dropped.

## Tests

- `SpecSchemaFacetTests`: the fidelity matrix as a unit-level assertion list - string facets, numeric bounds, the 2020-12 exclusive spelling, default and inline enum, the nullable type array, array bounds at both the property and named-schema level, and references left bare.
- `NamedArraySchemaBoundsTests`: the parser fills the new model fields.
- The serializer's fully-populated round-trip covers the new fields.
- Integration, both front ends: `GeneratedDocumentTests` asserts the constraints petstore already declares plus a newly nullable `Problem.detail` publishing `["string","null"]`; `SmithyServedDocumentTests` asserts `@length` reaching the request-body schema and an optional member publishing the type array.

Full suite green in Debug and Release; the Release build ran CI-style with the pinned Smithy CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)