### PR TITLE
Resolve described enum parameters and publish tag descriptions

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/GeneratedDocumentTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/GeneratedDocumentTests.cs
@@ -119,6 +119,22 @@ public class GeneratedDocumentTests {
     }
 
     /// <summary>
+    /// The description the contract's top-level tag declaration carries reaches the published
+    /// tags list, which used to carry the name alone.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheTagCarriesItsDeclaredDescription(ITestWebApp app) {
+        var tags = (await Document(app)).GetProperty("tags");
+
+        var pet = tags.EnumerateArray()
+            .Single(tag => tag.GetProperty("name").GetString() == "Pet");
+
+        Assert.Equal(
+            "Everything about the pets in the store.",
+            pet.GetProperty("description").GetString());
+    }
+
+    /// <summary>
     /// A property the contract marks nullable publishes the 2020-12 type array, the way the
     /// code-first writer already does. The framework's own 404 body sends <c>detail</c> as null.
     /// </summary>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -5,6 +5,11 @@ openapi: "3.0.0"
 info:
   title: Petstore API
   version: "1.0.0"
+# The group's own prose, which used to be parsed to nothing: the published document's tags
+# carried the name alone.
+tags:
+  - name: Pet
+    description: Everything about the pets in the store.
 paths:
   /pets:
     get:

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyServedDocumentTests.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyServedDocumentTests.cs
@@ -79,6 +79,27 @@ public class SmithyServedDocumentTests {
     }
 
     /// <summary>
+    /// An enum bound as a query value publishes its vocabulary. It published a bare string:
+    /// Smithy's <c>Describe()</c> returns the shape's reference and nothing else, and the builder
+    /// never resolved it, so the writer fell back to the C# type.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnEnumQueryParameterPublishesItsVocabulary(ITestWebApp app) {
+        var parameters = (await Document(app)).GetProperty("paths").GetProperty("/pets")
+            .GetProperty("get").GetProperty("parameters");
+
+        var kind = parameters.EnumerateArray()
+            .Single(parameter => parameter.GetProperty("name").GetString() == "kind");
+
+        var schema = kind.GetProperty("schema");
+
+        Assert.Equal("string", schema.GetProperty("type").GetString());
+        Assert.Equal(
+            new[] { "dog", "cat", "other" },
+            schema.GetProperty("enum").EnumerateArray().Select(value => value.GetString()));
+    }
+
+    /// <summary>
     /// A member that is neither <c>@required</c> nor defaulted is nullable under Smithy's rules,
     /// and the published schema says so with the 2020-12 type array.
     /// </summary>

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/PetStoreServiceImpl.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/PetStoreServiceImpl.cs
@@ -69,7 +69,7 @@ public class PetStoreServiceImpl : IPetStoreService {
             verbose == true ? pet : pet with { Nickname = null }));
     }
 
-    public Task<ListPetsOutput> ListPets(int? limit) =>
+    public Task<ListPetsOutput> ListPets(int? limit, PetKind? kind) =>
         Task.FromResult(new ListPetsOutput(
             limit.HasValue ? Pets.Take(limit.Value).ToList() : Pets.ToList()));
 

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/Specs/petstore.smithy
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/Specs/petstore.smithy
@@ -57,6 +57,12 @@ operation ListPets {
         @httpQuery("limit")
         @range(min: 1, max: 100)
         limit: Integer
+
+        // An enum bound as a query value and appearing nowhere in this operation's bodies. The
+        // parameter published as a bare string: Describe() returns the shape's reference and the
+        // builder never resolved it against the schema list.
+        @httpQuery("kind")
+        kind: PetKind
     }
     output := {
         @required

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceModel.cs
@@ -4,6 +4,13 @@ internal class ServiceModel : IEquatable<ServiceModel> {
     public string Tag { get; set; } = "";
 
     /// <summary>
+    /// The description the contract's top-level tag declaration gives this tag, or null. The
+    /// document's <c>tags</c> entry used to carry the name alone, so the prose an author wrote
+    /// for a group of operations reached nothing.
+    /// </summary>
+    public string? TagDescription { get; set; }
+
+    /// <summary>
     /// The C# name the service interface and controller are built from.
     /// </summary>
     /// <remarks>
@@ -35,6 +42,7 @@ internal class ServiceModel : IEquatable<ServiceModel> {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
         if (Tag != other.Tag) return false;
+        if (TagDescription != other.TagDescription) return false;
         if (DispatchHeader != other.DispatchHeader) return false;
         if (Operations.Count != other.Operations.Count) return false;
         for (var i = 0; i < Operations.Count; i++) {

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -197,6 +197,7 @@ internal static class SpecModelSerializer {
                 case "service":
                     service = new ServiceModel {
                         Tag = record.String("Tag") ?? "",
+                        TagDescription = record.String("TagDescription"),
                         TypeBaseName = record.String("TypeBaseName") ?? "",
                         DispatchHeader = record.String("DispatchHeader")
                     };
@@ -528,6 +529,7 @@ internal static class SpecModelSerializer {
     private static void WriteService(StringBuilder builder, ServiceModel service) {
         var record = new Record("service");
         record.Add("Tag", service.Tag);
+        record.Add("TagDescription", service.TagDescription);
         record.Add("TypeBaseName", service.TypeBaseName);
         record.Add("DispatchHeader", service.DispatchHeader);
         record.WriteTo(builder);

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
@@ -64,35 +64,11 @@ internal static class RequestModelBuilder {
                     }
                 }
 
-                result.Add(new RequestHandlerModel(
-                    model.Name,
-                    model.ControllerType,
-                    model.HandlerMethod,
-                    model.InvokeHandlerType,
-                    model.RequestParameterInformationList,
-                    responseInformation,
-                    filters) {
-                    // Carried across: this rebuilds the model to add [Handler] filters, and dropping
-                    // it here leaves Parameters not implementing the interface its validator is
-                    // typed on - so the filter's type test fails and validation silently does not
-                    // run, on a build that is otherwise green.
-                    ParametersInterface = model.ParametersInterface,
-
-                    // Everything else the builder decided, for the same reason: this constructor
-                    // takes seven of the model's members and an object initialiser is the only
-                    // thing carrying the rest, so anything not restated here is dropped. The
-                    // schemas going missing is what published a document describing no payloads.
-                    Summary = model.Summary,
-                    Description = model.Description,
-                    Tag = model.Tag,
-                    IsDeprecated = model.IsDeprecated,
-                    RequestSchema = model.RequestSchema,
-                    ResponseSchemas = model.ResponseSchemas,
-                    DeclaredResponsesAreComplete = model.DeclaredResponsesAreComplete,
-                    SecurityRequirements = model.SecurityRequirements,
-                    DeclaredSecuritySchemes = model.DeclaredSecuritySchemes,
-                    HasGeneratedValidation = model.HasGeneratedValidation,
-                });
+                // Through WithFilters, which carries every settable member, rather than a second
+                // hand-rolled copy. This used to restate the members one by one, and each field
+                // added to the model was silently dropped here until someone noticed - the tag's
+                // description was the latest. One copy site is the fix, not a longer list.
+                result.Add(model.WithFilters(filters, responseInformation));
             } else {
                 result.Add(model);
             }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
@@ -383,7 +383,7 @@ public class SpecModelSerializerTests {
                 },
                 new SchemaModel { Name = "PetStatus", Kind = SchemaKind.Enum, EnumValues = { "available", "sold" } },
             },
-            Services = { new ServiceModel { Tag = "Pet", Operations = { operation } } },
+            Services = { new ServiceModel { Tag = "Pet", TagDescription = "Everything about pets.", Operations = { operation } } },
             FilterTypes = {
                 new FilterTypeModel {
                     Name = "rateLimit",

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -200,6 +200,10 @@ internal static class OpenApiSpecParser {
         foreach (var kvp in operationsByTag) {
             model.Services.Add(new ServiceModel {
                 Tag = kvp.Key,
+                // From the document's top-level tags list, which is the one place a contract
+                // describes a group rather than an operation.
+                TagDescription = document.Tags?
+                    .FirstOrDefault(t => t.Name == kvp.Key)?.Description,
                 Operations = kvp.Value
             });
         }

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/TagDescriptionTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/TagDescriptionTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Generation.Models;
+using Hardened.Idl.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// The description a contract's top-level tag declaration carries, through to the handler model
+/// the document writer reads.
+/// </summary>
+public class TagDescriptionTests {
+
+    [Fact]
+    public void TheServiceDescriptionReachesEveryHandlerUnderTheTag() {
+        var spec = new ServiceSpecModel {
+            FileName = "pets",
+            Services = new List<ServiceModel> {
+                new() {
+                    Tag = "Pet",
+                    TagDescription = "Everything about pets.",
+                    Operations = new List<OperationModel> {
+                        new() {
+                            OperationId = "listPets",
+                            Tag = "Pet",
+                            Path = "/pets",
+                            HttpMethod = "GET",
+                            SuccessStatusCode = 200,
+                            SuccessResponses = { new SuccessResponseModel { StatusCode = 200 } }
+                        }
+                    }
+                }
+            }
+        };
+
+        var model = RequestModelBuilder
+            .BuildModels(spec, "Test.Api.Models", "Test.Api.Services", "Test.Api.Generated",
+                "Test.Api.Validation")
+            .Single();
+
+        Assert.Equal("Pet", model.Tag);
+        Assert.Equal("Everything about pets.", model.TagDescription);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -40,13 +40,15 @@ public class RequestHandlerModel {
     /// now the only place that has to change.
     /// </para>
     /// </remarks>
-    public RequestHandlerModel WithFilters(IReadOnlyList<AttributeModel> filters) =>
+    public RequestHandlerModel WithFilters(
+        IReadOnlyList<AttributeModel> filters,
+        ResponseInformationModel? responseInformation = null) =>
         new(Name,
             ControllerType,
             HandlerMethod,
             InvokeHandlerType,
             RequestParameterInformationList,
-            ResponseInformation,
+            responseInformation ?? ResponseInformation,
             filters) {
             ParametersInterface = ParametersInterface,
             ParametersValidator = ParametersValidator,
@@ -55,6 +57,7 @@ public class RequestHandlerModel {
             DeclaredResponsesAreComplete = DeclaredResponsesAreComplete,
             RequestSchema = RequestSchema,
             Tag = Tag,
+            TagDescription = TagDescription,
             Summary = Summary,
             Description = Description,
             IsDeprecated = IsDeprecated,
@@ -167,6 +170,12 @@ public class RequestHandlerModel {
     /// generators, and neither has tags or a document to put them in.
     /// </remarks>
     public string? Tag { get; set; }
+
+    /// <summary>
+    /// The description the contract gives this handler's tag, for the document's
+    /// <c>tags</c> list. Null for code-first, which has no way to describe a group yet.
+    /// </summary>
+    public string? TagDescription { get; set; }
 
     /// <summary>
     /// The handler's <c>&lt;summary&gt;</c> doc comment, as the operation's <c>summary</c>.
@@ -305,6 +314,11 @@ public class RequestHandlerModel {
         }
 
         if (!string.Equals(Tag, requestHandlerModel.Tag, StringComparison.Ordinal)) {
+            return false;
+        }
+
+        if (!string.Equals(
+                TagDescription, requestHandlerModel.TagDescription, StringComparison.Ordinal)) {
             return false;
         }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -335,12 +335,20 @@ public static class OpenApiDocumentGenerator {
     /// </remarks>
     private static void WriteTags(StringBuilder builder, IReadOnlyList<RequestHandlerModel> handlers) {
         var seen = new List<string>();
+        var descriptions = new Dictionary<string, string>();
 
         foreach (var handler in handlers) {
             var tag = Tag(handler);
 
             if (!seen.Contains(tag)) {
                 seen.Add(tag);
+            }
+
+            // The contract's prose for the group, where a handler carries it. First writer wins,
+            // which cannot disagree with itself: every handler under one tag came from the same
+            // service and carries the same description.
+            if (!descriptions.ContainsKey(tag) && !string.IsNullOrEmpty(handler.TagDescription)) {
+                descriptions[tag] = handler.TagDescription!;
             }
         }
 
@@ -355,7 +363,14 @@ public static class OpenApiDocumentGenerator {
                 builder.Append(',');
             }
 
-            builder.Append("{\"name\":\"").Append(JsonSchemaWriter.Escape(seen[i])).Append("\"}");
+            builder.Append("{\"name\":\"").Append(JsonSchemaWriter.Escape(seen[i])).Append('"');
+
+            if (descriptions.TryGetValue(seen[i], out var description)) {
+                builder.Append(",\"description\":\"")
+                    .Append(JsonSchemaWriter.Escape(description)).Append('"');
+            }
+
+            builder.Append('}');
         }
 
         builder.Append(']');

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -48,7 +48,8 @@ internal static class SpecHandlerModelBuilder {
                     modelsNamespace, generatedNamespace, validationNamespace,
                     spec.ResponseModel,
                     spec.ValidatedOperations, filterTypeLookup, spec.Schemas,
-                    service.DispatchHeader, Symbols(symbols, operation));
+                    service.DispatchHeader, Symbols(symbols, operation),
+                    service.TagDescription);
                 models.Add(model);
             }
         }
@@ -91,7 +92,8 @@ internal static class SpecHandlerModelBuilder {
         Dictionary<string, FilterTypeModel> filterTypeLookup,
         IReadOnlyList<SchemaModel> schemas,
         string? dispatchHeader = null,
-        OperationSymbols? symbols = null) {
+        OperationSymbols? symbols = null,
+        string? tagDescription = null) {
         var methodName = operation.MethodName;
 
         // Derived by convention from the service's name for a described application, because a
@@ -109,7 +111,7 @@ internal static class SpecHandlerModelBuilder {
         var nameModel = new RequestHandlerNameModel(
             ConstrainedPath(operation), operation.HttpMethod, dispatchHeader, operation.DispatchKey);
 
-        var parameters = BuildParameters(operation, modelsNamespace, symbols);
+        var parameters = BuildParameters(operation, modelsNamespace, schemas, symbols);
         var responseInfo = symbols?.ResponseInformation
                            ?? BuildResponseInfo(operation, schemas, modelsNamespace, responseModel);
 
@@ -187,6 +189,7 @@ internal static class SpecHandlerModelBuilder {
             // because a handler model that has lost its summary cannot be told from one whose
             // operation never had a summary - and the document written from it is silently poorer.
             Tag = operation.Tag,
+            TagDescription = tagDescription,
             Summary = operation.Summary,
             Description = operation.Description,
             IsDeprecated = operation.IsDeprecated,
@@ -223,11 +226,31 @@ internal static class SpecHandlerModelBuilder {
     }
 
     private static IReadOnlyList<RequestParameterInformation> BuildParameters(
-        OperationModel operation, string modelsNamespace, OperationSymbols? symbols = null) {
+        OperationModel operation, string modelsNamespace, IReadOnlyList<SchemaModel> schemas,
+        OperationSymbols? symbols = null) {
         var parameters = new List<RequestParameterInformation>();
         var index = 0;
 
         foreach (var param in operation.Parameters) {
+            // A described enum can arrive as a bare reference: Smithy's Describe() returns the
+            // shape's Ref and nothing else, so the document writer fell back to the C# type and
+            // published {"type":"string"} with no vocabulary. Resolved against the schema list the
+            // way response schemas already are, onto the parameter the writer reads. OpenAPI
+            // parameters are unaffected, because that parser inlines enum values at parse time.
+            if (param.Ref != null && param.EnumValues is not { Count: > 0 }) {
+                var referenced = NamingHelper.ToPascalCase(TypeMapper.GetRefName(param.Ref));
+
+                foreach (var schema in schemas) {
+                    if (schema.Kind == SchemaKind.Enum &&
+                        NamingHelper.ToPascalCase(schema.Name) == referenced) {
+                        param.EnumValues = new List<string>(schema.EnumValues);
+                        param.Type ??= "string";
+
+                        break;
+                    }
+                }
+            }
+
             // Still needed either way: the default literal is formatted against the C# spelling.
             var csType = TypeMapper.MapParameterToCSharpType(param);
 


### PR DESCRIPTION
F6 from the Forty-Four Fixes queue (D-C-04, D-B-15), plus a defect found on the way through.

- **Smithy enum parameters published `{"type":"string"}` with no vocabulary** (D-C-04). Smithy's `Describe()` returns only a reference for an enum shape and `SpecHandlerModelBuilder.BuildParameters` never resolved it. It now resolves the reference against the schema list already in scope - the way response schemas are resolved a few lines earlier - and copies the values onto the parameter the writer reads. OpenAPI parameters were unaffected because that parser inlines enum values at parse time.
- **Tag descriptions parsed to nothing** (D-B-15). `WriteTags` emitted the name alone and no model field existed to carry the prose. `ServiceModel` gains `TagDescription`, the OpenAPI parser fills it from the document's tags list, the serializer round-trips it, and the writer emits it beside the name.
- **Found while wiring it end to end:** `RequestModelBuilder.EnrichWithHandlerFilters` rebuilt the handler model with a hand-rolled copy - the exact hazard `WithFilters` exists to remove, noted in its own comment - so every member added to the model was silently dropped for any application with a `[Handler]` class. The copy now goes through `WithFilters`, which gains an optional `responseInformation` for the one thing the enrichment changes.

Next in the serial queue after #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)