### PR TITLE
Take ValidationModules 1.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ unmeasured rather than untested.
 ## Releasing
 
 A `v*` tag drives `release.yaml`, and the tag is the source of truth for the version. The current
-line is `0.15.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
+line is `0.17.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
 
 **The pack list in `release.yaml` is hand-maintained and has drifted four times.** A new packable
 project has to be added to it *and* to `EXPECTED`, which is a literal on purpose. Adding it to the

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -69,7 +69,7 @@
       in a reviewable commit rather than on whichever day CI happened to rerun.
     -->
     <PropertyGroup>
-        <ValidationModulesVersion Condition="'$(ValidationModulesVersion)' == ''">1.0.0-rc1012</ValidationModulesVersion>
+        <ValidationModulesVersion Condition="'$(ValidationModulesVersion)' == ''">1.0.0</ValidationModulesVersion>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Release-prep for 0.18.0-rc1000, caught before the tag: the pin sat at `1.0.0-rc1012` while the stable ValidationModules 1.0.0 shipped, so the release would have published packages declaring a prerelease floor for a dependency whose final exists. The in-flight release run was cancelled before its publish steps and the tag removed; this lands first and the tag goes back on the merge.

- `ValidationModulesVersion` moves to `1.0.0`. Both consumers move together, as the props comment requires - the runtime binding in `Hardened.Requests.Runtime` and the source-only Impl the generators compile in.
- Validated: Debug build and all 31 test suites pass, and the CI-style Release build is 0 warnings, 0 errors - nothing between rc1012 and 1.0.0 moved under the framework.
- The stale release line in AGENTS.md moves 0.15.0 to 0.17.0 while here.

The Amz bump branch pairs this with `ValidationModules.SourceGenerator.Impl` 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)