### PR TITLE
Warn when a nested type's constraints are never reached

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -80,6 +80,36 @@ framework's own `AspNetCoreRuntime` is one.
 
 One report per assembly, not one per route: there is a single thing to fix.
 
+## Validation
+
+### HRDV004 — nested constraints are never reached
+
+A generated validator descends into a member only where `[ValidateNested]` says to, so omitting it
+switches off every constraint on the child type. Nothing said so at build time or at run time: the
+trial's price tiers stored as 201 with an empty code and a negative price, from a model whose
+constraints were all declared and all correct.
+
+```
+'CreateEvent.PriceTiers' does not declare [ValidateNested] and its element type 'PriceTier'
+declares constraints, so none of them run and an invalid 'PriceTier' is accepted with no
+error. Add [ValidateNested] to the property, or set <NoWarn>$(NoWarn);HRDV004</NoWarn> if the
+skip is intended.
+```
+
+A warning rather than an error, because not descending is sometimes what was meant — a member
+validated by a later step, a shared type whose constraints belong to another operation. The
+`NoWarn` is what makes that choice deliberate rather than silent.
+
+Reported on a property of a type that constrains something itself, whose member, array element,
+collection element or dictionary value is a type declared in the same compilation carrying
+constraints in either vocabulary. A type that constrains nothing is not a model this generator
+validates — a data seed holding a list of records, a response case wrapping a body — and its
+validator was never going to descend anywhere.
+
+Descending by default is the better answer and is on the table for 1.0. It cannot be the answer in
+a 0.x release: it changes what an existing application answers, from 201 to 400, on payloads it
+accepts today.
+
 ## Other diagnostics
 
 | Id | Meaning |
@@ -88,7 +118,7 @@ One report per assembly, not one per route: there is a single thing to fix.
 | `HOAG002` | The description could not be parsed; the build task's message is passed through. |
 | `HOAG010` | A handler was skipped because a parameter type did not resolve. Other handlers are unaffected. |
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
-| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. `HRDR006` is above. |
+| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. The ones with an entry have a section above. |
 
 ## Description build tasks (HOAT, HSMT)
 

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
@@ -556,6 +556,246 @@ public class ValidationGeneratorTests {
 
     #endregion
 
+
+    // ---------------------------------------- nested constraints nothing reaches
+
+    /// <summary>
+    /// A parent that validates, a child that declares constraints, and the one attribute that
+    /// connects them.
+    /// </summary>
+    private static string Nested(string property) => $$"""
+        using System.Collections.Generic;
+        using ValidationModules.Constraints;
+
+        namespace TestApp.Models;
+
+        public class PriceTier {
+            [Pattern("^[A-Z]+$")]
+            public string Code { get; set; } = "";
+
+            [Range(1, 1000)]
+            public int Price { get; set; }
+        }
+
+        public class CreateEvent {
+            [Required]
+            [StringLength(Min = 1, Max = 200)]
+            public string Title { get; set; } = "";
+
+            {{property}}
+        }
+        """;
+
+    /// <summary>
+    /// CS-11. Removing <c>[ValidateNested]</c> from the collection stopped every constraint on
+    /// <c>PriceTier</c> from running, and invalid tiers stored as 201 with no build or runtime
+    /// signal - though the generator compiled those constraints itself and can see the property
+    /// that no longer reaches them.
+    /// </summary>
+    [Fact]
+    public void ACollectionWithoutValidateNestedIsReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", Nested("public List<PriceTier> PriceTiers { get; set; } = new();")));
+
+        var warning = Assert.Single(Warnings(result, "HRDV004"));
+
+        Assert.Contains("PriceTiers", warning.GetMessage());
+        Assert.Contains("PriceTier", warning.GetMessage());
+        Assert.Contains("element", warning.GetMessage());
+        Assert.Contains("[ValidateNested]", warning.GetMessage());
+    }
+
+    /// <summary>
+    /// The message names both fixes, because not descending is sometimes what was meant.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheSuppressionAsWellAsTheFix() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", Nested("public List<PriceTier> PriceTiers { get; set; } = new();")));
+
+        Assert.Contains("HRDV004", Assert.Single(Warnings(result, "HRDV004")).GetMessage());
+    }
+
+    [Fact]
+    public void AWarningRatherThanAnError() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", Nested("public List<PriceTier> PriceTiers { get; set; } = new();")));
+
+        Assert.Equal(
+            DiagnosticSeverity.Warning, Assert.Single(Warnings(result, "HRDV004")).Severity);
+    }
+
+    /// <summary>Every shape a descent can take, and every one of them stops without the attribute.</summary>
+    [Theory]
+    [InlineData("public PriceTier Tier { get; set; } = new();", "member")]
+    [InlineData("public PriceTier[] Tiers { get; set; } = [];", "element")]
+    [InlineData("public List<PriceTier> Tiers { get; set; } = new();", "element")]
+    [InlineData("public IReadOnlyList<PriceTier> Tiers { get; } = [];", "element")]
+    [InlineData("public Dictionary<string, PriceTier> Tiers { get; set; } = new();", "element")]
+    public void EveryNestedShapeIsReported(string property, string kind) {
+        var result = Run(("Entry.cs", EntryPoint), ("Models.cs", Nested(property)));
+
+        Assert.Contains(kind, Assert.Single(Warnings(result, "HRDV004")).GetMessage());
+    }
+
+    /// <summary>The attribute is the whole of what silences it.</summary>
+    [Theory]
+    [InlineData("[ValidateNested]\n    public PriceTier Tier { get; set; } = new();")]
+    [InlineData("[ValidateNested]\n    public List<PriceTier> Tiers { get; set; } = new();")]
+    public void DeclaringValidateNestedIsNotReported(string property) {
+        var result = Run(("Entry.cs", EntryPoint), ("Models.cs", Nested(property)));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+
+        result.AssertNoErrors();
+    }
+
+    /// <summary>A child with nothing to check has nothing to become unreachable.</summary>
+    [Fact]
+    public void AChildWithNoConstraintsIsNotReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class Address {
+                    public string City { get; set; } = "";
+                }
+
+                public class Customer {
+                    [Required]
+                    public string Name { get; set; } = "";
+
+                    public Address Home { get; set; } = new();
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>
+    /// A parent that constrains nothing is not a model this generator validates - a data seed
+    /// holding a list of records, a response case wrapping a body - and a validator that checks
+    /// nothing was never going to descend anywhere.
+    /// </summary>
+    [Fact]
+    public void AParentThatConstrainsNothingIsNotReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using System.Collections.Generic;
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class PriceTier {
+                    [Pattern("^[A-Z]+$")]
+                    public string Code { get; set; } = "";
+                }
+
+                public class SeedData {
+                    public IReadOnlyList<PriceTier> Tiers { get; } = [];
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>A string is a sequence of characters, not a nested model.</summary>
+    [Fact]
+    public void AStringMemberIsNotADescent() {
+        var result = Run(
+            ("Entry.cs", EntryPoint), ("Customer.cs", Model()));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>
+    /// A type that holds one of itself would otherwise report against its own constraints.
+    /// </summary>
+    [Fact]
+    public void ASelfReferenceIsNotReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class Node {
+                    [Required]
+                    public string Name { get; set; } = "";
+
+                    public Node? Parent { get; set; }
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>The DataAnnotations vocabulary reaches the same place, on both sides.</summary>
+    [Fact]
+    public void DataAnnotationsConstraintsCountAsConstraints() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using System.Collections.Generic;
+                using System.ComponentModel.DataAnnotations;
+
+                namespace TestApp.Models;
+
+                public class Line {
+                    [Range(1, 100)]
+                    public int Quantity { get; set; }
+                }
+
+                public class Order {
+                    [Required]
+                    public string Reference { get; set; } = "";
+
+                    public List<Line> Lines { get; set; } = new();
+                }
+                """));
+
+        Assert.Single(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>
+    /// An attribute that names a member rather than constraining it is not a constraint.
+    /// <c>[Display]</c> does not derive from <c>ValidationAttribute</c>, which is what the check
+    /// walks the base chain for rather than listing names.
+    /// </summary>
+    [Fact]
+    public void ANamingAttributeIsNotAConstraint() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using System.Collections.Generic;
+                using System.ComponentModel.DataAnnotations;
+
+                namespace TestApp.Models;
+
+                public class Line {
+                    [Display(Name = "How many")]
+                    public int Quantity { get; set; }
+                }
+
+                public class Order {
+                    [Required]
+                    public string Reference { get; set; } = "";
+
+                    public List<Line> Lines { get; set; } = new();
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
     /// <summary>
     /// The whole arrangement, compiled: entry point, several constrained models, both attribute
     /// vocabularies, and the registration that wires them together.

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator/HardenedValidationGenerator.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator/HardenedValidationGenerator.cs
@@ -180,8 +180,203 @@ public class HardenedValidationGenerator : IIncrementalGenerator {
         var diagnostics = frontEnd.Diagnostics.ToList();
 
         diagnostics.AddRange(RequiredValueTypesThatCannotBeMissed(symbol));
+        diagnostics.AddRange(UnreachableNestedConstraints(symbol, model));
 
         return new ModelResult(model, diagnostics.ToImmutableArray());
+    }
+
+    /// <summary>
+    /// Members whose type declares constraints that this type's validator will never reach.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The generated validator descends into a member only where <c>[ValidateNested]</c> says to,
+    /// so omitting it silently switches off every constraint on the child type. The generator
+    /// compiled those constraints and can see the property that fails to reach them, which is what
+    /// makes this sayable at all.
+    /// </para>
+    /// <para>
+    /// Sited on the symbol rather than the built model for the reason the required-value-type check
+    /// is: what decides it is the member's C# type and the child type's attributes, and the
+    /// validation IR has already resolved both away.
+    /// </para>
+    /// <para>
+    /// Only child types declared in this compilation are considered. Those are the ones this
+    /// generator emits validators for, so "a constraint that just became unreachable" is knowable
+    /// rather than guessed at - a type from a package may have been validated at its own boundary.
+    /// </para>
+    /// <para>
+    /// And only parents that constrain something themselves. Every type declaration in the
+    /// compilation reaches this generator, most of which are not models at all - a data seed
+    /// holding a list of records, a response case wrapping a body - and a validator that checks
+    /// nothing was never going to descend anywhere. What the warning is about is a model that
+    /// validates, with one property the validation stops at.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<Diagnostic> UnreachableNestedConstraints(
+        INamedTypeSymbol symbol, ValidatedTypeModel? model) {
+        if (!Constrains(model)) {
+            yield break;
+        }
+
+        foreach (var member in symbol.GetMembers()) {
+            if (member is not IPropertySymbol property || property.IsStatic ||
+                property.DeclaredAccessibility != Accessibility.Public) {
+                continue;
+            }
+
+            if (DeclaresValidateNested(property)) {
+                continue;
+            }
+
+            var nested = NestedType(property.Type, out var isElement);
+
+            if (nested == null || SymbolEqualityComparer.Default.Equals(nested, symbol) ||
+                !DeclaredInSource(nested) || !CarriesConstraints(nested)) {
+                continue;
+            }
+
+            yield return ValidationGeneratorDiagnostics.UnreachableNestedConstraints(
+                symbol, property, nested, isElement);
+        }
+    }
+
+    /// <summary>Whether the built model checks anything at all.</summary>
+    private static bool Constrains(ValidatedTypeModel? model) {
+        if (model == null) {
+            return false;
+        }
+
+        foreach (var property in model.Properties) {
+            if (property.Constraints.Count > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool DeclaresValidateNested(IPropertySymbol property) {
+        foreach (var attribute in property.GetAttributes()) {
+            if (attribute.AttributeClass?.ToDisplayString()
+                == "ValidationModules.Constraints.ValidateNestedAttribute") {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The type a descent would validate: the element of a collection, the value of a dictionary,
+    /// or the member's own type. Null where there is nothing with structure to descend into.
+    /// </summary>
+    /// <remarks>
+    /// A string is a sequence of characters and never a nested model, which is why it is taken out
+    /// before the enumerable test rather than after it.
+    /// </remarks>
+    private static INamedTypeSymbol? NestedType(ITypeSymbol type, out bool isElement) {
+        isElement = false;
+
+        if (type is IArrayTypeSymbol array) {
+            isElement = true;
+
+            return Model(array.ElementType);
+        }
+
+        if (type.SpecialType == SpecialType.System_String) {
+            return null;
+        }
+
+        if (type is INamedTypeSymbol named) {
+            if (named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T) {
+                return Model(named.TypeArguments[0]);
+            }
+
+            foreach (var candidate in Self(named).Concat(named.AllInterfaces)) {
+                var definition = candidate.OriginalDefinition.ToDisplayString();
+
+                if (definition is "System.Collections.Generic.IDictionary<TKey, TValue>"
+                               or "System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>") {
+                    isElement = true;
+
+                    return Model(candidate.TypeArguments[1]);
+                }
+            }
+
+            foreach (var candidate in Self(named).Concat(named.AllInterfaces)) {
+                if (candidate.OriginalDefinition.ToDisplayString()
+                    == "System.Collections.Generic.IEnumerable<T>") {
+                    isElement = true;
+
+                    return Model(candidate.TypeArguments[0]);
+                }
+            }
+        }
+
+        return Model(type);
+    }
+
+    private static IEnumerable<INamedTypeSymbol> Self(INamedTypeSymbol type) {
+        yield return type;
+    }
+
+    /// <summary>The type as something a validator could be generated for, or null.</summary>
+    private static INamedTypeSymbol? Model(ITypeSymbol type) =>
+        type is INamedTypeSymbol named &&
+        named.TypeKind is TypeKind.Class or TypeKind.Struct &&
+        named.SpecialType == SpecialType.None
+            ? named
+            : null;
+
+    private static bool DeclaredInSource(INamedTypeSymbol type) {
+        foreach (var location in type.Locations) {
+            if (location.IsInSource) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether any member of the type carries a constraint from either vocabulary the front end
+    /// reads.
+    /// </summary>
+    /// <remarks>
+    /// Matched by walking the attribute's base chain to <c>ValidationConstraintAttribute</c> or
+    /// <c>ValidationAttribute</c> rather than by listing names: those two bases are what the front
+    /// end compiles, and a list would go stale the first time either vocabulary gained a
+    /// constraint. It also keeps <c>[Display]</c> and <c>[Key]</c> out, which name a member rather
+    /// than constrain it.
+    /// </remarks>
+    private static bool CarriesConstraints(INamedTypeSymbol type) {
+        foreach (var member in type.GetMembers()) {
+            if (member is not IPropertySymbol property || property.IsStatic) {
+                continue;
+            }
+
+            foreach (var attribute in property.GetAttributes()) {
+                if (IsConstraint(attribute.AttributeClass)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsConstraint(INamedTypeSymbol? attributeClass) {
+        for (var type = attributeClass; type != null; type = type.BaseType) {
+            var name = type.ToDisplayString();
+
+            if (name is "ValidationModules.Constraints.ValidationConstraintAttribute"
+                     or "System.ComponentModel.DataAnnotations.ValidationAttribute") {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator/ValidationGeneratorDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator/ValidationGeneratorDiagnostics.cs
@@ -72,6 +72,50 @@ public static class ValidationGeneratorDiagnostics {
         isEnabledByDefault: true);
 
     /// <summary>
+    /// A property whose type carries constraints that nothing will run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A generated validator descends into a member only where <c>[ValidateNested]</c> says to.
+    /// Omit it and every constraint on the child type stops running: the trial's price tiers stored
+    /// as 201 with an empty code and a negative price, from a model whose constraints were all
+    /// declared and all correct. Nothing at build time and nothing at run time said so.
+    /// </para>
+    /// <para>
+    /// <b>A warning rather than an error</b>, because not descending is a legitimate choice - a
+    /// member validated by a later step, a shared type whose constraints belong to another
+    /// operation. The <c>NoWarn</c> is what makes that choice deliberate rather than silent.
+    /// </para>
+    /// <para>
+    /// Reported against the parent's property rather than the child's constraints, because that is
+    /// where the one-word fix goes. The child type is named too: the constraints that go unrun are
+    /// not visible from the line the diagnostic sits on.
+    /// </para>
+    /// </remarks>
+    public static readonly DiagnosticDescriptor UnreachableNestedConstraintsDescriptor = new(
+        "HRDV004",
+        "Nested constraints are never reached",
+        "'{0}.{1}' does not declare [ValidateNested] and its {2} type '{3}' declares constraints, " +
+        "so none of them run and an invalid '{3}' is accepted with no error. Add [ValidateNested] " +
+        "to the property, or set <NoWarn>$(NoWarn);HRDV004</NoWarn> if the skip is intended.",
+        "Hardened.Validation",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports <see cref="UnreachableNestedConstraintsDescriptor"/> against the parent's property.
+    /// </summary>
+    public static Diagnostic UnreachableNestedConstraints(
+        INamedTypeSymbol owner, IPropertySymbol property, ITypeSymbol nested, bool isElement) =>
+        Diagnostic.Create(
+            UnreachableNestedConstraintsDescriptor,
+            property.Locations.Length > 0 ? property.Locations[0] : Location.None,
+            owner.Name,
+            property.Name,
+            isElement ? "element" : "member",
+            nested.Name);
+
+    /// <summary>
     /// Reports <see cref="RequiredValueTypeCannotBeMissedDescriptor"/> against the member.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
A4 / H-06 from the 0.19 work order.

A generated validator descends into a member only where `[ValidateNested]` says to, so omitting it switches off every constraint on the child type. The trial's price tiers stored as 201 with an empty code and a negative price, from a model whose constraints were all declared and all correct — and nothing said so at build time or at run time, though the generator compiled those constraints itself and can see the property that no longer reaches them.

New `HRDV004` names that property, the child type, and both remedies:

```
'CreateEvent.PriceTiers' does not declare [ValidateNested] and its element type 'PriceTier'
declares constraints, so none of them run and an invalid 'PriceTier' is accepted with no
error. Add [ValidateNested] to the property, or set <NoWarn>$(NoWarn);HRDV004</NoWarn> if the
skip is intended.
```

A warning rather than an error: not descending is sometimes what was meant — a member validated by a later step, a shared type whose constraints belong to another operation. The `NoWarn` is what makes that choice deliberate rather than silent.

**Reported only on a parent that constrains something itself**, which is what keeps it quiet. Every type declaration in the compilation reaches this generator and most are not models — a data seed holding a list of records, a response case wrapping a body — and a validator that checks nothing was never going to descend anywhere. Without that gate the solution's own build carried seven of these, none of them actionable; with it, zero.

Constraints are recognised by walking the attribute's base chain to `ValidationConstraintAttribute` or `ValidationAttribute` rather than by listing names, so both vocabularies count and `[Display]` does not. Members, array elements, `IEnumerable<T>` elements and `IDictionary<K,V>` values are all descents; a string is not, and neither is a type from a package — those are validated at their own boundary.

The docs entry records that descending by default is the better answer and belongs to 1.0: it changes what an existing application answers, from 201 to 400, on payloads it accepts today.

Validated:

- CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors.
- `dotnet test` on the solution — 31 suites green, including 15 new cases covering every nested shape, both vocabularies, the suppression, and each way the check stays quiet.
- `scripts/verify-templates.sh` — green across all seven default rows; the scaffolded models raise nothing.

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
