### PR TITLE
Emit Range bounds as declared instead of inventing the absent one

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
@@ -105,6 +105,24 @@ public class RequiredAndNestedValidationTests {
     }
 
     /// <summary>
+    /// A single declared bound composes the single-bound message. The contract says
+    /// <c>minimum: 1</c> and nothing else, and the emitted attribute used to fill the absent
+    /// maximum with the decimal extreme - so the caller was told the value must be between 1 and
+    /// 7.92281625142643E+28, an upper bound nobody declared.
+    /// </summary>
+    [HardenedTest]
+    public async Task ASingleBoundNamesNoInventedExtreme(ITestWebApp testWebApp) {
+        var error = await Rejected(
+            testWebApp,
+            """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":0}]}""");
+
+        var quantity = Assert.Single(error.Errors!, e => e.Field.Contains("quantity"));
+
+        Assert.DoesNotContain("E+28", quantity.Message);
+        Assert.DoesNotContain("between", quantity.Message);
+    }
+
+    /// <summary>
     /// The failing element is identified, not merely the array. An error naming <c>lines</c> alone
     /// tells a caller with fifty lines nothing.
     /// </summary>

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
@@ -101,12 +101,20 @@ internal static class ConstraintAttributes {
         }
 
         if (numeric && (minimum.HasValue || maximum.HasValue)) {
-            // Range has no partially-bounded constructor, and its double overload takes the widest
-            // set of spec values - so an absent bound becomes the extreme rather than being omitted.
-            var arguments = new List<string> {
-                Literal(minimum, decimal.MinValue),
-                Literal(maximum, decimal.MaxValue),
-            };
+            // Named arguments, like every other bounded constraint here. This used to claim Range
+            // had no partially-bounded form and fill the absent bound with a decimal extreme - so
+            // `minimum: 1` validated as "must be between 1 and 7.92281625142643E+28", and
+            // ValidationModules' single-bound message templates, which cite that exact symptom as
+            // their reason to exist, never engaged. An absent bound emits no comparison at all.
+            var arguments = new List<string>();
+
+            if (minimum.HasValue) {
+                arguments.Add("Min = " + Literal(minimum.Value));
+            }
+
+            if (maximum.HasValue) {
+                arguments.Add("Max = " + Literal(maximum.Value));
+            }
 
             if (exclusiveMinimum) {
                 arguments.Add("ExclusiveMin = true");
@@ -160,8 +168,13 @@ internal static class ConstraintAttributes {
         return parts;
     }
 
-    private static string Literal(decimal? value, decimal fallback) =>
-        ((double)(value ?? fallback)).ToString("R", CultureInfo.InvariantCulture);
+    /// <summary>
+    /// A bound as a C# literal for Range's <c>object?</c> properties. Rendered through double
+    /// because decimal is not a legal attribute argument type; a whole-number bound renders as
+    /// the integer it is.
+    /// </summary>
+    private static string Literal(decimal value) =>
+        ((double)value).ToString("R", CultureInfo.InvariantCulture);
 
     private static string Quote(string value) =>
         "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ConstraintAttributesTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ConstraintAttributesTests.cs
@@ -158,35 +158,54 @@ public class ConstraintAttributesTests {
     }
 
     /// <summary>
-    /// <c>Range</c> has no partially-bounded constructor, so an absent bound becomes the extreme
-    /// rather than being omitted.
+    /// An absent bound is omitted, the way every other bounded constraint here writes its bounds.
+    /// It used to become the decimal extreme, because this file claimed Range had no
+    /// partially-bounded form - so <c>minimum: 5</c> validated as "must be between 5 and
+    /// 7.92281625142643E+28", and the single-bound message templates ValidationModules shipped
+    /// against that exact symptom never engaged.
     /// </summary>
     [Fact]
-    public void AnAbsentBoundBecomesTheExtreme() {
+    public void AnAbsentBoundIsOmitted() {
         var arguments = Single(For(Property(minimum: 5), "int"), "RangeAttribute").Arguments;
 
-        Assert.Equal(2, arguments.Count);
-        Assert.Equal("5", arguments[0]);
-        Assert.Equal(((double)decimal.MaxValue).ToString("R", System.Globalization.CultureInfo.InvariantCulture),
-            arguments[1]);
+        Assert.Equal(new[] { "Min = 5" }, arguments);
     }
 
     [Fact]
-    public void ExclusiveBoundsAreNamedArgumentsAfterThePositionalOnes() {
+    public void AnAbsentLowerBoundIsOmittedToo() {
+        var arguments = Single(For(Property(maximum: 10), "int"), "RangeAttribute").Arguments;
+
+        Assert.Equal(new[] { "Max = 10" }, arguments);
+    }
+
+    /// <summary>
+    /// The exclusive flag rides beside a single bound, which is what lets the exclusive
+    /// single-bound message templates engage.
+    /// </summary>
+    [Fact]
+    public void AnExclusiveSingleBoundKeepsItsFlag() {
+        var arguments = Single(
+            For(Property(minimum: 0, exclusiveMinimum: true), "double"), "RangeAttribute").Arguments;
+
+        Assert.Equal(new[] { "Min = 0", "ExclusiveMin = true" }, arguments);
+    }
+
+    [Fact]
+    public void ExclusiveBoundsAreNamedArgumentsAfterTheBounds() {
         var arguments =
             Single(For(Property(minimum: 1, maximum: 10, exclusiveMinimum: true, exclusiveMaximum: true), "int"),
                 "RangeAttribute").Arguments;
 
-        Assert.Equal(4, arguments.Count);
-        Assert.Equal("ExclusiveMin = true", arguments[2]);
-        Assert.Equal("ExclusiveMax = true", arguments[3]);
+        Assert.Equal(
+            new[] { "Min = 1", "Max = 10", "ExclusiveMin = true", "ExclusiveMax = true" },
+            arguments);
     }
 
     [Fact]
     public void AnInclusiveBoundWritesNoExclusiveFlag() {
         var arguments = Single(For(Property(minimum: 1, maximum: 10), "int"), "RangeAttribute").Arguments;
 
-        Assert.Equal(2, arguments.Count);
+        Assert.Equal(new[] { "Min = 1", "Max = 10" }, arguments);
     }
 
     /// <summary>
@@ -196,7 +215,7 @@ public class ConstraintAttributesTests {
     [Fact]
     public void AFractionalBoundIsWrittenInvariant() {
         Assert.Equal(
-            "1.5",
+            "Min = 1.5",
             Single(For(Property(minimum: 1.5m, maximum: 10), "double"), "RangeAttribute").Arguments[0]);
     }
 


### PR DESCRIPTION
F8 from the Forty-Four Fixes queue: both Range papercuts from the second trial (D-B-13, D-B-14), which turned out to be one Hardened defect.

`ConstraintAttributes.Build` claimed `[Range]` had no partially-bounded form and filled the absent bound with a decimal extreme rendered through `double`. A contract declaring `minimum: 1` and nothing else therefore validated as "must be between 1 and 7.92281625142643E+28" - and ValidationModules' single-bound message templates, which cite that exact symptom as their reason to exist, never engaged, because Hardened always supplied both bounds. `RangeAttribute` has a parameterless constructor with `Min`/`Max` init properties and its own XML example is `[Range(Min = 1)]`.

The emitter now writes named arguments and omits whichever bound the contract left undeclared - the same shape `Bounds()` forty lines below already writes for `StringLength` and `ItemCount` - and the exclusive flags ride beside a single bound, so the exclusive single-bound templates engage too. No ValidationModules change was needed; the runtime fix it already shipped does the rest once Hardened stops defeating it.

Next in the serial queue after #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)