### PR TITLE
Collect principal sources registered as their scheme's interface

### DIFF
--- a/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT.Tests/DefaultDenyTests.cs
+++ b/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT.Tests/DefaultDenyTests.cs
@@ -1,3 +1,4 @@
+using Hardened.IntegrationTests.Authorization.SUT;
 using Hardened.Requests.Testing;
 
 namespace Hardened.IntegrationTests.Authorization.SUT.Tests;
@@ -130,6 +131,50 @@ public class DefaultDenyTests {
 
         response.Assert.Ok();
     }
+
+    #endregion
+
+    #region the typed source
+
+    /// <summary>
+    /// CS-01 and SU-04, end to end. <c>ApiKeyPrincipalSource</c> implements only
+    /// <c>IPrincipalSource&lt;ApiKeyScheme&gt;</c> and carries the plain <c>[SingletonService]</c>,
+    /// so the generated registration names the closed generic and nothing else. Nothing but a real
+    /// application can show that such a source reaches the middleware: the whole failure was that
+    /// it was registered, resolvable, and never asked.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATypedSourceAuthenticatesARealRequest(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/guarded/implicit", WithApiKey());
+
+        response.Assert.Ok();
+    }
+
+    /// <summary>
+    /// And the principal it built is the one authorization judges, grants included.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATypedSourcesGrantsAreTheOnesJudged(ITestWebApp testWebApp) {
+        var admitted = await testWebApp.Get("/guarded/pets", WithApiKey());
+        var refused = await testWebApp.Get("/guarded/pets-manage", WithApiKey());
+
+        admitted.Assert.Ok();
+        refused.Assert.Forbidden();
+    }
+
+    /// <summary>
+    /// The two forms are one ordered list. A typed source that declines leaves the request to the
+    /// plain source registered beside it, rather than ending it.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATypedSourceDecliningFallsThroughToThePlainOne(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/guarded/implicit", Authenticated());
+
+        response.Assert.Ok();
+    }
+
+    private static Action<TestWebRequest> WithApiKey() =>
+        request => request.Headers[ApiKeyPrincipalSource.KeyHeader] = ApiKeyPrincipalSource.KnownKey;
 
     #endregion
 }

--- a/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT/ApiKeyPrincipalSource.cs
+++ b/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT/ApiKeyPrincipalSource.cs
@@ -1,0 +1,44 @@
+using DependencyModules.Runtime.Attributes;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.IntegrationTests.Authorization.SUT;
+
+/// <summary>A scheme, named as a type, the way <c>[Authorize&lt;TScheme&gt;]</c> names one.</summary>
+public class ApiKeyScheme : IAuthenticationScheme;
+
+/// <summary>
+/// A source written against the typed interface and registered with the plain attribute.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CS-01 and SU-04, as a fixture. A registration attribute registers a class as the interface it
+/// declares, so this lands in the container under <c>IPrincipalSource&lt;ApiKeyScheme&gt;</c> and
+/// under nothing else - and while the startup service resolved the non-generic interface alone,
+/// an application whose only source looked like this installed no middleware, answered 401 to
+/// every protected route, and said nothing about why. Two arms lost a debugging session to it.
+/// </para>
+/// <para>
+/// Declines every request that does not carry its own header, so the fixture's other source
+/// answers for every test written before this one.
+/// </para>
+/// </remarks>
+[SingletonService]
+public class ApiKeyPrincipalSource : IPrincipalSource<ApiKeyScheme> {
+    public const string KeyHeader = "X-Api-Key";
+
+    /// <summary>The one key this fixture knows, and the grant it carries.</summary>
+    public const string KnownKey = "open-sesame";
+
+    public const string KeyGrant = "pets:read";
+
+    public ValueTask<ICallerPrincipal?> Authenticate(IExecutionContext context) {
+        if (!context.Request.Headers.TryGetValue(KeyHeader, out var header) ||
+            header.ToString() != KnownKey) {
+            return new ValueTask<ICallerPrincipal?>((ICallerPrincipal?)null);
+        }
+
+        return new ValueTask<ICallerPrincipal?>(
+            new CallerPrincipal("api-key", [KeyGrant], subject: "api-key-caller"));
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/IPrincipalSource.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/IPrincipalSource.cs
@@ -41,12 +41,21 @@ public interface IPrincipalSource {
 /// A principal source for one declared authentication scheme.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The scheme type is the same one <c>[Authorize&lt;TScheme&gt;]</c> names and the published
 /// document keys its <c>securitySchemes</c> entry by, so "find references" connects the
 /// operations requiring a scheme with the source that implements it. The runtime does not
 /// dispatch on the type parameter - every registered source is asked in order - so implementing
 /// the plain <see cref="IPrincipalSource"/> works identically; this form exists to state the
 /// tie.
+/// </para>
+/// <para>
+/// A registration attribute registers a class as the interface it declares, so a source written
+/// this way is in the container under the closed generic rather than under
+/// <see cref="IPrincipalSource"/>. <c>AuthenticationStartupService</c> collects both, in one
+/// registration order, which is what makes "works identically" true of registration as well as
+/// of dispatch.
+/// </para>
 /// </remarks>
 public interface IPrincipalSource<TScheme> : IPrincipalSource
     where TScheme : IAuthenticationScheme;

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationStartupServiceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationStartupServiceTests.cs
@@ -1,0 +1,224 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.DependencyInjection;
+using Hardened.Requests.Runtime.Tests.Support;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Authorization;
+
+/// <summary>
+/// Whether an application has authentication at all. A source the startup service does not find is
+/// a source that never runs, and every caller stays anonymous with nothing said.
+///
+/// <para>
+/// The startup service itself is <c>internal</c>, so it is reached the way an application reaches
+/// it - through <c>HardenedRequestModule</c>'s registrations.
+/// </para>
+/// </summary>
+public class AuthenticationStartupServiceTests {
+
+    private sealed class BearerScheme : IAuthenticationScheme;
+
+    private sealed class CookieScheme : IAuthenticationScheme;
+
+    /// <summary>
+    /// Records what it was asked, so a source that was collected and never reached is
+    /// distinguishable from one that was not collected at all.
+    /// </summary>
+    private class RecordingSource : IPrincipalSource {
+        private readonly string? _subject;
+
+        protected RecordingSource(string? subject) => _subject = subject;
+
+        public int Calls { get; private set; }
+
+        public ValueTask<ICallerPrincipal?> Authenticate(IExecutionContext context) {
+            Calls++;
+
+            return new ValueTask<ICallerPrincipal?>(
+                _subject == null ? null : new CallerPrincipal("test", subject: _subject));
+        }
+    }
+
+    /// <summary>
+    /// Written against the typed interface alone, which is what an application following the
+    /// <c>[Authorize&lt;TScheme&gt;]</c> vocabulary writes.
+    /// </summary>
+    private sealed class BearerSource(string? subject = "ada")
+        : RecordingSource(subject), IPrincipalSource<BearerScheme>;
+
+    private sealed class CookieSource(string? subject = "grace")
+        : RecordingSource(subject), IPrincipalSource<CookieScheme>;
+
+    private sealed class PlainSource(string? subject = null) : RecordingSource(subject);
+
+    private sealed class OpenSource<TScheme>(string? subject = null)
+        : RecordingSource(subject), IPrincipalSource<TScheme>
+        where TScheme : IAuthenticationScheme;
+
+    /// <summary>
+    /// Composes the module, lets <paramref name="register"/> state the application's sources, runs
+    /// every startup service, and hands back the middleware that was installed.
+    /// </summary>
+    /// <remarks>
+    /// The authorization startup service runs alongside and installs into the filter registry
+    /// rather than the middleware service, so what comes back is authentication's alone. Its
+    /// configuration is registered after the module so it wins the resolve, the way the CORS
+    /// fixture does it - the module's own factory reads a configuration manager a test must not
+    /// depend on.
+    /// </remarks>
+    private static async Task<IReadOnlyList<IExecutionFilter>> Installed(
+        Action<IServiceCollection> register) {
+        var services = new ServiceCollection();
+
+        new HardenedRequestModule().ConfigureServices(services);
+
+        register(services);
+
+        var installed = new List<IExecutionFilter>();
+        var middlewareService = Substitute.For<IMiddlewareService>();
+
+        middlewareService
+            .When(m => m.Use(Arg.Any<Func<IExecutionContext, IExecutionFilter>>()))
+            .Do(call => installed.Add(
+                call.Arg<Func<IExecutionContext, IExecutionFilter>>()(
+                    Substitute.For<IExecutionContext>())));
+
+        services.AddSingleton(middlewareService);
+        services.AddSingleton(Substitute.For<IGlobalFilterRegistry>());
+        services.AddSingleton<IOptions<IAuthorizationConfiguration>>(
+            Options.Create(Substitute.For<IAuthorizationConfiguration>()));
+
+        var provider = services.BuildServiceProvider();
+
+        foreach (var startupService in provider.GetServices<IStartupService>()) {
+            Assert.True(await startupService.Startup(provider));
+        }
+
+        return installed;
+    }
+
+    /// <summary>
+    /// The caller a request comes out of the installed middleware with.
+    /// </summary>
+    private static async Task<string?> Caller(IExecutionFilter middleware) {
+        var context = Pipeline.Context();
+        var chain = Substitute.For<IExecutionChain>();
+
+        chain.Context.Returns(context);
+        chain.Next().Returns(Task.CompletedTask);
+
+        await middleware.Execute(chain);
+
+        return context.CallerPrincipal.Subject;
+    }
+
+    /// <summary>
+    /// CS-01 and SU-04. Two arms registered a source by attribute, got the typed interface as its
+    /// service type, and lost a debugging session to an application where every protected route
+    /// answered 401 and nothing said why.
+    /// </summary>
+    [Fact]
+    public async Task ATypedSourceInstallsTheMiddleware() {
+        var installed = await Installed(
+            services => services.AddSingleton<IPrincipalSource<BearerScheme>, BearerSource>());
+
+        Assert.IsType<AuthenticationMiddleware>(Assert.Single(installed));
+    }
+
+    [Fact]
+    public async Task ATypedSourceAuthenticatesTheRequest() {
+        var installed = await Installed(
+            services => services.AddSingleton<IPrincipalSource<BearerScheme>, BearerSource>());
+
+        Assert.Equal("ada", await Caller(Assert.Single(installed)));
+    }
+
+    /// <summary>
+    /// The workaround the arms found, which has to keep working.
+    /// </summary>
+    [Fact]
+    public async Task ASourceRegisteredAsThePlainInterfaceStillInstallsTheMiddleware() {
+        var installed = await Installed(
+            services => services.AddSingleton<IPrincipalSource, BearerSource>());
+
+        Assert.Single(installed);
+    }
+
+    /// <summary>
+    /// Two schemes are two service types, and one closed generic is not the whole of what the
+    /// application registered.
+    /// </summary>
+    [Fact]
+    public async Task EverySchemeIsCollected() {
+        var bearer = new BearerSource(subject: null);
+        var cookie = new CookieSource();
+
+        var installed = await Installed(services => {
+            services.AddSingleton<IPrincipalSource<BearerScheme>>(bearer);
+            services.AddSingleton<IPrincipalSource<CookieScheme>>(cookie);
+        });
+
+        Assert.Equal("grace", await Caller(Assert.Single(installed)));
+        Assert.Equal(1, bearer.Calls);
+        Assert.Equal(1, cookie.Calls);
+    }
+
+    /// <summary>
+    /// First answer wins in registration order, and a plain source declining falls through to a
+    /// typed one registered after it. The two forms are one ordered list, not two.
+    /// </summary>
+    [Fact]
+    public async Task RegistrationOrderHoldsAcrossBothForms() {
+        var installed = await Installed(services => {
+            services.AddSingleton<IPrincipalSource, PlainSource>();
+            services.AddSingleton<IPrincipalSource<CookieScheme>, CookieSource>();
+        });
+
+        Assert.Equal("grace", await Caller(Assert.Single(installed)));
+    }
+
+    /// <summary>
+    /// One instance registered under both interfaces is asked once. Asking it twice would only
+    /// cost a request a second read of a credential it has already declined.
+    /// </summary>
+    [Fact]
+    public async Task ASourceRegisteredUnderBothInterfacesIsAskedOnce() {
+        var source = new BearerSource(subject: null);
+
+        var installed = await Installed(services => {
+            services.AddSingleton<IPrincipalSource>(source);
+            services.AddSingleton<IPrincipalSource<BearerScheme>>(source);
+        });
+
+        await Caller(Assert.Single(installed));
+
+        Assert.Equal(1, source.Calls);
+    }
+
+    /// <summary>
+    /// An application that registered nothing gets no middleware, which is what keeps the anonymous
+    /// default free.
+    /// </summary>
+    [Fact]
+    public async Task NoSourceInstallsNoMiddleware() {
+        Assert.Empty(await Installed(_ => { }));
+    }
+
+    /// <summary>
+    /// An open generic registration is passed over rather than resolved: nothing implements the
+    /// source for every scheme, and asking the container for an unbound type throws.
+    /// </summary>
+    [Fact]
+    public async Task AnOpenGenericRegistrationIsPassedOver() {
+        Assert.Empty(await Installed(
+            services => services.AddSingleton(typeof(IPrincipalSource<>), typeof(OpenSource<>))));
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationStartupService.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationStartupService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Middleware;
 using Hardened.Shared.Runtime.Application;
@@ -9,21 +10,99 @@ namespace Hardened.Requests.Runtime.Authorization;
 /// Installs the authentication middleware at startup, when anything registered a source.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The sources are resolved once and the middleware instance is shared: a source establishes a
 /// caller from a request, so it holds no per-request state, and resolving per request would put
 /// a container lookup on every request of every application that opted in. An application that
 /// registered no source gets no middleware, which is what keeps the anonymous default free.
+/// </para>
+/// <para>
+/// <b>Both interfaces, which is why the collection is held.</b> A registration attribute registers
+/// a class as the interface it declares, so a source written against
+/// <see cref="IPrincipalSource{TScheme}"/> sits in the container under the closed generic and
+/// under nothing else. Resolving <see cref="IPrincipalSource"/> alone found none of them,
+/// installed no middleware, and left every caller anonymous with nothing said - the typed form's
+/// own remarks promise it works identically, and this is what makes that true. The service types
+/// cannot be reached from a built provider, so the collection the module configured is read here
+/// instead, once, after everything has registered into it.
+/// </para>
 /// </remarks>
 internal class AuthenticationStartupService : IStartupService {
-    public Task<bool> Startup(IServiceProvider rootProvider) {
-        var sources = rootProvider.GetServices<IPrincipalSource>().ToArray();
+    private readonly IServiceCollection _services;
 
-        if (sources.Length > 0) {
+    public AuthenticationStartupService(IServiceCollection services) {
+        _services = services;
+    }
+
+    public Task<bool> Startup(IServiceProvider rootProvider) {
+        var sources = Sources(rootProvider);
+
+        if (sources.Count > 0) {
             var middleware = new AuthenticationMiddleware(sources);
 
             rootProvider.GetRequiredService<IMiddlewareService>().Use(_ => middleware);
         }
 
         return Task.FromResult(true);
+    }
+
+    /// <summary>
+    /// Every registered source, in registration order, whichever interface it was registered as.
+    /// </summary>
+    /// <remarks>
+    /// A source registered under both interfaces is one source: the middleware asks each in turn
+    /// until one answers, and asking the same instance twice would only cost the request a second
+    /// read of a credential it already declined.
+    /// </remarks>
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Every service type read here is an interface, so the IEnumerable<T> the " +
+                        "container builds shares the canonical reference-type instantiation and " +
+                        "needs no native code of its own. The closed types are not constructed - " +
+                        "they are read from registrations the application already made.")]
+    private List<IPrincipalSource> Sources(IServiceProvider rootProvider) {
+        var sources = new List<IPrincipalSource>();
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        foreach (var serviceType in SourceServiceTypes()) {
+            foreach (var resolved in rootProvider.GetServices(serviceType)) {
+                if (resolved is IPrincipalSource source && seen.Add(source)) {
+                    sources.Add(source);
+                }
+            }
+        }
+
+        return sources;
+    }
+
+    /// <summary>
+    /// The service types a principal source can be registered under, in the order they were
+    /// registered: <see cref="IPrincipalSource"/> itself, and every closed
+    /// <see cref="IPrincipalSource{TScheme}"/> anything asked for.
+    /// </summary>
+    /// <remarks>
+    /// An open generic is skipped rather than resolved. Nothing can implement
+    /// <c>IPrincipalSource&lt;TScheme&gt;</c> for every scheme, and asking the container for an
+    /// unbound type throws.
+    /// </remarks>
+    private IEnumerable<Type> SourceServiceTypes() {
+        var seen = new HashSet<Type>();
+
+        foreach (var descriptor in _services) {
+            var serviceType = descriptor.ServiceType;
+
+            if (serviceType.ContainsGenericParameters) {
+                continue;
+            }
+
+            if (serviceType != typeof(IPrincipalSource) &&
+                !(serviceType.IsGenericType &&
+                  serviceType.GetGenericTypeDefinition() == typeof(IPrincipalSource<>))) {
+                continue;
+            }
+
+            if (seen.Add(serviceType)) {
+                yield return serviceType;
+            }
+        }
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -59,8 +59,10 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         services.AddSingleton<IStartupService, AuthorizationStartupService>();
 
         // Same footing: one resolve at startup, and no middleware at all unless something
-        // registered an IPrincipalSource.
-        services.AddSingleton<IStartupService, AuthenticationStartupService>();
+        // registered an IPrincipalSource. Constructed over this collection rather than resolved
+        // from the provider, because a source registered as IPrincipalSource<TScheme> is reachable
+        // only by its closed service type and a built provider cannot be asked what those are.
+        services.AddSingleton<IStartupService>(new AuthenticationStartupService(services));
     }
 
     /// <summary>


### PR DESCRIPTION
A1 / H-01 from the 0.18 work order, found independently by the code-first and Smithy arms. Both lost their only runtime debugging session to it.

A registration attribute registers a class as the interface it declares, so a source written against `IPrincipalSource<TScheme>` sits in the container under the closed generic and under nothing else. `AuthenticationStartupService` resolved the non-generic `IPrincipalSource`, found none, installed no middleware, and left every caller anonymous — so every protected route answered 401 and nothing said why. The typed interface's own remarks promise it "works identically".

**Made to work rather than diagnosed**, which is what the work order asked for first. The startup service reads the service collection it was configured over, takes every service type that is `IPrincipalSource` or a closed `IPrincipalSource<TScheme>` in registration order, and resolves each. One ordered list across both forms, so a typed source that declines falls through to a plain one registered after it, and one instance registered under both interfaces is asked once.

The collection is held rather than the sources resolved from it because a built provider cannot be asked what service types it holds. Open generic registrations are passed over — nothing implements the source for every scheme, and asking the container for an unbound type throws. `GetServices(Type)`'s IL3050 is suppressed with the reason it is safe here: every service type read is an interface, so the `IEnumerable<T>` shares the canonical reference-type instantiation.

Tests:

- `AuthenticationStartupServiceTests` — eight cases, reaching the internal startup service through `HardenedRequestModule`'s registrations the way `CorsStartupServiceTests` does, rather than opening the assembly up.
- The CS-01 repro as a fixture: `ApiKeyPrincipalSource` in the authorization SUT implements only `IPrincipalSource<ApiKeyScheme>` and carries a plain `[SingletonService]`. Three integration tests drive it through a real host — it authenticates, its grants are the ones authorization judges, and it falls through to the fixture's plain source when it declines. Nothing but a real application can show this: the whole failure was a source that was registered, resolvable, and never asked. Against the old startup service two of the three fail.

`IPrincipalSource<TScheme>`'s remarks now say what registration does, since the promise was the defect.

Validated: CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green; public API baseline unchanged.

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
