### PR TITLE
Honor the contract's declared validation status

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/DeclaredValidationStatusTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/DeclaredValidationStatusTests.cs
@@ -1,0 +1,66 @@
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests;
+
+/// <summary>
+/// A contract that declares its validation status is answered at it.
+/// </summary>
+/// <remarks>
+/// Arm C of the second trial declared <c>422</c> for its validation error; the build published
+/// it and the service answered the stock 400, because the declared status was wired to nothing.
+/// <c>/labels</c> POST is the same declaration here: its validation failures answer 422, the
+/// operations declaring nothing keep their 400, and the published document carries the declared
+/// 422 without a synthesized 400 beside it.
+/// </remarks>
+public class DeclaredValidationStatusTests {
+
+    [HardenedTest]
+    public async Task AValidationFailureAnswersTheDeclaredStatus(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            """{"name":""}""", "/labels",
+            request => request.Headers["Content-Type"] = "application/json");
+
+        Assert.Equal(422, response.StatusCode);
+
+        var error = response.Deserialize<ValidationShape>();
+
+        Assert.Equal("ValidationError", error!.Type);
+        Assert.Contains(error.Errors, e => e.Field.Contains("name"));
+    }
+
+    [HardenedTest]
+    public async Task AValidRequestStillAnswersItsSuccess(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            """{"name":"aisle four"}""", "/labels",
+            request => request.Headers["Content-Type"] = "application/json");
+
+        response.Assert.Ok();
+    }
+
+    /// <summary>
+    /// The document carries the declared 422 and no synthesized 400 beside it: validation no
+    /// longer produces a 400 on this operation, so publishing one would be the next untruth.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheDocumentCarriesTheDeclaredStatusAlone(ITestWebApp app) {
+        var response = await app.Get("/openapi.json");
+
+        response.Assert.Ok();
+        response.Body.Position = 0;
+
+        await using var gzip = new GZipStream(response.Body, CompressionMode.Decompress);
+
+        var document = JsonDocument.Parse(await new StreamReader(gzip).ReadToEndAsync()).RootElement;
+
+        var responses = document.GetProperty("paths").GetProperty("/labels")
+            .GetProperty("post").GetProperty("responses");
+
+        Assert.True(responses.TryGetProperty("422", out _));
+        Assert.False(responses.TryGetProperty("400", out _));
+    }
+
+    private record ValidationShape(string Type, string Message, List<FieldShape> Errors);
+
+    private record FieldShape(string Field, string Code, string Message);
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
@@ -21,6 +21,10 @@ public class LabelServiceImpl : ILabelService {
         return Task.FromResult<GetLabelResponse>(new GetLabelOk($"Label {labelId}"));
     }
 
+    public Task<CreateLabelResponse> CreateLabel(LabelRequest body) {
+        return Task.FromResult<CreateLabelResponse>(body);
+    }
+
     public Task<ArchiveLabelResponse> ArchiveLabel(string labelId) {
         if (labelId == "missing") {
             return Task.FromResult<ArchiveLabelResponse>(

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Specs/labels.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Specs/labels.yaml
@@ -52,8 +52,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Problem'
+  # A validated body under a contract that declares its validation status. Arm C declared a 422
+  # exactly like this, the build published it, and the service answered the stock 400 - the
+  # declared status was wired to nothing.
+  /labels:
+    post:
+      tags:
+        - Label
+      operationId: createLabel
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LabelRequest'
+      responses:
+        '200':
+          description: The label as stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LabelRequest'
+        '422':
+          description: The label was understood and refused by validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
 components:
   schemas:
+    LabelRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 40
     Problem:
       type: object
       properties:

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -362,6 +362,7 @@ namespace Hardened.Requests.Abstract.Execution
         System.Collections.Generic.IReadOnlyList<string> ProducedContentTypes { get; }
         Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; }
         int? SuccessStatus { get; }
+        int? ValidationErrorStatus { get; }
         Hardened.Requests.Abstract.Authorization.Requirement? RequirementFrom(System.Collections.Generic.IReadOnlyList<object> metadata);
     }
     public interface IExecutionRequestParameter

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -264,7 +264,7 @@ namespace Hardened.Requests.Runtime.Execution
     }
     public class ExecutionRequestHandlerInfo : Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo
     {
-        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null, Hardened.Requests.Abstract.Authorization.Requirement? requirement = null, int? successStatus = default, object? nullResponseBody = null, System.Collections.Generic.IReadOnlyList<string>? producedContentTypes = null, string? bodyParameterName = null) { }
+        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null, Hardened.Requests.Abstract.Authorization.Requirement? requirement = null, int? successStatus = default, object? nullResponseBody = null, System.Collections.Generic.IReadOnlyList<string>? producedContentTypes = null, string? bodyParameterName = null, int? validationErrorStatus = default) { }
         public string? BodyParameterName { get; }
         public System.Type HandlerType { get; }
         public string InvokeMethod { get; }
@@ -276,6 +276,7 @@ namespace Hardened.Requests.Runtime.Execution
         public System.Collections.Generic.IReadOnlyList<string> ProducedContentTypes { get; }
         public Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; }
         public int? SuccessStatus { get; }
+        public int? ValidationErrorStatus { get; }
         public Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo WithPath(string? path) { }
     }
     public static class ExecutionRequestHandlerInfoExtensions

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
@@ -91,6 +91,16 @@ public interface IExecutionRequestHandlerInfo {
     /// </remarks>
     string? BodyParameterName => null;
 
+    /// <summary>
+    /// The status a validation failure answers with, or null for the stock 400.
+    /// </summary>
+    /// <remarks>
+    /// Set only from a described operation declaring 422. A contract that publishes a 422 for its
+    /// validation error is a promise the converter has to keep; a hand-written handler has no
+    /// source of truth behind such an assertion, which is why no attribute carries this.
+    /// </remarks>
+    int? ValidationErrorStatus => null;
+
     IReadOnlyList<IExecutionRequestParameter> Parameters { get; }
 
     IReadOnlyList<object> Metadata => Array.Empty<object>();

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -29,7 +29,11 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
                     Message = e.Message
                 }).ToList()
             };
-            return (400, errorModel);
+
+            // The status the contract declared for validation failures, where it declared one.
+            // Arm C published a 422 and was answered 400; the declared status was wired to
+            // nothing.
+            return (context.HandlerInfo?.ValidationErrorStatus ?? 400, errorModel);
         }
 
         // An exception that names its own status, which is how a specification's declared error

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
@@ -15,7 +15,8 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         int? successStatus = null,
         object? nullResponseBody = null,
         IReadOnlyList<string>? producedContentTypes = null,
-        string? bodyParameterName = null) {
+        string? bodyParameterName = null,
+        int? validationErrorStatus = null) {
         Path = path;
         Method = method;
         HandlerType = handlerType;
@@ -27,6 +28,7 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         NullResponseBody = nullResponseBody;
         ProducedContentTypes = producedContentTypes ?? Array.Empty<string>();
         BodyParameterName = bodyParameterName;
+        ValidationErrorStatus = validationErrorStatus;
     }
 
     /// <summary>
@@ -64,7 +66,8 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
             source.SuccessStatus,
             source.NullResponseBody,
             source.ProducedContentTypes,
-            source.BodyParameterName) { }
+            source.BodyParameterName,
+            source.ValidationErrorStatus) { }
 
     public string Path { get; }
 
@@ -96,6 +99,9 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
 
     /// <inheritdoc />
     public string? BodyParameterName { get; }
+
+    /// <inheritdoc />
+    public int? ValidationErrorStatus { get; }
 
     /// <summary>
     /// The same handler, addressed at <paramref name="path"/>.

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
@@ -205,7 +205,8 @@ public class ModelComparisonTests {
             NullResponseBodyExpression = "Models.DefaultErrorBodies.NotFoundProblem",
             ProducedContentTypes = "text/plain,text/csv",
             UnionCases = "global::App.Todo|201|01;global::App.NotFound|404|01",
-            ThrowsDiagnostic = "OutOfStock"
+            ThrowsDiagnostic = "OutOfStock",
+            ValidationErrorStatus = 422
         };
 
         // Every field, because this string is what the incremental caches compare to decide
@@ -213,7 +214,7 @@ public class ModelComparisonTests {
         Assert.Equal(
             "True:System.Fortunes:text/csv:sse:System.String:201:" +
             "Models.DefaultErrorBodies.NotFoundProblem:text/plain,text/csv:" +
-            "global::App.Todo|201|01;global::App.NotFound|404|01::OutOfStock",
+            "global::App.Todo|201|01;global::App.NotFound|404|01::OutOfStock:422",
             model.ToString());
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
@@ -101,6 +101,18 @@ public record ResponseInformationModel {
     public string? RawResponseContentType { get; set; }
 
     /// <summary>
+    /// The status the contract declares validation failures answer with, or null for the stock
+    /// 400.
+    /// </summary>
+    /// <remarks>
+    /// Set only from a described operation declaring 422, which is the one status that names
+    /// validation refusal. The attribute that would have carried this code-first was removed
+    /// because a hand-written assertion has no source of truth behind it; a contract does, and
+    /// arm C of the second trial declared exactly this and was answered 400 anyway.
+    /// </remarks>
+    public int? ValidationErrorStatus { get; set; }
+
+    /// <summary>
     /// The cases of a declared response set, encoded, or null where the handler returns one type.
     /// </summary>
     /// <remarks>
@@ -168,6 +180,6 @@ public record ResponseInformationModel {
     public override string ToString() {
         return $"{IsAsync}:{OutputType}:{RawResponseContentType}:{StreamFraming}:{ReturnType}" +
                $":{DefaultStatusCode}:{NullResponseBodyExpression}:{ProducedContentTypes}" +
-               $":{UnionCases}:{UnionDiagnostic}:{ThrowsDiagnostic}";
+               $":{UnionCases}:{UnionDiagnostic}:{ThrowsDiagnostic}:{ValidationErrorStatus}";
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -662,6 +662,13 @@ public static class OpenApiDocumentGenerator {
             return;
         }
 
+        // An operation whose contract declares the validation status answers it there: the
+        // declared 422 is already in the response set, and a synthesized 400 beside it would
+        // describe a status validation no longer produces on this operation.
+        if (handler.ResponseInformation.ValidationErrorStatus != null) {
+            return;
+        }
+
         if (DeclaresStatus(handler, 400)) {
             return;
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
@@ -115,6 +115,12 @@ public static class HandlerInfoCodeGenerator {
             }
         }
 
+        // The status the contract declares validation failures answer with. The converter keeps
+        // the promise at run time; without this the build published a 422 the service never sent.
+        if (handlerModel.ResponseInformation.ValidationErrorStatus is { } validationStatus) {
+            declaredArgs += $", validationErrorStatus: {validationStatus}";
+        }
+
         // The type is handed over rather than named, so it is still a type when the file is
         // serialized: written qualified in a file that qualifies, and counted in the using list.
         // Spelled into the string it was neither, and resolved only while some other part of the

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -353,6 +353,7 @@ internal static class SpecHandlerModelBuilder {
                 ProducedContentTypes = operation.ProducedContentTypes.Count > 0
                     ? string.Join(",", operation.ProducedContentTypes)
                     : null,
+                ValidationErrorStatus = DeclaredValidationStatus(operation),
                 UnionCases = unionCases
             };
         }
@@ -420,8 +421,25 @@ internal static class SpecHandlerModelBuilder {
             // which leaves negotiation exactly as it was rather than declaring an empty set.
             ProducedContentTypes = operation.ProducedContentTypes.Count > 0
                 ? string.Join(",", operation.ProducedContentTypes)
-                : null
+                : null,
+
+            ValidationErrorStatus = DeclaredValidationStatus(operation)
         };
+    }
+
+    /// <summary>
+    /// The status the contract declares validation failures answer with: a declared 422, the one
+    /// status that names validation refusal. Arm C declared exactly this, the build published it,
+    /// and the service answered the stock 400 - the declared status was wired to nothing.
+    /// </summary>
+    private static int? DeclaredValidationStatus(OperationModel operation) {
+        foreach (var error in operation.ErrorResponses) {
+            if (error.StatusCode == 422) {
+                return 422;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
F10 from the Forty-Four Fixes queue (D-C-03, completing D-A-05/D-B-05), per the settled decision to generate the wiring rather than document-only.

Arm C declared `@httpError(422)` for its validation error; the build published the 422 and the service answered the stock 400, because the declared status was wired to nothing. Now:

- The spec bridge records a declared 422 - the one status that names validation refusal - as `ResponseInformationModel.ValidationErrorStatus`, the generated handler info carries it (`IExecutionRequestHandlerInfo.ValidationErrorStatus`, on the same plumbing #219 added for the body parameter name), and the stock converter answers validation failures at it, per operation.
- Operations declaring nothing keep their 400 untouched, and the document stops synthesizing a 400 beside a declared 422 the operation no longer produces.

One stated deviation from the plan's sketch: wired through handler info rather than a generated `IExceptionToModelConverter` class, because the declaration is per operation and one app-wide converter would answer 422 for every operation, declared or not. The body stays the standard envelope; a contract declaring a different 422 shape still owns the schema it published.

The integration fixture lives in the ResponseModel SUT rather than petstore.yaml: adding any operation to the OpenApi SUT's contract currently drops the `petId` route constraint from the generated table - a pre-existing tree-builder defect reproduced on pristine main and recorded separately (the shared wildcard token node takes its constraint guard from whichever route sorts first in its group).

Next in the serial queue after #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)