### PR TITLE
Repair the template's conditional output and hold its document to the suite

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -64,6 +64,33 @@ fi
 
 say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
 
+# The defect class the second trial shipped, checked at generation rather than left to a build
+# that cannot see it. A file whose whole body sits behind a false condition reaches the output as
+# zero bytes, and a conditional inside a table cell can desynchronise the markdown evaluator and
+# eat the rest of the README. Both build clean, which is exactly why they get their own check.
+check_generated() {
+    local out="$1"
+    local empty
+
+    empty=$(find "$out" -type f -empty -not -path '*/bin/*' -not -path '*/obj/*' | head -5)
+
+    if [ -n "$empty" ]; then
+        echo "   FAILED: generation left zero-byte file(s) in $out:"
+        echo "$empty" | sed 's/^/     /'
+        FAILED=1
+    fi
+
+    # Every template's README ends with the same section and closing line, so a truncated one is
+    # detectable without knowing which options were on.
+    if [ -f "$out/README.md" ]; then
+        if ! grep -q 'Where to go next' "$out/README.md" || \
+           [ "$(tail -1 "$out/README.md")" != "  code rather than reading it" ]; then
+            echo "   FAILED: $out/README.md does not end where the template's does"
+            FAILED=1
+        fi
+    fi
+}
+
 rm -rf "$FEED" "$WORK"
 mkdir -p "$FEED" "$WORK"
 
@@ -138,6 +165,8 @@ for COMBO in "${COMBOS[@]}"; do
     # needs testing. Passing it here would test the flag and leave the default unexercised.
     dotnet new hardened-web -n Sample -o "$OUT" --host "$HOST" --contract "$CONTRACT" \
         --response-model "$MODEL" --skip-restore
+
+    check_generated "$OUT"
 
     # The generated nuget.config names nuget.org only, which is what a real user wants. The
     # verification run also needs the framework build that has not been published yet.
@@ -341,6 +370,7 @@ say "hardened-library"
 # Framework packages only, so this one is verified against the build under test like hardened-web.
 LIB="$WORK/library"
 dotnet new hardened-library -n Sample -o "$LIB" --skip-restore
+check_generated "$LIB"
 dotnet nuget add source "$FEED" --name template-verify-local --configfile "$LIB/nuget.config" >/dev/null
 if ( cd "$LIB" && dotnet build -v q --nologo && dotnet test --no-build -v q --nologo ); then
     echo "   builds and tests"
@@ -357,6 +387,7 @@ say "dotted project names"
 for TEMPLATE in hardened-library hardened-web; do
     DOTTED="$WORK/dotted-$TEMPLATE"
     dotnet new "$TEMPLATE" -n Acme.Sample -o "$DOTTED" --skip-restore
+    check_generated "$DOTTED"
     dotnet nuget add source "$FEED" --name template-verify-local --configfile "$DOTTED/nuget.config" >/dev/null
     if ( cd "$DOTTED" && dotnet build -v q --nologo ); then
         echo "   $TEMPLATE builds as Acme.Sample"
@@ -379,6 +410,7 @@ for AMZ in "hardened-function --trigger invoke" "hardened-function --trigger sqs
     AMZ_OUT="$WORK/amz-$AMZ_TEMPLATE-$(echo "$*" | tr -cd 'a-z')"
 
     dotnet new "$AMZ_TEMPLATE" -n Sample -o "$AMZ_OUT" "$@" --skip-restore
+    check_generated "$AMZ_OUT"
     dotnet nuget add source "$FEED" --name template-verify-local --configfile "$AMZ_OUT/nuget.config" >/dev/null
 
     if ( cd "$AMZ_OUT" && dotnet build -v q --nologo && dotnet test --no-build -v q --nologo ); then
@@ -397,7 +429,10 @@ say "host independence"
 # The framework's claim is that handlers, filters, binding and routing do not change with the
 # host. If that is true, only the host project may differ between two generated applications.
 # Comparable only across hosts at the same contract, which is the claim being checked.
-A="$WORK/kestrel-code"; B="$WORK/aspnet-code"
+# The -standard suffix, because that is what the output directories are named since the response
+# model joined the combination. The old suffixless paths matched nothing, so this check was
+# silently skipped on every run - which is why it now says so instead of saying nothing.
+A="$WORK/kestrel-code-standard"; B="$WORK/aspnet-code-standard"
 if [ -d "$A" ] && [ -d "$B" ]; then
     # Source only. bin/ and obj/ carry absolute paths and compiler output, which differ for
     # reasons that have nothing to do with the host.
@@ -405,11 +440,13 @@ if [ -d "$A" ] && [ -d "$B" ]; then
         if diff -r -x bin -x obj "$A/$PART" "$B/$PART" >/dev/null 2>&1; then
             echo "   identical across hosts: $PART"
         else
-            echo "   FAILED: $PART differs between ${HOSTS[0]} and ${HOSTS[1]}"
+            echo "   FAILED: $PART differs between kestrel and aspnet"
             diff -r -x bin -x obj "$A/$PART" "$B/$PART" | head -20
             FAILED=1
         fi
     done
+else
+    echo "   skipped: both hosts are not in this run's combinations"
 fi
 
 dotnet new uninstall Hardened.Templates >/dev/null 2>&1 || true

--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
@@ -157,9 +157,11 @@
     {
       "modifiers": [
         {
+          "comment": "The JSON context too. Its whole body sits behind the same condition, so without the exclusion a spec-first project received it as a zero-byte file - which builds, and reads as debris.",
           "condition": "(!codeFirst)",
           "exclude": [
-            "src/Hardened1/TodoController.cs"
+            "src/Hardened1/TodoController.cs",
+            "src/Hardened1/TemplateModuleNameJsonContext.cs"
           ]
         },
         {

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -19,9 +19,9 @@ is wrong. Run `dotnet build` first.
 **They are ordinary C#, and reading them answers most questions faster than reading the framework:**
 
 ```
-src/Hardened1/obj/Debug/net8.0/generated/     one directory per generator
+src/Hardened1/obj/<configuration>/<tfm>/generated/     one directory per generator
 #if (specFirst)
-src/Hardened1/obj/Debug/net8.0/openapi/       the normalised contract and the code built from it
+src/Hardened1/obj/<configuration>/<tfm>/openapi/       the normalised contract and the code built from it
 #endif
 ```
 
@@ -73,8 +73,10 @@ implementation stops compiling until it matches — that is the design, not a br
 
 Generated types land in `Hardened1.Models`, `Hardened1.Services` and `Hardened1.Validation`.
 #if (smithy)
-The build needs the Smithy CLI on `PATH` at the pinned version; a mismatch fails with `HSMT011`
-naming both versions, because different CLI versions can produce different ASTs.
+The build wants the Smithy CLI on `PATH` at the pinned version, because different CLI versions
+can produce different ASTs. A mismatch warns locally with `HSMT011` naming both versions, and
+fails the build under `ContinuousIntegrationBuild` - so what CI publishes is produced by exactly
+one version.
 #endif
 #endif
 #if (codeFirst)

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -25,8 +25,21 @@ Four routes. `GET /todos` has one answer; the other three each declare more than
 |---|---|---|
 | `GET /todos` | 200 | |
 | `GET /todos/{id}` | 200 | 404 when no todo has that id |
-| `POST /todos` | #if (standardMode)#if (codeFirst)200#endif#if (specFirst)201#endif#endif#if (declaredMode)201 with a `Location`#endif | 409 when the title is taken |
-| `DELETE /todos/{id}` | #if (standardMode)200#endif#if (declaredMode)204#endif | 404 when no todo has that id |
+#if (standardMode && codeFirst)
+| `POST /todos` | 200 | 409 when the title is taken |
+#endif
+#if (standardMode && specFirst)
+| `POST /todos` | 201 | 409 when the title is taken |
+#endif
+#if (declaredMode)
+| `POST /todos` | 201 with a `Location` | 409 when the title is taken |
+#endif
+#if (standardMode)
+| `DELETE /todos/{id}` | 200 | 404 when no todo has that id |
+#endif
+#if (declaredMode)
+| `DELETE /todos/{id}` | 204 | 404 when no todo has that id |
+#endif
 
 ```bash
 curl -i -X POST localhost:5080/todos -H 'Content-Type: application/json' \
@@ -183,7 +196,7 @@ The fastest way to understand any of this is to read what the build wrote. It is
 `EmitCompilerGeneratedFiles` is already on:
 
 ```
-src/Hardened1/obj/Debug/net8.0/generated/
+src/Hardened1/obj/<configuration>/<tfm>/generated/
 ```
 
 One directory per generator: the routing table, the handler for each route, the parameter binding

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
@@ -121,8 +121,10 @@
     nothing at all.
 
     The Smithy CLI turns this into the JSON AST the generator reads, so a build needs it on PATH at
-    the pinned version - the build fails with HSMT011 naming both if the version differs, because
-    two CLI versions can produce different ASTs and therefore different generated C#.
+    the pinned version - a mismatch warns locally with HSMT011 naming both versions, because
+    two CLI versions can produce different ASTs and therefore different generated C#. Under
+    ContinuousIntegrationBuild the same mismatch is an error, so a published build is produced
+    by exactly one version.
   -->
   <ItemGroup>
     <HardenedSmithyModel Include="contracts\todos.smithy">

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameJsonContext.cs
@@ -1,4 +1,3 @@
-#if (codeFirst)
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -36,4 +35,3 @@ namespace Hardened1;
 // type that needs a JsonTypeInfo here.
 [JsonSerializable(typeof(List<Todo>))]
 public partial class TemplateModuleNameJsonContext : JsonSerializerContext;
-#endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
@@ -16,7 +16,7 @@ namespace Hardened1;
 /// and this class stops satisfying the interface, which is the point: the specification and the
 /// code cannot drift apart without the build saying so.
 ///
-/// Build, then read obj/Debug/net8.0/openapi/generated/ to see the interface, the models, the
+/// Build, then read obj/<configuration>/<tfm>/openapi/generated/ to see the interface, the models, the
 /// routing table and the validation the contract's constraints produced.
 /// </remarks>
 [Handler]

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
@@ -1,0 +1,86 @@
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace Hardened1.Tests;
+
+/// <summary>
+/// The published document's status set, operation by operation, against what this suite
+/// exercises through the pipeline.
+/// </summary>
+/// <remarks>
+/// A declared status nothing answers - or an answered status the document never mentions - is the
+/// defect class a reference page cannot reveal, because the page renders either way. The sets
+/// below are the contract's declared statuses plus what the framework synthesizes and answers
+/// itself: a 400 wherever generated validation or a non-string bound parameter can refuse a
+/// request. Each listed status is driven by a test in this project, so the document, the
+/// application and the suite have to agree or this fails naming the operation.
+/// </remarks>
+public class DocumentStatusTests {
+
+    private static readonly Dictionary<string, string[]> Expected = new() {
+#if (codeFirst)
+#if (standardMode)
+        // Standard mode documents what the signature declares. The thrown NotFound and Conflict
+        // answer at runtime and are invisible here - the declared models close exactly that gap.
+        ["GET /todos"] = ["200"],
+        ["GET /todos/{id}"] = ["200", "400"],
+        ["POST /todos"] = ["200"],
+        ["DELETE /todos/{id}"] = ["200", "400"],
+#endif
+#if (declaredMode)
+        ["GET /todos"] = ["200"],
+        ["GET /todos/{id}"] = ["200", "400", "404"],
+        ["POST /todos"] = ["201", "409"],
+        ["DELETE /todos/{id}"] = ["204", "400", "404"],
+#endif
+#endif
+#if (specFirst)
+        // The contract's statuses, plus the 400 the generated validation answers: the contract
+        // constrains the id and the title, so every operation binding either can refuse.
+        ["GET /todos"] = ["200"],
+        ["GET /todos/{id}"] = ["200", "400", "404"],
+        ["POST /todos"] = ["201", "400", "409"],
+        ["DELETE /todos/{id}"] = ["204", "400", "404"],
+#endif
+    };
+
+    [HardenedTest]
+    public async Task EveryOperationDeclaresExactlyTheStatusesThisSuiteExercises(ITestWebApp app) {
+        var document = await Document(app);
+        var declared = new Dictionary<string, string[]>();
+
+        foreach (var path in document.GetProperty("paths").EnumerateObject()) {
+            foreach (var operation in path.Value.EnumerateObject()) {
+                if (!operation.Value.TryGetProperty("responses", out var responses)) {
+                    continue;
+                }
+
+                declared[$"{operation.Name.ToUpperInvariant()} {path.Name}"] = responses
+                    .EnumerateObject()
+                    .Select(response => response.Name)
+                    .OrderBy(status => status, StringComparer.Ordinal)
+                    .ToArray();
+            }
+        }
+
+        Assert.Equal(
+            Expected.Keys.OrderBy(key => key, StringComparer.Ordinal),
+            declared.Keys.OrderBy(key => key, StringComparer.Ordinal));
+
+        foreach (var operation in Expected) {
+            Assert.Equal(operation.Value, declared[operation.Key]);
+        }
+    }
+
+    /// <summary>The served document, which is stored and answered gzipped.</summary>
+    private static async Task<JsonElement> Document(ITestWebApp app) {
+        var response = await app.Get("/openapi.json");
+
+        response.Assert.Ok();
+        response.Body.Position = 0;
+
+        await using var gzip = new GZipStream(response.Body, CompressionMode.Decompress);
+
+        return JsonDocument.Parse(await new StreamReader(gzip).ReadToEndAsync()).RootElement;
+    }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
@@ -116,5 +116,35 @@ public class TodoTests {
 
         Assert.Equal(400, response.StatusCode);
     }
+
+    /// <summary>
+    /// The id's minimum is enforced the same way the title's length is - and the published
+    /// document says so, which DocumentStatusTests holds it to.
+    /// </summary>
+    [HardenedTest]
+    public async Task GetTodo_IdBelowTheContractsMinimum_IsBadRequest(ITestWebApp app) {
+        Assert.Equal(400, (await app.Get("/todos/0")).StatusCode);
+    }
+
+    [HardenedTest]
+    public async Task RemoveTodo_IdBelowTheContractsMinimum_IsBadRequest(ITestWebApp app) {
+        Assert.Equal(400, (await app.Delete("/todos/0")).StatusCode);
+    }
+#endif
+#if (codeFirst)
+    /// <summary>
+    /// An id the parameter's type cannot carry is refused before the handler, with the same
+    /// field-level envelope a failed validation answers - and the published document says so,
+    /// which DocumentStatusTests holds it to.
+    /// </summary>
+    [HardenedTest]
+    public async Task GetTodo_MalformedId_IsBadRequest(ITestWebApp app) {
+        Assert.Equal(400, (await app.Get("/todos/not-a-number")).StatusCode);
+    }
+
+    [HardenedTest]
+    public async Task RemoveTodo_MalformedId_IsBadRequest(ITestWebApp app) {
+        Assert.Equal(400, (await app.Delete("/todos/not-a-number")).StatusCode);
+    }
 #endif
 }


### PR DESCRIPTION
F12 from the Forty-Four Fixes queue (D-B-01, D-C-11, D-B-02, D-C-12, D-C-13, D-C-14, and cluster 5's mitigation).

- **The zero-byte JSON context** (D-B-01/D-C-11): `TemplateModuleNameJsonContext.cs` joins `TodoController.cs` in the `(!codeFirst)` exclusion - its whole body sat behind that condition, so a spec-first project received it as a zero-byte file - and the now-redundant `#if` wrapper comes off, matching the other excluded files.
- **The truncated README** (D-B-02): the POST and DELETE table rows become whole-line conditionals. The nested inline `#if` inside a table cell desynchronised the wholeLine markdown evaluator on the false branch and ate the rest of the file.
- **`net8.0` prose** (D-C-12): the four places that spelled `obj/Debug/net8.0/` now use the `obj/<configuration>/<tfm>/` form `Directory.Build.props` already uses; the TFM is conditional, net11.0 under union.
- **HSMT011 prose** (D-C-13): AGENTS.md and the csproj comment now say what the pin does - warns locally naming both versions, errors under `ContinuousIntegrationBuild`.
- **Cluster 5's mitigation, from arm A**: `DocumentStatusTests` fetches `/openapi.json` and asserts each operation's status set - the contract's statuses plus the synthesized 400s - with new suite tests driving those 400s, so a declared status nothing answers fails a test naming the operation, in every mode, over the pipeline.
- **`verify-templates.sh` guards** (D-C-14 class): every generated output is checked for zero-byte files and a truncated README. The host-independence diff also runs again - the output directories gained a `-standard` suffix when the response model joined the combination and the check's paths never did, so it had been silently skipped on every run since; verified passing against the current outputs.

The full default matrix passes: nine hardened-web combinations (including both smithy rows under the pinned CLI), the library, dotted names and the three Lambda templates.

Last of the staged queue after #221. F14 follows once the DependencyModules release ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)