### PR TITLE
Report Smithy CLI findings at their file and line

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -62,9 +62,67 @@ only when *no* entry matches a described service.
 | `HOAG002` | The description could not be parsed; the build task's message is passed through. |
 | `HOAG010` | A handler was skipped because a parameter type did not resolve. Other handlers are unaffected. |
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
-| `HOAT0xx` | OpenAPI build task. |
-| `HSMT0xx` | Smithy build task. `HSMT011` is the CLI version pin, and is a warning locally by design. |
 | `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. |
+
+## Description build tasks (HOAT, HSMT)
+
+The two description front ends share one task shell, one packaged-targets layout and one
+model-diagnostics pass. Their codes share one numbering: a number means the same thing under
+`HOAT` (OpenAPI) as under `HSMT` (Smithy), and a finding is always reported under the prefix of
+the front end that read the document. Numbers that exist for one front end only leave a gap in
+the other.
+
+| Number | Meaning |
+|---|---|
+| `001` | The description file does not exist. |
+| `002` | The description could not be parsed; the reader's reasons are included. |
+| `003` | The description was declared as the wrong item kind. `HOAT003`: a spec left in `AdditionalFiles`, which the generator no longer reads. `HSMT003`: a `.smithy` IDL file pointed at `HardenedSmithyAst`, which takes a JSON AST. |
+| `004` | A model or generated source the extract step should have written is missing. Delete the model directory and rebuild. |
+| `005` | The targets file was imported before the specs were declared, so no generated source reached the compilation. Move the `<Import>` below the item group. |
+| `006` | Warning. The reader parsed the document and had something to say about it, including what a degraded trait promises that the code does not enforce. |
+| `007` | A slice selected no operations, so nothing would be generated. |
+| `008` | Warning. A slice removed a schema that is still referenced; the reference degrades to `JsonElement`. |
+| `009` | Warning. The spec is sliced but its document is embedded whole, so the served description claims operations the application does not implement. |
+| `010`–`014` | The Smithy CLI task; `HSMT` only. See below. |
+| `015` | `HSMT` only. The model declares more than one `PublishUrl` or `UiUrl`. One model is one service at one address. |
+| `016` | `UiUrl` without `PublishUrl`, so the page would have no document to render. |
+| `017` | `SourceUrl` without `EmbedDocument`, so there is no source to serve. |
+| `020`–`025` | The shared model-diagnostics pass. See below. |
+
+### The Smithy CLI task (HSMT010–HSMT014)
+
+| Id | Meaning |
+|---|---|
+| `HSMT010` | The Smithy CLI was not found. Install it, set `$(HardenedSmithyCliPath)`, or commit an AST and point `@(HardenedSmithyAst)` at it. |
+| `HSMT011` | The CLI is not the pinned version. A warning locally by design, and an error under the pin, because a different CLI can produce a different AST from identical sources. |
+| `HSMT012` | The CLI refused the model. One error per finding, at the file, line and column the CLI named; a report that does not parse is passed through whole. |
+| `HSMT013` | Warning. What the CLI said without failing, with the same per-finding attribution. |
+| `HSMT014` | The CLI exited cleanly but wrote no AST. Unlike `HSMT012`, the fix is not in a `.smithy` file. |
+
+### The model-diagnostics pass (020–025)
+
+Problems any description can state that would generate C# which does not compile, found before
+anything is emitted so they are reported against the document rather than as compiler errors in a
+generated file.
+
+| Number | Meaning |
+|---|---|
+| `020` | Warning. A schema declares a property named like the schema itself, which C# forbids (CS0542). The member is renamed; the wire name is unchanged. |
+| `021` | Warning. Two schemas generate one C# type name. Resolved automatically; rename one in the document to choose the names yourself. |
+| `022` | Warning. A `oneOf` with no discriminator whose branches cannot all be told apart by shape. Payloads are matched by parsing into each branch; declare a discriminator to decide it in the document. |
+| `023` | An `enum` declaring both string and numeric values, which no C# enum can carry. Declare one kind. |
+| `024` | Warning. A declared keyword or trait the generator does not enforce, named with a representative location. Remove it, or enforce the rule in the handler. |
+| `025` | Two error responses on one operation share one status, which would generate the same case type twice. Give them distinct statuses or merge the shapes. |
+
+### Renumbered in 0.18
+
+Codes moved so that every number has one meaning per prefix, and so findings from a Smithy model
+stop being reported as `HOAT`. If a `NoWarn` or a suppression names an old code, update it:
+`HOAT003`→`HOAT020`, `HOAT005`→`HOAT021`, `HOAT010`→`HOAT022`, `HOAT011`→`HOAT023`,
+`HOAT013`→`HOAT024`, `HSPEC010`→`025` under the front end's prefix, `010`→`016` and `011`→`017`
+under both prefixes for the publish checks, the silent-success `HSMT012`→`HSMT014`, and the
+multiple-`PublishUrl` `HSMT012`→`HSMT015`. The targets-layout `003`/`004`/`005` and the CLI codes
+`HSMT010`/`HSMT011` kept their numbers.
 
 ## Content negotiation
 

--- a/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
+++ b/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
@@ -153,6 +153,13 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
         string document, string fileName, string specPath, ICollection<string> diagnostics);
 
     /// <summary>The diagnostic code prefix this front end reports under - <c>HOAT</c> and friends.</summary>
+    /// <remarks>
+    /// A number means the same thing under every prefix, and everything reporting under one prefix
+    /// shares one numbering - which includes reporters that are not this class. This shell uses
+    /// 001-009 and 016-017, the packaged targets use 003-005 and 015, the Smithy CLI task uses
+    /// 010-014, and <see cref="SpecDiagnostics"/> uses 020 up. The full table is
+    /// docs/generator-diagnostics.md.
+    /// </remarks>
     protected abstract string DiagnosticPrefix { get; }
 
     /// <summary>What this front end calls the thing it reads, for diagnostics.</summary>
@@ -295,7 +302,7 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
         // A page renders exactly one document and fetches it by URL, so a page without one is a
         // page that renders an error. Said here rather than left to be discovered in a browser.
         if (uiUrl.Length > 0 && publishUrl.Length == 0) {
-            Log.LogError(null, DiagnosticPrefix + "010", null, path, 0, 0, 0, 0,
+            Log.LogError(null, DiagnosticPrefix + "016", null, path, 0, 0, 0, 0,
                 "'{0}' sets UiUrl but not PublishUrl, so the page at '{1}' would have no document " +
                 "to render. Set PublishUrl to where the document should be served.", path, uiUrl);
 
@@ -307,7 +314,7 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
         // Here rather than on PublishUrl: serving the contract itself is the one thing that needs
         // the contract in the assembly.
         if (sourceUrl.Length > 0 && !Embedded(spec)) {
-            Log.LogError(null, DiagnosticPrefix + "011", null, path, 0, 0, 0, 0,
+            Log.LogError(null, DiagnosticPrefix + "017", null, path, 0, 0, 0, 0,
                 "'{0}' sets SourceUrl but EmbedDocument is off, so there is no source to serve. " +
                 "Remove EmbedDocument or drop SourceUrl.", path);
 
@@ -419,7 +426,7 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
             // Checked before anything is written. These describe C# that will not compile, and
             // emitting it anyway turns a fixable spec problem into a compiler error in a generated
             // file the author cannot edit.
-            var problems = SpecDiagnostics.Find(model);
+            var problems = SpecDiagnostics.Find(model, DiagnosticPrefix);
             var fatal = false;
 
             foreach (var problem in problems) {

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
@@ -8,9 +8,18 @@ namespace Hardened.Idl;
 /// Problems a spec can describe that generate C# which will not compile.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Reported against the spec file, because that is what the author edits. Left undetected these
 /// surface as compiler errors in generated code under <c>obj/</c> - a file nobody can open and fix,
 /// with a message that never mentions the document that caused it.
+/// </para>
+/// <para>
+/// Codes are the front end's prefix plus 020-025, one number per finder. The prefix is a
+/// parameter because this pass runs for every front end and a finding belongs to the document
+/// that caused it: a Smithy model's mixed enum reported as HOAT anything sends its author to the
+/// OpenAPI documentation. 020 up is this pass's block; everything below it belongs to the task
+/// shell, the packaged targets and the Smithy CLI task, per docs/generator-diagnostics.md.
+/// </para>
 /// </remarks>
 internal static class SpecDiagnostics {
 
@@ -47,7 +56,8 @@ internal static class SpecDiagnostics {
     /// rather than leaving to be discovered: the fix is a discriminator in the document, or
     /// ShapeMatchOneOf if the branches really can be told apart by shape.
     /// </remarks>
-    private static void FindUnresolvableChoices(ServiceSpecModel model, List<Problem> problems) {
+    private static void FindUnresolvableChoices(
+        ServiceSpecModel model, string prefix, List<Problem> problems) {
         foreach (var schema in model.Schemas) {
             if (schema.Kind != SchemaKind.OneOf || schema.DiscriminatorPropertyName != null) {
                 continue;
@@ -66,7 +76,7 @@ internal static class SpecDiagnostics {
             }
 
             problems.Add(new Problem(
-                "HOAT010",
+                prefix + "022",
                 $"'{schema.Name}' declares no discriminator and nothing in the schemas separates " +
                 $"{string.Join(" from ", names)}, so those are told apart by reading the payload " +
                 "into each and requiring exactly one to fit. A payload matching several is an " +
@@ -99,7 +109,8 @@ internal static class SpecDiagnostics {
     /// <c>description</c>, because the parser mapped it.
     /// </para>
     /// </remarks>
-    private static void FindUnmappedKeywords(ServiceSpecModel model, List<Problem> problems) {
+    private static void FindUnmappedKeywords(
+        ServiceSpecModel model, string prefix, List<Problem> problems) {
         if (model.UnmappedKeywords.Count == 0) {
             return;
         }
@@ -139,7 +150,7 @@ internal static class SpecDiagnostics {
                   (locations.Count == 2 ? "place" : "places");
 
             problems.Add(new Problem(
-                "HOAT013",
+                prefix + "024",
                 $"'{keyword}' is declared {where} and is not enforced. The description promises it " +
                 "and the generated application does not apply it, so a payload this rejects on " +
                 "paper is accepted at runtime. Remove it, or keep it and enforce the rule in the " +
@@ -160,11 +171,12 @@ internal static class SpecDiagnostics {
     /// caller may send - which is the shape of defect the whole enum vocabulary work exists to
     /// close. The document has to say which it means.
     /// </remarks>
-    private static void FindMixedEnums(ServiceSpecModel model, List<Problem> problems) {
+    private static void FindMixedEnums(
+        ServiceSpecModel model, string prefix, List<Problem> problems) {
         foreach (var schema in model.Schemas) {
             if (schema.Kind == SchemaKind.Enum && schema.Type == MixedEnumType) {
                 problems.Add(new Problem(
-                    "HOAT011",
+                    prefix + "023",
                     $"Enum '{schema.Name}' declares both string and numeric values. A C# enum " +
                     "carries one wire form or the other, and picking one here would put every " +
                     "value of the other kind out of reach. Declare the members as all strings or " +
@@ -180,14 +192,14 @@ internal static class SpecDiagnostics {
     /// </summary>
     internal const string MixedEnumType = "mixed-enum";
 
-    public static IReadOnlyList<Problem> Find(ServiceSpecModel model) {
+    public static IReadOnlyList<Problem> Find(ServiceSpecModel model, string diagnosticPrefix) {
         var problems = new List<Problem>();
 
-        FindDuplicateSchemaNames(model, problems);
-        FindUnresolvableChoices(model, problems);
-        FindMixedEnums(model, problems);
-        FindUnmappedKeywords(model, problems);
-        FindCollidingErrorStatuses(model, problems);
+        FindDuplicateSchemaNames(model, diagnosticPrefix, problems);
+        FindUnresolvableChoices(model, diagnosticPrefix, problems);
+        FindMixedEnums(model, diagnosticPrefix, problems);
+        FindUnmappedKeywords(model, diagnosticPrefix, problems);
+        FindCollidingErrorStatuses(model, diagnosticPrefix, problems);
 
         foreach (var schema in model.Schemas) {
             var typeName = NamingHelper.ToPascalCase(schema.Name);
@@ -203,7 +215,7 @@ internal static class SpecDiagnostics {
                 // enclosing type". The emitted record would be
                 // "record Message(string Message)", which is not a compilable declaration.
                 problems.Add(new Problem(
-                    "HOAT003",
+                    diagnosticPrefix + "020",
                     $"Schema '{schema.Name}' declares property '{property.Name}', which would " +
                     $"generate a member named '{typeName}' inside a type of the same name - C# does " +
                     $"not allow that (CS0542). The member is generated as '{property.MemberName}'; " +
@@ -240,7 +252,8 @@ internal static class SpecDiagnostics {
     /// carry the same code), which is exactly why it has to be reported here: smithy validate
     /// accepts it and the compiler garbles it.
     /// </remarks>
-    private static void FindCollidingErrorStatuses(ServiceSpecModel model, List<Problem> problems) {
+    private static void FindCollidingErrorStatuses(
+        ServiceSpecModel model, string prefix, List<Problem> problems) {
         foreach (var service in model.Services) {
             foreach (var operation in service.Operations) {
                 var seen = new Dictionary<int, string?>();
@@ -248,7 +261,7 @@ internal static class SpecDiagnostics {
                 foreach (var error in operation.ErrorResponses) {
                     if (seen.TryGetValue(error.StatusCode, out var first)) {
                         problems.Add(new Problem(
-                            "HSPEC010",
+                            prefix + "025",
                             $"operation '{operation.OperationId}' declares two error responses " +
                             $"at status {error.StatusCode} ('{first}' and '{error.Ref}'). One " +
                             "status has one case type, so this generates the same record twice. " +
@@ -262,7 +275,8 @@ internal static class SpecDiagnostics {
         }
     }
 
-    private static void FindDuplicateSchemaNames(ServiceSpecModel model, List<Problem> problems) {
+    private static void FindDuplicateSchemaNames(
+        ServiceSpecModel model, string prefix, List<Problem> problems) {
         var seen = new Dictionary<string, string>();
 
         foreach (var schema in model.Schemas) {
@@ -274,7 +288,7 @@ internal static class SpecDiagnostics {
                 // the assertion that neither missed, and it does not stop the build, because a
                 // duplicate type name surfaces immediately as CS0101 anyway.
                 problems.Add(new Problem(
-                    "HOAT005",
+                    prefix + "021",
                     $"Schemas '{first}' and '{schema.Name}' both generate a type named " +
                     $"'{typeName}', which should have been resolved automatically. Rename one of " +
                     "them in the document.",

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OneOfTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OneOfTests.cs
@@ -192,18 +192,18 @@ public class OneOfTests {
     public void AnUnresolvableChoiceIsReported() {
         var model = Parse(Ambiguous);
 
-        var problems = Hardened.Idl.SpecDiagnostics.Find(model);
+        var problems = Hardened.Idl.SpecDiagnostics.Find(model, "HOAT");
         var codes = new List<string>();
 
         foreach (var problem in problems) {
             codes.Add(problem.Code);
         }
 
-        Assert.Contains("HOAT010", codes);
+        Assert.Contains("HOAT022", codes);
 
         // Reported, not fatal: JsonElement is a working answer, just the weakest one.
         foreach (var problem in problems) {
-            if (problem.Code == "HOAT010") {
+            if (problem.Code == "HOAT022") {
                 Assert.False(problem.Fatal);
             }
         }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecDiagnosticsTests.cs
@@ -28,9 +28,9 @@ public class SpecDiagnosticsTests {
     /// </summary>
     [Fact]
     public void APropertyNamedAfterItsSchemaIsReported() {
-        var problem = Assert.Single(SpecDiagnostics.Find(SpecWith("Message", "message")));
+        var problem = Assert.Single(SpecDiagnostics.Find(SpecWith("Message", "message"), "HOAT"));
 
-        Assert.Equal("HOAT003", problem.Code);
+        Assert.Equal("HOAT020", problem.Code);
         Assert.Contains("Message", problem.Message);
         Assert.Contains("message", problem.Message);
         Assert.Contains("CS0542", problem.Message);
@@ -42,23 +42,23 @@ public class SpecDiagnosticsTests {
     [InlineData("user", "User")]
     [InlineData("Order", "order")]
     public void TheCollisionIsOnThePascalCasedName(string schemaName, string propertyName) {
-        Assert.Single(SpecDiagnostics.Find(SpecWith(schemaName, propertyName)));
+        Assert.Single(SpecDiagnostics.Find(SpecWith(schemaName, propertyName), "HOAT"));
     }
 
     /// <summary>Snake case collides too, once both sides are PascalCased.</summary>
     [Fact]
     public void ASnakeCasePropertyCanCollide() {
-        Assert.Single(SpecDiagnostics.Find(SpecWith("RandomNumber", "random_number")));
+        Assert.Single(SpecDiagnostics.Find(SpecWith("RandomNumber", "random_number"), "HOAT"));
     }
 
     [Fact]
     public void AnOrdinaryScheamIsNotReported() {
-        Assert.Empty(SpecDiagnostics.Find(SpecWith("Message", "text", "id")));
+        Assert.Empty(SpecDiagnostics.Find(SpecWith("Message", "text", "id"), "HOAT"));
     }
 
     [Fact]
     public void EachCollidingPropertyIsReportedOnce() {
-        Assert.Single(SpecDiagnostics.Find(SpecWith("Thing", "thing", "other")));
+        Assert.Single(SpecDiagnostics.Find(SpecWith("Thing", "thing", "other"), "HOAT"));
     }
 
     /// <summary>
@@ -78,9 +78,9 @@ public class SpecDiagnosticsTests {
             }
         };
 
-        var problem = Assert.Single(SpecDiagnostics.Find(model));
+        var problem = Assert.Single(SpecDiagnostics.Find(model, "HOAT"));
 
-        Assert.Equal("HOAT005", problem.Code);
+        Assert.Equal("HOAT021", problem.Code);
         Assert.Contains("PetAddress", problem.Message);
     }
 
@@ -94,7 +94,7 @@ public class SpecDiagnosticsTests {
             }
         };
 
-        Assert.Empty(SpecDiagnostics.Find(model));
+        Assert.Empty(SpecDiagnostics.Find(model, "HOAT"));
     }
 
 }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnmappedKeywordTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnmappedKeywordTests.cs
@@ -173,12 +173,12 @@ public class UnmappedKeywordTests {
     [Fact]
     public void ADescriptionUsingOnlyMappedKeywordsIsSilent() {
         Assert.Empty(Parse(Clean).UnmappedKeywords);
-        Assert.DoesNotContain(SpecDiagnostics.Find(Parse(Clean)), p => p.Code == "HOAT013");
+        Assert.DoesNotContain(SpecDiagnostics.Find(Parse(Clean), "HOAT"), p => p.Code == "HOAT024");
     }
 
     [Fact]
     public void TheDiagnosticIsAWarningRatherThanAnError() {
-        var problems = SpecDiagnostics.Find(Parse(Dropping)).Where(p => p.Code == "HOAT013");
+        var problems = SpecDiagnostics.Find(Parse(Dropping), "HOAT").Where(p => p.Code == "HOAT024");
 
         Assert.NotEmpty(problems);
         Assert.All(problems, problem => Assert.False(problem.Fatal));
@@ -194,8 +194,8 @@ public class UnmappedKeywordTests {
 
         Assert.Equal(2, model.UnmappedKeywords.Count(u => u.Keyword == "uniqueItems"));
         Assert.Single(
-            SpecDiagnostics.Find(model),
-            p => p.Code == "HOAT013" && p.Message.Contains("uniqueItems"));
+            SpecDiagnostics.Find(model, "HOAT"),
+            p => p.Code == "HOAT024" && p.Message.Contains("uniqueItems"));
     }
 
     /// <summary>
@@ -204,8 +204,8 @@ public class UnmappedKeywordTests {
     /// </summary>
     [Fact]
     public void TheMessageCountsTheSitesItDidNotName() {
-        var problem = SpecDiagnostics.Find(Parse(TwiceDropped))
-            .First(p => p.Code == "HOAT013" && p.Message.Contains("uniqueItems"));
+        var problem = SpecDiagnostics.Find(Parse(TwiceDropped), "HOAT")
+            .First(p => p.Code == "HOAT024" && p.Message.Contains("uniqueItems"));
 
         Assert.Contains("1 other place", problem.Message);
     }
@@ -216,8 +216,8 @@ public class UnmappedKeywordTests {
     /// </summary>
     [Fact]
     public void TheMessageSaysThePromiseIsNotKept() {
-        var problem = SpecDiagnostics.Find(Parse(Dropping))
-            .First(p => p.Code == "HOAT013" && p.Message.Contains("multipleOf"));
+        var problem = SpecDiagnostics.Find(Parse(Dropping), "HOAT")
+            .First(p => p.Code == "HOAT024" && p.Message.Contains("multipleOf"));
 
         Assert.Contains("not enforced", problem.Message);
         Assert.Contains("accepted at runtime", problem.Message);

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -1277,7 +1277,7 @@ internal static class OpenApiSpecParser {
     /// which is a validator vocabulary question rather than a parser one, and answering it here
     /// would put a second constraint compiler beside the one ValidationModules owns. Until then the
     /// document says the rule and the build says it is not applied, which is the whole point of
-    /// <c>HOAT013</c>.
+    /// <c>HOAT024</c>.
     /// </para>
     /// </remarks>
     private static void NoteUnmappedItemConstraints(

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/GenerateSmithyAstTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/GenerateSmithyAstTests.cs
@@ -35,9 +35,25 @@ public class GenerateSmithyAstTests : IDisposable {
 
     /// <summary>
     /// A stand-in CLI: answers <c>--version</c>, and otherwise writes <paramref name="output"/> to
-    /// stdout and exits with <paramref name="exitCode"/>.
+    /// stdout and exits with <paramref name="exitCode"/>. <paramref name="report"/> reaches stderr
+    /// through a file, because the CLI's multi-line validation report is nothing <c>echo</c> can
+    /// carry on either platform.
     /// </summary>
-    private string FakeCli(string version, string output = "", int exitCode = 0, string error = "") {
+    private string FakeCli(
+        string version, string output = "", int exitCode = 0, string error = "",
+        string report = "") {
+        var reportEmit = "";
+
+        if (report.Length > 0) {
+            var reportPath = Path.Combine(_root, "report.txt");
+
+            File.WriteAllText(reportPath, report);
+
+            reportEmit = OperatingSystem.IsWindows()
+                ? $"type \"{reportPath}\" 1>&2\r\n"
+                : $"cat '{reportPath}' 1>&2\n";
+        }
+
         if (OperatingSystem.IsWindows()) {
             var batch = Path.Combine(_root, "smithy.cmd");
 
@@ -46,6 +62,7 @@ public class GenerateSmithyAstTests : IDisposable {
                 $"if \"%1\"==\"--version\" (echo {version}& exit /b 0)\r\n" +
                 (output.Length > 0 ? $"echo {output}\r\n" : "") +
                 (error.Length > 0 ? $"echo {error} 1>&2\r\n" : "") +
+                reportEmit +
                 $"exit /b {exitCode}\r\n");
 
             return batch;
@@ -58,6 +75,7 @@ public class GenerateSmithyAstTests : IDisposable {
             $"if [ \"$1\" = \"--version\" ]; then echo '{version}'; exit 0; fi\n" +
             (output.Length > 0 ? $"printf '%s' '{output}'\n" : "") +
             (error.Length > 0 ? $"echo '{error}' 1>&2\n" : "") +
+            reportEmit +
             $"exit {exitCode}\n");
 
         File.SetUnixFileMode(script,
@@ -170,8 +188,8 @@ public class GenerateSmithyAstTests : IDisposable {
     }
 
     /// <summary>
-    /// The CLI's own diagnostics name the .smithy file and line, so they are passed through rather
-    /// than summarised.
+    /// Stderr that is not the validation report - a crash, a launcher complaint - is passed
+    /// through whole rather than lost, against the first model because there is nothing better.
     /// </summary>
     [Fact]
     public void Execute_ReportsWhatTheCliSaidWhenItFails() {
@@ -181,6 +199,86 @@ public class GenerateSmithyAstTests : IDisposable {
         Assert.True(HasError(engine, "HSMT012"));
         Assert.Contains("Model.UnresolvedShape", engine.Errors.Single(e => e.Code == "HSMT012").Message);
         Assert.False(File.Exists(output));
+    }
+
+    /// <summary>
+    /// What the CLI prints when it refuses a model: one banner per finding, each naming its file,
+    /// line and column. The excerpt and the count line are the report's own layout.
+    /// </summary>
+    private const string Report =
+        """
+
+        ──  ERROR  ────────────────────────────────────────────── Target.UnresolvedShape
+        Shape: probe#Svc
+        File:  models/bad.smithy:4:1
+
+        4| service Svc {
+         | ^
+
+        service shape has an `operation` relationship to an unresolved shape
+        `probe#MissingOp`
+
+
+        ──  DANGER  ───────────────────────────────────────────── SyntacticShapeIdTarget
+        File:  models/bad.smithy:6:18
+
+        6|     operations: [MissingOp]
+         |                  ^
+
+        Syntactic shape ID `MissingOp` does not resolve to a valid shape ID:
+        `probe#MissingOp`. Did you mean to quote this string? Are you missing a model
+        file?
+
+        FAILURE: Validated 242 shapes (ERROR: 1, DANGER: 1)
+        """;
+
+    /// <summary>
+    /// The CLI names the file and line of every finding, and pinning the whole report to the
+    /// first model at 0,0 threw that away - a five-file model with one bad line pointed the
+    /// author at the wrong file.
+    /// </summary>
+    [Fact]
+    public void Execute_ReportsOneErrorPerFindingWhereTheCliPlacedIt() {
+        var (result, engine, _) = Run(FakeCli("1.73.0", exitCode: 1, report: Report));
+
+        Assert.False(result);
+        Assert.Equal(2, engine.Errors.Count);
+        Assert.All(engine.Errors, entry => Assert.Equal("HSMT012", entry.Code));
+
+        var unresolved = engine.Errors[0];
+
+        Assert.Equal(Path.GetFullPath(Path.Combine("models", "bad.smithy")), unresolved.File);
+        Assert.Equal(4, unresolved.LineNumber);
+        Assert.Equal(1, unresolved.ColumnNumber);
+        Assert.StartsWith("Target.UnresolvedShape on probe#Svc:", unresolved.Message);
+        Assert.Contains("unresolved shape", unresolved.Message);
+
+        var syntactic = engine.Errors[1];
+
+        Assert.Equal(6, syntactic.LineNumber);
+        Assert.StartsWith("SyntacticShapeIdTarget:", syntactic.Message);
+        Assert.DoesNotContain("FAILURE", syntactic.Message);
+    }
+
+    /// <summary>The same attribution for what the CLI got away with on a run it exited cleanly from.</summary>
+    [Fact]
+    public void Execute_AttributesWarningsTheCliPrintedOnASuccessfulRun() {
+        var (result, engine, _) = Run(FakeCli(
+            "1.73.0",
+            output: "{\"smithy\":\"2.0\",\"shapes\":{}}",
+            report: "──  WARNING  ──── HttpMethodSemantics\n" +
+                    "File:  models/ok.smithy:5:1\n" +
+                    "\n" +
+                    "POST on a @readonly operation\n"));
+
+        Assert.True(result, string.Join("\n", engine.Errors.Select(e => e.Message)));
+
+        var warning = Assert.Single(engine.Warnings);
+
+        Assert.Equal("HSMT013", warning.Code);
+        Assert.Equal(Path.GetFullPath(Path.Combine("models", "ok.smithy")), warning.File);
+        Assert.Equal(5, warning.LineNumber);
+        Assert.StartsWith("HttpMethodSemantics:", warning.Message);
     }
 
     /// <summary>
@@ -198,14 +296,17 @@ public class GenerateSmithyAstTests : IDisposable {
     }
 
     /// <summary>
-    /// A CLI that exits cleanly and emits nothing is a failure, not an empty model.
+    /// A CLI that exits cleanly and emits nothing is a failure, not an empty model. Its own code
+    /// rather than HSMT012, because that one means the CLI refused the model and this one's fix is
+    /// not in any .smithy file.
     /// </summary>
     [Fact]
     public void Execute_TreatsASilentSuccessAsAFailure() {
         var (result, engine, output) = Run(FakeCli("1.73.0"));
 
         Assert.False(result);
-        Assert.True(HasError(engine, "HSMT012"));
+        Assert.True(HasError(engine, "HSMT014"),
+            string.Join("\n", engine.Errors.Select(e => e.Code)));
         Assert.False(File.Exists(output));
     }
 

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyValidationReportTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyValidationReportTests.cs
@@ -1,0 +1,161 @@
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// The reader for the report the Smithy CLI prints on standard error.
+/// </summary>
+/// <remarks>
+/// The fixtures are the verbatim output of the pinned CLI (1.73.0) over small deliberately broken
+/// models, not hand-written approximations - the parser exists to read exactly what that version
+/// prints, and a fixture that drifts from it would prove nothing. Anything the parser does not
+/// recognise must yield no findings, because the caller's fallback is to pass the text through
+/// whole rather than lose it.
+/// </remarks>
+public class SmithyValidationReportTests {
+
+    /// <summary>
+    /// <c>smithy ast</c> over a service naming an operation that does not exist: one ERROR with a
+    /// shape, one DANGER without, and the FAILURE count line.
+    /// </summary>
+    private const string FailureReport =
+        """
+
+        ──  ERROR  ────────────────────────────────────────────── Target.UnresolvedShape
+        Shape: probe#Svc
+        File:  bad.smithy:4:1
+
+        4| service Svc {
+         | ^
+
+        service shape has an `operation` relationship to an unresolved shape
+        `probe#MissingOp`
+
+
+        ──  DANGER  ───────────────────────────────────────────── SyntacticShapeIdTarget
+        File:  bad.smithy:6:18
+
+        4| service Svc {
+        5|     version: "1"
+        6|     operations: [MissingOp]
+         |                  ^
+
+        Syntactic shape ID `MissingOp` does not resolve to a valid shape ID:
+        `probe#MissingOp`. Did you mean to quote this string? Are you missing a model
+        file?
+
+        FAILURE: Validated 242 shapes (ERROR: 1, DANGER: 1)
+        """;
+
+    [Fact]
+    public void EveryBannerBecomesOneFinding() {
+        Assert.Equal(2, SmithyValidationReport.Parse(FailureReport).Count);
+    }
+
+    [Fact]
+    public void TheSeverityAndEventIdComeFromTheBannerLine() {
+        var findings = SmithyValidationReport.Parse(FailureReport);
+
+        Assert.Equal("ERROR", findings[0].Severity);
+        Assert.Equal("Target.UnresolvedShape", findings[0].Id);
+        Assert.Equal("DANGER", findings[1].Severity);
+        Assert.Equal("SyntacticShapeIdTarget", findings[1].Id);
+    }
+
+    /// <summary>ERROR and DANGER are the two severities the CLI fails validation on.</summary>
+    [Fact]
+    public void BothFailingSeveritiesSaySo() {
+        Assert.All(
+            SmithyValidationReport.Parse(FailureReport),
+            finding => Assert.True(finding.FailedValidation));
+    }
+
+    [Fact]
+    public void TheLocationComesFromTheFileLine() {
+        var finding = SmithyValidationReport.Parse(FailureReport)[1];
+
+        Assert.Equal("bad.smithy", finding.File);
+        Assert.Equal(6, finding.Line);
+        Assert.Equal(18, finding.Column);
+    }
+
+    /// <summary>The Shape line is optional - the DANGER banner above has none.</summary>
+    [Fact]
+    public void TheShapeIsCarriedWhenNamedAndNullWhenNot() {
+        var findings = SmithyValidationReport.Parse(FailureReport);
+
+        Assert.Equal("probe#Svc", findings[0].Shape);
+        Assert.Null(findings[1].Shape);
+    }
+
+    /// <summary>
+    /// The CLI wraps one sentence across lines at its banner width; the message is reassembled
+    /// without the source excerpt, whose content the file and line already point an editor at.
+    /// </summary>
+    [Fact]
+    public void TheMessageIsReassembledWithoutTheExcerpt() {
+        var finding = SmithyValidationReport.Parse(FailureReport)[1];
+
+        Assert.Equal(
+            "Syntactic shape ID `MissingOp` does not resolve to a valid shape ID: " +
+            "`probe#MissingOp`. Did you mean to quote this string? Are you missing a model file?",
+            finding.Message);
+    }
+
+    /// <summary>Its content is the finding count, which the findings already carry.</summary>
+    [Fact]
+    public void TheSummaryLineIsNotPartOfAnyMessage() {
+        Assert.All(
+            SmithyValidationReport.Parse(FailureReport),
+            finding => Assert.DoesNotContain("FAILURE", finding.Message));
+    }
+
+    /// <summary>
+    /// A Windows path carries a colon of its own, so the line and column are read from the right.
+    /// </summary>
+    [Fact]
+    public void AWindowsPathKeepsItsDriveColon() {
+        var finding = SmithyValidationReport.Parse(
+            "──  ERROR  ──── Model.Broken\n" +
+            "File:  C:\\models\\bad.smithy:12:3\n" +
+            "\n" +
+            "the message\n").Single();
+
+        Assert.Equal("C:\\models\\bad.smithy", finding.File);
+        Assert.Equal(12, finding.Line);
+        Assert.Equal(3, finding.Column);
+    }
+
+    /// <summary>A banner with no File line still parses; the caller falls back to the model.</summary>
+    [Fact]
+    public void ABannerWithoutAFileLineYieldsAnEmptyFile() {
+        var finding = SmithyValidationReport.Parse(
+            "──  WARNING  ──── SomethingGeneral\n\nthe whole model is suspect\n").Single();
+
+        Assert.Equal("", finding.File);
+        Assert.Equal(0, finding.Line);
+        Assert.False(finding.FailedValidation);
+    }
+
+    /// <summary>
+    /// Anything that is not the report - a Java stacktrace, a launcher complaint - must yield
+    /// nothing, so the caller passes it through whole instead of losing it.
+    /// </summary>
+    [Fact]
+    public void TextThatIsNotTheReportYieldsNoFindings() {
+        Assert.Empty(SmithyValidationReport.Parse(
+            "Exception in thread \"main\" java.lang.OutOfMemoryError: Java heap space\n" +
+            "\tat software.amazon.smithy.cli.SmithyCli.run(SmithyCli.java:80)\n"));
+        Assert.Empty(SmithyValidationReport.Parse(""));
+    }
+
+    /// <summary>Carriage returns are the launcher's on Windows, not content.</summary>
+    [Fact]
+    public void CarriageReturnsAreTolerated() {
+        var finding = SmithyValidationReport.Parse(
+            "──  ERROR  ──── Model.Broken\r\nFile:  bad.smithy:2:1\r\n\r\nthe message\r\n").Single();
+
+        Assert.Equal("bad.smithy", finding.File);
+        Assert.Equal("the message", finding.Message);
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/UnmappedTraitTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/UnmappedTraitTests.cs
@@ -122,8 +122,8 @@ public class UnmappedTraitTests {
     /// </summary>
     [Fact]
     public void AMemberMetTwiceIsCountedOnce() {
-        var problem = SpecDiagnostics.Find(Parse(Ast))
-            .First(p => p.Code == "HOAT013" && p.Message.Contains("@uniqueItems"));
+        var problem = SpecDiagnostics.Find(Parse(Ast), "HSMT")
+            .First(p => p.Code == "HSMT024" && p.Message.Contains("@uniqueItems"));
 
         Assert.Contains("at tags", problem.Message);
         Assert.DoesNotContain("other place", problem.Message);
@@ -144,10 +144,33 @@ public class UnmappedTraitTests {
     /// </summary>
     [Fact]
     public void ItReachesTheSharedDiagnosticsPass() {
-        var problems = SpecDiagnostics.Find(Parse(Ast)).Where(p => p.Code == "HOAT013").ToList();
+        var problems = SpecDiagnostics.Find(Parse(Ast), "HSMT").Where(p => p.Code == "HSMT024").ToList();
 
         Assert.Equal(2, problems.Count);
         Assert.All(problems, problem => Assert.False(problem.Fatal));
+    }
+
+    /// <summary>
+    /// <c>@paginated</c> was ignorable as a client concern, and it is not one: it promises the
+    /// operation honours a paging protocol, and the generated server receives the named members
+    /// with nothing enforcing it. The model builds and the weakening is said out loud.
+    /// </summary>
+    [Fact]
+    public void PaginatedIsReportedAsADegrade() {
+        var ast = Ast.Replace(
+            "\"smithy.api#http\": { \"method\": \"POST\", \"uri\": \"/products\", \"code\": 201 }",
+            "\"smithy.api#http\": { \"method\": \"POST\", \"uri\": \"/products\", \"code\": 201 },\n" +
+            "                \"smithy.api#paginated\": { \"inputToken\": \"nextToken\", \"outputToken\": \"nextToken\" }");
+
+        // The replacement has to have happened, or this asserts nothing.
+        Assert.Contains("paginated", ast);
+
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(ast, "depot", diagnostics);
+
+        Assert.NotNull(model);
+        Assert.Contains(diagnostics,
+            d => d.Contains("smithy.api#paginated") && d.Contains("no equivalent"));
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/GenerateSmithyAst.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/GenerateSmithyAst.cs
@@ -196,24 +196,19 @@ public sealed class GenerateSmithyAst : Microsoft.Build.Utilities.Task {
 
         if (result.ExitCode != 0) {
             Delete(staging);
-
-            // The CLI's diagnostics name the .smithy file and line already, so they are passed
-            // through rather than summarised - and reported against the model rather than against
-            // this target, because that is the file the author edits.
-            Log.LogError(null, "HSMT012", null, FirstModel(), 0, 0, 0, 0,
-                "The Smithy CLI could not read the model (exit code {0}).\n{1}",
-                result.ExitCode, result.StandardError.TrimEnd());
+            ReportRefusal(result);
 
             return false;
         }
 
         // Success with nothing written is the shape of a CLI that validated and declined to emit.
         // Treated as a failure rather than parsed, because an empty AST reaches the reader as an
-        // unhelpful error about position zero.
+        // unhelpful error about position zero. Its own code, not HSMT012: that one means the CLI
+        // refused the model, and the fix for this one is not in any .smithy file.
         if (!File.Exists(staging) || new FileInfo(staging).Length == 0) {
             Delete(staging);
 
-            Log.LogError(null, "HSMT012", null, FirstModel(), 0, 0, 0, 0,
+            Log.LogError(null, "HSMT014", null, FirstModel(), 0, 0, 0, 0,
                 "The Smithy CLI exited successfully but wrote no AST.{0}",
                 result.StandardError.Length > 0 ? "\n" + result.StandardError.TrimEnd() : "");
 
@@ -222,8 +217,7 @@ public sealed class GenerateSmithyAst : Microsoft.Build.Utilities.Task {
 
         // Anything the CLI said on a successful run is a warning it got away with, not an error.
         if (result.StandardError.Trim().Length > 0) {
-            Log.LogWarning(null, "HSMT013", null, FirstModel(), 0, 0, 0, 0,
-                "{0}", result.StandardError.Trim());
+            ReportChatter(result.StandardError);
         }
 
         MoveIfChanged(staging, OutputPath);
@@ -231,6 +225,98 @@ public sealed class GenerateSmithyAst : Microsoft.Build.Utilities.Task {
         AstFile = new Microsoft.Build.Utilities.TaskItem(OutputPath);
 
         return true;
+    }
+
+    /// <summary>
+    /// The CLI refused the model: one MSBuild error per finding, each against the file and line
+    /// the CLI named.
+    /// </summary>
+    /// <remarks>
+    /// This used to pass the whole report through as one error pinned to the first model at 0,0,
+    /// which discarded the attribution the CLI had already done - a five-file model with one bad
+    /// line pointed at the wrong file. Findings below the two failing severities ride along as
+    /// HSMT013 warnings, and a report that does not parse - a crash, a format this pin has never
+    /// printed - still fails the build with the text passed through whole.
+    /// </remarks>
+    private void ReportRefusal(ProcessResult result) {
+        var findings = SmithyValidationReport.Parse(result.StandardError);
+        var failed = false;
+
+        foreach (var finding in findings) {
+            if (finding.FailedValidation) {
+                failed = true;
+
+                Log.LogError(null, "HSMT012", null,
+                    Attribute(finding.File), finding.Line, finding.Column, 0, 0,
+                    "{0}", Describe(finding));
+            } else {
+                Log.LogWarning(null, "HSMT013", null,
+                    Attribute(finding.File), finding.Line, finding.Column, 0, 0,
+                    "{0}", Describe(finding));
+            }
+        }
+
+        if (!failed) {
+            Log.LogError(null, "HSMT012", null, FirstModel(), 0, 0, 0, 0,
+                "The Smithy CLI could not read the model (exit code {0}).\n{1}",
+                result.ExitCode, result.StandardError.TrimEnd());
+        }
+    }
+
+    /// <summary>
+    /// What the CLI said on a run it exited cleanly from - per finding when the text is its
+    /// validation report, whole when it is something else.
+    /// </summary>
+    private void ReportChatter(string standardError) {
+        var findings = SmithyValidationReport.Parse(standardError);
+
+        if (findings.Count == 0) {
+            Log.LogWarning(null, "HSMT013", null, FirstModel(), 0, 0, 0, 0,
+                "{0}", standardError.Trim());
+
+            return;
+        }
+
+        foreach (var finding in findings) {
+            Log.LogWarning(null, "HSMT013", null,
+                Attribute(finding.File), finding.Line, finding.Column, 0, 0,
+                "{0}", Describe(finding));
+        }
+    }
+
+    /// <summary>
+    /// The file a finding is reported against.
+    /// </summary>
+    /// <remarks>
+    /// The CLI prints the path relative to its working directory even when the model was handed to
+    /// it absolute. The child inherited this process's directory, so resolving against it inverts
+    /// that exactly.
+    /// </remarks>
+    private string Attribute(string file) {
+        if (file.Length == 0) {
+            return FirstModel();
+        }
+
+        try {
+            return Path.GetFullPath(file);
+        } catch (ArgumentException) {
+            return file;
+        } catch (NotSupportedException) {
+            return file;
+        } catch (PathTooLongException) {
+            return file;
+        }
+    }
+
+    /// <summary>The CLI's own event id and shape, ahead of its message.</summary>
+    private static string Describe(SmithyValidationReport.Finding finding) {
+        if (finding.Id.Length == 0) {
+            return finding.Message;
+        }
+
+        return finding.Shape == null
+            ? $"{finding.Id}: {finding.Message}"
+            : $"{finding.Id} on {finding.Shape}: {finding.Message}";
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
@@ -111,7 +111,7 @@ internal static class SmithyTraits {
     /// <remarks>
     /// Three groups, and they are ignorable for different reasons. Documentation and metadata
     /// (<c>examples</c>, <c>since</c>, <c>externalDocumentation</c>) describe the model, not the
-    /// wire. Client concerns (<c>paginated</c>, <c>idempotencyToken</c>, <c>requestCompression</c>,
+    /// wire. Client concerns (<c>idempotencyToken</c>, <c>requestCompression</c>,
     /// <c>endpoint</c>, <c>hostLabel</c>) describe how a caller behaves, and a server that ignores
     /// them still answers correctly. Deployment and protocol concerns (<c>cors</c>, the
     /// <c>xml*</c> family, the auth traits) belong to something other than the description - CORS is
@@ -122,7 +122,7 @@ internal static class SmithyTraits {
         "smithy.api#examples", "smithy.api#recommended", "smithy.api#unstable",
         "smithy.api#since", "smithy.api#externalDocumentation", "smithy.api#suppress",
         "smithy.api#traitValidators", "smithy.api#idRef", "smithy.api#references",
-        "smithy.api#paginated", "smithy.api#idempotencyToken", "smithy.api#httpChecksumRequired",
+        "smithy.api#idempotencyToken", "smithy.api#httpChecksumRequired",
         "smithy.api#requestCompression", "smithy.api#requiresLength", "smithy.api#endpoint",
         "smithy.api#hostLabel", "smithy.api#cors", "smithy.api#sensitive",
         "smithy.api#noReplace", "smithy.api#nestedProperties", "smithy.api#notProperty",
@@ -138,8 +138,15 @@ internal static class SmithyTraits {
     /// Traits that change the contract and have no IR equivalent, so the code is weaker than the
     /// model. Warned rather than dropped.
     /// </summary>
+    /// <remarks>
+    /// <c>paginated</c> was <see cref="Ignorable"/> as a client concern, and it is not one: it
+    /// promises the operation honours a paging protocol - this input is the cursor, that output
+    /// member continues it - and the generated server receives those as ordinary members with
+    /// nothing enforcing the protocol between them. The handler author implements paging by hand
+    /// or the contract overstates what the service does, and either way it has to be said.
+    /// </remarks>
     internal static readonly HashSet<string> Degrades = new(StringComparer.Ordinal) {
-        HttpResponseCode, HttpPrefixHeaders, HttpQueryParams
+        HttpResponseCode, HttpPrefixHeaders, HttpQueryParams, "smithy.api#paginated"
     };
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/SmithyValidationReport.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/SmithyValidationReport.cs
@@ -1,0 +1,181 @@
+using System.Text.RegularExpressions;
+
+namespace Hardened.Smithy.BuildTask;
+
+/// <summary>
+/// Reads the validation report the Smithy CLI prints to standard error.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The CLI names the <c>.smithy</c> file, line and column of every finding, and passing its output
+/// through as one blob threw that away: MSBuild pinned the whole report to the first model at 0,0,
+/// so a five-file model with one bad line pointed the author at the wrong file. Parsing the report
+/// turns each finding back into a diagnostic MSBuild can attribute.
+/// </para>
+/// <para>
+/// The format is one banner block per finding:
+/// </para>
+/// <code>
+/// ──  ERROR  ────────────────────────────────────────── Target.UnresolvedShape
+/// Shape: probe#Svc
+/// File:  bad.smithy:4:1
+///
+/// 4| service Svc {
+///  | ^
+///
+/// service shape has an `operation` relationship to an unresolved shape
+/// `probe#MissingOp`
+/// </code>
+/// <para>
+/// The severity label is one of Smithy's four (<c>NOTE</c>, <c>WARNING</c>, <c>DANGER</c>,
+/// <c>ERROR</c>; the last two fail validation), the trailing word is the CLI's own event id, the
+/// <c>Shape:</c> line is optional, and the source excerpt is dropped here because a diagnostic
+/// carrying the file and line already points an editor at the source. This is not a stable contract
+/// the CLI publishes - it is the observed output of the pinned version, which is exactly what the
+/// pin is for - so anything that does not parse yields no findings and the caller falls back to
+/// passing the text through whole.
+/// </para>
+/// </remarks>
+internal static class SmithyValidationReport {
+
+    internal readonly struct Finding {
+        public Finding(
+            string severity, string id, string? shape,
+            string file, int line, int column, string message) {
+            Severity = severity;
+            Id = id;
+            Shape = shape;
+            File = file;
+            Line = line;
+            Column = column;
+            Message = message;
+        }
+
+        public string Severity { get; }
+
+        /// <summary>The CLI's event id - <c>Target.UnresolvedShape</c> and friends.</summary>
+        public string Id { get; }
+
+        public string? Shape { get; }
+
+        /// <summary>The path as the CLI printed it, which is relative to its working directory.</summary>
+        public string File { get; }
+
+        public int Line { get; }
+
+        public int Column { get; }
+
+        public string Message { get; }
+
+        /// <summary>Whether this finding is one of the two severities that fail validation.</summary>
+        public bool FailedValidation =>
+            Severity == "ERROR" || Severity == "DANGER";
+    }
+
+    /// <summary>
+    /// <c>──  ERROR  ─────── Target.UnresolvedShape</c>: box-drawing dashes, the severity, dashes
+    /// padding the banner to width, then the event id.
+    /// </summary>
+    private static readonly Regex Header = new(
+        "^──\\s+(NOTE|WARNING|DANGER|ERROR)\\s+─+(?:\\s+(\\S+))?\\s*$",
+        RegexOptions.Compiled);
+
+    internal static IReadOnlyList<Finding> Parse(string standardError) {
+        var findings = new List<Finding>();
+        var lines = standardError.Split('\n');
+        var index = 0;
+
+        while (index < lines.Length) {
+            var header = Header.Match(lines[index].TrimEnd('\r'));
+
+            index++;
+
+            if (!header.Success) {
+                continue;
+            }
+
+            string? shape = null;
+            var file = "";
+            var line = 0;
+            var column = 0;
+            var message = new List<string>();
+
+            for (; index < lines.Length; index++) {
+                var current = lines[index].TrimEnd('\r');
+
+                if (Header.IsMatch(current)) {
+                    break;
+                }
+
+                if (current.StartsWith("Shape:", StringComparison.Ordinal)) {
+                    shape = current.Substring("Shape:".Length).Trim();
+                } else if (current.StartsWith("File:", StringComparison.Ordinal)) {
+                    ParseLocation(
+                        current.Substring("File:".Length).Trim(), out file, out line, out column);
+                } else if (current.Trim().Length > 0 && !IsExcerpt(current) && !IsSummary(current)) {
+                    message.Add(current.Trim());
+                }
+            }
+
+            // Joined with spaces because the CLI wraps one sentence across lines at its banner
+            // width; the breaks are layout, not content.
+            findings.Add(new Finding(
+                header.Groups[1].Value, header.Groups[2].Value, shape,
+                file, line, column, string.Join(" ", message)));
+        }
+
+        return findings;
+    }
+
+    /// <summary>
+    /// A line of the source excerpt: a line number and a pipe, or the pipe alone under it carrying
+    /// the caret.
+    /// </summary>
+    private static bool IsExcerpt(string line) {
+        var index = 0;
+
+        while (index < line.Length && line[index] == ' ') {
+            index++;
+        }
+
+        while (index < line.Length && char.IsDigit(line[index])) {
+            index++;
+        }
+
+        return index < line.Length && line[index] == '|';
+    }
+
+    /// <summary>The count line after the last finding, whose content the findings already carry.</summary>
+    private static bool IsSummary(string line) =>
+        line.StartsWith("FAILURE: Validated ", StringComparison.Ordinal) ||
+        line.StartsWith("SUCCESS: Validated ", StringComparison.Ordinal);
+
+    /// <summary>
+    /// <c>path:line:column</c>, taken from the right because a Windows path carries a colon of
+    /// its own. A location that does not end in two numbers is kept whole as the file.
+    /// </summary>
+    private static void ParseLocation(string text, out string file, out int line, out int column) {
+        file = text;
+        line = 0;
+        column = 0;
+
+        var last = text.LastIndexOf(':');
+
+        if (last <= 0) {
+            return;
+        }
+
+        var second = text.LastIndexOf(':', last - 1);
+
+        if (second <= 0) {
+            return;
+        }
+
+        if (int.TryParse(text.Substring(second + 1, last - second - 1), out var parsedLine) &&
+            int.TryParse(text.Substring(last + 1), out var parsedColumn)) {
+            file = text.Substring(0, second);
+            line = parsedLine;
+            column = parsedColumn;
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
@@ -260,11 +260,11 @@
             is one service and it is served at one address.
         -->
         <Error Condition="$(_HardenedSmithyPublishUrlValue.Contains(';'))"
-               Code="HSMT012"
+               Code="HSMT015"
                Text="The Smithy model declares more than one PublishUrl: $(_HardenedSmithyPublishUrlValue). Every .smithy file in a project compiles into one model served at one address, so set it on one item." />
 
         <Error Condition="$(_HardenedSmithyUiUrlValue.Contains(';'))"
-               Code="HSMT012"
+               Code="HSMT015"
                Text="The Smithy model declares more than one UiUrl: $(_HardenedSmithyUiUrlValue). Every .smithy file in a project compiles into one model with one reference page, so set it on one item." />
 
         <ItemGroup>


### PR DESCRIPTION
F13 from the Forty-Four Fixes queue (D-C-09, D-C-10), plus the diagnostic-code collisions found while renumbering.

- **Per-finding CLI attribution.** The Smithy CLI names the file, line and column of every finding, and the task passed the report through as one blob pinned to the first model at 0,0 - a five-file model with one bad line pointed the author at the wrong file. `GenerateSmithyAst` now parses the banner report and logs one HSMT012 error per failing finding (HSMT013 warnings for what rode along without failing), each at the location the CLI named, with the whole-text fallback kept for output that is not the report - a crash, a launcher complaint. The parser is covered against the pinned 1.73.0's verbatim output.
- **HSMT012's meanings split.** The silent-success condition (exit 0, no AST) moves to HSMT014 - its fix is not in any `.smithy` file - and the targets' multiple-PublishUrl/UiUrl checks move to HSMT015.
- **`@paginated` moves from `Ignorable` to `Degrades`** (D-C-10). It promises a paging protocol the generated server does nothing to enforce, so the model builds and the weakening is said out loud.
- **`SpecDiagnostics` takes the front end's prefix** so a Smithy model's findings stop surfacing as HOAT. Its codes move to a 020-025 block, which also unpicks collisions beyond the duplicate HOAT003 the plan named: HOAT005 was claimed twice (targets vs shared pass), the task shell's publish checks collided with the CLI codes on 010/011 (the shell moves to 016/017), and HSPEC010 folds into the block as 025. `docs/generator-diagnostics.md` now carries the full per-prefix table and the rename map; no shipped `NoWarn` referenced any renumbered code.

Next in the serial queue after #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)