### PR TITLE
Read a route template strictly, and say when a token binds nothing

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -56,6 +56,47 @@ only when *no* entry matches a described service.
 
 ## Routing
 
+### HRDR002 — unsupported route token syntax
+
+A brace form the template accepts and Hardened does not compile, or a template that is not
+well formed at all. Both compile and route today, and neither does what it was written to do.
+
+| Written | What it actually means |
+|---|---|
+| `{id?}` | A mandatory segment named `id?`. The path it was meant to make optional does not match at all. |
+| `{id=5}` | A mandatory segment named `id=5`. Nothing binds to `id`; give the C# parameter the default. |
+| `{id:isbn}` | A constraint nothing declares. Declare it with `[RouteConstraint("isbn")]`, or drop it and let the parameter type refuse a bad value. |
+| `{id` | A brace with no partner. The rest is matched as literal text, so the route answers nothing anyone sends. |
+| `}` | The same, from the other end. |
+| `{}`, `{:int}` | A token with no name, which binds nothing. |
+| `{id}/x/{id}` | One name declared twice. Only one of the two segments a request sends could reach the parameter. |
+
+Every offending token in a route is reported, and the handler is still emitted — the routing table
+filters on unresolved parameters rather than on token syntax, so dropping it would bury this
+diagnostic under CS0246s.
+
+### HRDR005 — route token binds no parameter
+
+A token the template compiles that no parameter binds, beside a parameter that fell onto the
+request body because of it.
+
+```
+Route '/events/{eventid}' on 'EventController.Get' declares '{eventid}', which no parameter
+binds. 'eventId' differs from it only by case, so it is read from the request body instead.
+Route tokens bind by exact name: spell the token '{eventId}', or rename the parameter to
+'eventid'.
+```
+
+Both halves are required. A token that binds nothing is not a mistake on its own — one declared in
+a shared `[BasePath]` binds nothing on the handlers under it that do not need it. What makes it a
+defect is the parameter that went somewhere else because of it: onto a body a `GET`, `HEAD`,
+`OPTIONS` or `TRACE` does not carry, or — whatever the verb — onto a body when its name differs
+from the token only by case. `DELETE` is not treated as bodyless: HTTP permits a body on one and
+some APIs send it.
+
+A described parameter binds by the wire name its contract declares, not by the C# identifier
+allocated for it.
+
 ### HRDR006 — no routing generator is compiling this assembly's routes
 
 A module declaring routes with nothing turning them into a routing table. It compiled without a
@@ -88,7 +129,7 @@ One report per assembly, not one per route: there is a single thing to fix.
 | `HOAG002` | The description could not be parsed; the build task's message is passed through. |
 | `HOAG010` | A handler was skipped because a parameter type did not resolve. Other handlers are unaffected. |
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
-| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. `HRDR006` is above. |
+| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. The ones with an entry have a section above. |
 
 ## Description build tasks (HOAT, HSMT)
 

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RouteBindingConflictTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RouteBindingConflictTests.cs
@@ -1,0 +1,135 @@
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Web.Routing;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Requests;
+
+/// <summary>
+/// Which handlers declare a token that binds nothing while a parameter falls onto the body.
+/// </summary>
+/// <remarks>
+/// The decision, not the reporting - the split <c>FormAndBodyConflictTests</c> uses, and for the
+/// same reason. What is covered here rather than through a running generator is the described
+/// front end: a spec-first parameter carries the wire name the route declares and a C# identifier
+/// that may differ from it, so a rule that compared the identifier would report every described
+/// path parameter whose member name was allocated.
+/// </remarks>
+public class RouteBindingConflictTests {
+
+    private static ITypeDefinition Type(string name) => TypeDefinition.Get("System", name);
+
+    private static RequestParameterInformation Parameter(
+        ParameterBindType bindingType, string name, string bindingName = "") =>
+        new(Type("String"), name, true, null, bindingType, bindingName, 0, null);
+
+    private static RequestHandlerModel Handler(
+        string path, string method, params RequestParameterInformation[] parameters) =>
+        new(
+            new RequestHandlerNameModel(path, method),
+            TypeDefinition.Get("TestApp", "EventController"),
+            "Handle",
+            TypeDefinition.Get("TestApp.Generated", "EventController_Handle"),
+            parameters,
+            new ResponseInformationModel { ReturnType = Type("String") },
+            []);
+
+    /// <summary>
+    /// A described parameter binds by its wire name. <c>eventId</c> in the contract becomes the
+    /// member <c>EventId</c>, and the route still declares <c>{eventId}</c>.
+    /// </summary>
+    [Fact]
+    public void ADescribedParameterBindsByItsWireName() {
+        var findings = RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventId}", "GET",
+            Parameter(ParameterBindType.Path, "EventId", "eventId")));
+
+        Assert.Empty(findings);
+    }
+
+    /// <summary>A code-first parameter carries no wire name and binds by its identifier.</summary>
+    [Fact]
+    public void ACodeFirstParameterBindsByItsIdentifier() {
+        var findings = RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventId}", "GET", Parameter(ParameterBindType.Path, "eventId")));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void ATokenDifferingOnlyByCaseIsFound() {
+        var finding = Assert.Single(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventid}", "GET", Parameter(ParameterBindType.Body, "eventId"))));
+
+        Assert.Equal("eventid", finding.Token);
+        Assert.Equal("eventId", finding.BodyParameter);
+        Assert.True(finding.CaseOnly);
+    }
+
+    [Fact]
+    public void AMisspeltTokenOnABodylessVerbIsFound() {
+        var finding = Assert.Single(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventKey}", "GET", Parameter(ParameterBindType.Body, "eventId"))));
+
+        Assert.False(finding.CaseOnly);
+    }
+
+    /// <summary>
+    /// A POST reads a body because a POST carries one. Only a name that differs by case says the
+    /// author meant the token.
+    /// </summary>
+    [Fact]
+    public void AMisspeltTokenOnABodyCarryingVerbIsNotFound() {
+        Assert.Empty(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventKey}", "POST", Parameter(ParameterBindType.Body, "body"))));
+    }
+
+    /// <summary>
+    /// DELETE is not treated as bodyless. HTTP permits a body on one and some APIs send it, so a
+    /// body parameter there is a choice rather than a mistake.
+    /// </summary>
+    [Fact]
+    public void ADeleteIsNotTreatedAsBodyless() {
+        Assert.Empty(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventKey}", "DELETE", Parameter(ParameterBindType.Body, "body"))));
+    }
+
+    /// <summary>
+    /// A token nothing binds and nothing displaced is not a defect: a token declared in a shared
+    /// base path binds nothing on the handlers under it that do not need it.
+    /// </summary>
+    [Fact]
+    public void AnUnboundTokenWithNoBodyParameterIsNotFound() {
+        Assert.Empty(RouteBindingDiagnostics.Find(Handler(
+            "/tenants/{tenantId}/events/{eventId}", "GET",
+            Parameter(ParameterBindType.Path, "eventId"))));
+    }
+
+    /// <summary>
+    /// A dispatched handler is selected by an exact token in a header - awsJson sends every
+    /// operation to <c>POST /</c> - so its path declares nothing to bind.
+    /// </summary>
+    [Fact]
+    public void ADispatchedHandlerIsNotConsidered() {
+        var model = new RequestHandlerModel(
+            new RequestHandlerNameModel("/", "POST", "X-Amz-Target", "PetStore.GetPet"),
+            TypeDefinition.Get("TestApp", "EventController"),
+            "Handle",
+            TypeDefinition.Get("TestApp.Generated", "EventController_Handle"),
+            [Parameter(ParameterBindType.Body, "input")],
+            new ResponseInformationModel { ReturnType = Type("String") },
+            []);
+
+        Assert.Empty(RouteBindingDiagnostics.Find(model));
+    }
+
+    /// <summary>One finding per token, so fixing the first is not how you discover the second.</summary>
+    [Fact]
+    public void EveryUnboundTokenIsFound() {
+        var findings = RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventid}/holds/{holdid}", "GET",
+            Parameter(ParameterBindType.Body, "eventId")));
+
+        Assert.Equal(2, findings.Count);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RouteTokens.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RouteTokens.cs
@@ -1,4 +1,4 @@
-namespace Hardened.SourceGenerator.Models.Request;
+﻿namespace Hardened.SourceGenerator.Models.Request;
 
 /// <summary>
 /// How much of a path a route token matches, and what it may contain.
@@ -75,6 +75,37 @@ public static class RouteTokens {
         var index = depth - 1;
 
         return index >= 0 && index < tokens.Count ? Constraint(tokens[index]) : null;
+    }
+
+    /// <summary>
+    /// The names every well-formed token in <paramref name="pathTemplate"/> binds to, in order.
+    /// </summary>
+    /// <remarks>
+    /// An unclosed brace ends the walk, the way <see cref="BindsParameter"/> stops looking at one.
+    /// <c>RouteTokenSyntax</c> is what reports it; this only answers what does bind.
+    /// </remarks>
+    public static IReadOnlyList<string> Names(string pathTemplate) {
+        List<string>? names = null;
+
+        var open = pathTemplate.IndexOf('{');
+
+        while (open >= 0) {
+            var close = pathTemplate.IndexOf('}', open);
+
+            if (close < 0) {
+                break;
+            }
+
+            var name = Name(pathTemplate.Substring(open + 1, close - open - 1));
+
+            if (name.Length > 0) {
+                (names ??= new List<string>()).Add(name);
+            }
+
+            open = pathTemplate.IndexOf('{', close + 1);
+        }
+
+        return (IReadOnlyList<string>?)names ?? Array.Empty<string>();
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteBindingDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteBindingDiagnostics.cs
@@ -1,0 +1,190 @@
+using Hardened.SourceGenerator.Models.Request;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Web.Routing;
+
+/// <summary>
+/// A route token that binds nothing, beside a parameter read from a body the request does not
+/// carry.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>[Get("/{eventid}")]</c> against a parameter called <c>eventId</c> built with zero warnings.
+/// The token bound nothing, the parameter fell through to the body branch, and a GET answered 400
+/// "input does not contain any JSON tokens" at request time - from a route that matched perfectly.
+/// The generator has both lists in hand.
+/// </para>
+/// <para>
+/// <b>Both halves are required, which is deliberate.</b> A token that binds nothing is not a
+/// mistake on its own: a token declared in a <c>[BasePath]</c> and used by only some of the
+/// handlers under it binds nothing on the rest, and that is a route matching more than one handler
+/// needs, not a defect. What makes it a defect is the parameter that fell somewhere else because
+/// of it - either onto a body the verb does not carry, or, whatever the verb, onto a body when its
+/// name differs from the token only by case. A case-only difference is never what anyone meant.
+/// </para>
+/// </remarks>
+public static class RouteBindingDiagnostics {
+
+    /// <summary>
+    /// <c>HRDR005</c>. <c>HRDR002</c> reports a token Hardened does not compile; this reports one
+    /// it compiles and nothing binds.
+    /// </summary>
+    public const string DiagnosticId = "HRDR005";
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the reason
+    /// <c>FormAndBodyDiagnostics.Descriptor</c> is: RS2008 looks for the field, and these projects
+    /// set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "Route token binds no parameter",
+        messageFormat: "Route '{0}' on '{1}.{2}' declares '{{{3}}}', which no parameter binds. {4}",
+        category: "Hardened.Routing",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>The token that binds nothing, and the parameter that went to the body instead.</summary>
+    public readonly struct Finding {
+        public Finding(string token, string bodyParameter, bool caseOnly) {
+            Token = token;
+            BodyParameter = bodyParameter;
+            CaseOnly = caseOnly;
+        }
+
+        /// <summary>The token's name, braces and any constraint stripped.</summary>
+        public string Token { get; }
+
+        /// <summary>The parameter being read from the request body.</summary>
+        public string BodyParameter { get; }
+
+        /// <summary>Whether the two differ only by case.</summary>
+        public bool CaseOnly { get; }
+    }
+
+    /// <summary>Verbs whose requests carry no body to read a parameter out of.</summary>
+    /// <remarks>
+    /// DELETE is not among them. HTTP permits a body on one and some APIs send it, so a body
+    /// parameter there is a choice rather than a mistake - and a DELETE with the trial's typo is
+    /// still reported, through the case-only half of the rule.
+    /// </remarks>
+    private static readonly HashSet<string> BodylessVerbs =
+        new(StringComparer.OrdinalIgnoreCase) { "GET", "HEAD", "OPTIONS", "TRACE" };
+
+    /// <summary>
+    /// Every token that binds nothing while a parameter is read from the body it displaced.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Report"/> because a <c>SourceProductionContext</c> only exists
+    /// inside a running generator, and the decision this makes is worth testing on its own. Same
+    /// split as <c>FormAndBodyDiagnostics.FindConflict</c>.
+    /// </remarks>
+    public static IReadOnlyList<Finding> Find(RequestHandlerModel model) {
+        // A dispatched handler is selected by an exact token in a header, so its path declares
+        // nothing to bind - awsJson sends every operation to POST /.
+        if (model.Name.IsDispatched) {
+            return Array.Empty<Finding>();
+        }
+
+        var tokens = RouteTokens.Names(model.Name.Path);
+
+        if (tokens.Count == 0) {
+            return Array.Empty<Finding>();
+        }
+
+        List<string>? unbound = null;
+
+        foreach (var token in tokens) {
+            if (!Binds(model, token)) {
+                (unbound ??= new List<string>()).Add(token);
+            }
+        }
+
+        if (unbound == null) {
+            return Array.Empty<Finding>();
+        }
+
+        var bodyless = BodylessVerbs.Contains(model.Name.Method);
+        List<Finding>? findings = null;
+
+        foreach (var token in unbound) {
+            foreach (var parameter in model.RequestParameterInformationList) {
+                if (parameter.BindingType != ParameterBindType.Body) {
+                    continue;
+                }
+
+                var caseOnly = string.Equals(parameter.Name, token, StringComparison.OrdinalIgnoreCase);
+
+                if (!caseOnly && !bodyless) {
+                    continue;
+                }
+
+                (findings ??= new List<Finding>()).Add(new Finding(token, parameter.Name, caseOnly));
+
+                break;
+            }
+        }
+
+        return (IReadOnlyList<Finding>?)findings ?? Array.Empty<Finding>();
+    }
+
+    /// <summary>
+    /// Whether any parameter binds this token. Read the way the binder reads it: a described
+    /// parameter carries the wire name the route declares and a C# identifier that may differ, and
+    /// a code-first one carries only the identifier.
+    /// </summary>
+    private static bool Binds(RequestHandlerModel model, string token) {
+        foreach (var parameter in model.RequestParameterInformationList) {
+            if (parameter.BindingType != ParameterBindType.Path) {
+                continue;
+            }
+
+            var bound = string.IsNullOrEmpty(parameter.BindingName)
+                ? parameter.Name
+                : parameter.BindingName;
+
+            if (string.Equals(bound, token, StringComparison.Ordinal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// What to tell the author, built here rather than in the message format so it can carry both
+    /// identifiers.
+    /// </summary>
+    public static string Advice(RequestHandlerModel model, Finding finding) {
+        if (finding.CaseOnly) {
+            return
+                $"'{finding.BodyParameter}' differs from it only by case, so it is read from the " +
+                $"request body instead. Route tokens bind by exact name: spell the token " +
+                $"'{{{finding.BodyParameter}}}', or rename the parameter to '{finding.Token}'.";
+        }
+
+        return
+            $"'{finding.BodyParameter}' matches no token either, so it is read from the request " +
+            $"body - and a {model.Name.Method} carries none, so every request is refused before " +
+            $"the handler runs. Name a parameter '{finding.Token}', or bind " +
+            $"'{finding.BodyParameter}' with [FromQueryString] or [FromHeader].";
+    }
+
+    /// <summary>Reports every finding, if the handler has any.</summary>
+    public static void Report(SourceProductionContext context, RequestHandlerModel model) {
+        foreach (var finding in Find(model)) {
+            // Location.None, as everywhere else models are reported from: a syntax location would
+            // travel with the model through the incremental caches, which compare models for
+            // equality to decide whether to regenerate. The message carries the route and handler
+            // instead.
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptor(),
+                Location.None,
+                model.Name.Path,
+                model.ControllerType.Name,
+                model.HandlerMethod,
+                finding.Token,
+                Advice(model, finding)));
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTokenSyntax.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTokenSyntax.cs
@@ -25,6 +25,13 @@ namespace Hardened.SourceGenerator.Web.Routing;
 /// the application, so a declaration that does not mean what it says has to stop the build rather
 /// than reach production.
 /// </para>
+///
+/// <para>
+/// The template itself is read strictly for the same reason. An unbalanced brace, a token with no
+/// name, and one name declared twice each produced a route that compiled and matched nothing the
+/// author meant it to match — <c>[Get("/{eventId")]</c> built with zero warnings and answered 400
+/// to every request shape.
+/// </para>
 /// </summary>
 public static class RouteTokenSyntax {
 
@@ -39,7 +46,16 @@ public static class RouteTokenSyntax {
         Optional,
 
         /// <summary><c>{id=5}</c> — a default value.</summary>
-        Default
+        Default,
+
+        /// <summary><c>{id</c>, or a stray <c>}</c> — a brace with no partner.</summary>
+        Unbalanced,
+
+        /// <summary><c>{}</c> or <c>{:int}</c> — a token with nothing to bind to.</summary>
+        Unnamed,
+
+        /// <summary>The same token name twice in one route.</summary>
+        Duplicate
     }
 
     public readonly struct Finding {
@@ -77,33 +93,66 @@ public static class RouteTokenSyntax {
     public static IReadOnlyList<Finding> Scan(
         string pathTemplate, IReadOnlyCollection<string>? declaredConstraints = null) {
         List<Finding>? findings = null;
+        HashSet<string>? seen = null;
 
         var open = pathTemplate.IndexOf('{');
+        var stray = pathTemplate.IndexOf('}');
+
+        // A closing brace before any opening one is as unbalanced as the reverse, and reads the
+        // same way to whoever typed it.
+        if (stray >= 0 && (open < 0 || stray < open)) {
+            Add(ref findings, new Finding(
+                pathTemplate.Substring(stray, 1), Form.Unbalanced, "", null));
+        }
 
         while (open >= 0) {
             var close = pathTemplate.IndexOf('}', open);
 
+            // A brace that is never closed used to end the scan silently, which is how
+            // [Get("/{eventId")] built with zero warnings: the rest of the template became literal
+            // text, the route matched nothing anybody sent, and the parameter it was written to
+            // bind was read from the request body instead.
             if (close < 0) {
+                Add(ref findings, new Finding(
+                    pathTemplate.Substring(open), Form.Unbalanced,
+                    Name(pathTemplate.Substring(open + 1)), null));
+
                 break;
             }
 
             var body = pathTemplate.Substring(open + 1, close - open - 1);
-            var form = Classify(body, declaredConstraints);
+            var token = pathTemplate.Substring(open, close - open + 1);
+            var name = Name(body);
 
-            if (form != Form.Supported) {
-                findings ??= new List<Finding>();
+            // A second '{' inside a token is the same mistake seen from the other end: one of the
+            // two braces has no partner.
+            if (body.IndexOf('{') >= 0) {
+                Add(ref findings, new Finding(token, Form.Unbalanced, name, null));
+            }
+            else if (name.Length == 0) {
+                Add(ref findings, new Finding(token, Form.Unnamed, name, null));
+            }
+            else if (!(seen ??= new HashSet<string>(StringComparer.Ordinal)).Add(name)) {
+                Add(ref findings, new Finding(token, Form.Duplicate, name, null));
+            }
+            else {
+                var form = Classify(body, declaredConstraints);
 
-                findings.Add(new Finding(
-                    pathTemplate.Substring(open, close - open + 1),
-                    form,
-                    Name(body),
-                    RouteTokens.Constraint(body)));
+                if (form != Form.Supported) {
+                    Add(ref findings, new Finding(token, form, name, RouteTokens.Constraint(body)));
+                }
             }
 
             open = pathTemplate.IndexOf('{', close + 1);
         }
 
         return (IReadOnlyList<Finding>?)findings ?? Array.Empty<Finding>();
+    }
+
+    private static void Add(ref List<Finding>? findings, Finding finding) {
+        findings ??= new List<Finding>();
+
+        findings.Add(finding);
     }
 
     /// <summary>
@@ -143,6 +192,23 @@ public static class RouteTokenSyntax {
                     $"the token name, so nothing binds to '{name}'. Give the handler's '{name}' " +
                     $"parameter a C# default instead; the template controls matching and C# " +
                     $"supplies the value.";
+
+            case Form.Unbalanced:
+                return
+                    "This brace has no partner, so what was written as a token is matched as " +
+                    "literal text and the parameter it was written to bind is read from the " +
+                    "request body instead. Close the token.";
+
+            case Form.Unnamed:
+                return
+                    "A token with no name binds nothing. Name it, or drop the braces if the " +
+                    "segment is literal.";
+
+            case Form.Duplicate:
+                return
+                    $"'{name}' is declared twice in this route. Two tokens of one name cannot both " +
+                    $"bind the handler's '{name}' parameter, and only one of the two segments a " +
+                    $"request sends would reach it. Give them distinct names.";
 
             default:
                 return "";

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
@@ -49,6 +49,10 @@ public class WebExecutionHandlerCodeGenerator {
         // class that was never written.
         FormAndBodyDiagnostics.Report(sourceProductionContext, requestHandlerModel);
 
+        // And the same treatment again: a token that binds nothing leaves a handler that compiles
+        // and routes, and refuses every request once it is running.
+        RouteBindingDiagnostics.Report(sourceProductionContext, requestHandlerModel);
+
         var sourceFile = GenerateFile(requestHandlerModel, sourceProductionContext.CancellationToken, excludeFromCoverage);
 
         sourceProductionContext.AddSource(requestHandlerModel.InvokeHandlerType.Name, GeneratedSource.Header(sourceFile));

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteBindingDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteBindingDiagnosticsTests.cs
@@ -1,0 +1,163 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// A route token that binds nothing, beside a parameter that fell onto the request body because of
+/// it.
+///
+/// <para>
+/// CS-09. <c>[Get("/{eventid}")]</c> against a parameter called <c>eventId</c> built with zero
+/// warnings and answered 400 "input does not contain any JSON tokens" to every request, from a
+/// route that matched perfectly. Both lists are in the generator's hand.
+/// </para>
+/// </summary>
+public class RouteBindingDiagnosticsTests {
+    private const string DiagnosticId = "HRDR005";
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)   // Hardened.Requests.Abstract
+    ];
+
+    private static GeneratorResult Generate(string verb, string route, string parameters) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Test.cs"] = $$"""
+                    using Hardened.Requests.Abstract.Attributes;
+                    using Hardened.Shared.Runtime.Attributes;
+                    using Hardened.Web.Runtime.Attributes;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    public partial class TestApplication { }
+
+                    public class EventBody {
+                        public string Title { get; set; } = "";
+                    }
+
+                    public class EventController {
+                        [{{verb}}("{{route}}")]
+                        public string Handle({{parameters}}) => "";
+                    }
+                    """
+            },
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors);
+
+    private static Diagnostic Reported(string verb, string route, string parameters) {
+        var result = Generate(verb, route, parameters);
+
+        var diagnostic = result.GeneratorDiagnostics
+            .SingleOrDefault(reported => reported.Id == DiagnosticId);
+
+        Assert.True(diagnostic != null,
+            $"'{verb} {route}' with '{parameters}' reported no {DiagnosticId}. Reported: " +
+            string.Join(", ", result.GeneratorDiagnostics.Select(reported => reported.Id)));
+
+        return diagnostic!;
+    }
+
+    private static void NotReported(string verb, string route, string parameters) {
+        Assert.DoesNotContain(
+            Generate(verb, route, parameters).GeneratorDiagnostics,
+            reported => reported.Id == DiagnosticId);
+    }
+
+    /// <summary>The trial's exact repro.</summary>
+    [Fact]
+    public void ATokenDifferingOnlyByCaseIsAnError() {
+        Assert.Equal(
+            DiagnosticSeverity.Error,
+            Reported("Get", "/events/{eventid}", "string eventId").Severity);
+    }
+
+    /// <summary>
+    /// The message names both identifiers and says which way to fix it. Naming only the token
+    /// leaves the reader to spot a difference of one character.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesBothIdentifiersAndTheCaseDifference() {
+        var message = Reported("Get", "/events/{eventid}", "string eventId").GetMessage();
+
+        Assert.Contains("{eventid}", message);
+        Assert.Contains("eventId", message);
+        Assert.Contains("only by case", message);
+        Assert.Contains("EventController", message);
+        Assert.Contains("Handle", message);
+    }
+
+    /// <summary>
+    /// A case difference is never intentional, so the verb does not matter - a PUT with the same
+    /// typo silently takes two readings of one body.
+    /// </summary>
+    [Fact]
+    public void ACaseDifferenceIsReportedOnABodyCarryingVerbToo() {
+        Assert.Equal(
+            DiagnosticSeverity.Error,
+            Reported("Put", "/events/{eventid}", "string eventId, EventBody body").Severity);
+    }
+
+    /// <summary>
+    /// A misspelling that is not merely a case difference reaches the same place, and the message
+    /// says what the verb costs it.
+    /// </summary>
+    [Fact]
+    public void AMisspeltTokenOnABodylessVerbIsAnError() {
+        var message = Reported("Get", "/events/{eventKey}", "string eventId").GetMessage();
+
+        Assert.Contains("{eventKey}", message);
+        Assert.Contains("eventId", message);
+        Assert.Contains("carries none", message);
+        Assert.Contains("FromQueryString", message);
+    }
+
+    [Theory]
+    [InlineData("Get", "/events/{eventId}", "string eventId")]
+    [InlineData("Get", "/events/{eventId}/holds/{holdId}", "string eventId, string holdId")]
+    [InlineData("Get", "/events/{*path}", "string path")]
+    [InlineData("Get", "/events/{eventId:int}", "int eventId")]
+    [InlineData("Get", "/events", "")]
+    [InlineData("Post", "/events", "EventBody body")]
+    [InlineData("Post", "/events/{eventId}", "string eventId, EventBody body")]
+    public void ARouteThatBindsWhatItDeclaresIsNotReported(
+        string verb, string route, string parameters) {
+        NotReported(verb, route, parameters);
+    }
+
+    /// <summary>
+    /// A GET that reads nothing from the body has nothing to report, however its tokens are spelt -
+    /// which is what a token declared in a shared base path and used by only some handlers under it
+    /// looks like.
+    /// </summary>
+    [Fact]
+    public void AnUnboundTokenWithNoBodyParameterIsNotReported() {
+        NotReported("Get", "/events/{eventId}/holds/{holdId}", "string eventId");
+    }
+
+    /// <summary>
+    /// A parameter the author placed by hand is where the author put it, and the token that binds
+    /// nothing has nowhere else to have sent it.
+    /// </summary>
+    [Fact]
+    public void AParameterBoundFromTheQueryStringIsNotABodyRead() {
+        NotReported("Get", "/events/{eventKey}", "[FromQueryString(\"page\")] int page");
+    }
+
+    /// <summary>
+    /// The handler is still emitted, for the reason an unsupported token leaves it emitted: the
+    /// routing table would otherwise point at a class that was never written, burying the one
+    /// diagnostic that says what is wrong.
+    /// </summary>
+    [Fact]
+    public void TheHandlerIsStillEmitted() {
+        var result = Generate("Get", "/events/{eventid}", "string eventId");
+
+        Assert.Contains(result.GeneratedSources.Keys, key => key.Contains("EventController_Handle"));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteTokenSyntaxTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteTokenSyntaxTests.cs
@@ -66,6 +66,10 @@ public class RouteTokenSyntaxTests {
     [Theory]
     [InlineData("/items/{id?}")]
     [InlineData("/items/{id=5}")]
+    [InlineData("/items/{id")]
+    [InlineData("/items/}")]
+    [InlineData("/items/{}")]
+    [InlineData("/items/{id}/parts/{id}")]
     public void AnUnsupportedTokenFormIsAnError(string route) {
         Assert.Equal(DiagnosticSeverity.Error, Reported(route).Severity);
     }
@@ -77,6 +81,8 @@ public class RouteTokenSyntaxTests {
     [Theory]
     [InlineData("/items/{id?}", "{id?}")]
     [InlineData("/items/{id=5}", "{id=5}")]
+    [InlineData("/items/{id", "{id")]
+    [InlineData("/items/{}", "{}")]
     public void TheMessageNamesTheTokenAsWritten(string route, string token) {
         Assert.Contains(token, Reported(route).GetMessage());
     }
@@ -132,4 +138,61 @@ public class RouteTokenSyntaxTests {
 
         Assert.Contains(result.GeneratedSources.Keys, key => key.Contains("ItemController_ItemById"));
     }
+
+    #region a template that is not well formed
+
+    /// <summary>
+    /// CS-12. <c>[Get("/{eventId")]</c> built with zero warnings: the unclosed token was matched as
+    /// literal text, so the route answered nothing anybody sent, and the parameter it was written
+    /// to bind was read from the request body instead.
+    /// </summary>
+    [Fact]
+    public void AnUnclosedTokenSaysWhatItCostsAndHowToFixIt() {
+        var message = Reported("/items/{id").GetMessage();
+
+        Assert.Contains("no partner", message);
+        Assert.Contains("literal text", message);
+    }
+
+    /// <summary>
+    /// A closing brace with no opening one is the same mistake seen from the other end.
+    /// </summary>
+    [Fact]
+    public void AStrayClosingBraceIsReported() {
+        Assert.Equal(DiagnosticSeverity.Error, Reported("/items/}").Severity);
+    }
+
+    /// <summary>
+    /// A token with no name is not a token. It binds nothing and matches one segment of anything.
+    /// </summary>
+    [Theory]
+    [InlineData("/items/{}")]
+    [InlineData("/items/{:int}")]
+    public void AnUnnamedTokenIsReported(string route) {
+        Assert.Contains("binds nothing", Reported(route).GetMessage());
+    }
+
+    /// <summary>
+    /// One name declared twice cannot bind one parameter twice, so only one of the two segments a
+    /// request sends ever reaches it.
+    /// </summary>
+    [Fact]
+    public void ANameDeclaredTwiceIsReported() {
+        var message = Reported("/items/{id}/parts/{id}").GetMessage();
+
+        Assert.Contains("declared twice", message);
+        Assert.Contains("distinct names", message);
+    }
+
+    /// <summary>
+    /// Two tokens that differ are not a duplicate, which is the ordinary shape of a nested route.
+    /// </summary>
+    [Fact]
+    public void TwoDistinctTokensAreNotADuplicate() {
+        Assert.DoesNotContain(
+            Generate("/items/{id}/parts/{partId}").GeneratorDiagnostics,
+            reported => reported.Id == DiagnosticId);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
A2 / H-04 and A6 / H-18 from the 0.19 work order. They share the route-template parser, so they share a PR.

**A6 — the template is read strictly.** `RouteTokenSyntax.Scan` ended its walk at an unclosed brace, so `[Get("/{eventId")]` built with zero warnings: the rest of the template became literal text, the route matched nothing anybody sent, and the parameter it was written to bind fell through to the request body. Three malformed shapes now join the brace forms HRDR002 already refuses — an unbalanced brace (either direction, including a `{` nested inside a token), a token with no name, and one name declared twice. Each says what the route actually does and how to fix it.

**A2 — a token that binds nothing.** `[Get("/{eventid}")]` against a parameter called `eventId` built clean and generated a body read on a GET, which answered 400 "input does not contain any JSON tokens" to every request from a route that matched perfectly. New `HRDR005` reports the token beside the parameter that went to the body because of it, naming both identifiers:

```
Route '/events/{eventid}' on 'EventController.Get' declares '{eventid}', which no parameter
binds. 'eventId' differs from it only by case, so it is read from the request body instead.
Route tokens bind by exact name: spell the token '{eventId}', or rename the parameter to
'eventid'.
```

**Both halves are required, which is what keeps HRDR005 quiet on correct code.** A token that binds nothing is not a mistake on its own — one declared in a shared `[BasePath]` binds nothing on the handlers under it that do not need it, and that is a route matching more than one handler needs. What makes it a defect is the parameter that went somewhere else because of it: onto a body a `GET`, `HEAD`, `OPTIONS` or `TRACE` does not carry, or — whatever the verb — onto a body when its name differs from the token only by case, which is never what anyone meant. `DELETE` is not treated as bodyless; HTTP permits a body on one and some APIs send it.

A described parameter binds by the wire name its contract declares rather than by the C# identifier allocated for it, or every spec-first path parameter would be reported. `RouteBindingConflictTests` pins that directly.

Both diagnostics leave the handler emitted, for the reason HRDR002 already did: the routing table filters on unresolved parameters rather than on token syntax, so dropping it would bury the one useful diagnostic under a pile of CS0246s.

`docs/generator-diagnostics.md` gains a Routing section with both codes.

Validated:

- CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors. Every route in the solution still builds.
- `dotnet test` on the solution — 31 suites green, including 12 new generator-driven cases and 11 new rule-level ones.
- `scripts/verify-templates.sh` — green across all seven default rows; Smithy rows self-skip on this machine (CLI 1.56.0 against the 1.73.0 pin).

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
