### PR TITLE
Rename the standard response model to throws, and make response the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ can be swapped without touching the code.
 
 | Template | What you get |
 |---|---|
-| `hardened-web` | The todo API above: an implementation library, a host, and tests. `--host kestrel\|aspnet\|aws-lambda`, `--contract code\|openapi\|smithy`, `--response-model standard\|response\|union` |
+| `hardened-web` | The todo API above: an implementation library, a host, and tests. `--host kestrel\|aspnet\|aws-lambda`, `--contract code\|openapi\|smithy`, `--response-model response\|throws\|union` |
 | `hardened-function` | A serverless function and tests, on AWS Lambda today. `--trigger invoke\|sqs` |
 | `hardened-library` | A reusable module an application picks up with one attribute |
 
@@ -64,8 +64,8 @@ public partial class TodosLibrary;
 
 public class TodoController {
     [Get("/{id}")]
-    public Todo ById(ITodoStore store, int id) =>
-        store.Find(id) ?? throw new NotFound("todo", $"No todo has id {id}.").AsException();
+    public Response<Todo, NotFound> ById(ITodoStore store, int id) =>
+        store.Find(id) ?? new NotFound("todo", $"No todo has id {id}.").AsResponse<Todo, NotFound>();
 }
 ```
 
@@ -74,8 +74,9 @@ the route and body values, so anything the container knows about can be asked fo
 nothing has to be stored on the class. A parameter typed as a concrete class is bound from the
 request body instead.
 
-The 404 is thrown here because the return type names only the success case. Putting it in the
-signature instead is what the [three return models](#three-return-models) below are about.
+The 404 is in the signature, so the compiler knows the route can answer it and the document
+describes it. Naming only the success type and throwing the rest is a mode of its own - the
+[three return models](#three-return-models) below are the choice.
 
 The application names its runtime and the libraries it composes, and that is the whole bootstrap:
 
@@ -194,13 +195,18 @@ three work side by side.
 
 | | The handler says | Other statuses | Needs |
 |---|---|---|---|
-| **Standard** | one success type | thrown | any SDK |
 | **Response** | the whole set, as `Response<T1..Tn>` | in the return type | any SDK |
+| **Throws** | one success type | thrown | any SDK |
 | **Union** | the whole set, as a C# `union` | in the return type | .NET 11, `LangVersion` preview |
 
-**Standard** is the default. The signature names the success type and every other status is thrown.
-Nothing in the signature says the route can answer a 404, so nothing checks that you handled it, and
-the document describes only the 200.
+**Response** is the default: the declared set is where the compiler's checking and the document's
+truthfulness come from, so it is the mode the template reaches for when you say nothing.
+
+**Throws** names the success type and throws every other status. It was called **standard** until
+0.19.0, and it is not a legacy mode - a team that wants errors decided in filters and handlers kept
+lean chooses it deliberately. Nothing in the signature says the route can answer a 404, so nothing
+checks that you handled it, and the document describes only the 200 unless the handler declares the
+rest with `[Throws<NotFound>]` - the attribute the mode is named for.
 
 ```csharp
 [Get("/{id}")]
@@ -217,7 +223,8 @@ public Todo ById(ITodoStore store, int id) {
 
 **Response** puts the whole set in the return type. `Response<T1..Tn>` is an ordinary struct with an
 implicit conversion per case, so the handler returns payloads and never names the wrapper. The
-compiler knows the set and the document describes all of it.
+compiler knows the set and the document describes all of it. In throws mode the same handler names
+`Todo` alone and throws the `NotFound`.
 
 ```csharp
 [Get("/{id}")]
@@ -249,13 +256,13 @@ are built-in records that carry their status, and most have a `<T>` form that ta
 in place of the default one.
 
 Code-first, the return type alone decides. Contract-first, the statuses come from the contract and
-`<HardenedResponseModel>Standard|Response|Union</HardenedResponseModel>` decides the generated
+`<HardenedResponseModel>Response|Throws|Union</HardenedResponseModel>` decides the generated
 interface's shape. Declared 404s as nullable returns, and operations with two success statuses, are
 in [declared responses](https://ipjohnson.github.io/Hardened.Docs/guide/responses).
 
-`--response-model standard|response|union` on the template generates the todo API in whichever of
+`--response-model response|throws|union` on the template generates the todo API in whichever of
 the three you pick, so the difference between them is something to read rather than to take on
-trust.
+trust. The old value `standard` still scaffolds throws mode, and goes away at 1.0.
 
 ## Filters
 

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -88,6 +88,7 @@ the other.
 | `016` | `UiUrl` without `PublishUrl`, so the page would have no document to render. |
 | `017` | `SourceUrl` without `EmbedDocument`, so there is no source to serve. |
 | `020`–`025` | The shared model-diagnostics pass. See below. |
+| `026` | Warning. `$(HardenedResponseModel)` is `Standard`, the throws mode's name before 0.19.0. The mode selected is unchanged; write `Throws`. Reported once per project. |
 
 ### The Smithy CLI task (HSMT010–HSMT014)
 

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -115,6 +115,7 @@ the other.
 | `017` | `SourceUrl` without `EmbedDocument`, so there is no source to serve. |
 | `020`–`025` | The shared model-diagnostics pass. See below. |
 | `026` | Warning. `$(HardenedResponseModel)` is `Standard`, the throws mode's name before 0.19.0. The mode selected is unchanged; write `Throws`. Reported once per project. |
+| `027` | The description references something it does not declare. Part of the model-diagnostics pass; see below. |
 
 ### The Smithy CLI task (HSMT010–HSMT014)
 
@@ -140,6 +141,34 @@ generated file.
 | `023` | An `enum` declaring both string and numeric values, which no C# enum can carry. Declare one kind. |
 | `024` | Warning. A declared keyword or trait the generator does not enforce, named with a representative location. Remove it, or enforce the rule in the handler. |
 | `025` | Two error responses on one operation share one status, which would generate the same case type twice. Give them distinct statuses or merge the shapes. |
+| `027` | A reference to something the description does not declare. |
+
+#### 027 — a reference to something the description does not declare
+
+```
+'GET /events (200)' references '#/components/schemas/DoesNotExist', which the description
+does not declare. Nothing is generated for it, so the member it types would be absent and a
+response body would be dropped. Declare the schema, or point the reference at one that exists.
+```
+
+Fatal, unlike everything else in the block, because there is no answer to fall back on. A dangling
+`$ref` in a response degraded the success case to a bodyless one, so a handler written against the
+generated interface compiled and answered 200 with an empty body; the only errors were CS0246s a
+hop away in application code that happened to name the missing model.
+
+One report per place the reference is made — a document referencing a schema it dropped usually
+does so from several, and each is a separate edit. The operation's flat response fields mirror its
+primary success, so those count as one place rather than two.
+
+Under `HSMT` this covers a target the model references and does not declare: an operation a service
+binds, an operation's input or output, a member's target, and an error shape bound to an operation.
+The Smithy CLI refuses all of these before the parser sees them, so only a committed AST reaches it.
+
+**What it does not catch.** A `$ref` on a schema property is resolved by the reader before this
+parser sees it, and an unresolvable one is discarded there — the property arrives with no reference,
+no type and no shape, and becomes `JsonElement`. Nothing in the object model records that the
+reference was ever made, and the reader reports nothing either. Catching that needs the raw
+document rather than the object model.
 
 ### Renumbered in 0.18
 

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -54,6 +54,32 @@ public class CatalogHandler : HandlerBase, ICatalogService { }
 C# requires the base class to come first, and the base list is searched by name, so HOAG031 fires
 only when *no* entry matches a described service.
 
+## Routing
+
+### HRDR006 — no routing generator is compiling this assembly's routes
+
+A module declaring routes with nothing turning them into a routing table. It compiled without a
+warning into an application that answered 404 to every route it declared, and the template's
+`AGENTS.md` documented the trap without the build ever mentioning it.
+
+```
+'Depot.EventsController' declares routes and nothing in this project turns them into a routing
+table, so every one of them answers 404 at run time. Reference Hardened.Web.SourceGenerator as
+an analyzer, or drop the route attributes if this assembly is not meant to serve them.
+```
+
+The build cannot see a missing analyzer from inside the analyzer that is missing, so the question
+is asked from one that is still there. `Hardened.Web.SourceGenerator` and
+`Hardened.Idl.SourceGenerator` each declare `Hardened.Web.Generated.WebRoutingGeneratorMarker` as
+post-initialization output — the one kind of generated source another generator can see — and
+`Hardened.Library.SourceGenerator`, which every Hardened project references, reports its absence.
+
+Triggered by a route declaration rather than by `[HardenedWebModule]`. That attribute means "bring
+the web pipeline", which is a thing an assembly with no routes of its own legitimately does — the
+framework's own `AspNetCoreRuntime` is one.
+
+One report per assembly, not one per route: there is a single thing to fix.
+
 ## Other diagnostics
 
 | Id | Meaning |
@@ -62,7 +88,7 @@ only when *no* entry matches a described service.
 | `HOAG002` | The description could not be parsed; the build task's message is passed through. |
 | `HOAG010` | A handler was skipped because a parameter type did not resolve. Other handlers are unaffected. |
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
-| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. |
+| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. `HRDR006` is above. |
 
 ## Description build tasks (HOAT, HSMT)
 

--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -49,7 +49,7 @@ serving the source verbatim where that is wanted.
   `application/json`, because the exception path serializes JSON whatever the success was. An
   operation with a generated validator declares the `400` that validator answers, with the
   `RequestValidationError` schema.
-- **Statuses in Standard mode** - `[Throws<T>(status)]` puts a thrown status into the document
+- **Statuses in throws mode** - `[Throws<T>(status)]` puts a thrown status into the document
   with its schema; `SuccessStatus` on the verb attribute names the success. Neither is checked
   against what the handler actually throws - the declared response models are where the compiler
   holds the set.
@@ -61,12 +61,12 @@ serving the source verbatim where that is wanted.
 | `[Enable<OpenApiDocumentPublishing>]` | entry point | emits and serves the document (code-first) |
 | `<HardenedOpenApiSpec>` + `PublishUrl`/`SourceUrl`/`UiUrl` | csproj item | the contract, where the generated document, the source text and the reference page are served |
 | `<HardenedSmithyModel>` / `<HardenedSmithyAst>` | csproj item | the Smithy contract, same metadata |
-| `$(HardenedResponseModel)` | csproj property | `Standard` / `Response` / `Union` for a described project |
+| `$(HardenedResponseModel)` | csproj property | `Response` / `Throws` / `Union` for a described project; absent means `Throws`, and the pre-0.19.0 value `Standard` still reads as `Throws` under a 026 warning |
 | `[ResponseModel(...)]` | entry point | the same choice, code-first |
 | `[OpenApiInfo(title, version, description)]` | entry point | the document's `info`, code-first |
 | `[Server(url, description)]` | entry point | a `servers` entry |
 | `[Throws<T>(status)]` | handler | a thrown status, into the document |
-| `SuccessStatus = 201` | verb attribute | the success status, code-first Standard mode |
+| `SuccessStatus = 201` | verb attribute | the success status, code-first throws mode |
 | `[JsonEnumNaming(...)]` | assembly or enum | the wire vocabulary: converters, binder, document |
 | `IAuthenticationScheme` + shape attribute | scheme class | a security scheme, declared by being used |
 | `[Authorize<TAuth>]` / `[Authorize<TAuth, TPolicy>]` | handler or controller | the requirement, enforced and published |

--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -8,7 +8,8 @@
 # from source proves nothing about packaging, which is where the 0.8.0-rc1000 quickstart broke.
 #
 # Usage: scripts/verify-templates.sh [host:contract ...]
-#        default: kestrel:code aspnet:code kestrel:openapi kestrel:smithy
+#        default: the template default (response) on three host/contract rows, throws and union
+#        on both spec directions, and kestrel:smithy rows when the pinned CLI is present
 #
 # smithy is skipped unless the Smithy CLI is on PATH at the pinned version - a build without it
 # fails by design (HSMT011), and that is the toolchain's problem rather than the template's.
@@ -47,15 +48,15 @@ if [ ${#COMBOS[@]} -eq 0 ]; then
     # comment containing a double hyphen, which every other combination was immune to only because
     # that comment sat behind #if (unionMode).
     COMBOS=(kestrel:code aspnet:code kestrel:openapi
-            kestrel:code:response kestrel:openapi:response
+            kestrel:code:throws kestrel:openapi:throws
             kestrel:code:union kestrel:openapi:union)
 
     if command -v smithy >/dev/null 2>&1 && [ "$(smithy --version 2>/dev/null)" = "$SMITHY_PIN" ]; then
-        # The declared model too, not only standard. Smithy's half of it had never run: the targets
-        # file did not pass $(HardenedResponseModel) at all, so a Smithy project asking for a
-        # response set got Standard and got it silently. A row that only ever exercises the default
-        # is how that survived.
-        COMBOS+=(kestrel:smithy kestrel:smithy:response)
+        # The throws model too, not only the default. Smithy's half of the property had never run:
+        # the targets file did not pass $(HardenedResponseModel) at all, so a Smithy project asking
+        # for a response set got throws mode and got it silently. A row that only ever exercises
+        # the default is how that survived.
+        COMBOS+=(kestrel:smithy kestrel:smithy:throws)
     else
         FOUND="$(command -v smithy >/dev/null 2>&1 && smithy --version || echo none)"
         echo "note: skipping the smithy contract - it needs the Smithy CLI at $SMITHY_PIN, found $FOUND"
@@ -149,10 +150,12 @@ for COMBO in "${COMBOS[@]}"; do
     REST="${COMBO#*:}"
     CONTRACT="${REST%%:*}"
 
-    # host:contract, or host:contract:model. Defaulted rather than required, so every combo written
-    # before the response model existed still means what it said.
+    # host:contract, or host:contract:model. A bare combo scaffolds with no --response-model at
+    # all, for the same reason --HardenedVersion is not passed below: the default is what a real
+    # user gets, so the default is what needs testing - and since 0.19.0 the default is response.
+    # Naming a model exercises the flag.
     if [ "$REST" = "$CONTRACT" ]; then
-        MODEL=standard
+        MODEL=default
     else
         MODEL="${REST#*:}"
     fi
@@ -163,8 +166,13 @@ for COMBO in "${COMBOS[@]}"; do
     # --HardenedVersion is deliberately NOT passed. The template stamps the version it was
     # packed with as the default, and that default is what a real user gets - so it is what
     # needs testing. Passing it here would test the flag and leave the default unexercised.
-    dotnet new hardened-web -n Sample -o "$OUT" --host "$HOST" --contract "$CONTRACT" \
-        --response-model "$MODEL" --skip-restore
+    if [ "$MODEL" = "default" ]; then
+        dotnet new hardened-web -n Sample -o "$OUT" --host "$HOST" --contract "$CONTRACT" \
+            --skip-restore
+    else
+        dotnet new hardened-web -n Sample -o "$OUT" --host "$HOST" --contract "$CONTRACT" \
+            --response-model "$MODEL" --skip-restore
+    fi
 
     check_generated "$OUT"
 
@@ -270,8 +278,8 @@ for COMBO in "${COMBOS[@]}"; do
 
         # Which status a create answers with, and the three-way split is the point.
         #
-        # Code-first Standard has one success type per handler and nowhere to name a status beside
-        # it, so it answers 200. Specification-first Standard answers 201, because the contract names
+        # Code-first throws mode has one success type per handler and nowhere to name a status beside
+        # it, so it answers 200. Specification-first throws mode answers 201, because the contract names
         # the status and the generated dispatch carries it - what that mode cannot do is name more
         # than one. The declared models answer 201 from the case itself, either way.
         #
@@ -282,7 +290,7 @@ for COMBO in "${COMBOS[@]}"; do
             -d '{"title":"Written by the verification run"}' \
             "http://localhost:$PORT/todos" || true)
 
-        if [ "$MODEL" = "standard" ] && [ "$CONTRACT" = "code" ]; then
+        if [ "$MODEL" = "throws" ] && [ "$CONTRACT" = "code" ]; then
             EXPECT_CREATED=200
         else
             EXPECT_CREATED=201
@@ -429,10 +437,10 @@ say "host independence"
 # The framework's claim is that handlers, filters, binding and routing do not change with the
 # host. If that is true, only the host project may differ between two generated applications.
 # Comparable only across hosts at the same contract, which is the claim being checked.
-# The -standard suffix, because that is what the output directories are named since the response
-# model joined the combination. The old suffixless paths matched nothing, so this check was
+# The -default suffix, because that is what the bare rows' output directories are named now that
+# they scaffold without the flag. The old suffixless paths matched nothing, so this check was
 # silently skipped on every run - which is why it now says so instead of saying nothing.
-A="$WORK/kestrel-code-standard"; B="$WORK/aspnet-code-standard"
+A="$WORK/kestrel-code-default"; B="$WORK/aspnet-code-default"
 if [ -d "$A" ] && [ -d "$B" ]; then
     # Source only. bin/ and obj/ carry absolute paths and compiler output, which differ for
     # reasons that have nothing to do with the host.
@@ -447,6 +455,25 @@ if [ -d "$A" ] && [ -d "$B" ]; then
     done
 else
     echo "   skipped: both hosts are not in this run's combinations"
+fi
+
+say "renamed value"
+# --response-model standard was the throws mode's name until 0.19.0. The choice stays accepted for
+# one release and scaffolds the same project, and this is the row that notices if either half
+# stops being true - at generation, because the claim is about the template, not the build.
+if [ -d "$WORK/kestrel-code-throws" ]; then
+    OUT_ALIAS="$WORK/alias-standard"
+    dotnet new hardened-web -n Sample -o "$OUT_ALIAS" --host kestrel --contract code \
+        --response-model standard --skip-restore
+    if diff -r -x bin -x obj -x nuget.config \
+        "$WORK/kestrel-code-throws/src" "$OUT_ALIAS/src" >/dev/null 2>&1; then
+        echo "   --response-model standard scaffolds the throws project"
+    else
+        echo "   FAILED: --response-model standard no longer scaffolds what throws scaffolds"
+        FAILED=1
+    fi
+else
+    echo "   skipped: kestrel:code:throws is not in this run's combinations"
 fi
 
 dotnet new uninstall Hardened.Templates >/dev/null 2>&1 || true

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/ScalarSuccessBodyTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/ScalarSuccessBodyTests.cs
@@ -14,7 +14,7 @@ namespace Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests;
 /// front end that reached the response-set path.
 /// </para>
 /// <para>
-/// The sibling SUT could not catch this: it runs the Standard model, its declared errors are
+/// The sibling SUT could not catch this: it runs the Throws model, its declared errors are
 /// thrown, and <c>RequiresResponseSet</c> stays false - the broken branch never executed there.
 /// </para>
 /// </remarks>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.csproj
@@ -9,7 +9,7 @@
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 
         <!--
-            The whole point of this fixture. The sibling OpenApi SUT runs Standard, where declared
+            The whole point of this fixture. The sibling OpenApi SUT runs Throws, where declared
             errors are thrown and RequiresResponseSet stays false - so the response-set dispatch,
             the branch that decided a scalar success was bodyless, never executed there.
         -->

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelsApp.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelsApp.cs
@@ -5,7 +5,7 @@ namespace Hardened.IntegrationTests.OpenApi.ResponseModel.SUT;
 
 /// <summary>
 /// The specification-first application under the <c>Response</c> model, which the sibling SUT's
-/// <c>Standard</c> mode never exercises: every declared status here is a returned case rather
+/// <c>Throws</c> mode never exercises: every declared status here is a returned case rather
 /// than a throw, so the response-set dispatch runs for every operation.
 /// </summary>
 [HardenedModule]

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
@@ -1,3 +1,5 @@
+using Hardened.Requests.Testing;
+
 namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
 
 /// <summary>
@@ -70,4 +72,50 @@ public class DescribedSecurityTests {
 
         response.Assert.Ok();
     }
+
+    #region the caller, in a handler
+
+    /// <summary>
+    /// H-03. A specification-first handler implements a generated interface, so the code-first
+    /// escape - an <c>IExecutionContext</c> parameter - does not exist, and nothing scoped exposed
+    /// the caller. Ownership checks and grant-dependent filtering could not be written without
+    /// hand-rolled plumbing, and both spec-first arms of the trial invented the same bridge
+    /// independently. <c>ICurrentCaller</c> is that bridge, shipped and injected by constructor.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerReadsTheCallerAndAdmitsTheOwner(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/secured/owned/integration-test", Holding("pets:read"));
+
+        Assert.Equal(200, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The refusal the contract cannot express. Both requests hold the grant the description asks
+    /// for and pass authorization; only the handler can tell which of them owns the row.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerReadsTheCallerAndRefusesSomebodyElse(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/owned/somebody-else", Holding("pets:read"));
+
+        Assert.Equal(403, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Present on every request, empty where nothing authenticated - so a handler reads the same
+    /// shape either way and never checks for null. Authorization refuses this one first, which is
+    /// the arrangement: what a caller may do is judged before the handler runs.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnAnonymousRequestIsRefusedBeforeTheHandlerReadsAnything(
+        ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/owned/integration-test");
+
+        Assert.Equal(401, response.StatusCode);
+    }
+
+    private static Action<TestWebRequest> Holding(string grants) =>
+        request => request.Headers[TestGrantsPrincipalSource.GrantsHeader] = grants;
+
+    #endregion
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
@@ -177,4 +177,42 @@ public class ValidationTests {
 
         response.Assert.Ok();
     }
+
+    #region the name a caller can act on
+
+    private const string ValidOrder =
+        """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":2}]}""";
+
+    /// <summary>
+    /// OR-04. <c>Idempotency-Key</c> failing its pattern reported <c>"field": "idempotencyKey"</c>
+    /// - a name that appears nowhere in the request or the contract. Body failures already used
+    /// wire names with indexed paths; header and query failures leaked the C# identifier the
+    /// generator allocated.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHeaderFailureNamesTheHeader(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            ValidOrder, "/orders", request => request.Headers["Idempotency-Key"] = "not-hex");
+
+        Assert.Equal(400, response.StatusCode);
+
+        var error = response.Deserialize<RequestValidationError>();
+
+        Assert.Contains(error.Errors, e => e.Field == "Idempotency-Key");
+        Assert.DoesNotContain(error.Errors, e => e.Field == "idempotencyKey");
+    }
+
+    /// <summary>
+    /// A valid key gets through, so the constraint is the thing being tested rather than the
+    /// parameter merely being present.
+    /// </summary>
+    [HardenedTest]
+    public async Task AValidHeaderIsAccepted(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            ValidOrder, "/orders", request => request.Headers["Idempotency-Key"] = "0f9ac3b2");
+
+        response.Assert.Ok();
+    }
+
+    #endregion
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
@@ -14,6 +14,9 @@
     <ItemGroup>
         <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
         <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <!-- TestGrantsPrincipalSource, the shipped testing source. A fixture states its caller
+             through the same seam a production application authenticates through. -->
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
         <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OpenApiTestApp.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OpenApiTestApp.cs
@@ -1,10 +1,14 @@
+using DependencyModules.Runtime.Interfaces;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Testing;
 using Hardened.Shared.Runtime.Attributes;
 using Hardened.Web.Runtime.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT;
 
 /// <summary>
-/// A specification-first application, which registers nothing of its own.
+/// A specification-first application, whose one registration is a caller for its tests to state.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -20,6 +24,18 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// emitter back in the path that exists to have none.
 /// </para>
 /// </remarks>
+/// <remarks>
+/// <para>
+/// <c>TestGrantsPrincipalSource</c> is the shipped testing source, through the same seam a
+/// production one uses. It declines every request that does not carry <c>X-Test-Grants</c>, so
+/// every route in this fixture answers exactly as it did before it was registered - and a test
+/// that wants a caller now has one to name.
+/// </para>
+/// </remarks>
 [HardenedModule]
 [HardenedWebModule]
-public partial class OpenApiTestApp { }
+public partial class OpenApiTestApp : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddSingleton<IPrincipalSource, TestGrantsPrincipalSource>();
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OrderServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OrderServiceImpl.cs
@@ -10,9 +10,11 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// <remarks>
 /// Deliberately does no checking of its own. The point of the route is that a request reaching this
 /// method at all is a failure of validation - both defects it covers ended with the handler running
-/// on a body the caller never sent.
+/// on a body the caller never sent. The idempotency key is taken and ignored for the same reason:
+/// what is under test is the refusal it never reaches.
 /// </remarks>
 [Handler]
 public class OrderServiceImpl : IOrderService {
-    public Task<OrderRequest> PlaceOrder(OrderRequest body) => Task.FromResult(body);
+    public Task<OrderRequest> PlaceOrder(string? idempotencyKey, OrderRequest body) =>
+        Task.FromResult(body);
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
@@ -1,5 +1,7 @@
 using Hardened.IntegrationTests.OpenApi.SUT.Services;
 using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Errors;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT;
 
@@ -7,12 +9,26 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// Handlers that exist to be refused.
 /// </summary>
 /// <remarks>
-/// Neither carries an authorization attribute. Everything guarding them came from the description,
-/// which is the point: reaching either method at all is the failure these routes test for.
+/// <para>
+/// None carries an authorization attribute. Everything guarding them came from the description,
+/// which is the point: reaching one of these methods at all is the failure these routes test for.
+/// </para>
+/// <para>
+/// <c>SecuredOwned</c> is the other half. A contract can say the caller must hold a grant and
+/// cannot say the row must be theirs, so the ownership check belongs to the handler - which needs
+/// to know who the caller is. A specification-first handler implements a generated interface, so
+/// it cannot take <c>IExecutionContext</c> as a parameter; <see cref="ICurrentCaller"/> is what it
+/// takes instead, by plain constructor injection with nothing wired by hand.
+/// </para>
 /// </remarks>
 [Handler]
-public class SecuredServiceImpl : ISecuredService {
+public class SecuredServiceImpl(ICurrentCaller caller) : ISecuredService {
     public Task<string> SecuredScoped() => Task.FromResult("reached");
 
     public Task<string> SecuredEither() => Task.FromResult("reached");
+
+    public Task<string> SecuredOwned(string ownerId) =>
+        ownerId == caller.Principal.Subject
+            ? Task.FromResult(ownerId)
+            : throw new StatusCodeException(403);
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -115,6 +115,31 @@ paths:
             application/json:
               schema:
                 type: string
+  # An ownership check, which is the decision only the handler can make: the contract says the
+  # caller must hold pets:read, and nothing in a document can say "and the row must be theirs".
+  # The handler takes ICurrentCaller and compares.
+  /secured/owned/{ownerId}:
+    get:
+      tags:
+        - Secured
+      operationId: securedOwned
+      security:
+        - petstoreOAuth: ["pets:read"]
+      parameters:
+        - name: ownerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The caller owns it.
+          content:
+            application/json:
+              schema:
+                type: string
+        '403':
+          description: The caller is not the owner.
   /secured/either:
     get:
       tags:

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -160,6 +160,15 @@ paths:
       tags:
         - Order
       operationId: placeOrder
+      parameters:
+        # A wire name no C# identifier can be. The member becomes IdempotencyKey and the failure
+        # has to still name the header the caller sent.
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            pattern: '^[0-9a-f]{8}$'
       requestBody:
         required: true
         content:

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
@@ -50,6 +50,16 @@ public class EncodedPathTests {
         Assert.Equal("a%2Fb", await Token(app, "a%2Fb"));
     }
 
+    /// <summary>
+    /// In either case. An escape is hex, and hex is case-insensitive - Kestrel decodes
+    /// <c>%c3%a9</c> and leaves <c>%2f</c>, exactly as it does the capitals.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheCaseOfAnEscapeDoesNotMatter(ITestWebApp app) {
+        Assert.Equal("a%2fb", await Token(app, "a%2fb"));
+        Assert.Equal("café", await Token(app, "caf%c3%a9"));
+    }
+
     /// <summary>A plus is a plus in a path. Only a query string reads one as a space.</summary>
     [HardenedTest]
     public async Task APlusIsNotASpace(ITestWebApp app) {
@@ -60,5 +70,23 @@ public class EncodedPathTests {
     [HardenedTest]
     public async Task SomethingThatIsNotAnEscapeIsLeftAlone(ITestWebApp app) {
         Assert.Equal("a%zz", await Token(app, "a%zz"));
+    }
+
+    /// <summary>
+    /// And neither is an escape that runs out of path before it has two digits.
+    /// </summary>
+    /// <summary>
+    /// Nor are two characters that sit outside hex on the other side of it.
+    /// </summary>
+    [HardenedTest]
+    public async Task DigitsBelowHexAreNotAnEscapeEither(ITestWebApp app) {
+        Assert.Equal("a%-1b", await Token(app, "a%-1b"));
+        Assert.Equal("a%G0b", await Token(app, "a%G0b"));
+    }
+
+    [HardenedTest]
+    public async Task AnEscapeWithNothingAfterItIsLeftAlone(ITestWebApp app) {
+        Assert.Equal("a%", await Token(app, "a%"));
+        Assert.Equal("a%2", await Token(app, "a%2"));
     }
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
@@ -1,0 +1,64 @@
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// A percent-encoded path, through the harness, answering what a socket answers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SU-07. <c>app.Get("/binding/path/%20")</c> reached the handler as the literal three characters
+/// while the same request over Kestrel decoded to whitespace - so a test could pass here and the
+/// application behave differently in production, which is the one thing a harness exists not to
+/// do.
+/// </para>
+/// <para>
+/// Every expectation below was measured against the Kestrel integration application over a real
+/// socket rather than reasoned about: the separator that stays encoded and the plus that is not a
+/// space are both surprises.
+/// </para>
+/// </remarks>
+public class EncodedPathTests {
+
+    private static async Task<string> Token(ITestWebApp app, string encoded) {
+        var response = await app.Get("/binding/path/" + encoded);
+
+        response.Assert.Ok();
+
+        return response.Deserialize<string>();
+    }
+
+    [HardenedTest]
+    public async Task AnEscapedSpaceReachesTheHandlerAsASpace(ITestWebApp app) {
+        Assert.Equal(" ", await Token(app, "%20"));
+    }
+
+    [HardenedTest]
+    public async Task AMultiByteCharacterIsDecodedWhole(ITestWebApp app) {
+        Assert.Equal("café", await Token(app, "caf%C3%A9"));
+    }
+
+    [HardenedTest]
+    public async Task AnEscapedPercentIsAPercent(ITestWebApp app) {
+        Assert.Equal("a%b", await Token(app, "a%25b"));
+    }
+
+    /// <summary>
+    /// The one escape that stays. Decoding it would put a separator inside a segment, changing how
+    /// many segments the path has.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnEscapedSeparatorStaysEncoded(ITestWebApp app) {
+        Assert.Equal("a%2Fb", await Token(app, "a%2Fb"));
+    }
+
+    /// <summary>A plus is a plus in a path. Only a query string reads one as a space.</summary>
+    [HardenedTest]
+    public async Task APlusIsNotASpace(ITestWebApp app) {
+        Assert.Equal("a+b", await Token(app, "a+b"));
+    }
+
+    /// <summary>Two characters that are not hex are not an escape.</summary>
+    [HardenedTest]
+    public async Task SomethingThatIsNotAnEscapeIsLeftAlone(ITestWebApp app) {
+        Assert.Equal("a%zz", await Token(app, "a%zz"));
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
@@ -120,4 +120,37 @@ public class RegistrationValidationTests {
 
         response.Assert.Ok();
     }
+
+    #region a body the harness sends as it is
+
+    /// <summary>
+    /// H-29. Every <c>Post</c> overload takes <c>object</c>, and everything that is not a string
+    /// was serialized - so a body that is not text at all could only be exercised against a live
+    /// socket. Bytes go as themselves now.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABodySentAsBytesGoesOnTheWireAsItself(ITestWebApp testWebApp) {
+        var body = System.Text.Encoding.UTF8.GetBytes(
+            """{"name":"Ada","age":36,"address":{"city":"London","country":"GB"}}""");
+
+        var response = await testWebApp.Post(body, "/registration");
+
+        response.Assert.Ok();
+        Assert.Equal("Ada", response.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// And a malformed one is refused rather than serialized into something well formed, which is
+    /// what makes the JSON-reader refusal testable in process.
+    /// </summary>
+    [HardenedTest]
+    public async Task MalformedBytesReachTheDeserializerAsMalformed(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            System.Text.Encoding.UTF8.GetBytes("{\"name\":"), "/registration");
+
+        response.Assert.BadRequest();
+        Assert.Equal("ValidationError", response.Deserialize<RequestValidationError>().Type);
+    }
+
+    #endregion
 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -924,9 +924,12 @@ namespace Hardened.Requests.Abstract.Responses
     }
     public enum ResponseModel
     {
-        Standard = 0,
+        Throws = 0,
         Response = 1,
         Union = 2,
+        [System.Obsolete("The Standard response model was renamed Throws in 0.19.0; write ResponseModel.Thr" +
+            "ows.")]
+        Standard = 0,
     }
     [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
     public sealed class ResponseModelAttribute : System.Attribute

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -202,6 +202,10 @@ namespace Hardened.Requests.Abstract.Authorization
         string? Subject { get; }
         bool TryGetClaim(string name, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out string value);
     }
+    public interface ICurrentCaller
+    {
+        Hardened.Requests.Abstract.Authorization.ICallerPrincipal Principal { get; }
+    }
     public interface IPrincipalSource
     {
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.ICallerPrincipal?> Authenticate(Hardened.Requests.Abstract.Execution.IExecutionContext context);

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/ResponseExceptionTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/ResponseExceptionTests.cs
@@ -7,7 +7,7 @@ namespace Hardened.Requests.Abstract.Tests.Responses;
 /// Throwing a response type, which is how these reach the wire before the response modes exist.
 ///
 /// <para>
-/// A handler in standard mode returns one type and has nowhere to put a second, so without this the
+/// A handler in throws mode returns one type and has nowhere to put a second, so without this the
 /// built-in types would be declarations and nothing else until the union work landed. What makes it
 /// work is that <c>ExceptionToModelConverter</c> already answers an <c>IStatusCodeException</c> with
 /// its status and its headers, and reads a declared body off <c>StatusCodeException.Value</c> - so

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/ICurrentCaller.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/ICurrentCaller.cs
@@ -1,0 +1,46 @@
+namespace Hardened.Requests.Abstract.Authorization;
+
+/// <summary>
+/// The caller of the request being handled, as a service a handler can take.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>IExecutionContext.CallerPrincipal</c> is where the principal lives, and a code-first handler
+/// reaches it by taking an <see cref="Execution.IExecutionContext"/> parameter. A specification-first
+/// handler implements a generated interface, so its signature is fixed and that escape does not
+/// exist - which left ownership checks and grant-dependent filtering unwritable without
+/// hand-rolled plumbing. Both spec-first arms of the 0.18 trial invented the same scoped holder
+/// independently; this is it, shipped.
+/// </para>
+/// <code>
+/// [Handler]
+/// public class OrderService(ICurrentCaller caller, IOrderStore store) : IOrderService {
+///     public async Task&lt;Order&gt; GetOrder(string orderId) {
+///         var order = await store.Get(orderId);
+///
+///         if (order.OwnerSubject != caller.Principal.Subject) {
+///             throw new ForbiddenException();
+///         }
+///
+///         return order;
+///     }
+/// }
+/// </code>
+/// <para>
+/// Scoped, and present on every request. A request no principal source answered for carries
+/// <see cref="AnonymousCallerPrincipal.Instance"/>, so a handler reads the same shape either way
+/// and never checks for null.
+/// </para>
+/// <para>
+/// Registered by <c>HardenedRequestModule</c>, so plain constructor injection works with nothing
+/// wired by hand. It is not a substitute for <c>[Authorize]</c> and its friends: what a caller may
+/// do is declared on the operation and judged before the handler runs. This is for the decisions
+/// only the handler can make - whether this caller owns this row.
+/// </para>
+/// </remarks>
+public interface ICurrentCaller {
+    /// <summary>
+    /// The caller this request established, or <see cref="AnonymousCallerPrincipal.Instance"/>.
+    /// </summary>
+    ICallerPrincipal Principal { get; }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ResponseException.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ResponseException.cs
@@ -9,7 +9,7 @@ namespace Hardened.Requests.Abstract.Responses;
 /// <remarks>
 /// <para>
 /// The built-in types are declarations first: what a response set is built from, and what the
-/// generator reads a status off. But a handler in standard mode returns one type and has nowhere to
+/// generator reads a status off. But a handler in throws mode returns one type and has nowhere to
 /// put a second, so without this they would be useful only after the union work landed. Throwing
 /// one costs nothing extra - <c>ExceptionToModelConverter</c> already answers an
 /// <see cref="IStatusCodeException"/> with its status, its headers and its declared body - and it

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ResponseModel.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ResponseModel.cs
@@ -20,15 +20,23 @@ namespace Hardened.Requests.Abstract.Responses;
 public enum ResponseModel {
 
     /// <summary>
-    /// One return type per handler, other statuses reached by throwing. The default, and what every
-    /// application does today.
+    /// One return type per handler, other statuses reached by throwing. What an application that
+    /// says nothing gets today; new projects scaffold as <see cref="Response"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Not a legacy mode. An organisation that wants authorization decided only in filters closes
     /// the return path deliberately and leaves the throw path open, which is a coherent policy - so
     /// this keeps working alongside the other two rather than being replaced by them.
+    /// </para>
+    /// <para>
+    /// Named for its mechanism, like the other two: errors are thrown, and <c>[Throws&lt;T&gt;]</c>
+    /// is how the thrown statuses reach the document. It was called <c>Standard</c> until 0.19.0 -
+    /// a positional name, and the position moved. The old member remains below as an alias so the
+    /// rename is a warning rather than a break.
+    /// </para>
     /// </remarks>
-    Standard,
+    Throws,
 
     /// <summary>
     /// The handler returns <c>Response&lt;T1..Tn&gt;</c>, a Hardened struct that any C# compiler can
@@ -50,5 +58,15 @@ public enum ResponseModel {
     /// depending on who built it, which is the same objection that keeps any Hardened type from
     /// carrying <c>[Union]</c>.
     /// </remarks>
-    Union
+    Union,
+
+    /// <summary>
+    /// The old name for <see cref="Throws"/>.
+    /// </summary>
+    /// <remarks>
+    /// Same value, so <c>[ResponseModel(ResponseModel.Standard)]</c> keeps meaning what it meant.
+    /// Goes away at 1.0.
+    /// </remarks>
+    [Obsolete("The Standard response model was renamed Throws in 0.19.0; write ResponseModel.Throws.")]
+    Standard = Throws
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ResponseModelAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ResponseModelAttribute.cs
@@ -8,7 +8,7 @@ namespace Hardened.Requests.Abstract.Responses;
 /// On the module entry point, which is where <c>[CaseInsensitiveRoutes]</c> and <c>[BasePath]</c>
 /// already live and for the same reason: an assembly can hold two entry points, so neither the
 /// csproj nor an <c>.editorconfig</c> can say that module A is <see cref="ResponseModel.Union"/>
-/// and module B is <see cref="ResponseModel.Standard"/>. A project-level property would have to
+/// and module B is <see cref="ResponseModel.Throws"/>. A project-level property would have to
 /// pick one for both.
 /// </para>
 /// <para>
@@ -17,8 +17,17 @@ namespace Hardened.Requests.Abstract.Responses;
 /// invoke method, and by the time a request arrives there is only the emitted code.
 /// </para>
 /// <para>
-/// Absent means <see cref="ResponseModel.Standard"/>, so every application that has never heard of
-/// this keeps building exactly as it did.
+/// Absent means <see cref="ResponseModel.Throws"/>, so every application that has never heard of
+/// this keeps building exactly as it did. New projects scaffold as
+/// <see cref="ResponseModel.Response"/>: code-first, the return types say so on their own and the
+/// template writes no attribute; spec-first, the template writes
+/// <c>&lt;HardenedResponseModel&gt;</c> out for every mode.
+/// </para>
+/// <para>
+/// Known limit: the module writer replays a module's attributes by re-instantiating them and
+/// renders an enum argument as its bare integer, which C# converts implicitly only when it is 0 -
+/// so today this attribute compiles on an entry point only with <see cref="ResponseModel.Throws"/>.
+/// The fix belongs to DependencyModules' writer, not here.
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationMiddlewareTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationMiddlewareTests.cs
@@ -1,7 +1,9 @@
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.DependencyInjection;
 using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
 
@@ -95,4 +97,79 @@ public class AuthenticationMiddlewareTests {
 
         Assert.Equal("one", seen?.Subject);
     }
+
+    #region the caller, on the request scope
+
+    /// <summary>
+    /// A context whose services are an application's - the request module's own registrations,
+    /// which is what puts the holder there.
+    /// </summary>
+    private static IExecutionContext ApplicationContext() =>
+        Pipeline.Context(
+            configureServices: services => new HardenedRequestModule().ConfigureServices(services));
+
+    private static ICallerPrincipal Resolved(IExecutionContext context) =>
+        context.RequestServices.GetRequiredService<ICurrentCaller>().Principal;
+
+    /// <summary>
+    /// H-03. A specification-first handler implements a generated interface, so it cannot take
+    /// <c>IExecutionContext</c> as a parameter and had no way to read the caller at all. The
+    /// middleware puts the answer on the request scope as well as on the context, which is what
+    /// makes <see cref="ICurrentCaller"/> resolvable in one.
+    /// </summary>
+    [Fact]
+    public async Task TheEstablishedCallerIsPutOnTheRequestScope() {
+        var context = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(context));
+
+        Assert.Equal("ada", Resolved(context).Subject);
+    }
+
+    /// <summary>
+    /// Written from the context rather than from the source's return value, so a request no source
+    /// answered for reads what the context holds - the anonymous principal, present rather than
+    /// null.
+    /// </summary>
+    [Fact]
+    public async Task ARequestNoSourceAnsweredForReadsTheAnonymousPrincipal() {
+        var context = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(null)]).Execute(Chain(context));
+
+        Assert.Same(AnonymousCallerPrincipal.Instance, Resolved(context));
+        Assert.False(Resolved(context).IsAuthenticated);
+    }
+
+    /// <summary>
+    /// One request's caller is not another's, which is the whole reason the holder is scoped.
+    /// </summary>
+    [Fact]
+    public async Task OneRequestsCallerDoesNotReachAnother() {
+        var authenticated = ApplicationContext();
+        var untouched = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(authenticated));
+
+        Assert.Equal("ada", Resolved(authenticated).Subject);
+        Assert.Same(AnonymousCallerPrincipal.Instance, Resolved(untouched));
+    }
+
+    /// <summary>
+    /// Asked for rather than required: a host that composed this middleware without the request
+    /// module's registrations still has a caller to establish.
+    /// </summary>
+    [Fact]
+    public async Task AContextWithoutTheHolderStillAuthenticates() {
+        var context = Pipeline.Context();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(context));
+
+        Assert.Equal("ada", context.CallerPrincipal.Subject);
+    }
+
+    #endregion
 }

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationMiddleware.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationMiddleware.cs
@@ -1,5 +1,6 @@
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.Requests.Runtime.Authorization;
 
@@ -23,6 +24,13 @@ namespace Hardened.Requests.Runtime.Authorization;
 /// Installed by <see cref="AuthenticationStartupService"/> only when at least one source is
 /// registered, so an application using none carries no per-request cost at all.
 /// </para>
+/// <para>
+/// The answer is put on the request scope as well as on the context, which is what makes
+/// <see cref="ICurrentCaller"/> resolvable in a specification-first handler - one whose signature a
+/// generated interface fixes, so it cannot take the context as a parameter. Written from the
+/// context rather than from the source's return value, so a request no source answered for reads
+/// whatever the context holds.
+/// </para>
 /// </remarks>
 public sealed class AuthenticationMiddleware : IExecutionFilter {
     private readonly IPrincipalSource[] _sources;
@@ -42,6 +50,13 @@ public sealed class AuthenticationMiddleware : IExecutionFilter {
 
                 break;
             }
+        }
+
+        // One resolve per request of an application that opted into authentication. Asked for
+        // rather than required, because a host that composed this middleware without the request
+        // module's registrations still has a caller to establish.
+        if (context.RequestServices?.GetService<CurrentCaller>() is { } caller) {
+            caller.Principal = context.CallerPrincipal;
         }
 
         await chain.Next();

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/CurrentCaller.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/CurrentCaller.cs
@@ -1,0 +1,26 @@
+using Hardened.Requests.Abstract.Authorization;
+
+namespace Hardened.Requests.Runtime.Authorization;
+
+/// <summary>
+/// The scoped holder <see cref="ICurrentCaller"/> resolves to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written by <see cref="AuthenticationMiddleware"/>, which runs ahead of the whole handler chain
+/// inside the request's own scope, and read by whatever the handler was resolved with. A mutable
+/// holder rather than a factory over the execution context, because the container has no per-request
+/// instance of the context to hand one.
+/// </para>
+/// <para>
+/// <b>What it reflects, exactly.</b> The principal the authentication seam established. An
+/// application with no <see cref="IPrincipalSource"/> installs no middleware and every request
+/// reads <see cref="AnonymousCallerPrincipal.Instance"/> - which is the same answer
+/// <c>IExecutionContext.CallerPrincipal</c> gives, at no per-request cost. A principal assigned to
+/// the context by something else after the middleware has run is not reflected here; nothing else
+/// is asked to run, which is what keeps this free for the applications that use none of it.
+/// </para>
+/// </remarks>
+internal sealed class CurrentCaller : ICurrentCaller {
+    public ICallerPrincipal Principal { get; set; } = AnonymousCallerPrincipal.Instance;
+}

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using DependencyModules.Runtime.Attributes;
 using DependencyModules.Runtime.Interfaces;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Runtime.Authorization;
 using Hardened.Requests.Runtime.Configuration;
 using Hardened.Requests.Runtime.Links;
@@ -44,6 +45,13 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         services.AddSingleton(
             s => Options.Create(s.GetRequiredService<IConfigurationManager>()
                 .GetConfiguration<IAuthorizationConfiguration>()));
+
+        // The caller, as a service a handler can take. Scoped rather than resolved from the
+        // context, because the container has no per-request instance of the context to build one
+        // from. Two registrations rather than one: the middleware fills the holder and everything
+        // else reads the interface, which is what keeps the setter off the contract.
+        services.AddScoped<CurrentCaller>();
+        services.AddScoped<ICurrentCaller>(provider => provider.GetRequiredService<CurrentCaller>());
 
         // Always installed. It costs one call per handler at startup and returns null for a handler
         // that carries no authorization attribute, so an application that has not opted in to

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/DanglingReferenceModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/DanglingReferenceModel.cs
@@ -1,0 +1,38 @@
+namespace Hardened.Generation.Models;
+
+/// <summary>
+/// A reference the description makes to something it never declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recorded as the document is read, for the reason <see cref="UnmappedKeywordModel"/> is: by the
+/// time <c>SpecDiagnostics.Find</c> sees the model the reference has been cleared, because a
+/// reference naming nothing generates C# naming nothing. The model can say what it holds and never
+/// what it was told and dropped.
+/// </para>
+/// <para>
+/// <b>Not the same thing as a reference to a schema that produced no type.</b> A top-level array
+/// alias, an <c>anyOf</c> with no shape of its own, an undecidable <c>oneOf</c> - each is declared,
+/// read, and deliberately resolved to something else, which the parser's own passes handle and say
+/// nothing about because there is nothing wrong. This is the other case: the name is not in the
+/// document at all.
+/// </para>
+/// <para>
+/// Deliberately not serialized into the model file, and deliberately absent from the model's
+/// equality. The build stops on one of these, so nothing downstream ever reads a model carrying
+/// any - and a diagnostic in a cache key is a cache miss for a build that generates identical code.
+/// </para>
+/// </remarks>
+internal sealed class DanglingReferenceModel {
+
+    public DanglingReferenceModel(string reference, string location) {
+        Reference = reference;
+        Location = location;
+    }
+
+    /// <summary>The reference as the document spells it - <c>#/components/schemas/Pet</c>.</summary>
+    public string Reference { get; }
+
+    /// <summary>Where it was made, as far as the parser knows.</summary>
+    public string Location { get; }
+}

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ResponseSetPlan.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ResponseSetPlan.cs
@@ -27,7 +27,7 @@ internal static class ResponseSetPlan {
     /// <para>
     /// Per operation rather than per service, because the second clause is not a preference the
     /// module expressed. An operation declaring more than one success has nowhere to put the second
-    /// except its return type: Standard mode reaches its other statuses by throwing, and a throw
+    /// except its return type: Throws mode reaches its other statuses by throwing, and a throw
     /// carries a failure - there is no way to throw a 202. Left alone it would emit a document
     /// describing a status the handler cannot produce.
     /// </para>
@@ -47,13 +47,13 @@ internal static class ResponseSetPlan {
         var declaresMultipleSuccesses = operation.SuccessResponses.Count > 1;
 
         // A declared header forces a set the same way a second success does, and for the same
-        // reason: the bare payload type cannot express it. Standard mode is already dragged into a
+        // reason: the bare payload type cannot express it. Throws mode is already dragged into a
         // set by a second success - "there is no way to throw a 202" - and there is no way to put a
         // Location on a returned Pet either. Without this the fix reaches two response models of
-        // three and standard-mode documents go on declaring headers nothing sends.
+        // three and throws-mode documents go on declaring headers nothing sends.
         var declaresResponseHeaders = DeclaresResponseHeaders(operation);
 
-        return (responseModel != SpecResponseModel.Standard ||
+        return (responseModel != SpecResponseModel.Throws ||
                 declaresMultipleSuccesses ||
                 declaresResponseHeaders) &&
                !operation.RawBytesResponse &&

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
@@ -103,7 +103,7 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     /// <c>ResponseSetPlan.RequiresResponseSet</c>, which reads this and the operation both.
     /// </para>
     /// </remarks>
-    public SpecResponseModel ResponseModel { get; set; } = SpecResponseModel.Standard;
+    public SpecResponseModel ResponseModel { get; set; } = SpecResponseModel.Throws;
 
     /// <summary>
     /// Keywords the description declared that the parser did not map, in the order they were met.

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
@@ -117,6 +117,18 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     /// </remarks>
     public List<UnmappedKeywordModel> UnmappedKeywords { get; set; } = new();
 
+    /// <summary>
+    /// References the description makes to schemas it never declares, in the order they were met.
+    /// </summary>
+    /// <remarks>
+    /// Filled by the parser and read by <c>SpecDiagnostics</c>, on the same terms as
+    /// <see cref="UnmappedKeywords"/>: the reference is cleared before anything is named, so this
+    /// is the only record that it was ever made. Not serialized and absent from
+    /// <see cref="Equals(ServiceSpecModel?)"/> - the build stops on one of these, so no model
+    /// carrying any is ever read back.
+    /// </remarks>
+    public List<DanglingReferenceModel> DanglingReferences { get; set; } = new();
+
     public bool Equals(ServiceSpecModel? other) {
         if (other is not null && ContentNegotiation != other.ContentNegotiation) return false;
         if (other is not null && ResponseModel != other.ResponseModel) return false;

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/SpecResponseModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/SpecResponseModel.cs
@@ -36,10 +36,12 @@ namespace Hardened.Generation.Models;
 public enum SpecResponseModel {
 
     /// <summary>
-    /// <c>Task&lt;Pet&gt;</c>, with declared errors thrown. The default, and what every generated
-    /// interface says today.
+    /// <c>Task&lt;Pet&gt;</c>, with declared errors thrown. What an unset
+    /// <c>$(HardenedResponseModel)</c> still means, so a project scaffolded before the property
+    /// existed keeps generating the interfaces it had. Named <c>Standard</c> until 0.19.0; the
+    /// build task still reads the old property value and says so.
     /// </summary>
-    Standard,
+    Throws,
 
     /// <summary>
     /// <c>Task&lt;GetPetResponse&gt;</c>, where the container is a generated struct matching the

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/SuccessResponseModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/SuccessResponseModel.cs
@@ -16,12 +16,12 @@ namespace Hardened.Generation.Models;
 /// </para>
 /// <para>
 /// <b>The flat fields on <c>OperationModel</c> stay</b> and keep naming the primary success, which
-/// is the lowest declared 2xx. Standard mode returns one type and every existing consumer reads
+/// is the lowest declared 2xx. Throws mode returns one type and every existing consumer reads
 /// those individually, so this list is additive rather than a replacement - nothing that worked
 /// before has to learn about it.
 /// </para>
 /// <para>
-/// <b>Why a second success cannot be left out.</b> Standard mode reaches its other statuses by
+/// <b>Why a second success cannot be left out.</b> Throws mode reaches its other statuses by
 /// throwing, and a throw carries a failure. There is no way to throw a 202. So an operation with
 /// more than one declared success has to state them in its return type whatever mode the module is
 /// in, which is why <c>ServiceInterfaceEmitter</c> returns a response set for these regardless.

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -885,12 +885,14 @@ internal static class SpecModelSerializer {
     }
 
     /// <summary>
-    /// The response model a written record names, defaulting to Standard.
+    /// The response model a written record names, defaulting to Throws.
     /// </summary>
     /// <remarks>
-    /// An unrecognised value is Standard rather than a throw, matching how the build task reads
+    /// An unrecognised value is Throws rather than a failure, matching how the build task reads
     /// $(HardenedResponseModel): a model file written by a newer build should degrade to the shape
-    /// every consumer already understands rather than fail the read.
+    /// every consumer already understands rather than fail the read. The same branch covers a
+    /// record written before the 0.19.0 rename, whose "Standard" parses to the value it always
+    /// meant.
     /// </remarks>
     private static SpecResponseModel ParseResponseModel(string? value) {
         if (string.Equals(value, nameof(SpecResponseModel.Response), StringComparison.OrdinalIgnoreCase)) {
@@ -899,6 +901,6 @@ internal static class SpecModelSerializer {
 
         return string.Equals(value, nameof(SpecResponseModel.Union), StringComparison.OrdinalIgnoreCase)
             ? SpecResponseModel.Union
-            : SpecResponseModel.Standard;
+            : SpecResponseModel.Throws;
     }
 }

--- a/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
+++ b/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
@@ -81,9 +81,11 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
     /// what the emitter writes.
     /// </para>
     /// <para>
-    /// An unrecognised value is Standard rather than a build failure. The property is set by hand
+    /// An unrecognised value is Throws rather than a build failure. The property is set by hand
     /// in a csproj with no completion behind it, and failing every build of a project that
-    /// mistyped it would be a worse trade than generating the interfaces it had yesterday.
+    /// mistyped it would be a worse trade than generating the interfaces it had yesterday. Absent
+    /// means Throws for the same reason: that is what every project scaffolded before 0.19.0
+    /// gets, and those projects wrote no property at all.
     /// </para>
     /// </remarks>
     public string ResponseModel { get; set; } = "";
@@ -156,8 +158,8 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
     /// <remarks>
     /// A number means the same thing under every prefix, and everything reporting under one prefix
     /// shares one numbering - which includes reporters that are not this class. This shell uses
-    /// 001-009 and 016-017, the packaged targets use 003-005 and 015, the Smithy CLI task uses
-    /// 010-014, and <see cref="SpecDiagnostics"/> uses 020 up. The full table is
+    /// 001-009, 016-017 and 026, the packaged targets use 003-005 and 015, the Smithy CLI task
+    /// uses 010-014, and <see cref="SpecDiagnostics"/> uses 020-025. The full table is
     /// docs/generator-diagnostics.md.
     /// </remarks>
     protected abstract string DiagnosticPrefix { get; }
@@ -492,22 +494,38 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
             model, Namespace, ExcludeFromCoverage, document, specPath, SelectedResponseModel());
 
     /// <summary>
-    /// The mode <c>$(HardenedResponseModel)</c> names, defaulting to Standard.
+    /// The mode <c>$(HardenedResponseModel)</c> names, defaulting to Throws.
     /// </summary>
     /// <remarks>
-    /// An unrecognised value is Standard rather than a build failure. The property is set by hand
+    /// An unrecognised value is Throws rather than a build failure. The property is set by hand
     /// in a csproj with no completion behind it, and failing every build of a project that mistyped
-    /// it would be a worse trade than generating the interfaces it had yesterday.
+    /// it would be a worse trade than generating the interfaces it had yesterday. The one value
+    /// that gets a word said about it is "Standard", the mode's name before 0.19.0: it still
+    /// selects the same mode, under a 026 warning naming the new value, so a project upgrading its
+    /// packages keeps building and learns the current spelling from the build that proved it.
     /// </remarks>
     private SpecResponseModel SelectedResponseModel() {
         if (string.Equals(ResponseModel, "Response", System.StringComparison.OrdinalIgnoreCase)) {
             return SpecResponseModel.Response;
         }
 
-        return string.Equals(ResponseModel, "Union", System.StringComparison.OrdinalIgnoreCase)
-            ? SpecResponseModel.Union
-            : SpecResponseModel.Standard;
+        if (string.Equals(ResponseModel, "Union", System.StringComparison.OrdinalIgnoreCase)) {
+            return SpecResponseModel.Union;
+        }
+
+        if (string.Equals(ResponseModel, "Standard", System.StringComparison.OrdinalIgnoreCase) &&
+            !_renamedResponseModelWarned) {
+            _renamedResponseModelWarned = true;
+            Log.LogWarning(null, DiagnosticPrefix + "026", null, null, 0, 0, 0, 0,
+                "$(HardenedResponseModel) is 'Standard', which was renamed 'Throws' in 0.19.0. " +
+                "The mode selected is unchanged; write <HardenedResponseModel>Throws</HardenedResponseModel>.");
+        }
+
+        return SpecResponseModel.Throws;
     }
+
+    /// <summary>Whether the 026 rename notice has been reported, so one project logs it once.</summary>
+    private bool _renamedResponseModelWarned;
 
     /// <summary>
     /// Rewriting an unchanged file would bump its timestamp, and both the compiler's up-to-date

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
@@ -13,7 +13,7 @@ internal static class ServiceInterfaceEmitter {
 
     public static InterfaceDefinition Emit(
         IConstructContainer container, ServiceModel service, string modelsNamespace,
-        SpecResponseModel responseModel = SpecResponseModel.Standard) {
+        SpecResponseModel responseModel = SpecResponseModel.Throws) {
         var interfaceDefinition = container.AddInterface(NamingHelper.ToInterfaceName(service.TypeBaseName));
 
         interfaceDefinition.Modifiers |= ComponentModifier.Public | ComponentModifier.Partial;
@@ -55,7 +55,7 @@ internal static class ServiceInterfaceEmitter {
 
     internal static ITypeDefinition GetReturnType(
         OperationModel operation, string modelsNamespace,
-        SpecResponseModel responseModel = SpecResponseModel.Standard) {
+        SpecResponseModel responseModel = SpecResponseModel.Throws) {
         // Ahead of everything below, because a declared response set replaces the question the rest
         // of this method answers. The two overrides that follow are still checked first inside
         // UnionResponseEmitter's own success branch: a streamed body is many responses rather than

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
@@ -40,7 +40,7 @@ internal static class SpecFileEmitter {
         bool excludeFromCoverage,
         string document = "",
         string specPath = "",
-        SpecResponseModel responseModel = SpecResponseModel.Standard) {
+        SpecResponseModel responseModel = SpecResponseModel.Throws) {
         // An unnamed namespace writes no wrapper of its own, so this is the file rather than a
         // namespace in it. Filter types declare their own namespace in the spec and may sit outside
         // the root entirely, which is why the file needs to hold more than one top-level block.

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
@@ -9,7 +9,7 @@ namespace Hardened.Idl;
 /// </summary>
 /// <remarks>
 /// <para>
-/// There are thirteen of them, and every pass that walks references needs all thirteen. Two passes used
+/// There are fifteen of them, and every pass that walks references needs all fifteen. Two passes used
 /// to enumerate them by hand and one listed five: Cloudflare and PagerDuty reference hundreds of
 /// schemas that produce no type, and the references the incomplete pass never visited - parameters,
 /// declared error responses, base types, discriminator branches - each became a CS0234 naming
@@ -27,12 +27,21 @@ internal static class ModelRefs {
     internal readonly struct Handle {
         private readonly Action<string?> _set;
 
-        public Handle(string? value, Action<string?> set) {
+        public Handle(string? value, string location, Action<string?> set) {
             Value = value;
+            Location = location;
             _set = set;
         }
 
         public string? Value { get; }
+
+        /// <summary>Where the reference was made, for a message the author can act on.</summary>
+        /// <remarks>
+        /// Carried rather than derived: the two passes that rewrite references do not need it, and
+        /// the one that reports a reference naming nothing cannot reconstruct it - by then the
+        /// handle is all there is.
+        /// </remarks>
+        public string Location { get; }
 
         public void Set(string? value) => _set(value);
     }
@@ -41,34 +50,44 @@ internal static class ModelRefs {
         foreach (var schema in model.Schemas) {
             var captured = schema;
 
-            yield return new Handle(schema.BaseRef, value => captured.BaseRef = value);
-            yield return new Handle(schema.ArrayItemsRef, value => captured.ArrayItemsRef = value);
+            yield return new Handle(
+                schema.BaseRef, schema.Name + " (base type)", value => captured.BaseRef = value);
+            yield return new Handle(
+                schema.ArrayItemsRef, schema.Name + " (items)",
+                value => captured.ArrayItemsRef = value);
 
             foreach (var branch in schema.OneOf) {
                 var branchCaptured = branch;
 
-                yield return new Handle(branch.Ref, value => branchCaptured.Ref = value);
+                yield return new Handle(
+                    branch.Ref, schema.Name + " (oneOf branch)", value => branchCaptured.Ref = value);
             }
 
             foreach (var mapping in schema.DiscriminatorMapping) {
                 var mappingCaptured = mapping;
 
-                yield return new Handle(mapping.Ref, value => mappingCaptured.Ref = value ?? "");
+                yield return new Handle(
+                    mapping.Ref, schema.Name + " (discriminator mapping)",
+                    value => mappingCaptured.Ref = value ?? "");
             }
 
             foreach (var property in schema.Properties) {
                 var propertyCaptured = property;
+                var where = schema.Name + "." + property.Name;
 
-                yield return new Handle(property.Ref, value => propertyCaptured.Ref = value);
+                yield return new Handle(property.Ref, where, value => propertyCaptured.Ref = value);
                 yield return new Handle(
-                    property.ArrayItemsRef, value => propertyCaptured.ArrayItemsRef = value);
+                    property.ArrayItemsRef, where + " (items)",
+                    value => propertyCaptured.ArrayItemsRef = value);
                 yield return new Handle(
-                    property.DictionaryValueRef, value => propertyCaptured.DictionaryValueRef = value);
+                    property.DictionaryValueRef, where + " (values)",
+                    value => propertyCaptured.DictionaryValueRef = value);
 
                 foreach (var branch in property.OneOf) {
                     var branchCaptured = branch;
 
-                    yield return new Handle(branch.Ref, value => branchCaptured.Ref = value);
+                    yield return new Handle(
+                        branch.Ref, where + " (oneOf branch)", value => branchCaptured.Ref = value);
                 }
             }
         }
@@ -76,26 +95,57 @@ internal static class ModelRefs {
         foreach (var service in model.Services) {
             foreach (var operation in service.Operations) {
                 var captured = operation;
+                var where = operation.HttpMethod + " " + operation.Path;
 
                 yield return new Handle(
-                    operation.RequestBodyRef, value => captured.RequestBodyRef = value);
+                    operation.RequestBodyRef, where + " (request body)",
+                    value => captured.RequestBodyRef = value);
+
+                // The success responses were not here, and every pass that walks references needs
+                // all of them: a schema renamed by the allocator left a success case pointing at
+                // the old name, which is the shape this class exists to stop happening again.
+                foreach (var success in operation.SuccessResponses) {
+                    var successCaptured = success;
+                    var status = where + " (" + success.StatusCode + ")";
+
+                    yield return new Handle(
+                        success.Ref, status, value => successCaptured.Ref = value);
+                    yield return new Handle(
+                        success.ArrayItemsRef, status + " items",
+                        value => successCaptured.ArrayItemsRef = value);
+                }
+
+                // The flat fields mirror the primary success - the lowest declared 2xx - so they
+                // are labelled as it rather than as somewhere of their own. A caller reporting one
+                // reference per place reports these once, because the document declares them once.
+                // They are still yielded: a pass that rewrites references has to rewrite both
+                // copies or the two disagree.
+                var primary = where + " (" + operation.SuccessStatusCode + ")";
+
                 yield return new Handle(
-                    operation.ResponseRef, value => captured.ResponseRef = value);
+                    operation.ResponseRef, primary, value => captured.ResponseRef = value);
                 yield return new Handle(
-                    operation.ResponseArrayItemsRef, value => captured.ResponseArrayItemsRef = value);
+                    operation.ResponseArrayItemsRef, primary + " items",
+                    value => captured.ResponseArrayItemsRef = value);
 
                 foreach (var error in operation.ErrorResponses) {
                     var errorCaptured = error;
 
-                    yield return new Handle(error.Ref, value => errorCaptured.Ref = value);
+                    yield return new Handle(
+                        error.Ref, where + " (" + error.StatusCode + ")",
+                        value => errorCaptured.Ref = value);
                 }
 
                 foreach (var parameter in operation.Parameters) {
                     var parameterCaptured = parameter;
 
-                    yield return new Handle(parameter.Ref, value => parameterCaptured.Ref = value);
                     yield return new Handle(
-                        parameter.ArrayItemsRef, value => parameterCaptured.ArrayItemsRef = value);
+                        parameter.Ref, where + " parameter '" + parameter.Name + "'",
+                        value => parameterCaptured.Ref = value);
+                    yield return new Handle(
+                        parameter.ArrayItemsRef,
+                        where + " parameter '" + parameter.Name + "' (items)",
+                        value => parameterCaptured.ArrayItemsRef = value);
                 }
             }
         }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
@@ -14,7 +14,7 @@ namespace Hardened.Idl;
 /// with a message that never mentions the document that caused it.
 /// </para>
 /// <para>
-/// Codes are the front end's prefix plus 020-025, one number per finder. The prefix is a
+/// Codes are the front end's prefix plus 020-025 and 027, one number per finder. The prefix is a
 /// parameter because this pass runs for every front end and a finding belongs to the document
 /// that caused it: a Smithy model's mixed enum reported as HOAT anything sends its author to the
 /// OpenAPI documentation. 020 up is this pass's block; everything below it belongs to the task
@@ -192,9 +192,38 @@ internal static class SpecDiagnostics {
     /// </summary>
     internal const string MixedEnumType = "mixed-enum";
 
+    /// <summary>
+    /// References the description makes to something it never declares.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Fatal, unlike everything else in the 020 block that resolves to a workable answer. There is
+    /// no answer here: a dangling reference in a response degraded the success case to a bodyless
+    /// one, so a handler written against the generated interface compiled and answered 200 with an
+    /// empty body. The only errors were CS0246s a hop away in application code that happened to
+    /// name the missing model, or nothing at all.
+    /// </para>
+    /// <para>
+    /// One report per reference rather than per name: a document referencing a schema it dropped
+    /// usually does so from several places, and each is a separate edit.
+    /// </para>
+    /// </remarks>
+    private static void FindDanglingReferences(
+        ServiceSpecModel model, string prefix, List<Problem> problems) {
+        foreach (var dangling in model.DanglingReferences) {
+            problems.Add(new Problem(
+                prefix + "027",
+                $"'{dangling.Location}' references '{dangling.Reference}', which the description " +
+                "does not declare. Nothing is generated for it, so the member it types would be " +
+                "absent and a response body would be dropped. Declare the schema, or point the " +
+                "reference at one that exists."));
+        }
+    }
+
     public static IReadOnlyList<Problem> Find(ServiceSpecModel model, string diagnosticPrefix) {
         var problems = new List<Problem>();
 
+        FindDanglingReferences(model, diagnosticPrefix, problems);
         FindDuplicateSchemaNames(model, diagnosticPrefix, problems);
         FindUnresolvableChoices(model, diagnosticPrefix, problems);
         FindMixedEnums(model, diagnosticPrefix, problems);

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
@@ -30,10 +30,15 @@ internal static class OperationParameters {
     internal sealed record Model(string OperationId, string InterfaceName, IReadOnlyList<Member> Members);
 
     /// <param name="Name">The C# name, matching what the handler's Parameters class declares.</param>
+    /// <param name="WireName">
+    /// What the caller calls it - the header, query or path name the contract declares - or null
+    /// where that is already the C# name.
+    /// </param>
     /// <param name="Type">Its type.</param>
     /// <param name="Attributes">Constraints, already rendered.</param>
     internal sealed record Member(
-        string Name, ITypeDefinition Type, IReadOnlyList<ConstraintAttributes.Model> Attributes);
+        string Name, string? WireName, ITypeDefinition Type,
+        IReadOnlyList<ConstraintAttributes.Model> Attributes);
 
     public static Model? Build(
         OperationModel operation, ServiceSpecModel spec, string modelsNamespace, PatternRegistry patterns) {
@@ -67,6 +72,7 @@ internal static class OperationParameters {
 
             members.Add(new Member(
                 parameter.MemberName,
+                parameter.Name == parameter.MemberName ? null : parameter.Name,
                 TypeMapper.GetTypeDefinition(modelsNamespace, csType, parameter.IsCSharpNullable),
                 attributes));
         }
@@ -96,7 +102,7 @@ internal static class OperationParameters {
 
             constrained |= attributes.Length > 0;
 
-            members.Add(new Member("body", bodyType, attributes));
+            members.Add(new Member("body", null, bodyType, attributes));
         }
 
         return constrained

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/ValidationEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/ValidationEmitter.cs
@@ -57,6 +57,17 @@ internal static class ValidationEmitter {
 
             property.Set = null;
 
+            // What the caller calls it, where that is not the C# name. ValidationModules reads
+            // [JsonPropertyName] to spell a failure's field, so Idempotency-Key failing its pattern
+            // reports "Idempotency-Key" rather than "idempotencyKey" - a name that appears nowhere
+            // in the request or the contract. Nothing serializes this interface; the attribute is
+            // here as the field-naming vocabulary the validator already reads.
+            if (member.WireName != null) {
+                property.AddAttribute(
+                    TypeDefinition.Get("System.Text.Json.Serialization", "JsonPropertyNameAttribute"),
+                    new CodeOutputComponent($"\"{member.WireName}\"") { Indented = false });
+            }
+
             foreach (var attribute in member.Attributes) {
                 Apply(property, attribute);
             }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
@@ -47,6 +47,14 @@ namespace Hardened.Idl.SourceGenerator;
 public class SpecSourceGenerator : IIncrementalGenerator {
 
     public void Initialize(IncrementalGeneratorInitializationContext context) {
+        // Says "a routing generator is running" to the library generator, which reports its
+        // absence. A specification-first project carries no attribute routes of its own, but one
+        // may declare a code-first module beside its contract - and it is this generator that
+        // would compile the routes if it did.
+        context.RegisterPostInitializationOutput(static production => production.AddSource(
+            "Hardened.Web.Marker.g.cs",
+            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+
         // Read the models the build task wrote, keeping both successes and errors for diagnostics
         var parseResults = context.AdditionalTextsProvider
             .Where(IsSpecModelFile)

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
@@ -53,7 +53,7 @@ public class SpecSourceGenerator : IIncrementalGenerator {
         // would compile the routes if it did.
         context.RegisterPostInitializationOutput(static production => production.AddSource(
             "Hardened.Web.Marker.g.cs",
-            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+            GeneratedSource.Header(RoutingGeneratorMarker.Source)));
 
         // Read the models the build task wrote, keeping both successes and errors for diagnostics
         var parseResults = context.AdditionalTextsProvider

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
@@ -47,7 +47,7 @@ public class LibrarySourceGenerator : IIncrementalGenerator {
         IncrementalGeneratorInitializationContext context) {
         IncrementalValueProvider<ImmutableArray<string>>? routes = null;
 
-        foreach (var attribute in RoutingGeneratorPresence.VerbAttributes) {
+        foreach (var attribute in MissingRoutingGenerator.VerbAttributes) {
             var declared = context.SyntaxProvider.ForAttributeWithMetadataName(
                     attribute,
                     static (node, _) => node is Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax,
@@ -68,7 +68,7 @@ public class LibrarySourceGenerator : IIncrementalGenerator {
 
         context.RegisterSourceOutput(
             context.CompilationProvider.Combine(routes.Value),
-            static (production, pair) => RoutingGeneratorPresence.Report(
+            static (production, pair) => MissingRoutingGenerator.Report(
                 production, pair.Left, pair.Right.Distinct().OrderBy(name => name).ToArray()));
     }
 }

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Hardened.SourceGenerator.Configuration;
 using Hardened.SourceGenerator.DependencyInjection;
@@ -20,5 +22,53 @@ public class LibrarySourceGenerator : IIncrementalGenerator {
             SourceGeneratorWrapper.Wrap<EntryPointSelector.Model>(generator.GenerateFile));
 
         ConfigurationIncrementalGenerator.Setup(context, applicationModel);
+
+        ReportAMissingRoutingGenerator(context);
+    }
+
+    /// <summary>
+    /// Says so when this project declares routes and nothing is compiling them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A module with handlers and no routing generator built without a warning into an application
+    /// that answered 404 to everything - the trial arm deleted one PackageReference and lost an
+    /// afternoon to it. The build cannot see a missing analyzer from inside the analyzer that is
+    /// missing, so the question is asked here: this generator is referenced by every Hardened
+    /// project, and the routing generators declare a marker type saying they ran.
+    /// </para>
+    /// <para>
+    /// The route declarations are found through <c>ForAttributeWithMetadataName</c>, which is
+    /// Roslyn's attribute index rather than a walk over every node - the same cost discipline
+    /// DependencyModules' own generator is built around.
+    /// </para>
+    /// </remarks>
+    private static void ReportAMissingRoutingGenerator(
+        IncrementalGeneratorInitializationContext context) {
+        IncrementalValueProvider<ImmutableArray<string>>? routes = null;
+
+        foreach (var attribute in RoutingGeneratorPresence.VerbAttributes) {
+            var declared = context.SyntaxProvider.ForAttributeWithMetadataName(
+                    attribute,
+                    static (node, _) => node is Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax,
+                    static (target, _) =>
+                        target.TargetSymbol.ContainingType?.ToDisplayString() ?? "")
+                .Where(static name => name.Length > 0)
+                .Collect();
+
+            routes = routes == null
+                ? declared
+                : routes.Value.Combine(declared).Select(
+                    static (pair, _) => pair.Left.AddRange(pair.Right));
+        }
+
+        if (routes == null) {
+            return;
+        }
+
+        context.RegisterSourceOutput(
+            context.CompilationProvider.Combine(routes.Value),
+            static (production, pair) => RoutingGeneratorPresence.Report(
+                production, pair.Left, pair.Right.Distinct().OrderBy(name => name).ToArray()));
     }
 }

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/MissingRoutingGenerator.cs
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/MissingRoutingGenerator.cs
@@ -1,48 +1,26 @@
 using System.Collections.Generic;
+using Hardened.SourceGenerator.Shared;
 using Microsoft.CodeAnalysis;
 
-namespace Hardened.SourceGenerator.Shared;
+namespace Hardened.Library.SourceGenerator;
 
 /// <summary>
-/// Whether anything in this compilation is turning route declarations into a routing table.
+/// Routes with nothing compiling them into a routing table.
 /// </summary>
 /// <remarks>
 /// <para>
-/// A module with handlers and no routing generator compiles without a warning into an application
-/// that answers 404 to everything. The build cannot see a missing analyzer from inside the analyzer
-/// that is missing, so the question is asked from one that is still there: the routing generators
-/// declare <see cref="MarkerTypeName"/> as post-initialization output - the one kind of generated
-/// source another generator can see - and the library generator reports its absence.
+/// Reported from this generator because it is the one still referenced when the routing generator
+/// is not - a build cannot see a missing analyzer from inside the analyzer that is missing.
+/// <see cref="RoutingGeneratorMarker"/> is how a routing generator says it ran.
 /// </para>
 /// <para>
-/// The same arrangement <c>ValidationGeneratorMarker</c> uses, and for a related reason: a
-/// generator cannot observe another's regular output, so a marker is the only channel between two
-/// of them.
+/// Here rather than beside the marker in the shared source. Five generator assemblies link that
+/// folder in and one asks this question, so a decision compiled into the other four is dead weight
+/// in each of them - the same reason the library generator's own project file leaves out
+/// <c>Models/Request</c>.
 /// </para>
 /// </remarks>
-public static class RoutingGeneratorPresence {
-
-    /// <summary>The type a routing generator declares to say it is running.</summary>
-    public const string MarkerTypeName = "Hardened.Web.Generated.WebRoutingGeneratorMarker";
-
-    /// <summary>
-    /// Deliberately plain C#: block-scoped namespace, ordinary class body. This lands in whatever
-    /// project references the generator, and a marker that needs a language version to compile
-    /// would fail the builds it exists to keep working.
-    /// </summary>
-    /// <remarks>
-    /// Written without the generated-file header so <c>GeneratedSource.Header</c> adds it - that
-    /// method leaves a source that already opens with the marker alone, which would mean this file
-    /// carrying the marker and neither the nullable context nor the CS1591 pragma that travel with
-    /// it.
-    /// </remarks>
-    public const string MarkerSource =
-        "namespace Hardened.Web.Generated {\n" +
-        "    /// <summary>Declared by a Hardened routing generator so other generators can tell\n" +
-        "    /// whether route declarations are being compiled for this compilation.</summary>\n" +
-        "    internal static class WebRoutingGeneratorMarker {\n" +
-        "    }\n" +
-        "}\n";
+internal static class MissingRoutingGenerator {
 
     /// <summary>The attributes a hand-written route is declared with.</summary>
     public static readonly string[] VerbAttributes = {
@@ -54,8 +32,8 @@ public static class RoutingGeneratorPresence {
     };
 
     /// <summary>
-    /// <c>HRDR006</c>. <c>HRDR002</c> and <c>HRDR005</c> are about one route; this is about every
-    /// route in the assembly at once.
+    /// <c>HRDR006</c>. <c>HRDR002</c> is about one route; this is about every route in the
+    /// assembly at once.
     /// </summary>
     public const string DiagnosticId = "HRDR006";
 
@@ -86,7 +64,7 @@ public static class RoutingGeneratorPresence {
         SourceProductionContext context, Compilation compilation,
         IReadOnlyList<string> declaringTypes) {
         if (declaringTypes.Count == 0 ||
-            compilation.GetTypeByMetadataName(MarkerTypeName) is not null) {
+            compilation.GetTypeByMetadataName(RoutingGeneratorMarker.TypeName) is not null) {
             return;
         }
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DanglingReferenceTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DanglingReferenceTests.cs
@@ -1,0 +1,246 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Idl;
+using Hardened.Generation;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// A reference the description makes to something it never declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// OR-07. <c>$ref: '#/components/schemas/DoesNotExist'</c> in a response produced no diagnostic at
+/// all: the success case became a bodyless record, so a handler written against the generated
+/// interface compiled and answered 200 with an empty body. The only errors were CS0246s a hop away
+/// in application code that happened to name the missing model, or - where nothing named it -
+/// nothing.
+/// </para>
+/// <para>
+/// The check has to run in the parser, for the reason the unmapped-keyword check does: every
+/// reference pass after it clears what it cannot resolve, and afterwards a reference naming
+/// nothing is indistinguishable from one naming something the parser deliberately resolved to a
+/// different shape.
+/// </para>
+/// </remarks>
+public class DanglingReferenceTests {
+
+    private static string Document(string responseSchema, string components) => $$"""
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            get:
+              operationId: listProducts
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: {{responseSchema}}
+        components:
+          schemas:
+        {{components}}
+        """;
+
+    private const string Product = """
+            Product:
+              type: object
+              properties:
+                sku: { type: string }
+        """;
+
+    private static ServiceSpecModel Parse(string yaml) {
+        var model = OpenApiSpecParser.Parse(yaml, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static SpecDiagnostics.Problem[] Problems(ServiceSpecModel model) =>
+        SpecDiagnostics.Find(model, "HOAT").ToArray();
+
+    /// <summary>The exact repro.</summary>
+    [Fact]
+    public void AReferenceToAnUndeclaredSchemaIsRecorded() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("#/components/schemas/DoesNotExist", dangling.Reference);
+    }
+
+    [Fact]
+    public void ItStopsTheBuild() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var problem = Assert.Single(Problems(model), p => p.Code == "HOAT027");
+
+        Assert.True(problem.Fatal);
+    }
+
+    /// <summary>
+    /// The message names the reference and where it was made, because a document referencing a
+    /// dropped schema usually does so from several places and each is a separate edit.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheReferenceAndWhereItWasMade() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var message = Assert.Single(Problems(model), p => p.Code == "HOAT027").Message;
+
+        Assert.Contains("#/components/schemas/DoesNotExist", message);
+        Assert.Contains("/products", message);
+        Assert.Contains("(200)", message);
+    }
+
+    /// <summary>A reference from a property carries the member it was made from.</summary>
+    /// <summary>
+    /// A request body reference names the operation it was made from.
+    /// </summary>
+    [Fact]
+    public void ARequestBodyReferenceNamesTheOperation() {
+        var model = Parse("""
+            openapi: 3.0.0
+            info: { title: Depot, version: '1.0' }
+            paths:
+              /products:
+                post:
+                  operationId: createProduct
+                  requestBody:
+                    content:
+                      application/json:
+                        schema: { $ref: '#/components/schemas/Missing' }
+                  responses:
+                    '201': { description: created }
+            components:
+              schemas:
+                Product:
+                  type: object
+                  properties:
+                    sku: { type: string }
+            """);
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("#/components/schemas/Missing", dangling.Reference);
+        Assert.Contains("request body", dangling.Location);
+    }
+
+    /// <summary>
+    /// What this does not catch, pinned so nobody reads the check as complete.
+    /// </summary>
+    /// <remarks>
+    /// A <c>$ref</c> on a schema property is resolved by the reader before this parser sees it, and
+    /// an unresolvable one is discarded there: the property arrives carrying no reference, no type
+    /// and no shape, and becomes <c>JsonElement</c>. The reader reports nothing about it either -
+    /// its own diagnostics are empty. There is no record left in the model to report from, so
+    /// catching this needs the raw document rather than the object model, which is a separate
+    /// piece of work.
+    /// </remarks>
+    [Fact]
+    public void APropertyReferenceTheReaderDiscardsIsNotCaught() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/Product' }", """
+            Product:
+              type: object
+              properties:
+                supplier: { $ref: '#/components/schemas/Missing' }
+        """));
+
+        var property = Assert.Single(Assert.Single(model.Schemas).Properties);
+
+        Assert.Null(property.Ref);
+        Assert.Null(property.Type);
+        Assert.Empty(model.DanglingReferences);
+    }
+
+    /// <summary>
+    /// A schema that is declared and produces no type is not this. A top-level array alias is read,
+    /// used, and resolved into the property that names it - which is the parser working, not
+    /// failing.
+    /// </summary>
+    [Fact]
+    public void AnArrayAliasIsNotDangling() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/ProductList' }", """
+            ProductList:
+              type: array
+              items: { $ref: '#/components/schemas/Product' }
+            Product:
+              type: object
+              properties:
+                sku: { type: string }
+        """));
+
+        Assert.Empty(model.DanglingReferences);
+        Assert.DoesNotContain(Problems(model), p => p.Code == "HOAT027");
+    }
+
+    /// <summary>A document that declares what it references says nothing at all.</summary>
+    [Fact]
+    public void ADocumentThatResolvesIsSilent() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/Product' }", Product));
+
+        Assert.Empty(model.DanglingReferences);
+        Assert.Empty(Problems(model));
+    }
+
+    /// <summary>
+    /// Every place the reference was made, not the first: two operations naming one missing schema
+    /// are two edits.
+    /// </summary>
+    [Fact]
+    public void EveryReferenceToTheMissingSchemaIsReported() {
+        var model = Parse("""
+            openapi: 3.0.0
+            info: { title: Depot, version: '1.0' }
+            paths:
+              /products:
+                get:
+                  operationId: listProducts
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema: { $ref: '#/components/schemas/Missing' }
+              /suppliers:
+                get:
+                  operationId: listSuppliers
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema: { $ref: '#/components/schemas/Missing' }
+            components:
+              schemas:
+                Product:
+                  type: object
+                  properties:
+                    sku: { type: string }
+            """);
+
+        Assert.Equal(2, model.DanglingReferences.Count);
+        Assert.Equal(2, Problems(model).Count(p => p.Code == "HOAT027"));
+    }
+
+    /// <summary>
+    /// Not serialized, and absent from the model's equality: the build stops on one of these, so
+    /// no model carrying any is ever read back, and a diagnostic in a cache key is a cache miss
+    /// for a build that generates identical code.
+    /// </summary>
+    [Fact]
+    public void ItDoesNotTravelInTheModelFile() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var restored = SpecModelSerializer.Read(SpecModelSerializer.Write(model));
+
+        Assert.NotNull(restored);
+        Assert.Empty(restored!.DanglingReferences);
+        Assert.Equal(model, restored);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/MultipleSuccessResponseTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/MultipleSuccessResponseTests.cs
@@ -20,7 +20,7 @@ namespace Hardened.OpenApi.BuildTask.Tests;
 /// one of it was kept.
 /// </para>
 /// <para>
-/// The other half is that a second success cannot be reached by throwing. Standard mode names one
+/// The other half is that a second success cannot be reached by throwing. Throws mode names one
 /// success and throws for everything else, and a throw carries a failure - there is no way to throw
 /// a 202. So these operations answer with a response set whatever mode the module asked for, which
 /// is the one place the module's choice is overridden rather than obeyed.
@@ -110,11 +110,11 @@ public class MultipleSuccessResponseTests {
     #region the signature
 
     /// <summary>
-    /// Standard mode, and still a response set - because the alternative is a document describing a
+    /// Throws mode, and still a response set - because the alternative is a document describing a
     /// 202 the handler has no way to produce.
     /// </summary>
     [Fact]
-    public void ServiceInterface_MultipleSuccesses_ReturnsAResponseSetEvenInStandardMode() {
+    public void ServiceInterface_MultipleSuccesses_ReturnsAResponseSetEvenInThrowsMode() {
         var service = new ServiceModel {
             Tag = "Jobs",
             Operations = new List<OperationModel> { Operation("getJob") }
@@ -126,10 +126,10 @@ public class MultipleSuccessResponseTests {
     }
 
     /// <summary>
-    /// One success and one error is the case Standard mode was built for, and it is unchanged.
+    /// One success and one error is the case throws mode was built for, and it is unchanged.
     /// </summary>
     [Fact]
-    public void ServiceInterface_OneSuccess_StillThrowsInStandardMode() {
+    public void ServiceInterface_OneSuccess_StillThrowsInThrowsMode() {
         var service = new ServiceModel {
             Tag = "Jobs",
             Operations = new List<OperationModel> { Operation("cancelJob") }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ResponseModelPropertyTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ResponseModelPropertyTests.cs
@@ -1,0 +1,102 @@
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// How the task reads <c>$(HardenedResponseModel)</c> after the 0.19.0 rename: <c>Throws</c> is
+/// the value, <c>Standard</c> is the value's old name, and absence still means throws mode.
+/// </summary>
+/// <remarks>
+/// The rename cases assert output equality against an explicit <c>Throws</c> run rather than
+/// asserting anything about the generated text, because the claim is "the same mode", not "a mode
+/// that looks like this".
+/// </remarks>
+public class ResponseModelPropertyTests {
+
+    private const string Spec = """
+        openapi: 3.0.0
+        info: { title: Pets, version: 1.0.0 }
+        paths:
+          /pets/{id}:
+            get:
+              operationId: getPet
+              tags: [Pets]
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema: { type: string }
+              responses:
+                '200':
+                  description: One pet.
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Pet' }
+        components:
+          schemas:
+            Pet:
+              type: object
+              properties:
+                name: { type: string }
+        """;
+
+    private static string Generated(string responseModel) {
+        using var harness = new TaskHarness();
+        var path = harness.WriteSpec("pets.yaml", Spec);
+
+        var result = harness.RunWithResponseModel(responseModel, path);
+        Assert.True(result.Succeeded, result.ErrorText);
+
+        return File.ReadAllText(harness.SourcePathFor("pets.yaml"));
+    }
+
+    [Fact]
+    public void TheRenamedStandardValue_SelectsThrowsMode() {
+        Assert.Equal(Generated("Throws"), Generated("Standard"));
+    }
+
+    [Fact]
+    public void AnAbsentValue_StillMeansThrowsMode() {
+        Assert.Equal(Generated("Throws"), Generated(""));
+    }
+
+    [Fact]
+    public void TheRenamedStandardValue_DrawsThe026RenameNotice() {
+        using var harness = new TaskHarness();
+        var path = harness.WriteSpec("pets.yaml", Spec);
+
+        var result = harness.RunWithResponseModel("Standard", path);
+
+        Assert.True(result.Succeeded, result.ErrorText);
+        Assert.Equal(1, result.WarningCount("HOAT026"));
+    }
+
+    /// <summary>
+    /// Once per project, not once per spec: the property is project-wide, and a project with four
+    /// descriptions has one thing to fix.
+    /// </summary>
+    [Fact]
+    public void TheRenameNotice_IsReportedOnceForManySpecs() {
+        using var harness = new TaskHarness();
+        var first = harness.WriteSpec("pets.yaml", Spec);
+        var second = harness.WriteSpec("more-pets.yaml", Spec.Replace("getPet", "getMorePet"));
+
+        var result = harness.RunWithResponseModel("Standard", first, second);
+
+        Assert.True(result.Succeeded, result.ErrorText);
+        Assert.Equal(1, result.WarningCount("HOAT026"));
+    }
+
+    [Fact]
+    public void TheCurrentValues_DrawNoRenameNotice() {
+        foreach (var value in new[] { "Throws", "Response", "Union", "" }) {
+            using var harness = new TaskHarness();
+            var path = harness.WriteSpec("pets.yaml", Spec);
+
+            var result = harness.RunWithResponseModel(value, path);
+
+            Assert.True(result.Succeeded, result.ErrorText);
+            Assert.Equal(0, result.WarningCount("HOAT026"));
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/TaskHarness.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/TaskHarness.cs
@@ -33,7 +33,9 @@ internal sealed class TaskHarness : IDisposable {
         return path;
     }
 
-    public Result Run(params string[] specPaths) {
+    public Result Run(params string[] specPaths) => RunWithResponseModel("", specPaths);
+
+    public Result RunWithResponseModel(string responseModel, params string[] specPaths) {
         var engine = new RecordingBuildEngine();
 
         var task = new ExtractOpenApiSpec {
@@ -42,6 +44,7 @@ internal sealed class TaskHarness : IDisposable {
             OutputDirectory = OutputDirectory,
             GeneratedSourceDirectory = GeneratedSourceDirectory,
             Namespace = "Test.Api",
+            ResponseModel = responseModel,
         };
 
         var succeeded = task.Execute();
@@ -49,6 +52,7 @@ internal sealed class TaskHarness : IDisposable {
         return new Result(
             succeeded,
             engine.Errors,
+            engine.Warnings,
             task.ModelFiles.Select(item => item.ItemSpec).ToArray(),
             task.GeneratedSources.Select(item => item.ItemSpec).ToArray());
     }
@@ -70,9 +74,12 @@ internal sealed class TaskHarness : IDisposable {
     internal sealed record Result(
         bool Succeeded,
         IReadOnlyList<BuildErrorEventArgs> Errors,
+        IReadOnlyList<BuildWarningEventArgs> Warnings,
         IReadOnlyList<string> ModelFiles,
         IReadOnlyList<string> GeneratedSources) {
         public bool HasError(string code) => Errors.Any(error => error.Code == code);
+
+        public int WarningCount(string code) => Warnings.Count(warning => warning.Code == code);
 
         public string ErrorText => string.Join("\n", Errors.Select(error => $"{error.Code}: {error.Message}"));
     }
@@ -80,9 +87,11 @@ internal sealed class TaskHarness : IDisposable {
     private sealed class RecordingBuildEngine : IBuildEngine {
         public List<BuildErrorEventArgs> Errors { get; } = new();
 
+        public List<BuildWarningEventArgs> Warnings { get; } = new();
+
         public void LogErrorEvent(BuildErrorEventArgs e) => Errors.Add(e);
 
-        public void LogWarningEvent(BuildWarningEventArgs e) { }
+        public void LogWarningEvent(BuildWarningEventArgs e) => Warnings.Add(e);
 
         public void LogMessageEvent(BuildMessageEventArgs e) { }
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnionResponseEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnionResponseEmitterTests.cs
@@ -251,7 +251,7 @@ public class UnionResponseEmitterTests {
         var operation = Operation(errors: [Error(404, "#/components/schemas/ApiError")]);
 
         var standard = ServiceInterfaceEmitter.GetReturnType(
-            operation, EmitterHarness.ModelsNamespace, SpecResponseModel.Standard);
+            operation, EmitterHarness.ModelsNamespace, SpecResponseModel.Throws);
 
         var response = ServiceInterfaceEmitter.GetReturnType(
             operation, EmitterHarness.ModelsNamespace, SpecResponseModel.Response);

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -212,6 +212,7 @@ internal static class OpenApiSpecParser {
         // allocator never names a type nothing will emit; base types are dropped before that
         // because a dropped base changes which members a type declares. Choices go first of all,
         // because dropping one is another way a reference stops naming something.
+        RecordDanglingReferences(model);
         DropUndecidableChoices(model);
         InlineNonObjectRefs(model);
         DropIncompatibleBaseTypes(model);
@@ -361,6 +362,49 @@ internal static class OpenApiSpecParser {
                 dropped.Contains(TypeMapper.GetRefName(reference.Value))) {
                 reference.Set(null);
             }
+        }
+    }
+
+    /// <summary>
+    /// References the document makes to schemas it never declares.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// First of the reference passes, because every one after it clears references, and a
+    /// <c>$ref</c> naming nothing is indistinguishable afterwards from one naming something the
+    /// parser deliberately resolved to a different shape. A dangling reference in a response
+    /// degraded the success case to a bodyless one, so a handler written against the broken
+    /// interface compiled and answered 200 with an empty body - and the only errors were CS0246s
+    /// in application code that happened to name the missing model, or nothing at all.
+    /// </para>
+    /// <para>
+    /// Compared against the schemas the reader produced rather than against the ones that will be
+    /// emitted. A top-level array alias, an <c>anyOf</c> with no shape of its own and an
+    /// undecidable <c>oneOf</c> are all declared and all resolved to something else on purpose;
+    /// what this is looking for is a name the document does not contain.
+    /// </para>
+    /// </remarks>
+    private static void RecordDanglingReferences(ServiceSpecModel model) {
+        var declared = new HashSet<string>();
+
+        foreach (var schema in model.Schemas) {
+            declared.Add(schema.Name);
+        }
+
+        // One report per place the document makes the reference, and the primary success is one
+        // place: the operation's flat response fields mirror it, and reporting both would make one
+        // edit look like two.
+        var reported = new HashSet<string>();
+
+        foreach (var reference in ModelRefs.All(model)) {
+            if (string.IsNullOrEmpty(reference.Value) ||
+                declared.Contains(TypeMapper.GetRefName(reference.Value!)) ||
+                !reported.Add(reference.Location + "\u0000" + reference.Value)) {
+                continue;
+            }
+
+            model.DanglingReferences.Add(
+                new DanglingReferenceModel(reference.Value!, reference.Location));
         }
     }
 

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/OpenApiGenerator.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/OpenApiGenerator.cs
@@ -86,7 +86,7 @@ internal static class OpenApiGenerator {
         var responseModel = Property(buildProperties, "HardenedResponseModel") switch {
             "Response" => SpecResponseModel.Response,
             "Union" => SpecResponseModel.Union,
-            _ => SpecResponseModel.Standard
+            _ => SpecResponseModel.Throws
         };
 
         foreach (var spec in specs) {

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseSetDispatchModelTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseSetDispatchModelTests.cs
@@ -108,7 +108,7 @@ public class ResponseSetDispatchModelTests {
     [Fact]
     public void Standard_CarriesNoCases() {
         var model = RequestModelBuilder
-            .BuildModels(Spec(SpecResponseModel.Standard), "Test.Api.Models", "Test.Api.Services",
+            .BuildModels(Spec(SpecResponseModel.Throws), "Test.Api.Models", "Test.Api.Services",
                 "Test.Api.Generated", "Test.Api.Validation")
             .Single(m => m.HandlerMethod == "GetTodo");
 

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseSetSourceTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseSetSourceTests.cs
@@ -126,9 +126,9 @@ public class ResponseSetSourceTests {
     #region the mode selector
 
     [Fact]
-    public void AnEntryPointWithNoAttributeIsStandard() {
+    public void AnEntryPointWithNoAttributeIsThrows() {
         Assert.Equal(
-            ResponseModelValue.Standard,
+            ResponseModelValue.Throws,
             ResponseModelSelector.Read(new EntryPointSelector.Model {
                 EntryPointType = CSharpAuthor.TypeDefinition.Get("MyApp", "Application"),
                 AttributeModels = System.Array.Empty<AttributeModel>()
@@ -139,8 +139,9 @@ public class ResponseSetSourceTests {
     [InlineData("Hardened.Requests.Abstract.Responses.ResponseModel.Union", ResponseModelValue.Union)]
     [InlineData("ResponseModel.Response", ResponseModelValue.Response)]
     [InlineData("Union", ResponseModelValue.Union)]
-    [InlineData("ResponseModel.Standard", ResponseModelValue.Standard)]
-    [InlineData("ResponseModel.Whatever", ResponseModelValue.Standard)]
+    [InlineData("ResponseModel.Throws", ResponseModelValue.Throws)]
+    [InlineData("ResponseModel.Standard", ResponseModelValue.Throws)]
+    [InlineData("ResponseModel.Whatever", ResponseModelValue.Throws)]
     public void TheDeclaredModeIsRead(string arguments, ResponseModelValue expected) {
         var model = new EntryPointSelector.Model {
             EntryPointType = CSharpAuthor.TypeDefinition.Get("MyApp", "Application"),

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
@@ -76,6 +76,10 @@ public class SpecFirstDocumentTests {
 
         Assert.Empty(result.Errors);
 
+        return PublishedDocumentFrom(result);
+    }
+
+    private static JsonElement PublishedDocumentFrom(GeneratorResult result) {
         var source = result.GeneratedSources
             .First(pair => pair.Key.Contains("OpenApiDocument")).Value;
 
@@ -347,6 +351,58 @@ public class SpecFirstDocumentTests {
             .GetProperty("RequestValidationError");
 
         Assert.Equal("object", schema.GetProperty("type").GetString());
+    }
+
+    #endregion
+
+    #region what the contract says about itself
+
+    /// <summary>
+    /// An entry point that also declares <c>[OpenApiInfo]</c>, with a comma in its description.
+    /// </summary>
+    private const string EntryPointDeclaringInfo =
+        """
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+
+        namespace TestNamespace;
+
+        [HardenedModule]
+        [OpenApiInfo("Attribute Title", "9.9", "Parcels, pallets and freight")]
+        public partial class TestApp {
+        }
+        """;
+
+    private static JsonElement Info(string spec, string source) {
+        var result = OpenApiGenerator.Run(spec, source);
+
+        Assert.Empty(result.Errors);
+
+        return PublishedDocumentFrom(result).GetProperty("info");
+    }
+
+    /// <summary>
+    /// The contract's own <c>info</c> wins, which is what <c>[OpenApiInfo]</c>'s remarks promise
+    /// and what nothing was driving.
+    /// </summary>
+    [Fact]
+    public void TheContractsInfoWinsOverTheAttribute() {
+        var info = Info(ConstrainedParameters, EntryPointDeclaringInfo);
+
+        Assert.Equal("Pets", info.GetProperty("title").GetString());
+        Assert.Equal("1.0", info.GetProperty("version").GetString());
+    }
+
+    /// <summary>
+    /// A description the contract does not state is taken from the attribute, commas and all - the
+    /// reading is the same on both front ends, so H-16's truncation would have shown here too.
+    /// </summary>
+    [Fact]
+    public void ADescriptionTheContractOmitsComesFromTheAttributeWhole() {
+        var info = Info(ConstrainedParameters, EntryPointDeclaringInfo);
+
+        Assert.True(info.TryGetProperty("description", out var description));
+        Assert.Equal("Parcels, pallets and freight", description.GetString());
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
@@ -162,7 +162,7 @@
         as a property. It is a filter stamp by name and history; it is the task-input stamp in fact.
 
         $(HardenedResponseModel) is the property case, and it was missing. Switching a project
-        between Standard, Response and Union changes every generated signature and touches no spec
+        between Throws, Response and Union changes every generated signature and touches no spec
         file, so the check found the stamp unmoved, skipped the target, and left the previous mode's
         service interfaces on disk - a build that reports success and generates the mode you were in
         yesterday. Nothing surfaces it: the old code still compiles, because it was valid output for

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/DanglingTargetTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/DanglingTargetTests.cs
@@ -1,0 +1,144 @@
+using Hardened.Generation.Models;
+using Hardened.Idl;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// A target the model references and does not declare.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Smithy half of the OpenAPI front end's dangling <c>$ref</c>. These were warnings that named
+/// what the parser did instead - <c>JsonElement</c> for a member, a dropped operation - and one of
+/// them, an error shape bound to an operation, said nothing at all: the interface simply never
+/// declared that error and the status the model promised was answered by nothing.
+/// </para>
+/// <para>
+/// The CLI refuses an undeclared target before this parser ever sees it, so a model built from
+/// sources cannot reach here. A committed AST can, which is exactly the case with no other check
+/// in front of it.
+/// </para>
+/// </remarks>
+public class DanglingTargetTests {
+
+    private static ServiceSpecModel Parse(string shapes) {
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(
+            $$"""
+              { "smithy": "2.0", "shapes": { {{shapes}} } }
+              """, "depot", diagnostics);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static SpecDiagnostics.Problem[] Problems(ServiceSpecModel model) =>
+        SpecDiagnostics.Find(model, "HSMT").ToArray();
+
+    private const string Service = """
+        "com.example#Svc": {
+          "type": "service", "version": "1",
+          "operations": [ { "target": "com.example#Op" } ] }
+        """;
+
+    /// <summary>An error shape bound to an operation that the model never declares.</summary>
+    [Fact]
+    public void AnUndeclaredErrorShapeIsRecorded() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "errors": [ { "target": "com.example#NoSuchError" } ],
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } }
+            """);
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("com.example#NoSuchError", dangling.Reference);
+        Assert.Contains("declares error", dangling.Location);
+    }
+
+    [Fact]
+    public void AnUndeclaredInputShapeIsRecorded() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "input": { "target": "com.example#NoSuchInput" },
+              "traits": { "smithy.api#http": { "method": "POST", "uri": "/x", "code": 200 } } }
+            """);
+
+        Assert.Equal(
+            "com.example#NoSuchInput", Assert.Single(model.DanglingReferences).Reference);
+    }
+
+    [Fact]
+    public void AnUndeclaredOutputShapeIsRecorded() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "output": { "target": "com.example#NoSuchOutput" },
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } }
+            """);
+
+        Assert.Equal(
+            "com.example#NoSuchOutput", Assert.Single(model.DanglingReferences).Reference);
+    }
+
+    /// <summary>
+    /// An operation the service binds and the model never declares, beside one it does. A service
+    /// with no readable operation at all fails earlier, as a model that describes no service.
+    /// </summary>
+    private const string OneGoodOneMissing = """
+        "com.example#Svc": {
+          "type": "service", "version": "1",
+          "operations": [
+            { "target": "com.example#Good" },
+            { "target": "com.example#Missing" } ] },
+        "com.example#Good": {
+          "type": "operation",
+          "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } }
+        """;
+
+    [Fact]
+    public void AnUndeclaredOperationIsRecorded() {
+        var model = Parse(OneGoodOneMissing);
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("com.example#Missing", dangling.Reference);
+        Assert.Contains("binds operation", dangling.Location);
+    }
+
+    /// <summary>It stops the build, under the front end that read the model.</summary>
+    [Fact]
+    public void ItStopsTheBuildUnderTheSmithyPrefix() {
+        var problem = Assert.Single(
+            Problems(Parse(OneGoodOneMissing)), p => p.Code == "HSMT027");
+
+        Assert.True(problem.Fatal);
+        Assert.Contains("com.example#Missing", problem.Message);
+    }
+
+    /// <summary>A model that declares what it references says nothing.</summary>
+    [Fact]
+    public void AModelThatResolvesIsSilent() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "output": { "target": "com.example#Out" },
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } },
+            "com.example#Out": {
+              "type": "structure",
+              "members": { "sku": { "target": "smithy.api#String" } } }
+            """);
+
+        Assert.Empty(model.DanglingReferences);
+        Assert.DoesNotContain(Problems(model), p => p.Code == "HSMT027");
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyResponseHeaderTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyResponseHeaderTests.cs
@@ -182,6 +182,6 @@ public class SmithyResponseHeaderTests {
         Assert.True(ResponseSetPlan.PrimarySuccessIsBarePayload(operation));
 
         Assert.False(ResponseSetPlan.DeclaresResponseHeaders(operation));
-        Assert.False(ResponseSetPlan.RequiresResponseSet(operation, SpecResponseModel.Standard));
+        Assert.False(ResponseSetPlan.RequiresResponseSet(operation, SpecResponseModel.Throws));
     }
 }

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -200,8 +200,8 @@ internal static class SmithySpecParser {
 
         foreach (var operationId in Operations(context, service)) {
             if (!context.Ast.TryGetShape(operationId, out var operation)) {
-                context.Diagnostics.Add(
-                    $"service '{tag}' binds operation '{operationId}', which the model does not declare.");
+                Dangling(context, operationId, "service '" + tag + "' binds operation");
+
                 continue;
             }
 
@@ -525,8 +525,7 @@ internal static class SmithySpecParser {
         }
 
         if (!context.Ast.TryGetShape(inputId, out var input)) {
-            context.Diagnostics.Add(
-                $"operation '{operationName}' takes '{inputId}', which the model does not declare.");
+            Dangling(context, inputId, "operation '" + operationName + "' takes");
 
             return;
         }
@@ -674,8 +673,7 @@ internal static class SmithySpecParser {
         }
 
         if (!context.Ast.TryGetShape(outputId, out var output)) {
-            context.Diagnostics.Add(
-                $"operation '{operationName}' returns '{outputId}', which the model does not declare.");
+            Dangling(context, outputId, "operation '" + operationName + "' returns");
 
             return headers;
         }
@@ -804,6 +802,11 @@ internal static class SmithySpecParser {
         ParseContext context, JsonElement operation, OperationModel model, ProtocolBinding protocol) {
         foreach (var errorId in SmithyAst.TargetList(operation, "errors")) {
             if (!context.Ast.TryGetShape(errorId, out var error)) {
+                // Dropped in silence until now, which is the quietest of the four: the operation
+                // keeps its other errors, the generated interface simply never declares this one,
+                // and the status the model promised is answered by nothing.
+                Dangling(context, errorId, "operation '" + model.OperationId + "' declares error");
+
                 continue;
             }
 
@@ -1079,7 +1082,7 @@ internal static class SmithySpecParser {
         }
 
         if (!context.Ast.TryGetShape(target, out var shape)) {
-            context.Diagnostics.Add($"'{target}' is referenced but not declared; it becomes JsonElement.");
+            Dangling(context, target, "member");
 
             return;
         }
@@ -1384,6 +1387,26 @@ internal static class SmithySpecParser {
 
         return SmithyAst.Kind(shape) is "list" or "set" or "map";
     }
+
+    /// <summary>
+    /// Records a shape the model references and does not declare.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These were warnings that named what the parser did instead - JsonElement for a member, a
+    /// dropped operation, an error the interface never declares. Every one of them is the shape
+    /// the OpenAPI front end's dangling <c>$ref</c> takes, and it is an error there: a reference
+    /// naming nothing is not a degrade the author chose, it is a model that says one thing and
+    /// generates another.
+    /// </para>
+    /// <para>
+    /// The CLI refuses an undeclared target before this parser ever sees it, so a model built from
+    /// sources cannot reach here. A committed AST can, which is exactly the case with no other
+    /// check in front of it.
+    /// </para>
+    /// </remarks>
+    private static void Dangling(ParseContext context, string target, string where) =>
+        context.Model.DanglingReferences.Add(new DanglingReferenceModel(target, where));
 
     /// <summary>Records every trait a shape carries, for the report at the end.</summary>
     private static void Note(ParseContext context, JsonElement shape) {

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
@@ -307,10 +307,10 @@
 
     <!--
         ResponseModel is passed here for the same reason the OpenAPI target passes it: ExtractSpecTask
-        reads $(HardenedResponseModel) to choose between Standard, Response and Union, and
+        reads $(HardenedResponseModel) to choose between Throws, Response and Union, and
         ExtractSmithySpec inherits that property along with the rest of the shell.
 
-        It was absent, so a Smithy project setting the property got Standard however it was set, and
+        It was absent, so a Smithy project setting the property got throws mode however it was set, and
         got it silently - the interfaces it generated were valid, just not the ones asked for. The
         OpenAPI path had been passing it since the property existed, which is what made this look
         like a mode that did not work for Smithy rather than a line that was never written.

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
@@ -689,4 +689,63 @@ public class OpenApiDocumentEmissionTests {
     }
 
     #endregion
+
+    #region prose with commas in it
+
+    /// <summary>
+    /// CS-06. <c>Arguments.Split(',')</c> cut the description at its first comma, and the document
+    /// published the truncation with nothing said.
+    /// </summary>
+    [Fact]
+    public void ADescriptionKeepsItsCommas() {
+        using var document = JsonDocument.Parse(Extract(Generate(
+            Enable + "\n[OpenApiInfo(\"Depot\", \"1.0\", \"Parcels, pallets and freight\")]")));
+
+        Assert.Equal(
+            "Parcels, pallets and freight",
+            document.RootElement.GetProperty("info").GetProperty("description").GetString());
+    }
+
+    /// <summary>And the title and version beside it are still their own arguments.</summary>
+    [Fact]
+    public void TheTitleAndVersionAreUnaffected() {
+        using var document = JsonDocument.Parse(Extract(Generate(
+            Enable + "\n[OpenApiInfo(\"Depot\", \"1.0\", \"Parcels, pallets and freight\")]")));
+
+        var info = document.RootElement.GetProperty("info");
+
+        Assert.Equal("Depot", info.GetProperty("title").GetString());
+        Assert.Equal("1.0", info.GetProperty("version").GetString());
+    }
+
+    /// <summary>
+    /// A description written as a named argument reaches the document under its own name rather
+    /// than as the text "description: ...".
+    /// </summary>
+    [Fact]
+    public void ANamedDescriptionIsRead() {
+        using var document = JsonDocument.Parse(Extract(Generate(
+            Enable + "\n[OpenApiInfo(\"Depot\", description: \"Parcels, pallets\")]")));
+
+        Assert.Equal(
+            "Parcels, pallets",
+            document.RootElement.GetProperty("info").GetProperty("description").GetString());
+    }
+
+    /// <summary>
+    /// A server's description carries its commas too - the same reading, and the one place that
+    /// already split on the first comma only.
+    /// </summary>
+    [Fact]
+    public void AServerDescriptionKeepsItsCommas() {
+        using var document = JsonDocument.Parse(Extract(Generate(
+            Enable + "\n[Server(\"https://api.example.com\", \"Production, and the only one\")]")));
+
+        var server = document.RootElement.GetProperty("servers").EnumerateArray().First();
+
+        Assert.Equal("https://api.example.com", server.GetProperty("url").GetString());
+        Assert.Equal("Production, and the only one", server.GetProperty("description").GetString());
+    }
+
+    #endregion
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ResponseModelParityTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ResponseModelParityTests.cs
@@ -10,7 +10,7 @@ namespace Hardened.SourceGenerator.Tests.Requests;
 /// There are two enums on purpose: the generator targets <c>netstandard2.0</c> and references no
 /// Hardened runtime package, so it reads the attribute as source text and never loads the type that
 /// declares it. What that buys in isolation it costs in the ability to drift - a member added to
-/// one and not the other produces a generator that silently reads the new mode as Standard, which
+/// one and not the other produces a generator that silently reads the new mode as Throws, which
 /// is the failure mode this whole feature is arranged to avoid.
 /// </para>
 ///
@@ -24,24 +24,46 @@ public class ResponseModelParityTests {
 
     [Fact]
     public void TheTwoEnums_DeclareTheSameMembers() {
-        var publicNames = Enum.GetNames(typeof(Hardened.Requests.Abstract.Responses.ResponseModel));
+        var publicNames = Enum.GetNames(typeof(Hardened.Requests.Abstract.Responses.ResponseModel))
+            .Where(n => n != "Standard");
         var generatorNames = Enum.GetNames(typeof(ResponseModelValue));
 
         Assert.Equal(publicNames.OrderBy(n => n), generatorNames.OrderBy(n => n));
     }
 
     /// <summary>
-    /// Standard has to be the zero value on both sides. It is what an entry point that says nothing
+    /// The pre-0.19.0 name. Kept out of the parity list above because the generator never needs
+    /// it - its parser answers Throws for any spelling it does not know, which covers this one.
+    /// What has to hold is that the alias still names the same mode and is still marked, so
+    /// removing either half at 1.0 is a deliberate act.
+    /// </summary>
+    [Fact]
+    public void TheRenamedStandardMember_IsAnObsoleteAliasOfThrows() {
+#pragma warning disable CS0618
+        Assert.Equal(
+            Hardened.Requests.Abstract.Responses.ResponseModel.Throws,
+            Hardened.Requests.Abstract.Responses.ResponseModel.Standard);
+
+        var member = typeof(Hardened.Requests.Abstract.Responses.ResponseModel)
+            .GetField(nameof(Hardened.Requests.Abstract.Responses.ResponseModel.Standard));
+#pragma warning restore CS0618
+
+        Assert.NotNull(member);
+        Assert.True(member!.IsDefined(typeof(ObsoleteAttribute), false));
+    }
+
+    /// <summary>
+    /// Throws has to be the zero value on both sides. It is what an entry point that says nothing
     /// gets, and <c>default(ResponseModel)</c> is what an attribute reader lands on when anything
     /// upstream fails to supply a value.
     /// </summary>
     [Fact]
-    public void Standard_IsTheDefaultOnBothSides() {
+    public void Throws_IsTheDefaultOnBothSides() {
         Assert.Equal(
-            Hardened.Requests.Abstract.Responses.ResponseModel.Standard,
+            Hardened.Requests.Abstract.Responses.ResponseModel.Throws,
             default(Hardened.Requests.Abstract.Responses.ResponseModel));
 
-        Assert.Equal(ResponseModelValue.Standard, default(ResponseModelValue));
-        Assert.Equal(ResponseModelValue.Standard, ResponseModelSelector.Default);
+        Assert.Equal(ResponseModelValue.Throws, default(ResponseModelValue));
+        Assert.Equal(ResponseModelValue.Throws, ResponseModelSelector.Default);
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ResponseModelSelectorTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ResponseModelSelectorTests.cs
@@ -24,25 +24,25 @@ public class ResponseModelSelectorTests {
     /// exactly as it did.
     /// </summary>
     [Fact]
-    public void Read_DefaultsToStandardWhenTheEntryPointSaysNothing() {
+    public void Read_DefaultsToThrowsWhenTheEntryPointSaysNothing() {
         var model = EntryPoint();
 
-        Assert.Equal(ResponseModelValue.Standard, ResponseModelSelector.Read(model));
+        Assert.Equal(ResponseModelValue.Throws, ResponseModelSelector.Read(model));
     }
 
     [Fact]
-    public void Read_DefaultsToStandardWhenThereAreNoAttributesAtAll() {
+    public void Read_DefaultsToThrowsWhenThereAreNoAttributesAtAll() {
         var model = EntryPoint();
         model.AttributeModels = null!;
 
-        Assert.Equal(ResponseModelValue.Standard, ResponseModelSelector.Read(model));
+        Assert.Equal(ResponseModelValue.Throws, ResponseModelSelector.Read(model));
     }
 
     [Fact]
     public void Read_IgnoresOtherModuleAttributes() {
         var model = EntryPoint(Attribute("CaseInsensitiveRoutesAttribute", ""));
 
-        Assert.Equal(ResponseModelValue.Standard, ResponseModelSelector.Read(model));
+        Assert.Equal(ResponseModelValue.Throws, ResponseModelSelector.Read(model));
     }
 
     #endregion
@@ -70,7 +70,7 @@ public class ResponseModelSelectorTests {
 
     /// <summary>
     /// Legal C# where the parameter type makes the enum unambiguous, and a spelling a generator
-    /// that only handled the qualified form would silently read as Standard.
+    /// that only handled the qualified form would silently read as Throws.
     /// </summary>
     [Fact]
     public void Read_UnderstandsTheBareMember() {
@@ -96,21 +96,33 @@ public class ResponseModelSelectorTests {
     }
 
     [Fact]
-    public void Read_ReadsStandardAsStandard() {
+    public void Read_ReadsThrowsAsThrows() {
+        var model = EntryPoint(Attribute("ResponseModelAttribute", "ResponseModel.Throws"));
+
+        Assert.Equal(ResponseModelValue.Throws, ResponseModelSelector.Read(model));
+    }
+
+    /// <summary>
+    /// The mode's name until 0.19.0. The public enum keeps the member as an obsolete alias, so
+    /// source that wrote it still compiles - and this is the half that keeps it meaning the same
+    /// mode.
+    /// </summary>
+    [Fact]
+    public void Read_ReadsTheRenamedStandardSpellingAsThrows() {
         var model = EntryPoint(Attribute("ResponseModelAttribute", "ResponseModel.Standard"));
 
-        Assert.Equal(ResponseModelValue.Standard, ResponseModelSelector.Read(model));
+        Assert.Equal(ResponseModelValue.Throws, ResponseModelSelector.Read(model));
     }
 
     /// <summary>
     /// A value this generator does not know means the attribute was written against a newer
-    /// Hardened. Standard is the answer that still builds.
+    /// Hardened. Throws is the answer that still builds.
     /// </summary>
     [Fact]
-    public void Read_FallsBackToStandardForAnUnknownMember() {
+    public void Read_FallsBackToThrowsForAnUnknownMember() {
         var model = EntryPoint(Attribute("ResponseModelAttribute", "ResponseModel.Whatever"));
 
-        Assert.Equal(ResponseModelValue.Standard, ResponseModelSelector.Read(model));
+        Assert.Equal(ResponseModelValue.Throws, ResponseModelSelector.Read(model));
     }
 
     #endregion
@@ -118,14 +130,14 @@ public class ResponseModelSelectorTests {
     #region declared versus defaulted
 
     /// <summary>
-    /// Saying Standard and saying nothing produce the same emit and are not the same statement.
+    /// Saying Throws and saying nothing produce the same emit and are not the same statement.
     /// </summary>
     [Fact]
-    public void IsDeclared_SeparatesAnExplicitStandardFromSilence() {
+    public void IsDeclared_SeparatesAnExplicitThrowsFromSilence() {
         Assert.False(ResponseModelSelector.IsDeclared(EntryPoint()));
 
         Assert.True(ResponseModelSelector.IsDeclared(
-            EntryPoint(Attribute("ResponseModelAttribute", "ResponseModel.Standard"))));
+            EntryPoint(Attribute("ResponseModelAttribute", "ResponseModel.Throws"))));
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/AttributeArguments.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/AttributeArguments.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Hardened.SourceGenerator.Shared;
+namespace Hardened.SourceGenerator.OpenApiDocument;
 
 /// <summary>
 /// The positional arguments of an attribute, read back out of the source text
 /// <see cref="AttributeModel.Arguments"/> holds.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Beside its only caller rather than in the shared folder. Five generator assemblies link that
+/// folder in, and a reader of attribute arguments compiled into the four that never call one is
+/// dead weight in each of them.
+/// </para>
 /// <para>
 /// The model joins arguments with ", " and keeps each one as it was written, quotes included - so
 /// reading them back is splitting on the commas that separate arguments and no others.

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -248,8 +248,13 @@ public static class OpenApiDocumentGenerator {
     /// <summary>
     /// The <c>[OpenApiInfo("title", "version")]</c> an entry point declares, read the way
     /// <see cref="WriteServers"/> reads <c>[Server]</c>: off the attribute list, by name prefix,
-    /// arguments as source text with their quotes trimmed.
+    /// arguments as source text with their quotes taken off.
     /// </summary>
+    /// <remarks>
+    /// Split at the commas that separate arguments rather than at every comma. A description is
+    /// prose and prose has commas in it, and the truncation was silent: the document published
+    /// everything up to the first one.
+    /// </remarks>
     private static (string? Title, string? Version, string? Description) InfoAttribute(
         EntryPointSelector.Model appModel) {
         if (appModel.AttributeModels == null) {
@@ -261,11 +266,11 @@ public static class OpenApiDocumentGenerator {
                 continue;
             }
 
-            var parts = attribute.Arguments.Split(',');
+            var parts = AttributeArguments.Split(attribute.Arguments);
 
-            var title = parts.Length > 0 ? parts[0].Trim().Trim('"') : "";
-            var infoVersion = parts.Length > 1 ? parts[1].Trim().Trim('"') : "";
-            var description = parts.Length > 2 ? parts[2].Trim().Trim('"') : "";
+            var title = AttributeArguments.Text(parts, 0, "title");
+            var infoVersion = AttributeArguments.Text(parts, 1, "version");
+            var description = AttributeArguments.Text(parts, 2, "description");
 
             return (
                 title.Length > 0 ? title : null,
@@ -288,12 +293,10 @@ public static class OpenApiDocumentGenerator {
                 continue;
             }
 
-            // "url", "description" - split on the first comma only, because a URL may contain one
-            // and the description is whatever remains.
-            var arguments = attribute.Arguments;
-            var comma = arguments.IndexOf(',');
-
-            var url = (comma < 0 ? arguments : arguments.Substring(0, comma)).Trim().Trim('"');
+            // "url", "description" - split at the commas between arguments, because both may
+            // contain one of their own.
+            var parts = AttributeArguments.Split(attribute.Arguments);
+            var url = AttributeArguments.Text(parts, 0, "url");
 
             if (url.Length == 0) {
                 continue;
@@ -303,13 +306,11 @@ public static class OpenApiDocumentGenerator {
 
             builder.Append("{\"url\":\"").Append(JsonSchemaWriter.Escape(url)).Append('"');
 
-            if (comma >= 0) {
-                var description = arguments.Substring(comma + 1).Trim().Trim('"');
+            var description = AttributeArguments.Text(parts, 1, "description");
 
-                if (description.Length > 0) {
-                    builder.Append(",\"description\":\"")
-                        .Append(JsonSchemaWriter.Escape(description)).Append('"');
-                }
+            if (description.Length > 0) {
+                builder.Append(",\"description\":\"")
+                    .Append(JsonSchemaWriter.Escape(description)).Append('"');
             }
 
             builder.Append('}');

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeMethodCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeMethodCodeGenerator.cs
@@ -57,7 +57,7 @@ public static class InvokeMethodCodeGenerator {
     /// has any. A response set reaches <c>ApplyHeaders</c> through its switch, and this path had no
     /// switch to reach it through - so a type carrying a header answered without one, which is what
     /// a Smithy output binding <c>@httpHeader</c> and a hand-written <c>Created&lt;T&gt;</c> both
-    /// looked like in standard mode.
+    /// looked like in throws mode.
     /// </para>
     /// <para>
     /// A run-time test rather than a generated decision, because the generator does not always know:

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/ResponseModelSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/ResponseModelSelector.cs
@@ -34,7 +34,7 @@ public static class ResponseModelSelector {
     /// What an entry point that says nothing gets, which is what every application built before
     /// this existed says.
     /// </summary>
-    public const ResponseModelValue Default = ResponseModelValue.Standard;
+    public const ResponseModelValue Default = ResponseModelValue.Throws;
 
     /// <summary>
     /// The declared model, or <see cref="Default"/>.
@@ -43,7 +43,10 @@ public static class ResponseModelSelector {
     /// An unrecognised argument also yields the default rather than throwing. The enum is the only
     /// thing a caller can write and the compiler already rejects anything else, so a value that
     /// does not parse here means the attribute was written against a newer Hardened than this
-    /// generator - and emitting standard-mode code is the answer that still builds.
+    /// generator - and emitting throws-mode code is the answer that still builds. The same branch
+    /// reads the pre-0.19.0 spelling <c>Standard</c>, whose member still exists as an obsolete
+    /// alias of <c>Throws</c>: the compiler tells the author about the rename, so nothing here
+    /// has to.
     /// </remarks>
     public static ResponseModelValue Read(EntryPointSelector.Model appModel) {
         if (appModel.AttributeModels == null) {
@@ -61,11 +64,11 @@ public static class ResponseModelSelector {
     }
 
     /// <summary>
-    /// Whether the entry point said anything at all, as opposed to saying <c>Standard</c>.
+    /// Whether the entry point said anything at all, as opposed to saying <c>Throws</c>.
     /// </summary>
     /// <remarks>
     /// The two are the same emit and a different diagnostic. An entry point that wrote
-    /// <c>[ResponseModel(ResponseModel.Standard)]</c> has made a choice and should not be told
+    /// <c>[ResponseModel(ResponseModel.Throws)]</c> has made a choice and should not be told
     /// anything; one that wrote nothing has not, and is not the subject of any message either. Kept
     /// separate so a later mode-mismatch diagnostic can tell them apart without re-reading.
     /// </remarks>
@@ -98,7 +101,7 @@ public static class ResponseModelSelector {
             case nameof(ResponseModelValue.Union):
                 return ResponseModelValue.Union;
             default:
-                return ResponseModelValue.Standard;
+                return ResponseModelValue.Throws;
         }
     }
 }
@@ -113,7 +116,7 @@ public static class ResponseModelSelector {
 /// <c>ResponseModelSelectorTests</c> asserts rather than assumes.
 /// </remarks>
 public enum ResponseModelValue {
-    Standard,
+    Throws,
     Response,
     Union
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/AttributeArguments.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/AttributeArguments.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// The positional arguments of an attribute, read back out of the source text
+/// <see cref="AttributeModel.Arguments"/> holds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The model joins arguments with ", " and keeps each one as it was written, quotes included - so
+/// reading them back is splitting on the commas that separate arguments and no others.
+/// <c>Arguments.Split(',')</c> is not that: <c>[OpenApiInfo("Depot", "1.0", "Parcels, pallets and
+/// freight")]</c> lost everything after "Parcels", and the document published a truncated
+/// description with nothing said.
+/// </para>
+/// <para>
+/// A comma inside a string, a collection expression or a nested call belongs to that argument, so
+/// the walk tracks strings - ordinary, verbatim and character literals - and bracket depth. A
+/// named argument written positionally, <c>description: "..."</c>, carries its name into the text
+/// and <see cref="Text"/> takes it back off.
+/// </para>
+/// </remarks>
+internal static class AttributeArguments {
+
+    /// <summary>The arguments as written, in order.</summary>
+    public static IReadOnlyList<string> Split(string arguments) {
+        var parts = new List<string>();
+
+        if (arguments.Length == 0) {
+            return parts;
+        }
+
+        var start = 0;
+        var depth = 0;
+
+        for (var index = 0; index < arguments.Length; index++) {
+            var character = arguments[index];
+
+            switch (character) {
+                case '"':
+                case '\'':
+                    index = SkipLiteral(arguments, index);
+                    break;
+
+                case '(':
+                case '[':
+                case '{':
+                    depth++;
+                    break;
+
+                case ')':
+                case ']':
+                case '}':
+                    depth--;
+                    break;
+
+                case ',' when depth == 0:
+                    parts.Add(arguments.Substring(start, index - start));
+                    start = index + 1;
+                    break;
+            }
+        }
+
+        parts.Add(arguments.Substring(start));
+
+        return parts;
+    }
+
+    /// <summary>
+    /// The string the argument at <paramref name="index"/> holds, or the empty string where the
+    /// attribute has no such argument.
+    /// </summary>
+    /// <param name="name">
+    /// The parameter's name, so an argument written as <c>name: value</c> is found wherever it
+    /// sits. C# allows a named argument out of position, and the position is only meaningful for
+    /// the ones written without a name - which is why the count skips them.
+    /// </param>
+    /// <remarks>
+    /// Anything that is not a string literal comes back as its source text. Nothing here reads a
+    /// non-string argument, and returning the text is a better answer than an empty one for
+    /// whatever does next.
+    /// </remarks>
+    public static string Text(IReadOnlyList<string> parts, int index, string? name = null) {
+        var position = 0;
+
+        foreach (var part in parts) {
+            var argument = part.Trim();
+            var declared = Name(argument);
+
+            if (declared != null) {
+                if (declared == name) {
+                    return Unquote(argument.Substring(declared.Length + 1).TrimStart());
+                }
+
+                continue;
+            }
+
+            if (position++ == index) {
+                return Unquote(argument);
+            }
+        }
+
+        return "";
+    }
+
+    /// <summary>
+    /// The index after a string or character literal beginning at <paramref name="start"/>.
+    /// </summary>
+    private static int SkipLiteral(string text, int start) {
+        var quote = text[start];
+        var verbatim = quote == '"' && start > 0 && text[start - 1] == '@';
+
+        for (var index = start + 1; index < text.Length; index++) {
+            var character = text[index];
+
+            if (!verbatim && character == '\\') {
+                index++;
+
+                continue;
+            }
+
+            if (character != quote) {
+                continue;
+            }
+
+            // A doubled quote inside a verbatim string is one quote, not the end of it.
+            if (verbatim && index + 1 < text.Length && text[index + 1] == quote) {
+                index++;
+
+                continue;
+            }
+
+            return index;
+        }
+
+        // Unterminated, which the compiler will have its own thing to say about. Consuming the
+        // rest is what keeps this from splitting the remainder into arguments nobody wrote.
+        return text.Length - 1;
+    }
+
+    /// <summary>
+    /// The parameter <c>name: value</c> names, or null for an argument written positionally.
+    /// </summary>
+    private static string? Name(string argument) {
+        for (var index = 0; index < argument.Length; index++) {
+            var character = argument[index];
+
+            if (character == ':') {
+                return index == 0 ? null : argument.Substring(0, index);
+            }
+
+            if (!char.IsLetterOrDigit(character) && character != '_' && character != '@') {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static string Unquote(string argument) {
+        var verbatim = argument.StartsWith("@\"");
+        var start = verbatim ? 2 : 1;
+
+        if (argument.Length < start + 1 || argument[argument.Length - 1] != '"' ||
+            (!verbatim && argument[0] != '"')) {
+            return argument;
+        }
+
+        var body = argument.Substring(start, argument.Length - start - 1);
+
+        if (verbatim) {
+            return body.Replace("\"\"", "\"");
+        }
+
+        var builder = new StringBuilder(body.Length);
+
+        for (var index = 0; index < body.Length; index++) {
+            if (body[index] == '\\' && index + 1 < body.Length) {
+                index++;
+
+                builder.Append(body[index] switch {
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    '0' => '\0',
+                    var escaped => escaped
+                });
+
+                continue;
+            }
+
+            builder.Append(body[index]);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorMarker.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorMarker.cs
@@ -1,0 +1,48 @@
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// The type a routing generator declares to say it is running.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A module with handlers and no routing generator compiles without a warning into an application
+/// that answers 404 to everything. The build cannot see a missing analyzer from inside the analyzer
+/// that is missing, so the question is asked from one that is still there: the routing generators
+/// emit this as post-initialization output - the one kind of generated source another generator
+/// can see - and <c>Hardened.Library.SourceGenerator</c> reports its absence as HRDR006.
+/// </para>
+/// <para>
+/// The same arrangement <c>ValidationGeneratorMarker</c> uses, and for a related reason: a
+/// generator cannot observe another's regular output, so a marker is the only channel between two
+/// of them.
+/// </para>
+/// <para>
+/// Two constants and no logic, deliberately. This file is linked into five generator assemblies
+/// because three of them declare the marker, and only one asks the question - so what the others
+/// compile in has to be small enough to carry.
+/// </para>
+/// </remarks>
+public static class RoutingGeneratorMarker {
+
+    /// <summary>The metadata name the check looks for.</summary>
+    public const string TypeName = "Hardened.Web.Generated.WebRoutingGeneratorMarker";
+
+    /// <summary>
+    /// Deliberately plain C#: block-scoped namespace, ordinary class body. This lands in whatever
+    /// project references the generator, and a marker that needs a language version to compile
+    /// would fail the builds it exists to keep working.
+    /// </summary>
+    /// <remarks>
+    /// Written without the generated-file header so <c>GeneratedSource.Header</c> adds it - that
+    /// method leaves a source that already opens with the marker alone, which would mean this file
+    /// carrying the marker and neither the nullable context nor the CS1591 pragma that travel with
+    /// it.
+    /// </remarks>
+    public const string Source =
+        "namespace Hardened.Web.Generated {\n" +
+        "    /// <summary>Declared by a Hardened routing generator so other generators can tell\n" +
+        "    /// whether route declarations are being compiled for this compilation.</summary>\n" +
+        "    internal static class WebRoutingGeneratorMarker {\n" +
+        "    }\n" +
+        "}\n";
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorPresence.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorPresence.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// Whether anything in this compilation is turning route declarations into a routing table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A module with handlers and no routing generator compiles without a warning into an application
+/// that answers 404 to everything. The build cannot see a missing analyzer from inside the analyzer
+/// that is missing, so the question is asked from one that is still there: the routing generators
+/// declare <see cref="MarkerTypeName"/> as post-initialization output - the one kind of generated
+/// source another generator can see - and the library generator reports its absence.
+/// </para>
+/// <para>
+/// The same arrangement <c>ValidationGeneratorMarker</c> uses, and for a related reason: a
+/// generator cannot observe another's regular output, so a marker is the only channel between two
+/// of them.
+/// </para>
+/// </remarks>
+public static class RoutingGeneratorPresence {
+
+    /// <summary>The type a routing generator declares to say it is running.</summary>
+    public const string MarkerTypeName = "Hardened.Web.Generated.WebRoutingGeneratorMarker";
+
+    /// <summary>
+    /// Deliberately plain C#: block-scoped namespace, ordinary class body. This lands in whatever
+    /// project references the generator, and a marker that needs a language version to compile
+    /// would fail the builds it exists to keep working.
+    /// </summary>
+    /// <remarks>
+    /// Written without the generated-file header so <c>GeneratedSource.Header</c> adds it - that
+    /// method leaves a source that already opens with the marker alone, which would mean this file
+    /// carrying the marker and neither the nullable context nor the CS1591 pragma that travel with
+    /// it.
+    /// </remarks>
+    public const string MarkerSource =
+        "namespace Hardened.Web.Generated {\n" +
+        "    /// <summary>Declared by a Hardened routing generator so other generators can tell\n" +
+        "    /// whether route declarations are being compiled for this compilation.</summary>\n" +
+        "    internal static class WebRoutingGeneratorMarker {\n" +
+        "    }\n" +
+        "}\n";
+
+    /// <summary>The attributes a hand-written route is declared with.</summary>
+    public static readonly string[] VerbAttributes = {
+        "Hardened.Web.Runtime.Attributes.GetAttribute",
+        "Hardened.Web.Runtime.Attributes.PostAttribute",
+        "Hardened.Web.Runtime.Attributes.PutAttribute",
+        "Hardened.Web.Runtime.Attributes.PatchAttribute",
+        "Hardened.Web.Runtime.Attributes.DeleteAttribute"
+    };
+
+    /// <summary>
+    /// <c>HRDR006</c>. <c>HRDR002</c> and <c>HRDR005</c> are about one route; this is about every
+    /// route in the assembly at once.
+    /// </summary>
+    public const string DiagnosticId = "HRDR006";
+
+    /// <summary>
+    /// Built per call rather than held in a static field: RS2008 looks for the field, and these
+    /// projects set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "No routing generator is compiling this assembly's routes",
+        messageFormat:
+        "'{0}' declares routes and nothing in this project turns them into a routing table, so " +
+        "every one of them answers 404 at run time. Reference Hardened.Web.SourceGenerator as an " +
+        "analyzer, or drop the route attributes if this assembly is not meant to serve them.",
+        category: "Hardened.Routing",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports the absence, having been handed the route declarations the compilation carries.
+    /// </summary>
+    /// <param name="declaringTypes">
+    /// The types carrying route attributes, in the order they were found. One report for the first
+    /// of them rather than one per route: there is a single thing to fix, and an assembly with
+    /// forty routes would otherwise produce forty copies of it.
+    /// </param>
+    public static void Report(
+        SourceProductionContext context, Compilation compilation,
+        IReadOnlyList<string> declaringTypes) {
+        if (declaringTypes.Count == 0 ||
+            compilation.GetTypeByMetadataName(MarkerTypeName) is not null) {
+            return;
+        }
+
+        // Location.None, as everywhere else models are reported from: a syntax location would
+        // travel through the incremental caches, which compare for equality to decide whether to
+        // regenerate. The message carries the type instead.
+        context.ReportDiagnostic(Diagnostic.Create(
+            Descriptor(), Location.None, declaringTypes[0]));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeGenerator.cs
@@ -130,14 +130,41 @@ public class RouteTreeGenerator<T> {
 
             // Per continuation rather than across the whole position: /users/{id:int} and
             // /users/{id}/posts become two nodes here - grouped by what follows the token - and only
-            // routes sharing a continuation have to agree. Two that do and disagree is HRDR001,
-            // reported before this runs.
-            node.WildCardConstraint = RouteTokens.Constraint(group.Value[0].WildCardTokens, wildCardDepth);
+            // routes sharing a continuation have to agree. Two that do and declare different
+            // constraints is HRDR001, reported before this runs.
+            //
+            // Read across the group rather than from its first entry, for the reason the catch-all
+            // above is. One path is one node however many verbs answer at it, and a description
+            // routinely declares the same path parameter twice: the petstore fixture gives
+            // /pets/{petId} a pattern on GET and a bare string on PATCH, PUT and DELETE. Taking the
+            // first entry meant the segment was constrained or not according to which operation the
+            // table happened to reach first - so adding an unrelated route elsewhere in the
+            // document silently turned a 404 into a 400.
+            node.WildCardConstraint = Constraint(group.Value, wildCardDepth);
 
             returnList.Add(node);
         }
 
         return returnList;
+    }
+
+    /// <summary>
+    /// The constraint the routes through this continuation declare, or null where none does.
+    /// </summary>
+    /// <remarks>
+    /// A segment either names a resource or does not, and that is a fact about the path rather than
+    /// about the verb - so one route declaring a constraint constrains the node. The alternative,
+    /// applying it only where every route agrees, would let a document loosen a declared constraint
+    /// by describing the same parameter twice and leaving it off the second time.
+    /// </remarks>
+    private static string? Constraint(List<Entry> entries, int wildCardDepth) {
+        foreach (var entry in entries) {
+            if (RouteTokens.Constraint(entry.WildCardTokens, wildCardDepth) is { } constraint) {
+                return constraint;
+            }
+        }
+
+        return null;
     }
 
     private IReadOnlyList<RouteTreeLeafNode<T>> CreateLeafNodes(List<Entry> entries, int stringIndex) {

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Authorization/RequireAuthorizationTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Authorization/RequireAuthorizationTests.cs
@@ -355,12 +355,19 @@ public class RequireAuthorizationTests {
         Assert.Equal(result.FirstRun, result.SecondRun);
 
         // And nothing it emitted was rebuilt to find that out: as many outputs were served from
-        // cache as there are generated files. The steps that did run are the diagnostic ones, which
-        // emit no source.
+        // cache as there are generated files with a step behind them. The steps that did run are
+        // the diagnostic ones, which emit no source.
+        //
+        // The routing-generator marker is not one of them. Post-initialization output is written
+        // once for the compilation and has no incremental step at all, which is better than cached
+        // rather than worse - so it is taken out of the count rather than expected in it.
         var cached = result.OutputReasons.Count(
             reason => reason == IncrementalStepRunReason.Cached);
 
-        Assert.Equal(result.FirstRun.Count, cached);
+        var fromSteps = result.FirstRun.Count(
+            source => !source.Key.Contains("Hardened.Web.Marker"));
+
+        Assert.Equal(fromSteps, cached);
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
@@ -39,6 +39,15 @@
         <ProjectReference Include="..\Hardened.DependencyModules.SourceGenerator\Hardened.DependencyModules.SourceGenerator.csproj"/>
 
         <!--
+            For the routing-generator-absent diagnostic, which is decided in the library generator
+            because that is the one still referenced when the web generator is not. Same terms as
+            the reference above: this assembly compiles its own copy of the shared source, so every
+            shared type is ambiguous across the two, and the tests that touch it name only
+            LibrarySourceGenerator and the diagnostic's id.
+        -->
+        <ProjectReference Include="..\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj"/>
+
+        <!--
             The same OpenAPI reader the build task parses specifications with, so the round trip can
             check the emitted document against something other than the code that wrote it. Reading
             it back with Hardened's own parser would let a misunderstanding shared by the writer and

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseModelGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseModelGeneratorTests.cs
@@ -76,24 +76,36 @@ public class ResponseModelGeneratorTests {
     }
 
     /// <summary>
-    /// Saying Standard is a choice, and a choice that works. It must not be told anything.
+    /// Saying Throws is a choice, and a choice that works. It must not be told anything.
     /// </summary>
     [Fact]
-    public void AnExplicitStandard_BuildsWithNoDiagnostic() {
+    public void AnExplicitThrows_BuildsWithNoDiagnostic() {
+        AssertNoModeDiagnostics(Generate(
+            "[Hardened.Requests.Abstract.Responses.ResponseModel(" +
+            "Hardened.Requests.Abstract.Responses.ResponseModel.Throws)]"));
+    }
+
+    /// <summary>
+    /// The pre-0.19.0 spelling. The member survives as an obsolete alias, so the compiler tells
+    /// the author about the rename; the generator reads it as the mode it always meant and adds
+    /// nothing.
+    /// </summary>
+    [Fact]
+    public void TheRenamedStandardSpelling_StillBuildsWithNoModeDiagnostic() {
         AssertNoModeDiagnostics(Generate(
             "[Hardened.Requests.Abstract.Responses.ResponseModel(" +
             "Hardened.Requests.Abstract.Responses.ResponseModel.Standard)]"));
     }
 
     /// <summary>
-    /// Standard mode still emits a routing table, which is what says the attribute did not
+    /// Throws mode still emits a routing table, which is what says the attribute did not
     /// disturb anything on the path that already worked.
     /// </summary>
     [Fact]
-    public void AnExplicitStandard_StillEmitsTheRoutingTable() {
+    public void AnExplicitThrows_StillEmitsTheRoutingTable() {
         var result = Generate(
             "[Hardened.Requests.Abstract.Responses.ResponseModel(" +
-            "Hardened.Requests.Abstract.Responses.ResponseModel.Standard)]");
+            "Hardened.Requests.Abstract.Responses.ResponseModel.Throws)]");
 
         Assert.Contains(result.GeneratedSources, pair => pair.Key.Contains("Routing"));
     }

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/MissingRoutingGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/MissingRoutingGeneratorTests.cs
@@ -1,0 +1,160 @@
+using Hardened.Library.SourceGenerator;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// A module with handlers and nothing compiling them into a routing table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CS-10. Removing <c>Hardened.Web.SourceGenerator</c> built without a warning into an application
+/// that answered 404 to every route it declared. The template's AGENTS.md documented the trap and
+/// the build said nothing, which is the worst of both: written down where you look after you have
+/// already lost the afternoon.
+/// </para>
+/// <para>
+/// The build cannot see a missing analyzer from inside the analyzer that is missing, so the
+/// question is asked from one that is still there. <c>Hardened.Library.SourceGenerator</c> is
+/// referenced by every Hardened project and by the template, and the routing generators declare a
+/// marker type saying they ran - post-initialization output being the one kind of generated source
+/// another generator can see.
+/// </para>
+/// <para>
+/// The diagnostic is named by its id rather than through <c>RoutingGeneratorPresence</c>: this test
+/// assembly compiles the shared source that type lives in, so the constant is ambiguous across the
+/// three generator assemblies referenced here.
+/// </para>
+/// </remarks>
+public class MissingRoutingGeneratorTests {
+    private const string DiagnosticId = "HRDR006";
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)   // Hardened.Requests.Abstract
+    ];
+
+    private const string WithRoutes = """
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        [HardenedWebModule]
+        public partial class TestApplication { }
+
+        public class ItemController {
+            [Get("/items/{id}")]
+            public string Item(string id) => id;
+        }
+        """;
+
+    private const string WithNoRoutes = """
+        using Hardened.Shared.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        public partial class TestApplication { }
+
+        public class ItemService {
+            public string Item(string id) => id;
+        }
+        """;
+
+    private static GeneratorResult Generate(string source, params IIncrementalGenerator[] generators) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Test.cs"] = source }, generators, Anchors);
+
+    private static bool Reported(GeneratorResult result) =>
+        result.GeneratorDiagnostics.Any(diagnostic => diagnostic.Id == DiagnosticId);
+
+    /// <summary>The repro: routes declared, and only the library generator running.</summary>
+    [Fact]
+    public void RoutesWithNoRoutingGeneratorAreAnError() {
+        var result = Generate(WithRoutes, new LibrarySourceGenerator());
+
+        var diagnostic = Assert.Single(
+            result.GeneratorDiagnostics.Where(reported => reported.Id == DiagnosticId));
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    /// <summary>
+    /// The message names the type that declared them, what it costs, and both ways out - the
+    /// second of which is the one an assembly that never meant to serve them wants.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheTypeAndTheGenerator() {
+        var message = Generate(WithRoutes, new LibrarySourceGenerator()).GeneratorDiagnostics
+            .Single(reported => reported.Id == DiagnosticId).GetMessage();
+
+        Assert.Contains("TestApp.ItemController", message);
+        Assert.Contains("404", message);
+        Assert.Contains("Hardened.Web.SourceGenerator", message);
+    }
+
+    /// <summary>With the routing generator beside it, nothing is reported.</summary>
+    [Fact]
+    public void RoutesWithTheRoutingGeneratorAreNotReported() {
+        Assert.False(Reported(
+            Generate(WithRoutes, new LibrarySourceGenerator(), new WebLibrarySourceGenerator())));
+    }
+
+    /// <summary>
+    /// Order does not matter. The marker is post-initialization output, which every generator sees
+    /// whichever ran first.
+    /// </summary>
+    [Fact]
+    public void TheOrderTheGeneratorsRunInDoesNotMatter() {
+        Assert.False(Reported(
+            Generate(WithRoutes, new WebLibrarySourceGenerator(), new LibrarySourceGenerator())));
+    }
+
+    /// <summary>
+    /// An assembly that declares no routes needs no routing generator - which is what the
+    /// framework's own web runtime assemblies are, and the reason the check is not on
+    /// <c>[HardenedWebModule]</c>: <c>AspNetCoreRuntime</c> declares that attribute to bring the
+    /// pipeline and carries no routes at all.
+    /// </summary>
+    [Fact]
+    public void AnAssemblyWithNoRoutesIsNotReported() {
+        Assert.False(Reported(Generate(WithNoRoutes, new LibrarySourceGenerator())));
+    }
+
+    /// <summary>
+    /// One report for an assembly, not one per route. There is a single thing to fix.
+    /// </summary>
+    [Fact]
+    public void EveryRouteInTheAssemblyProducesOneReport() {
+        var result = Generate("""
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class ItemController {
+                [Get("/items/{id}")]
+                public string Item(string id) => id;
+
+                [Post("/items")]
+                public string Create(string body) => body;
+            }
+
+            public class PartController {
+                [Delete("/parts/{id}")]
+                public string Remove(string id) => id;
+            }
+            """, new LibrarySourceGenerator());
+
+        Assert.Single(result.GeneratorDiagnostics.Where(reported => reported.Id == DiagnosticId));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteConstraintTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteConstraintTests.cs
@@ -337,4 +337,98 @@ public class RouteConstraintTests {
             Generate(route).GeneratorDiagnostics,
             diagnostic => diagnostic.Id == DiagnosticId);
     }
+
+    #region one path, several verbs
+
+    /// <summary>
+    /// One path is one node however many verbs answer at it, so a constraint declared on any of
+    /// them constrains the segment.
+    /// </summary>
+    /// <remarks>
+    /// A description routinely declares the same path parameter twice - the petstore fixture gives
+    /// <c>/pets/{petId}</c> a pattern on GET and a bare string on PATCH, PUT and DELETE - and the
+    /// tree took the constraint from whichever entry it reached first. So the segment was
+    /// constrained or not according to the order the operations happened to arrive in, and adding
+    /// an unrelated route elsewhere in the document silently turned a 404 into a 400.
+    /// </remarks>
+    private static GeneratedRoutingTable TwoVerbs(string first, string second) =>
+        GeneratedRoutingTable.For($$"""
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class ItemController {
+                [Get("/items/{{first}}")]
+                public string Read(string id) => id;
+
+                [Delete("/items/{{second}}")]
+                public string Remove(string id) => id;
+            }
+            """);
+
+    [Fact]
+    public void AConstraintDeclaredOnTheFirstVerbConstrainsTheSegment() {
+        var routing = TwoVerbs("{id:int}", "{id}");
+
+        Assert.Equal("Read", routing.Handler("GET", "/items/42").InvokeMethod);
+        Assert.Null(routing.Route("GET", "/items/abc"));
+        Assert.Null(routing.Route("DELETE", "/items/abc"));
+    }
+
+    /// <summary>
+    /// And on the second, which is the half that was order-dependent.
+    /// </summary>
+    [Fact]
+    public void AConstraintDeclaredOnTheSecondVerbConstrainsTheSegmentToo() {
+        var routing = TwoVerbs("{id}", "{id:int}");
+
+        Assert.Equal("Read", routing.Handler("GET", "/items/42").InvokeMethod);
+        Assert.Null(routing.Route("GET", "/items/abc"));
+        Assert.Null(routing.Route("DELETE", "/items/abc"));
+    }
+
+    /// <summary>
+    /// Neither declaring one leaves the segment unconstrained, which is where the binder answers.
+    /// </summary>
+    [Fact]
+    public void NoVerbDeclaringOneLeavesTheSegmentUnconstrained() {
+        var routing = TwoVerbs("{id}", "{id}");
+
+        Assert.Equal("Read", routing.Handler("GET", "/items/abc").InvokeMethod);
+    }
+
+    /// <summary>
+    /// Per continuation, not across the whole position: <c>/items/{id:int}</c> and
+    /// <c>/items/{id}/parts</c> are two nodes, and the first's constraint does not reach the
+    /// second.
+    /// </summary>
+    [Fact]
+    public void AConstraintDoesNotLeakToADifferentContinuation() {
+        var routing = GeneratedRoutingTable.For("""
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class ItemController {
+                [Get("/items/{id:int}")]
+                public string Item(string id) => id;
+
+                [Get("/items/{id}/parts")]
+                public string Parts(string id) => id;
+            }
+            """);
+
+        Assert.Null(routing.Route("GET", "/items/abc"));
+        Assert.Equal("Parts", routing.Handler("GET", "/items/abc/parts").InvokeMethod);
+    }
+
+    #endregion
 }

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
@@ -7,6 +7,14 @@ namespace Hardened.Web.SourceGenerator;
 [Generator]
 public class WebLibrarySourceGenerator : IIncrementalGenerator {
     public void Initialize(IncrementalGeneratorInitializationContext context) {
+        // Says "a routing generator is running" to the library generator, which reports its
+        // absence - a module with handlers and no routing generator builds clean into an
+        // application that answers 404 to everything. Post-init because that is the only generated
+        // source another generator can see.
+        context.RegisterPostInitializationOutput(static production => production.AddSource(
+            "Hardened.Web.Marker.g.cs",
+            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+
         var applicationModel = context.SyntaxProvider.CreateSyntaxProvider(
             EntryPointSelector.UsingAttribute(),
             EntryPointSelector.TransformModel(false)

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
@@ -13,7 +13,7 @@ public class WebLibrarySourceGenerator : IIncrementalGenerator {
         // source another generator can see.
         context.RegisterPostInitializationOutput(static production => production.AddSource(
             "Hardened.Web.Marker.g.cs",
-            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+            GeneratedSource.Header(RoutingGeneratorMarker.Source)));
 
         var applicationModel = context.SyntaxProvider.CreateSyntaxProvider(
             EntryPointSelector.UsingAttribute(),

--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
@@ -115,26 +115,30 @@
     "responseModel": {
       "type": "parameter",
       "datatype": "choice",
-      "defaultValue": "standard",
+      "defaultValue": "response",
       "description": "How a handler declares more than one kind of response.",
       "choices": [
         {
-          "choice": "standard",
-          "description": "One return type per handler; other statuses are reached by throwing. The default, and what an application that says nothing gets."
+          "choice": "response",
+          "description": "Handlers return Response<T1..Tn>, a struct any C# compiler can build. The declared set reaches the generated document, so 404 and 409 are described rather than implied. The default."
         },
         {
-          "choice": "response",
-          "description": "Handlers return Response<T1..Tn>, a struct any C# compiler can build. The declared set reaches the generated document, so 404 and 409 are described rather than implied."
+          "choice": "throws",
+          "description": "One return type per handler; other statuses are reached by throwing, and [Throws<T>] is how they reach the document."
         },
         {
           "choice": "union",
           "description": "Handlers return a C# 15 union. Same declared set as response, plus exhaustiveness in your own code. Needs a compiler that can do C# 15 - the .NET 11 SDK - and reports a build error naming LangVersion below it."
+        },
+        {
+          "choice": "standard",
+          "description": "The old name for throws; scaffolds the same project. Goes away at 1.0."
         }
       ]
     },
-    "standardMode": {
+    "throwsMode": {
       "type": "computed",
-      "value": "(responseModel == 'standard')"
+      "value": "(responseModel == 'throws' || responseModel == 'standard')"
     },
     "responseMode": {
       "type": "computed",

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -97,8 +97,8 @@ compile.
 
 ## How this application declares its responses
 
-#if (standardMode)
-**Standard.** Each handler names one success type, and every other status is thrown:
+#if (throwsMode)
+**Throws.** Each handler names one success type, and every other status is thrown. Named **standard** before 0.19.0:
 
 ```csharp
 throw new NotFound("todo", $"No todo has id {id}.").AsException();

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -25,16 +25,16 @@ Four routes. `GET /todos` has one answer; the other three each declare more than
 |---|---|---|
 | `GET /todos` | 200 | |
 | `GET /todos/{id}` | 200 | 404 when no todo has that id |
-#if (standardMode && codeFirst)
+#if (throwsMode && codeFirst)
 | `POST /todos` | 200 | 409 when the title is taken |
 #endif
-#if (standardMode && specFirst)
+#if (throwsMode && specFirst)
 | `POST /todos` | 201 | 409 when the title is taken |
 #endif
 #if (declaredMode)
 | `POST /todos` | 201 with a `Location` | 409 when the title is taken |
 #endif
-#if (standardMode)
+#if (throwsMode)
 | `DELETE /todos/{id}` | 200 | 404 when no todo has that id |
 #endif
 #if (declaredMode)
@@ -79,7 +79,7 @@ A route is an attribute on a method of a plain class - no base type, no interfac
 
 ```csharp
 [Get("/{id}")]
-public #if (standardMode)Todo#endif#if (responseMode)Response<Todo, NotFound>#endif#if (unionMode)TodoResult#endif ById(ITodoStore store, int id)
+public #if (throwsMode)Todo#endif#if (responseMode)Response<Todo, NotFound>#endif#if (unionMode)TodoResult#endif ById(ITodoStore store, int id)
 ```
 
 `[BasePath]` on `TemplateModuleNameLibrary` prefixes every route in the assembly, so that one is
@@ -111,9 +111,9 @@ because disagreeing is a build error. There are no route attributes anywhere in 
 
 ## How responses are declared
 
-#if (standardMode)
-This application is in **standard** mode. A handler names one success type and reaches every other
-status by throwing:
+#if (throwsMode)
+This application is in **throws** mode (named **standard** before 0.19.0). A handler names one
+success type and reaches every other status by throwing:
 
 ```csharp
 throw new NotFound("todo", $"No todo has id {id}.").AsException();
@@ -121,7 +121,8 @@ throw new NotFound("todo", $"No todo has id {id}.").AsException();
 
 The 404 body is the same one the declared modes return. What is missing is any statement in the
 signature that the route can answer it - so the generated document describes fewer statuses than
-the application actually has.
+the application actually has, unless the handler declares them with `[Throws<NotFound>]`, which is
+this mode's half of the contract and where its name comes from.
 
 #if (codeFirst)
 A single success status is nameable — `[Post("/todos", SuccessStatus = 201)]` answers 201 and says

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
@@ -23,7 +23,6 @@
   </PropertyGroup>
 <!--#endif -->
 <!--#if (specFirst) -->
-<!--#if (declaredMode) -->
 
   <!--
     Which response model the build generates the service interface in. The contract declares the
@@ -33,8 +32,15 @@
     An MSBuild property rather than the [ResponseModel] attribute, because in a contract-first
     project the interface is generated before any attribute is read - the build task writes the
     signature this names, and the handler implements whatever it wrote.
+
+    Written for every mode, Throws included, so the choice is in this file rather than in a
+    default. An absent property still means Throws, because that is what every project scaffolded
+    before the property was written out got.
   -->
   <PropertyGroup>
+<!--#if (throwsMode) -->
+    <HardenedResponseModel>Throws</HardenedResponseModel>
+<!--#endif -->
 <!--#if (responseMode) -->
     <HardenedResponseModel>Response</HardenedResponseModel>
 <!--#endif -->
@@ -42,7 +48,6 @@
     <HardenedResponseModel>Union</HardenedResponseModel>
 <!--#endif -->
   </PropertyGroup>
-<!--#endif -->
 <!--#endif -->
 
   <ItemGroup>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
@@ -42,10 +42,10 @@ public class TodoController {
     [Get("/")]
     public IReadOnlyList<Todo> All(ITodoStore store) => store.All();
 
-#if (standardMode)
+#if (throwsMode)
     /// <summary>One todo, or 404.</summary>
     /// <remarks>
-    /// Standard mode: the signature names the success type, and every other status is thrown. The
+    /// Throws mode: the signature names the success type, and every other status is thrown. The
     /// thrown value is the same NotFound record the declared modes return, so the 404 body is
     /// identical either way - what differs is whether the compiler knows the route can answer it.
     /// </remarks>
@@ -64,7 +64,7 @@ public class TodoController {
     /// <remarks>
     /// This answers 200 rather than 201. A handler in this mode has one success type and no way to
     /// name a status beside it - returning Created&lt;Todo&gt; would serialise it as an ordinary
-    /// body at 200, because the standard dispatch does not read IHttpStatusResponse off a returned
+    /// body at 200, because the throws-mode dispatch does not read IHttpStatusResponse off a returned
     /// value. Compare the same method under --response-model response, where 201 is in the type.
     /// </remarks>
     [Post("/")]

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
@@ -54,7 +54,7 @@ public class TodoService : ITodosService {
     public Task<List<Todo>> ListTodos() =>
         Task.FromResult(_store.All().ToList());
 
-#if (standardMode)
+#if (throwsMode)
     /// <summary>
     /// Null is the 404.
     /// </summary>
@@ -74,11 +74,11 @@ public class TodoService : ITodosService {
     /// A 201 carrying the Location the contract declares, or a 409.
     /// </summary>
     /// <remarks>
-    /// The one operation here that names a response set in standard mode, and the contract is why:
+    /// The one operation here that names a response set in throws mode, and the contract is why:
     /// its 201 declares a Location, and a returned Todo has nowhere to put one - Todo is the type
     /// GetTodo answers with too, so a header on it would go out on every read. Declaring a header is
     /// the only thing that does this. Every other operation below declares none and keeps the bare
-    /// return type that standard mode is chosen for.
+    /// return type that throws mode is chosen for.
     ///
     /// The 409 is a case rather than a throw for the same reason: once an operation has a set, the
     /// set is where all of its statuses live.

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
@@ -19,8 +19,8 @@ public class DocumentStatusTests {
 
     private static readonly Dictionary<string, string[]> Expected = new() {
 #if (codeFirst)
-#if (standardMode)
-        // Standard mode documents what the signature declares. The thrown NotFound and Conflict
+#if (throwsMode)
+        // Throws mode documents what the signature declares. The thrown NotFound and Conflict
         // answer at runtime and are invisible here - the declared models close exactly that gap.
         ["GET /todos"] = ["200"],
         ["GET /todos/{id}"] = ["200", "400"],

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
@@ -56,12 +56,12 @@ public class TodoTests {
         (await app.Delete("/todos/9999")).Assert.NotFound();
     }
 
-#if (standardMode)
+#if (throwsMode)
     /// <summary>
     /// 200, not 201 - and that is the point of the assertion rather than an oversight.
     /// </summary>
     /// <remarks>
-    /// Standard mode names one success type per handler and has no way to put a status beside it,
+    /// Throws mode names one success type per handler and has no way to put a status beside it,
     /// so a created todo comes back at 200. Generate this template with --response-model response
     /// and the same route answers 201 with a Location header, because the status moved into the
     /// signature. This test is what makes that difference visible rather than a claim in a comment.

--- a/src/Web/Hardened.Web.Testing/ITestWebApp.cs
+++ b/src/Web/Hardened.Web.Testing/ITestWebApp.cs
@@ -8,7 +8,12 @@ public interface ITestWebApp : ITestContext {
     /// <summary>
     /// Get method
     /// </summary>
-    /// <param name="path">request path</param>
+    /// <param name="path">
+    /// The request path, percent-encoded as a client would send it. It is decoded before the
+    /// pipeline sees it, the way a transport decodes one - so <c>"/events/%20"</c> reaches the
+    /// handler as a space, and <c>%2F</c> alone stays as written because decoding it would put a
+    /// separator inside a segment.
+    /// </param>
     /// <param name="webRequest">web request configuration</param>
     /// <returns></returns>
     Task<TestWebResponse> Get(string path, Action<TestWebRequest>? webRequest = null);
@@ -16,9 +21,16 @@ public interface ITestWebApp : ITestContext {
     /// <summary>
     /// Post value to path
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="path"></param>
-    /// <param name="webRequest"></param>
+    /// <param name="value">
+    /// The body. A <c>string</c> or a <c>byte[]</c> goes on the wire as itself; anything else is
+    /// serialized as JSON. That is how a malformed body is sent - <c>Post("{", path)</c> is a
+    /// request the deserializer refuses - and how a body that is not text at all is.
+    /// </param>
+    /// <param name="path">
+    /// The request path, percent-encoded as a client would send it. It is decoded before the
+    /// pipeline sees it, the way a transport decodes one.
+    /// </param>
+    /// <param name="webRequest">Headers and cancellation for the request.</param>
     /// <returns></returns>
     Task<TestWebResponse> Post(object value, string path, Action<TestWebRequest>? webRequest = null);
 

--- a/src/Web/Hardened.Web.Testing/RequestPathDecoder.cs
+++ b/src/Web/Hardened.Web.Testing/RequestPathDecoder.cs
@@ -1,0 +1,91 @@
+using System.Text;
+
+namespace Hardened.Web.Testing;
+
+/// <summary>
+/// Percent-decodes a request path the way a transport hands one over.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The harness's whole value is that it drives the real pipeline, so a request that answers 404
+/// here and 400 on Kestrel is worse than no harness for that case. <c>app.Get("/events/%20")</c>
+/// reached the handler as the literal <c>%20</c> and matched nothing, while the same request over
+/// a socket decoded to whitespace and reached the validator.
+/// </para>
+/// <para>
+/// <b>The rule is Kestrel's, measured rather than assumed.</b> Probed against the Kestrel
+/// integration application over a real socket:
+/// </para>
+/// <code>
+/// /echo/path/%20         -> " "
+/// /echo/path/caf%C3%A9   -> "café"
+/// /echo/path/a%5Cb       -> "a\b"
+/// /echo/path/a%25b       -> "a%b"
+/// /echo/path/a%2Fb       -> "a%2Fb"   the one escape that stays
+/// /echo/path/a+b         -> "a+b"     a plus is a plus in a path
+/// /echo/path/a%zz        -> "a%zz"    not an escape at all
+/// </code>
+/// <para>
+/// <c>%2F</c> survives because decoding it would put a separator inside a segment, which would
+/// change how many segments the path has. <c>Uri.UnescapeDataString</c> decodes it, which is why
+/// this is written out rather than delegated.
+/// </para>
+/// </remarks>
+internal static class RequestPathDecoder {
+
+    public static string Decode(string path) {
+        if (path.IndexOf('%') < 0) {
+            return path;
+        }
+
+        var builder = new StringBuilder(path.Length);
+        List<byte>? pending = null;
+
+        for (var index = 0; index < path.Length; index++) {
+            if (path[index] == '%' && index + 2 < path.Length &&
+                Hex(path[index + 1]) is { } high && Hex(path[index + 2]) is { } low) {
+                var value = (byte)((high << 4) | low);
+
+                // A separator inside a segment would change how many segments the path has, so
+                // this one escape is left as the caller wrote it.
+                if (value == (byte)'/') {
+                    Flush(builder, ref pending);
+                    builder.Append(path, index, 3);
+                }
+                else {
+                    (pending ??= new List<byte>()).Add(value);
+                }
+
+                index += 2;
+
+                continue;
+            }
+
+            Flush(builder, ref pending);
+            builder.Append(path[index]);
+        }
+
+        Flush(builder, ref pending);
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Decoded bytes become characters together, because one character may take several of them.
+    /// </summary>
+    private static void Flush(StringBuilder builder, ref List<byte>? pending) {
+        if (pending == null || pending.Count == 0) {
+            return;
+        }
+
+        builder.Append(Encoding.UTF8.GetString(pending.ToArray()));
+        pending.Clear();
+    }
+
+    private static int? Hex(char character) => character switch {
+        >= '0' and <= '9' => character - '0',
+        >= 'a' and <= 'f' => character - 'a' + 10,
+        >= 'A' and <= 'F' => character - 'A' + 10,
+        _ => null
+    };
+}

--- a/src/Web/Hardened.Web.Testing/TestWebApp.cs
+++ b/src/Web/Hardened.Web.Testing/TestWebApp.cs
@@ -130,6 +130,17 @@ public class TestWebApp : TestContext, ITestWebApp {
             return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(raw));
         }
 
+        // And bytes go as themselves too, for a body that is not text at all. Without this they
+        // serialized as a JSON array of numbers, so an upload, a truncated payload or a byte
+        // sequence that is not valid UTF-8 could only be exercised against a live socket.
+        if (bodyValue is byte[] bytes) {
+            return new MemoryStream(bytes);
+        }
+
+        if (bodyValue is ReadOnlyMemory<byte> memory) {
+            return new MemoryStream(memory.ToArray());
+        }
+
         // Resolve IJsonSerializer first so its constructor populates the
         // shared JsonSerializerConfiguration.Options TypeInfoResolverChain
         // with the source-gen contexts the application has registered. The
@@ -164,6 +175,13 @@ public class TestWebApp : TestContext, ITestWebApp {
         if (questionMark > -1) {
             pathMinusQuery = path.Substring(0, questionMark);
         }
+
+        // Decoded, because a transport hands one over decoded. Passing it through undecoded made
+        // /events/%20 reach the handler as the literal three characters and match nothing, while
+        // the same request over a socket decoded to whitespace and reached the validator - which
+        // is the divergence a harness exists not to have. See RequestPathDecoder for the rule and
+        // where it was measured.
+        pathMinusQuery = RequestPathDecoder.Decode(pathMinusQuery);
 
         // Read from the headers the caller set rather than passed as "", which is what it used to
         // be. TestExecutionRequest takes Accept as a constructor argument instead of parsing it, so


### PR DESCRIPTION
`standard` was a positional name, and the position moved. Three adoption trials say the declared set is where the compiler's checking and the document's truthfulness come from, so `response` is what the template scaffolds when you say nothing. The old mode takes the name of its mechanism: errors are thrown, and `[Throws<T>]` is how they reach the document.

One release of compatibility everywhere the old name can appear:

- `ResponseModel.Standard` stays as an `[Obsolete]` alias of `ResponseModel.Throws`.
- `$(HardenedResponseModel)` still reads `Standard`, under a once-per-project HOAT026/HSMT026 warning.
- `--response-model standard` scaffolds the throws project.

An absent `$(HardenedResponseModel)` and an absent `[ResponseModel]` still mean throws mode, so nothing built before the rename moves. The template now writes the property out for every spec-first mode, so absence stays the legacy state rather than the recommendation.

The template stays attribute-free code-first, found the hard way: DependencyModules' module writer replays entry-point attributes with enum arguments rendered as bare integers, so `[ResponseModel(ResponseModel.Response)]` on an entry point is CS1503 today. Recorded in the attribute's remarks; the fix belongs to DependencyModules and is the first item of that repo's next release.

Validated: `dotnet build src/Hardened.Framework.sln` is 0 warnings, 0 errors, and `scripts/verify-templates.sh` is green across all seven default rows — the Smithy rows self-skip on this machine (CLI 1.56.0 against the 1.73.0 pin), as the script documents.

This is the base the 0.19 remediation branches build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
