### PR TITLE
Close the code-first typing gaps the document carried

### DIFF
--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -83,6 +83,8 @@ multi-line description that stopped being escaped fails these suites rather than
 page.
 
 Known gaps, stated rather than implied: code-first cannot express a
-constraint on a query, header or path parameter (`HRDV001` names the ways out); a `Nullable`
-scalar parameter whose type argument did not survive the syntax transform still publishes as a
-string; and `@timestampFormat` is read for nullability and otherwise inert.
+constraint on a query, header or path parameter (`HRDV001` names the ways out), and
+`@timestampFormat` is read for nullability and otherwise inert. Nullable scalar parameters used
+to be listed here too, blamed on a type argument lost in the syntax transform. The diagnosis was
+wrong: the argument survived, the definition arrived named with the C# keyword, and the schema
+switch matched only CLR names. `ScalarSchema` accepts both spellings now.

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
@@ -297,14 +297,23 @@ public class OpenApiDocumentEmissionTests {
     #region what the document says about code-first parameters and members
 
     /// <summary>The application the fidelity tests drive: enums, defaults, constraints, nulls.</summary>
+    /// <remarks>
+    /// <c>Priority</c> deliberately appears in no body. <c>Carrier</c> rides in
+    /// <c>Shipment</c> too, so the response walk collected its vocabulary and the parameter test
+    /// passed while parameter-only enums were broken - the second trial's exact shape.
+    /// </remarks>
     private const string FidelityControllers = """
         public enum Carrier { Dhl, Fedex, RoyalMail }
+
+        public enum Priority { Low, High }
 
         public record Shipment(string Id, int Quantity, string? Note, Carrier Carrier);
 
         public record NewShipment(
             [property: ValidationModules.Constraints.Range("0.5", "30", ExclusiveMin = true)]
-            decimal WeightKg);
+            decimal WeightKg,
+            [property: ValidationModules.Constraints.ItemCount(Min = 1, Max = 10)]
+            List<Shipment> Batch);
 
         public class ShipmentController {
             [Get("/shipments")]
@@ -312,9 +321,21 @@ public class OpenApiDocumentEmissionTests {
                 [FromQueryString] int limit = 20, [FromQueryString] Carrier? carrier = null) =>
                 Task.FromResult(new List<Shipment>());
 
+            [Get("/shipments/urgent")]
+            public Task<List<Shipment>> Urgent([FromQueryString] Priority priority) =>
+                Task.FromResult(new List<Shipment>());
+
+            [Get("/shipments/paged")]
+            public Task<List<Shipment>> Paged(
+                [FromQueryString] long? cursor = null, [FromQueryString] int? limit = null) =>
+                Task.FromResult(new List<Shipment>());
+
             [Post("/shipments")]
             public Task<Shipment> Create([FromBody] NewShipment body) =>
                 Task.FromResult(new Shipment("1", 1, null, Carrier.Dhl));
+
+            [Post("/shipments/{id}/archive")]
+            public Task Archive(string id) => Task.CompletedTask;
         }
         """;
 
@@ -358,6 +379,93 @@ public class OpenApiDocumentEmissionTests {
         Assert.Equal(
             new[] { "dhl", "fedex", "royalMail" },
             schema.GetProperty("enum").EnumerateArray().Select(value => value.GetString()));
+    }
+
+    /// <summary>
+    /// The unmasked half of the assertion above. Carrier also rides in the response body, so the
+    /// body walk collected its vocabulary and the test passed while the parameter walk collected
+    /// nothing. Priority appears in no body: its vocabulary exists only because the parameter
+    /// transform now captures it.
+    /// </summary>
+    [Fact]
+    public void AParameterOnlyEnumCarriesItsVocabulary() {
+        var schema = Parameter(FidelityDocument(), "/shipments/urgent", "priority")
+            .GetProperty("schema");
+
+        Assert.Equal("string", schema.GetProperty("type").GetString());
+        Assert.Equal(
+            new[] { "low", "high" },
+            schema.GetProperty("enum").EnumerateArray().Select(value => value.GetString()));
+    }
+
+    /// <summary>
+    /// int? and long? describe as the integers they are. The unwrap hands on a definition named
+    /// with the C# keyword, and the schema switch matched only the CLR names a bare parameter
+    /// produces - so a nullable scalar published as a string while its bare twin published as an
+    /// integer.
+    /// </summary>
+    [Fact]
+    public void ANullableScalarParameterIsAnInteger() {
+        var document = FidelityDocument();
+
+        var limit = Parameter(document, "/shipments/paged", "limit").GetProperty("schema");
+
+        Assert.Equal("integer", limit.GetProperty("type").GetString());
+        Assert.Equal("int32", limit.GetProperty("format").GetString());
+
+        var cursor = Parameter(document, "/shipments/paged", "cursor").GetProperty("schema");
+
+        Assert.Equal("integer", cursor.GetProperty("type").GetString());
+        Assert.Equal("int64", cursor.GetProperty("format").GetString());
+    }
+
+    /// <summary>
+    /// A bare Task is void with a different spelling. The schema writer used to walk Task itself,
+    /// so the 200 carried a Task schema and components gained its BCL entourage.
+    /// </summary>
+    [Fact]
+    public void ABareTaskPublishesNoSchemaAtAll() {
+        var document = FidelityDocument();
+
+        var ok = document.GetProperty("paths").GetProperty("/shipments/{id}/archive")
+            .GetProperty("post").GetProperty("responses").GetProperty("200");
+
+        Assert.False(ok.TryGetProperty("content", out _));
+
+        if (document.TryGetProperty("components", out var components)) {
+            foreach (var schema in components.GetProperty("schemas").EnumerateObject()) {
+                Assert.NotEqual("Task", schema.Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// [ItemCount] on an array of referenced objects keeps its bounds. The guard against writing
+    /// facets beside a $ref searched the whole schema string, so an items reference cost the
+    /// array every facet it had - and the bounds sit on the array, where no reference is.
+    /// </summary>
+    [Fact]
+    public void ItemCountOnAnArrayOfReferencesKeepsItsBounds() {
+        var batch = FidelityDocument().GetProperty("components").GetProperty("schemas")
+            .GetProperty("NewShipment").GetProperty("properties").GetProperty("batch");
+
+        Assert.Equal(1, batch.GetProperty("minItems").GetInt32());
+        Assert.Equal(10, batch.GetProperty("maxItems").GetInt32());
+        Assert.Equal(
+            "#/components/schemas/Shipment",
+            batch.GetProperty("items").GetProperty("$ref").GetString());
+    }
+
+    private static JsonElement Parameter(JsonElement document, string path, string name) {
+        foreach (var parameter in document
+                     .GetProperty("paths").GetProperty(path).GetProperty("get")
+                     .GetProperty("parameters").EnumerateArray()) {
+            if (parameter.GetProperty("name").GetString() == name) {
+                return parameter;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"No parameter named '{name}' at '{path}'.");
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/EnumVocabularies.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/EnumVocabularies.cs
@@ -33,6 +33,13 @@ public static class EnumVocabularies {
             foreach (var response in handler.ResponseSchemas) {
                 Add(found, response.Schema);
             }
+
+            // The parameter-bound enums, captured separately: a body walk cannot see them, and an
+            // enum that appears only as a query, header or path value had no vocabulary at all -
+            // no enum array in the document, no wire converter for the binder.
+            foreach (var vocabulary in handler.ParameterEnums) {
+                found[vocabulary.QualifiedName] = vocabulary;
+            }
         }
 
         return found.Values.ToList();

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -63,6 +63,7 @@ public class RequestHandlerModel {
             // [Handler] filters, which is the worst kind of sometimes.
             SecurityRequirements = SecurityRequirements,
             DeclaredSecuritySchemes = DeclaredSecuritySchemes,
+            ParameterEnums = ParameterEnums,
             MisplacedSchemeAttributes = MisplacedSchemeAttributes,
             HasGeneratedValidation = HasGeneratedValidation
         };
@@ -215,6 +216,18 @@ public class RequestHandlerModel {
         System.Array.Empty<SecuritySchemeDeclaration>();
 
     /// <summary>
+    /// The wire vocabulary of every enum bound as a parameter of this handler.
+    /// </summary>
+    /// <remarks>
+    /// Body enums are collected off the body schemas; a parameter-only enum has no schema to ride
+    /// and lost its vocabulary entirely - no <c>enum</c> array in the document, no wire converter.
+    /// Deduplicated against the body-collected set by qualified name in
+    /// <c>EnumVocabularies.Collect</c>.
+    /// </remarks>
+    public IReadOnlyList<EnumVocabulary> ParameterEnums { get; set; } =
+        System.Array.Empty<EnumVocabulary>();
+
+    /// <summary>
     /// Scheme-shape attributes found where nothing reads them, as <c>owner|attribute</c> pairs.
     /// </summary>
     /// <remarks>
@@ -317,6 +330,16 @@ public class RequestHandlerModel {
 
         for (var i = 0; i < DeclaredSecuritySchemes.Count; i++) {
             if (!DeclaredSecuritySchemes[i].Equals(requestHandlerModel.DeclaredSecuritySchemes[i])) {
+                return false;
+            }
+        }
+
+        if (ParameterEnums.Count != requestHandlerModel.ParameterEnums.Count) {
+            return false;
+        }
+
+        for (var i = 0; i < ParameterEnums.Count; i++) {
+            if (!ParameterEnums[i].Equals(requestHandlerModel.ParameterEnums[i])) {
                 return false;
             }
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -676,11 +676,7 @@ public static class OpenApiDocumentGenerator {
                 continue;
             }
 
-            var type = parameter.ParameterType;
-
-            var name = (type.Name == "Nullable" && type.TypeArguments.Count == 1
-                ? type.TypeArguments[0].Name
-                : type.Name).TrimEnd('?');
+            var name = parameter.ParameterType.Name.TrimEnd('?');
 
             if (name is not ("String" or "string" or "Object" or "object")) {
                 return true;
@@ -1005,11 +1001,7 @@ public static class OpenApiDocumentGenerator {
     /// </remarks>
     private static string? EnumSchema(
         ITypeDefinition type, IReadOnlyDictionary<string, EnumVocabulary> enums) {
-        var unwrapped = type.Name == "Nullable" && type.TypeArguments.Count == 1
-            ? type.TypeArguments[0]
-            : type;
-
-        var qualified = "global::" + unwrapped.Namespace + "." + unwrapped.Name.TrimEnd('?');
+        var qualified = "global::" + type.Namespace + "." + type.Name.TrimEnd('?');
 
         if (!enums.TryGetValue(qualified, out var vocabulary)) {
             return null;
@@ -1045,12 +1037,13 @@ public static class OpenApiDocumentGenerator {
     /// which is what it arrived as.
     /// </para>
     /// <para>
-    /// <b>Known gap.</b> A nullable scalar - <c>int?</c> on a query value or header - still
-    /// describes as a string. The type reaches here as a <c>Nullable</c> definition carrying no
-    /// type argument, so the underlying type is not recoverable from the model as it stands;
-    /// recovering it means changing what the syntax transform records, which is a wider change than
-    /// this. Not a regression - every parameter described as a string before - and the value does
-    /// arrive as text, so the schema is unspecific rather than wrong.
+    /// A nullable scalar - <c>int?</c> on a query value or header - described as a string until
+    /// <see cref="ScalarSchema"/> learned the keyword spellings. The earlier account of this gap
+    /// blamed the model, claiming the type arrived as a <c>Nullable</c> with no argument to read.
+    /// It never did: the unwrap resolves the underlying type fine and hands on a definition named
+    /// with the C# keyword - <c>int</c>, by way of <c>TypeDefinition.Get(typeof(int))</c>, whose
+    /// whole point is the keyword - while the schema switch matched only the CLR names a bare
+    /// parameter's symbol produces.
     /// </para>
     /// </remarks>
     /// <summary>
@@ -1224,23 +1217,24 @@ public static class OpenApiDocumentGenerator {
     }
 
     private static string ScalarSchema(ITypeDefinition type) {
-        // int? and friends: the schema describes the value, and "required" already says whether one
-        // has to be there. Two spellings reach here - Nullable<T> with a type argument, and the
-        // underlying name with a '?' on it, depending on how the parameter was written - so both
-        // are unwrapped rather than guessing which the generator produced.
-        var name = (type.Name == "Nullable" && type.TypeArguments.Count == 1
-            ? type.TypeArguments[0].Name
-            : type.Name).TrimEnd('?');
+        // Two spellings of every predefined type reach here, and both must match. A bare `int`
+        // parameter is built from its symbol and named "Int32"; `int?` is unwrapped through
+        // TypeDefinition.Get(typeof(int)), whose whole point is the C# keyword name, so it
+        // arrives as "int". Matching only the CLR names is how int? and long? published as
+        // strings while int and long published as integers - the same type disagreeing with
+        // itself about what it is. The trailing '?' is the third spelling, trimmed.
+        var name = type.Name.TrimEnd('?');
 
         return name switch {
-            "String" or "Char" => "{\"type\":\"string\"}",
-            "Boolean" => "{\"type\":\"boolean\"}",
-            "Byte" or "SByte" or "Int16" or "UInt16" or "Int32" or "UInt32" =>
+            "String" or "string" or "Char" or "char" => "{\"type\":\"string\"}",
+            "Boolean" or "bool" => "{\"type\":\"boolean\"}",
+            "Byte" or "byte" or "SByte" or "sbyte" or "Int16" or "short" or "UInt16" or "ushort"
+                or "Int32" or "int" or "UInt32" or "uint" =>
                 "{\"type\":\"integer\",\"format\":\"int32\"}",
-            "Int64" or "UInt64" => "{\"type\":\"integer\",\"format\":\"int64\"}",
-            "Single" => "{\"type\":\"number\",\"format\":\"float\"}",
-            "Double" => "{\"type\":\"number\",\"format\":\"double\"}",
-            "Decimal" => "{\"type\":\"number\"}",
+            "Int64" or "long" or "UInt64" or "ulong" => "{\"type\":\"integer\",\"format\":\"int64\"}",
+            "Single" or "float" => "{\"type\":\"number\",\"format\":\"float\"}",
+            "Double" or "double" => "{\"type\":\"number\",\"format\":\"double\"}",
+            "Decimal" or "decimal" => "{\"type\":\"number\"}",
             "DateTime" or "DateTimeOffset" => "{\"type\":\"string\",\"format\":\"date-time\"}",
             "DateOnly" => "{\"type\":\"string\",\"format\":\"date\"}",
             "Guid" => "{\"type\":\"string\",\"format\":\"uuid\"}",

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/SchemaConstraintWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/SchemaConstraintWriter.cs
@@ -45,13 +45,17 @@ internal static class SchemaConstraintWriter {
     /// <paramref name="schema"/> with the facets <paramref name="property"/>'s constraints imply.
     /// </summary>
     /// <remarks>
-    /// A property whose schema is a <c>$ref</c> is returned untouched. OpenAPI 3.0 ignores every
-    /// sibling of a <c>$ref</c>, so facets written beside one would be silently dropped by any
-    /// reader - which is worse than not writing them, because the document would claim a
-    /// constraint it does not communicate.
+    /// A property whose schema <em>is</em> a <c>$ref</c> is returned untouched. OpenAPI 3.0
+    /// ignores every sibling of a <c>$ref</c>, so facets written beside one would be silently
+    /// dropped by any reader - which is worse than not writing them, because the document would
+    /// claim a constraint it does not communicate. Only the top level: this used to search the
+    /// whole string, so an array of referenced objects - whose <c>items</c> nests a
+    /// <c>$ref</c> - lost every facet it had, <c>[ItemCount]</c>'s bounds included, and the
+    /// bounds belong on the array where no reference sits.
     /// </remarks>
     public static string Apply(string schema, IPropertySymbol property) {
-        if (schema.Length < 2 || schema.IndexOf("\"$ref\"", System.StringComparison.Ordinal) >= 0) {
+        if (schema.Length < 2 ||
+            schema.StartsWith("{\"$ref\"", System.StringComparison.Ordinal)) {
             return schema;
         }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -57,7 +57,65 @@ public abstract class BaseRequestModelGenerator {
         // assembling it: what the attributes declare for the published document.
         SecurityDeclarationSelector.Apply(context, methodDeclaration, model, cancellationToken);
 
+        model.ParameterEnums = ParameterEnums(context, methodDeclaration);
+
         return model;
+    }
+
+    /// <summary>
+    /// The wire vocabulary of every enum bound as a parameter, captured while the symbol is in
+    /// hand.
+    /// </summary>
+    /// <remarks>
+    /// <c>EnumVocabularies.Collect</c> walks body schemas, so an enum that appears only as a
+    /// query, header or path value had no vocabulary anywhere: the parameter published as a bare
+    /// string and no wire converter was emitted for it. An enum that also appears in a body
+    /// resolves to the same entry by qualified name, which is what masked this - the fixture's
+    /// enum happened to be in a response too.
+    /// </remarks>
+    private static IReadOnlyList<EnumVocabulary> ParameterEnums(
+        GeneratorSyntaxContext context, MethodDeclarationSyntax methodDeclaration) {
+        List<EnumVocabulary>? found = null;
+
+        foreach (var parameter in methodDeclaration.ParameterList.Parameters) {
+            if (parameter.Type == null) {
+                continue;
+            }
+
+            var symbol = context.SemanticModel.GetTypeInfo(parameter.Type).Type;
+
+            if (symbol is INamedTypeSymbol {
+                    OriginalDefinition.SpecialType: SpecialType.System_Nullable_T
+                } nullable) {
+                symbol = nullable.TypeArguments[0];
+            }
+
+            if (symbol is not INamedTypeSymbol { TypeKind: TypeKind.Enum } enumSymbol ||
+                !EnumWireNaming.IsOwned(enumSymbol, context.SemanticModel.Compilation.Assembly)) {
+                continue;
+            }
+
+            var naming = EnumWireNaming.For(enumSymbol, EnumWireNaming.AssemblyDefault(enumSymbol));
+            var members = EnumWireNaming.Members(enumSymbol, naming);
+
+            if (members.Count == 0) {
+                continue;
+            }
+
+            var qualified = "global::" + enumSymbol.ToDisplayString();
+
+            found ??= new List<EnumVocabulary>();
+
+            if (found.All(vocabulary => vocabulary.QualifiedName != qualified)) {
+                found.Add(new EnumVocabulary(
+                    qualified,
+                    enumSymbol.Name,
+                    naming,
+                    members.Select(pair => new EnumWireValue(pair.Member, pair.Wire)).ToList()));
+            }
+        }
+
+        return found ?? (IReadOnlyList<EnumVocabulary>)System.Array.Empty<EnumVocabulary>();
     }
 
     /// <summary>
@@ -159,6 +217,14 @@ public abstract class BaseRequestModelGenerator {
         MethodDeclarationSyntax methodDeclaration,
         ResponseInformationModel response) {
         var declared = context.SemanticModel.GetTypeInfo(methodDeclaration.ReturnType).Type;
+
+        // The invoker's substitution, made here as well: a bare Task is void with a different
+        // spelling. Without it the schema writer walked Task itself, and the document published a
+        // Task component with its BCL entourage as the operation's 200.
+        if (declared is INamedTypeSymbol { Arity: 0, Name: "Task" or "ValueTask" } bare &&
+            bare.ContainingNamespace.ToDisplayString() == "System.Threading.Tasks") {
+            return null;
+        }
 
         if (response.UnionCases == null) {
             return declared;


### PR DESCRIPTION
F5 from the Forty-Four Fixes queue: the four code-first typing defects the second trial's document diffing surfaced (D-A-04, D-A-09, D-A-03, and the code-first half of D-A-10).

- **`int?` published as a string** (D-A-04). `ScalarSchema` matched CLR spellings only, and the `Nullable<T>` unwrap builds its definition through `TypeDefinition.Get(typeof(int))`, whose whole point is the keyword name. The switch now knows both spellings, the dead `Name == "Nullable"` guards are deleted, and the "Known gap" comment that misdiagnosed this - plus its echo in `docs/openapi-document.md` - is corrected. Affects the signed and unsigned integer family; other nullable scalars already took the healthy path.
- **Parameter-only enums lost their vocabulary** (D-A-09). `EnumVocabularies.Collect` walks body schemas only, so an enum that appears in no body published as `{"type":"string"}`. The vocabulary is now captured while the Roslyn symbol is in hand and carried on the handler model. The one existing document test passed by accident - its enum also rode in a response body - so the new fixture uses an enum no body mentions.
- **Bare `Task` leaked into `components.schemas`** (D-A-03). `SchemaSubject` now makes the same Task-to-void substitution `GetResponseInformation` already made eight methods away, so the `Task` schema and its BCL entourage leave the document.
- **`SchemaConstraintWriter` ate constraints beside any nested `$ref`** (found while grounding, folded into this queue entry). The guard ran `IndexOf("\"$ref\"")` over the whole serialized schema, so `[ItemCount]` on an array of referenced objects - and every other facet on such a property - was dropped. It now checks the top level only.

Stacked on #212's merge; this is the next PR in the serial queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)