### PR TITLE
Tell the docs repo when a release ships

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -309,3 +309,21 @@ jobs:
             --generate-notes \
             ${prerelease} \
             ./artifacts/*.nupkg
+
+      # The docs site went two releases stale silently, because nothing told it a release
+      # happened. This is not automation of the docs, just an interrupt that fires: one issue
+      # naming the version, into the repository that declares its package version once.
+      #
+      # Cross-repo issue creation needs a token with issues:write on Hardened.Docs, which
+      # GITHUB_TOKEN does not carry - set a DOCS_ISSUE_TOKEN fine-grained PAT for this to fire.
+      # continue-on-error, because a release must never fail over its reminder.
+      - name: Open the Docs version-bump issue
+        if: startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_ISSUE_TOKEN != '' && secrets.DOCS_ISSUE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --repo ipjohnson/Hardened.Docs \
+            --title "Point the documented version at ${{ steps.version.outputs.version }}" \
+            --body "Hardened.Framework ${{ steps.version.outputs.version }} is on nuget.org. The site declares its package version once, as hardenedVersion in website/.vitepress/config.ts; move it and the whole site follows."


### PR DESCRIPTION
The Framework half of D5 from the Forty-Four Fixes queue: the docs site went two releases stale silently, because nothing told it a release happened.

The release workflow now opens one issue in Hardened.Docs naming the new version, as a final step after the GitHub release. It uses `DOCS_ISSUE_TOKEN` when that secret is set - a fine-grained PAT with issues:write on the docs repository, which cross-repo issue creation needs - and falls back to `GITHUB_TOKEN` otherwise. The step is `continue-on-error` either way: a release must never fail over its reminder.

One action item on merge: add the `DOCS_ISSUE_TOKEN` secret to this repository, or the step will attempt with `GITHUB_TOKEN` and log a failure it swallows.

Next in the serial queue after #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)