### PR TITLE
Open the 0.19.0 preview line

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -316,8 +316,8 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           # The open line, which is the one previews belong under - not the last one released.
-          # Released so far: v0.1.0-rc1, v0.2.0-rc1000, v0.3.0-rc1000.
-          RELEASE_LINE: 0.4.0
+          # The line has released through v0.18.0-rc1000; there was no 0.7.0.
+          RELEASE_LINE: 0.19.0
         run: |
           BUILD=$(printf '%06d' "$GITHUB_RUN_NUMBER")
           echo "Packing $RELEASE_LINE-preview$BUILD"


### PR DESCRIPTION
Post-release housekeeping for 0.18.0-rc1000: `build-package.yaml`'s `RELEASE_LINE` sat at 0.4.0 while fourteen release lines opened - its own comment requires the bump when a line opens. Previews kept sorting below every release, which is the safe direction, but they claimed a closed line. The open line is 0.19.0 and the released-so-far note points at the current tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)