### PR TITLE
Publish the statuses the framework itself answers

### DIFF
--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
@@ -520,5 +520,65 @@ public class OpenApiDocumentEmissionTests {
         Assert.False(list.TryGetProperty("security", out _));
     }
 
+    /// <summary>
+    /// The status enforcing a requirement produces. AuthorizationFilter refuses an
+    /// unauthenticated caller before the handler runs, with a WWW-Authenticate challenge and the
+    /// standard error body - the document published the requirement and promised nothing about
+    /// the refusal.
+    /// </summary>
+    [Fact]
+    public void ASecuredOperationPublishesTheFourOhOne() {
+        var document = SecuredDocument();
+
+        var responses = document.GetProperty("paths").GetProperty("/pets/{id}")
+            .GetProperty("get").GetProperty("responses");
+
+        var unauthorized = responses.GetProperty("401");
+
+        Assert.True(unauthorized.GetProperty("headers").TryGetProperty("WWW-Authenticate", out _));
+        Assert.Equal(
+            "#/components/schemas/ErrorModel",
+            unauthorized.GetProperty("content").GetProperty("application/json")
+                .GetProperty("schema").GetProperty("$ref").GetString());
+
+        Assert.True(document.GetProperty("components").GetProperty("schemas")
+            .TryGetProperty("ErrorModel", out _));
+    }
+
+    /// <summary>And an operation naming no scheme answers no 401, so nothing is added to it.</summary>
+    [Fact]
+    public void AnUnsecuredOperationPublishesNoFourOhOne() {
+        var responses = SecuredDocument().GetProperty("paths").GetProperty("/pets")
+            .GetProperty("get").GetProperty("responses");
+
+        Assert.False(responses.TryGetProperty("401", out _));
+    }
+
+    /// <summary>
+    /// A scheme-shape attribute on the controller itself is a silent no-op - it is read from the
+    /// type [Authorize&lt;TScheme&gt;] names and from nowhere else. The second trial's code-first
+    /// arm put it exactly here, published nothing, and concluded the emission did not exist.
+    /// </summary>
+    [Fact]
+    public void ASchemeAttributeOnTheControllerIsReported() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public record Pet(string Id);
+
+            [Hardened.Requests.Abstract.Authorization.HttpAuthenticationScheme("bearer")]
+            public class PetController {
+                [Get("/pets/{id}")]
+                public Task<Pet> Get(string id) => Task.FromResult(new Pet(id));
+            }
+            """, Enable));
+
+        var diagnostic = Assert.Single(
+            result.GeneratorDiagnostics,
+            entry => entry.Id == Hardened.SourceGenerator.Requests
+                .SecuritySchemeDiagnostics.MisplacedSchemeId);
+
+        Assert.Contains("PetController", diagnostic.GetMessage());
+        Assert.Contains("Authorize<TScheme>", diagnostic.GetMessage());
+    }
+
     #endregion
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -63,6 +63,7 @@ public class RequestHandlerModel {
             // [Handler] filters, which is the worst kind of sometimes.
             SecurityRequirements = SecurityRequirements,
             DeclaredSecuritySchemes = DeclaredSecuritySchemes,
+            MisplacedSchemeAttributes = MisplacedSchemeAttributes,
             HasGeneratedValidation = HasGeneratedValidation
         };
 
@@ -213,6 +214,19 @@ public class RequestHandlerModel {
     public IReadOnlyList<SecuritySchemeDeclaration> DeclaredSecuritySchemes { get; set; } =
         System.Array.Empty<SecuritySchemeDeclaration>();
 
+    /// <summary>
+    /// Scheme-shape attributes found where nothing reads them, as <c>owner|attribute</c> pairs.
+    /// </summary>
+    /// <remarks>
+    /// <c>[HttpAuthenticationScheme]</c> and its siblings describe a scheme <em>type</em> - the
+    /// class <c>[Authorize&lt;TScheme&gt;]</c> names - and are read from nowhere else. Applied to
+    /// a handler or controller directly they publish nothing and enforce nothing, which is a
+    /// silent no-op the second trial walked straight into. Carried on the model because a syntax
+    /// transform cannot report; reported when source is written.
+    /// </remarks>
+    public IReadOnlyList<string> MisplacedSchemeAttributes { get; set; } =
+        System.Array.Empty<string>();
+
     public override bool Equals(object obj) {
         if (obj is not RequestHandlerModel requestHandlerModel) {
             return false;
@@ -303,6 +317,18 @@ public class RequestHandlerModel {
 
         for (var i = 0; i < DeclaredSecuritySchemes.Count; i++) {
             if (!DeclaredSecuritySchemes[i].Equals(requestHandlerModel.DeclaredSecuritySchemes[i])) {
+                return false;
+            }
+        }
+
+        if (MisplacedSchemeAttributes.Count != requestHandlerModel.MisplacedSchemeAttributes.Count) {
+            return false;
+        }
+
+        for (var i = 0; i < MisplacedSchemeAttributes.Count; i++) {
+            if (!string.Equals(
+                    MisplacedSchemeAttributes[i], requestHandlerModel.MisplacedSchemeAttributes[i],
+                    StringComparison.Ordinal)) {
                 return false;
             }
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -468,6 +468,8 @@ public static class OpenApiDocumentGenerator {
         }
 
         WriteValidationResponse(builder, handler, components);
+        WriteAuthenticationResponse(builder, handler, components);
+        WriteConstrainedPathResponse(builder, handler);
 
         builder.Append('}');
     }
@@ -640,17 +642,12 @@ public static class OpenApiDocumentGenerator {
     private static void WriteValidationResponse(
         StringBuilder builder, RequestHandlerModel handler,
         SortedDictionary<string, string> components) {
-        if (handler.ParametersValidator == null && !handler.HasGeneratedValidation) {
+        if (handler.ParametersValidator == null && !handler.HasGeneratedValidation &&
+            !HasBindingRefusals(handler)) {
             return;
         }
 
-        foreach (var response in handler.ResponseSchemas) {
-            if (response.Status == 400) {
-                return;
-            }
-        }
-
-        if ((handler.ResponseInformation.DefaultStatusCode ?? 200) == 400) {
+        if (DeclaresStatus(handler, 400)) {
             return;
         }
 
@@ -659,6 +656,136 @@ public static class OpenApiDocumentGenerator {
         builder.Append(",\"400\":{\"description\":\"The request failed validation.\"," +
                        "\"content\":{\"application/json\":{\"schema\":" +
                        "{\"$ref\":\"#/components/schemas/RequestValidationError\"}}}}");
+    }
+
+    /// <summary>
+    /// Whether binding alone can refuse this request with the validation envelope.
+    /// </summary>
+    /// <remarks>
+    /// A bound value that fails to parse as its declared type never reaches the handler:
+    /// <c>StringConverterService.Parse</c> answers 400 with the same field-level envelope a
+    /// generated validator produces. So the status is a fact about any operation binding a
+    /// non-string value, whether or not a validator was generated for it - the gate that required
+    /// one is why a documented 400 depended on the operation happening to declare a constraint.
+    /// A string binds as itself and cannot fail conversion.
+    /// </remarks>
+    private static bool HasBindingRefusals(RequestHandlerModel handler) {
+        foreach (var parameter in handler.RequestParameterInformationList) {
+            if (parameter.BindingType is not (ParameterBindType.Path or ParameterBindType.QueryString
+                or ParameterBindType.Header or ParameterBindType.Cookie or ParameterBindType.Form)) {
+                continue;
+            }
+
+            var type = parameter.ParameterType;
+
+            var name = (type.Name == "Nullable" && type.TypeArguments.Count == 1
+                ? type.TypeArguments[0].Name
+                : type.Name).TrimEnd('?');
+
+            if (name is not ("String" or "string" or "Object" or "object")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Whether the handler already declares <paramref name="status"/> itself.</summary>
+    private static bool DeclaresStatus(RequestHandlerModel handler, int status) {
+        foreach (var response in handler.ResponseSchemas) {
+            if (response.Status == status) {
+                return true;
+            }
+        }
+
+        return (handler.ResponseInformation.DefaultStatusCode ?? 200) == status;
+    }
+
+    /// <summary>The schema of the framework's undeclared error body, written once into components.</summary>
+    private const string ErrorModelSchema =
+        "{\"type\":\"object\"," +
+        "\"description\":\"How a refused or failed request is answered when the contract declared no body for it.\"," +
+        "\"required\":[\"type\",\"message\",\"details\"]," +
+        "\"properties\":{" +
+        "\"type\":{\"type\":\"string\"}," +
+        "\"message\":{\"type\":\"string\"}," +
+        "\"details\":{\"type\":\"string\"}}}";
+
+    /// <summary>
+    /// The 401 an operation with security requirements can answer, declared rather than implied.
+    /// </summary>
+    /// <remarks>
+    /// <c>AuthorizationFilter</c> refuses an unauthenticated caller before the handler runs, with
+    /// a <c>WWW-Authenticate</c> challenge and the standard error body. The requirement itself was
+    /// already published under <c>security</c>; this is the status enforcing it produces, which
+    /// the document promised nothing about. Skipped where the operation declared its own 401,
+    /// whose description then wins.
+    /// </remarks>
+    private static void WriteAuthenticationResponse(
+        StringBuilder builder, RequestHandlerModel handler,
+        SortedDictionary<string, string> components) {
+        if (handler.SecurityRequirements.Count == 0) {
+            return;
+        }
+
+        if (DeclaresStatus(handler, 401)) {
+            return;
+        }
+
+        components["ErrorModel"] = ErrorModelSchema;
+
+        builder.Append(",\"401\":{\"description\":\"Authentication required.\"," +
+                       "\"headers\":{\"WWW-Authenticate\":{" +
+                       "\"description\":\"The challenge naming the scheme to authenticate with.\"," +
+                       "\"schema\":{\"type\":\"string\"}}}," +
+                       "\"content\":{\"application/json\":{\"schema\":" +
+                       "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}");
+    }
+
+    /// <summary>
+    /// The 404 a constrained path token produces, stated rather than implied.
+    /// </summary>
+    /// <remarks>
+    /// A value that violates a route constraint means the route did not match, so the answer is
+    /// the router's 404 - deliberately bodyless, before binding and before the handler. The
+    /// constraint itself is stripped from the path template, because a template expression is a
+    /// name and nothing else, which left the document with no trace of the refusal at all.
+    /// Skipped where the operation declares its own 404, whose description then wins.
+    /// </remarks>
+    private static void WriteConstrainedPathResponse(
+        StringBuilder builder, RequestHandlerModel handler) {
+        if (!HasConstrainedPathToken(handler.Name.Path)) {
+            return;
+        }
+
+        if (DeclaresStatus(handler, 404)) {
+            return;
+        }
+
+        builder.Append(",\"404\":{\"description\":" +
+                       "\"The path did not name a resource: a token failed its route constraint.\"}");
+    }
+
+    private static bool HasConstrainedPathToken(string path) {
+        var open = path.IndexOf('{');
+
+        while (open >= 0) {
+            var close = path.IndexOf('}', open);
+
+            if (close < 0) {
+                return false;
+            }
+
+            var colon = path.IndexOf(':', open);
+
+            if (colon > open && colon < close) {
+                return true;
+            }
+
+            open = path.IndexOf('{', close);
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/SecurityDeclarationSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/SecurityDeclarationSelector.cs
@@ -50,12 +50,21 @@ internal static class SecurityDeclarationSelector {
         CancellationToken cancellationToken) {
         var schemes = new List<SecuritySchemeDeclaration>();
         var grants = new List<string>();
+        var misplaced = new List<string>();
 
-        Read(context, method.AttributeLists, schemes, grants, cancellationToken);
+        Read(context, method.AttributeLists,
+            model.ControllerType.Name + "." + model.HandlerMethod,
+            schemes, grants, misplaced, cancellationToken);
 
         if (method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault()
             is { } controller) {
-            Read(context, controller.AttributeLists, schemes, grants, cancellationToken);
+            Read(context, controller.AttributeLists,
+                model.ControllerType.Name,
+                schemes, grants, misplaced, cancellationToken);
+        }
+
+        if (misplaced.Count > 0) {
+            model.MisplacedSchemeAttributes = misplaced;
         }
 
         if (schemes.Count == 0) {
@@ -75,8 +84,10 @@ internal static class SecurityDeclarationSelector {
     private static void Read(
         GeneratorSyntaxContext context,
         SyntaxList<AttributeListSyntax> attributeLists,
+        string owner,
         List<SecuritySchemeDeclaration> schemes,
         List<string> grants,
+        List<string> misplaced,
         CancellationToken cancellationToken) {
         foreach (var attributeList in attributeLists) {
             foreach (var attribute in attributeList.Attributes) {
@@ -103,6 +114,17 @@ internal static class SecurityDeclarationSelector {
                     // The literal form only. The generic form computes its grants in a provider
                     // the generator cannot run.
                     LiteralGrants(attribute, context, grants, cancellationToken);
+                } else if (type.Name is "HttpAuthenticationSchemeAttribute"
+                           or "ApiKeyAuthenticationSchemeAttribute"
+                           or "OAuth2AuthenticationSchemeAttribute") {
+                    // A scheme-shape attribute in a position nothing reads. It belongs on a scheme
+                    // type named by [Authorize<TScheme>]; here it publishes nothing and enforces
+                    // nothing, which is the silent no-op the second trial walked into.
+                    var entry = owner + "|" + type.Name;
+
+                    if (!misplaced.Contains(entry)) {
+                        misplaced.Add(entry);
+                    }
                 }
             }
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/SecuritySchemeDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/SecuritySchemeDiagnostics.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Requests;
+
+/// <summary>
+/// A scheme-shape attribute in a position nothing reads.
+/// </summary>
+/// <remarks>
+/// <c>[HttpAuthenticationScheme]</c> and its siblings describe the scheme <em>type</em> that
+/// <c>[Authorize&lt;TScheme&gt;]</c> names - <c>SecurityDeclarationSelector</c> reads them from
+/// that type and from nowhere else. Applied to a handler, a controller or the application module
+/// they publish no <c>securitySchemes</c>, no <c>security</c>, and enforce nothing. The build
+/// accepted that silently, and the second trial's code-first arm concluded from the silence that
+/// the emission did not exist - the working spelling was never suggested to them.
+/// </remarks>
+public static class SecuritySchemeDiagnostics {
+
+    public const string MisplacedSchemeId = "HRDSC001";
+
+    internal static DiagnosticDescriptor MisplacedSchemeDescriptor() => new(
+        id: MisplacedSchemeId,
+        title: "An authentication scheme attribute is not read here",
+        messageFormat:
+            "'{0}' carries [{1}], which nothing reads in this position. The attribute describes " +
+            "an authentication scheme type: declare a class implementing IAuthenticationScheme, " +
+            "put the attribute on it, and name it as [Authorize<TScheme>] on the handler or " +
+            "controller. Where it is now, it publishes no securitySchemes and enforces nothing.",
+        category: "Hardened.Security",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports each misplaced attribute once, however many handlers saw it.
+    /// </summary>
+    /// <remarks>
+    /// The selector runs per handler and a controller-level attribute is seen by every handler on
+    /// the controller, so the entries are deduplicated here on their <c>owner|attribute</c> form.
+    /// Decided where the symbols are and reported here, the same split every finding in this
+    /// generator uses - a syntax transform cannot report.
+    /// </remarks>
+    public static void ReportMisplacedSchemes(
+        SourceProductionContext context,
+        IEnumerable<IReadOnlyList<string>> findings) {
+        var reported = new HashSet<string>();
+
+        foreach (var handlerFindings in findings) {
+            foreach (var finding in handlerFindings) {
+                if (!reported.Add(finding)) {
+                    continue;
+                }
+
+                var separator = finding.IndexOf('|');
+
+                if (separator <= 0) {
+                    continue;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    MisplacedSchemeDescriptor(), Location.None,
+                    finding.Substring(0, separator),
+                    Short(finding.Substring(separator + 1))));
+            }
+        }
+    }
+
+    /// <summary>The attribute as an author writes it, without the suffix.</summary>
+    private static string Short(string attributeTypeName) =>
+        attributeTypeName.EndsWith("Attribute", System.StringComparison.Ordinal)
+            ? attributeTypeName.Substring(0, attributeTypeName.Length - "Attribute".Length)
+            : attributeTypeName;
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -92,6 +92,12 @@ public static class RoutingTableGenerator {
                 handler.ResponseInformation.UnionDiagnostic);
         }
 
+        // A scheme-shape attribute somewhere nothing reads it is a silent no-op - the build was
+        // green, nothing published, and the author had no way to learn the working spelling.
+        SecuritySchemeDiagnostics.ReportMisplacedSchemes(
+            context,
+            MisplacedSchemeFindings(models.Left, routable));
+
         // Before the document is written, because an unrecognised version has no answer to fall
         // back to - see OpenApiVersionDiagnostics.ReportUnknownVersion.
         var version = OpenApiVersionFacts.Parse(options.OpenApiVersion);
@@ -145,6 +151,34 @@ public static class RoutingTableGenerator {
         LinkGenerator.Generate(context, models.Left, routable, GetBasePath(models.Left));
     }
     
+    /// <summary>
+    /// Every misplaced scheme-shape attribute in this table's reach: each handler's findings, and
+    /// the entry point's own attribute list - the module position, which no handler transform
+    /// sees.
+    /// </summary>
+    private static IEnumerable<IReadOnlyList<string>> MisplacedSchemeFindings(
+        EntryPointSelector.Model appModel, IReadOnlyList<RequestHandlerModel> handlers) {
+        foreach (var handler in handlers) {
+            if (handler.MisplacedSchemeAttributes.Count > 0) {
+                yield return handler.MisplacedSchemeAttributes;
+            }
+        }
+
+        if (appModel.AttributeModels == null) {
+            yield break;
+        }
+
+        foreach (var attribute in appModel.AttributeModels) {
+            var name = attribute.TypeDefinition.Name;
+
+            if (name.StartsWith("HttpAuthenticationScheme", System.StringComparison.Ordinal) ||
+                name.StartsWith("ApiKeyAuthenticationScheme", System.StringComparison.Ordinal) ||
+                name.StartsWith("OAuth2AuthenticationScheme", System.StringComparison.Ordinal)) {
+                yield return new[] { appModel.EntryPointType.Name + "|" + name };
+            }
+        }
+    }
+
     public static string GenerateCSharpRouteFile(EntryPointSelector.Model appModel,
         IReadOnlyList<RequestHandlerModel> handlers, CancellationToken cancellationToken,
         RoutingTableOptions? options = null) {

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDocumentTests.cs
@@ -92,7 +92,7 @@ public class ResponseSetDocumentTests {
     public void AnUndeclaredSuccessStatusIsStillTwoHundred() {
         var responses = Responses(Document("""
                 [Get("/todos/{id}")]
-                public Todo ById(int id) => new Todo(id, "t");
+                public Todo ById(string id) => new Todo(1, "t");
             """), "/todos/{id}", "get");
 
         Assert.Equal(new[] { "200" }, Statuses(responses));
@@ -112,7 +112,7 @@ public class ResponseSetDocumentTests {
     public void EveryDeclaredCaseBecomesAResponse() {
         var responses = Responses(Document("""
                 [Get("/todos/{id}")]
-                public Response<Todo, NotFound, Conflict> ById(int id) => new Todo(id, "t");
+                public Response<Todo, NotFound, Conflict> ById(string id) => new Todo(1, "t");
             """), "/todos/{id}", "get");
 
         Assert.Equal(new[] { "200", "404", "409" }, Statuses(responses));
@@ -126,7 +126,7 @@ public class ResponseSetDocumentTests {
     public void EachResponseCarriesItsReasonPhrase() {
         var responses = Responses(Document("""
                 [Get("/todos/{id}")]
-                public Response<Todo, NotFound, Gone> ById(int id) => new Todo(id, "t");
+                public Response<Todo, NotFound, Gone> ById(string id) => new Todo(1, "t");
             """), "/todos/{id}", "get");
 
         Assert.Equal("OK", responses.GetProperty("200").GetProperty("description").GetString());
@@ -156,7 +156,7 @@ public class ResponseSetDocumentTests {
     public void ABodylessCaseDeclaresNoContent() {
         var responses = Responses(Document("""
                 [Delete("/todos/{id}")]
-                public Response<NoContent, NotFound> Remove(int id) => new NoContent();
+                public Response<NoContent, NotFound> Remove(string id) => new NoContent();
             """), "/todos/{id}", "delete");
 
         Assert.Equal(new[] { "204", "404" }, Statuses(responses));
@@ -172,7 +172,7 @@ public class ResponseSetDocumentTests {
     public void TwoCasesSharingAStatusBecomeAOneOf() {
         var responses = Responses(Document("""
                 [Get("/todos/{id}")]
-                public Response<Todo, Archived, NotFound> ById(int id) => new Todo(id, "t");
+                public Response<Todo, Archived, NotFound> ById(string id) => new Todo(1, "t");
             """), "/todos/{id}", "get");
 
         Assert.Equal(new[] { "200", "404" }, Statuses(responses));
@@ -192,7 +192,7 @@ public class ResponseSetDocumentTests {
     public void TheResponseWrapperIsNeverASchemaComponent() {
         var document = Document("""
                 [Get("/todos/{id}")]
-                public Response<Todo, NotFound> ById(int id) => new Todo(id, "t");
+                public Response<Todo, NotFound> ById(string id) => new Todo(1, "t");
             """);
 
         if (document.TryGetProperty("components", out var components)) {
@@ -200,6 +200,71 @@ public class ResponseSetDocumentTests {
                 Assert.DoesNotContain("Response", schema.Name, StringComparison.Ordinal);
             }
         }
+    }
+
+    #endregion
+
+    #region the statuses the framework itself answers
+
+    /// <summary>
+    /// A bound value that fails to parse never reaches the handler:
+    /// <c>StringConverterService.Parse</c> answers 400 with the validation envelope. The gate used
+    /// to require a generated validator, so a documented 400 depended on the operation happening
+    /// to declare a constraint - binding an <c>int</c> was enough to answer one and the document
+    /// said nothing.
+    /// </summary>
+    [Fact]
+    public void ABindingRefusalPublishesTheFourHundred() {
+        var responses = Responses(Document("""
+                [Get("/todos/{id}")]
+                public Todo ById(int id) => new Todo(id, "t");
+            """), "/todos/{id}", "get");
+
+        Assert.Equal(new[] { "200", "400" }, Statuses(responses));
+
+        Assert.Equal(
+            "#/components/schemas/RequestValidationError",
+            responses.GetProperty("400").GetProperty("content").GetProperty("application/json")
+                .GetProperty("schema").GetProperty("$ref").GetString());
+    }
+
+    /// <summary>A string binds as itself and cannot fail conversion, so nothing is added.</summary>
+    [Fact]
+    public void AStringBoundOperationPublishesNoFourHundred() {
+        var responses = Responses(Document("""
+                [Get("/todos/{title}")]
+                public Todo ByTitle(string title) => new Todo(1, title);
+            """), "/todos/{title}", "get");
+
+        Assert.Equal(new[] { "200" }, Statuses(responses));
+    }
+
+    /// <summary>
+    /// A value that violates a route constraint means the route did not match, and the answer is
+    /// the router's bodyless 404. The constraint is stripped from the path template, so this entry
+    /// is the one trace of it the document carries.
+    /// </summary>
+    [Fact]
+    public void AConstrainedPathTokenPublishesTheFourOhFour() {
+        var responses = Responses(Document("""
+                [Get("/todos/{id:int}")]
+                public Todo ById(int id) => new Todo(id, "t");
+            """), "/todos/{id}", "get");
+
+        Assert.Equal(new[] { "200", "400", "404" }, Statuses(responses));
+        Assert.False(responses.GetProperty("404").TryGetProperty("content", out _));
+    }
+
+    /// <summary>An operation that declares its own 404 keeps its own description.</summary>
+    [Fact]
+    public void ADeclaredFourOhFourIsNotOverwritten() {
+        var responses = Responses(Document("""
+                [Get("/todos/{id:int}")]
+                public Response<Todo, NotFound> ById(int id) => new Todo(id, "t");
+            """), "/todos/{id}", "get");
+
+        Assert.Equal(new[] { "200", "400", "404" }, Statuses(responses));
+        Assert.True(responses.GetProperty("404").TryGetProperty("content", out _));
     }
 
     #endregion
@@ -229,8 +294,8 @@ public class ResponseSetDocumentTests {
 
             public class TodoController {
                 [Get("/todos/{id}")]
-                public Response<Todo, NotFound, Conflict, NoContent> ById(int id) =>
-                    new Todo(id, "t");
+                public Response<Todo, NotFound, Conflict, NoContent> ById(string id) =>
+                    new Todo(1, "t");
             }
             """,
             new WebLibrarySourceGenerator(),


### PR DESCRIPTION
F4 from the Forty-Four Fixes plan. Fixes D-A-06 (the synthesis half), D-B-07, D-C-07, D-A-07 and D-B-06.

## Three statuses the service answers and the document never carried

All three land in the shared emitter, so every front end gets them at once. Each is skipped where the operation declares the status itself, whose description then wins.

- **401.** An operation with security requirements publishes the refusal `AuthorizationFilter` produces: `WWW-Authenticate` declared as a header, the standard error body under a new `ErrorModel` component. The requirement was already under `security`; the status enforcing it was nowhere. `WriteAuthenticationResponse` sits beside `WriteValidationResponse` and is gated on `handler.SecurityRequirements`, which both front ends already populate.
- **400.** The validation-response gate no longer requires a generated validator. Binding a non-string value is enough to answer 400 through `StringConverterService.Parse`, with the identical envelope, so it is enough to publish one. A string binds as itself and cannot fail conversion, so string-only operations gain nothing.
- **404.** An operation whose path tokens carry route constraints publishes the bodyless 404 the router answers. The constraint is stripped from the path template, because a template expression is a name and nothing else, so this entry is the one trace of it the document carries.

## HRDSC001

`[HttpAuthenticationScheme]` and its siblings describe the scheme type `[Authorize<TScheme>]` names, and `SecurityDeclarationSelector` reads them from that type and nowhere else. On a handler, controller or the application module they publish nothing and enforce nothing, silently. The second trial's code-first arm put the attribute exactly there and concluded the emission did not exist. The selector now records those positions on the handler model, the routing generator also checks the entry point's own attribute list (the module position no handler transform sees), and each finding reports once as a warning naming the working spelling.

## Tests

- `ResponseSetDocumentTests` gains a section for the synthesized statuses: the binding 400 with its `RequestValidationError` reference, the string-bound operation that gains nothing, the constrained-token 404 with no content, and a declared 404 keeping its own description. Its existing fixtures move to string ids so the declared-set assertions stay about declared sets.
- `OpenApiDocumentEmissionTests`: the secured operation publishes the 401 with its header and `ErrorModel` reference, the unsecured one does not, and a scheme attribute on a controller reports `HRDSC001` naming the controller and the `Authorize<TScheme>` spelling.

Full suite green in Debug and Release; Release built CI-style with the pinned Smithy CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)