### PR TITLE
Refuse a description that references what it does not declare

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -89,6 +89,7 @@ the other.
 | `017` | `SourceUrl` without `EmbedDocument`, so there is no source to serve. |
 | `020`–`025` | The shared model-diagnostics pass. See below. |
 | `026` | Warning. `$(HardenedResponseModel)` is `Standard`, the throws mode's name before 0.19.0. The mode selected is unchanged; write `Throws`. Reported once per project. |
+| `027` | The description references something it does not declare. Part of the model-diagnostics pass; see below. |
 
 ### The Smithy CLI task (HSMT010–HSMT014)
 
@@ -114,6 +115,34 @@ generated file.
 | `023` | An `enum` declaring both string and numeric values, which no C# enum can carry. Declare one kind. |
 | `024` | Warning. A declared keyword or trait the generator does not enforce, named with a representative location. Remove it, or enforce the rule in the handler. |
 | `025` | Two error responses on one operation share one status, which would generate the same case type twice. Give them distinct statuses or merge the shapes. |
+| `027` | A reference to something the description does not declare. |
+
+#### 027 — a reference to something the description does not declare
+
+```
+'GET /events (200)' references '#/components/schemas/DoesNotExist', which the description
+does not declare. Nothing is generated for it, so the member it types would be absent and a
+response body would be dropped. Declare the schema, or point the reference at one that exists.
+```
+
+Fatal, unlike everything else in the block, because there is no answer to fall back on. A dangling
+`$ref` in a response degraded the success case to a bodyless one, so a handler written against the
+generated interface compiled and answered 200 with an empty body; the only errors were CS0246s a
+hop away in application code that happened to name the missing model.
+
+One report per place the reference is made — a document referencing a schema it dropped usually
+does so from several, and each is a separate edit. The operation's flat response fields mirror its
+primary success, so those count as one place rather than two.
+
+Under `HSMT` this covers a target the model references and does not declare: an operation a service
+binds, an operation's input or output, a member's target, and an error shape bound to an operation.
+The Smithy CLI refuses all of these before the parser sees them, so only a committed AST reaches it.
+
+**What it does not catch.** A `$ref` on a schema property is resolved by the reader before this
+parser sees it, and an unresolvable one is discarded there — the property arrives with no reference,
+no type and no shape, and becomes `JsonElement`. Nothing in the object model records that the
+reference was ever made, and the reader reports nothing either. Catching that needs the raw
+document rather than the object model.
 
 ### Renumbered in 0.18
 

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/DanglingReferenceModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/DanglingReferenceModel.cs
@@ -1,0 +1,38 @@
+namespace Hardened.Generation.Models;
+
+/// <summary>
+/// A reference the description makes to something it never declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recorded as the document is read, for the reason <see cref="UnmappedKeywordModel"/> is: by the
+/// time <c>SpecDiagnostics.Find</c> sees the model the reference has been cleared, because a
+/// reference naming nothing generates C# naming nothing. The model can say what it holds and never
+/// what it was told and dropped.
+/// </para>
+/// <para>
+/// <b>Not the same thing as a reference to a schema that produced no type.</b> A top-level array
+/// alias, an <c>anyOf</c> with no shape of its own, an undecidable <c>oneOf</c> - each is declared,
+/// read, and deliberately resolved to something else, which the parser's own passes handle and say
+/// nothing about because there is nothing wrong. This is the other case: the name is not in the
+/// document at all.
+/// </para>
+/// <para>
+/// Deliberately not serialized into the model file, and deliberately absent from the model's
+/// equality. The build stops on one of these, so nothing downstream ever reads a model carrying
+/// any - and a diagnostic in a cache key is a cache miss for a build that generates identical code.
+/// </para>
+/// </remarks>
+internal sealed class DanglingReferenceModel {
+
+    public DanglingReferenceModel(string reference, string location) {
+        Reference = reference;
+        Location = location;
+    }
+
+    /// <summary>The reference as the document spells it - <c>#/components/schemas/Pet</c>.</summary>
+    public string Reference { get; }
+
+    /// <summary>Where it was made, as far as the parser knows.</summary>
+    public string Location { get; }
+}

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
@@ -117,6 +117,18 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     /// </remarks>
     public List<UnmappedKeywordModel> UnmappedKeywords { get; set; } = new();
 
+    /// <summary>
+    /// References the description makes to schemas it never declares, in the order they were met.
+    /// </summary>
+    /// <remarks>
+    /// Filled by the parser and read by <c>SpecDiagnostics</c>, on the same terms as
+    /// <see cref="UnmappedKeywords"/>: the reference is cleared before anything is named, so this
+    /// is the only record that it was ever made. Not serialized and absent from
+    /// <see cref="Equals(ServiceSpecModel?)"/> - the build stops on one of these, so no model
+    /// carrying any is ever read back.
+    /// </remarks>
+    public List<DanglingReferenceModel> DanglingReferences { get; set; } = new();
+
     public bool Equals(ServiceSpecModel? other) {
         if (other is not null && ContentNegotiation != other.ContentNegotiation) return false;
         if (other is not null && ResponseModel != other.ResponseModel) return false;

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
@@ -9,7 +9,7 @@ namespace Hardened.Idl;
 /// </summary>
 /// <remarks>
 /// <para>
-/// There are thirteen of them, and every pass that walks references needs all thirteen. Two passes used
+/// There are fifteen of them, and every pass that walks references needs all fifteen. Two passes used
 /// to enumerate them by hand and one listed five: Cloudflare and PagerDuty reference hundreds of
 /// schemas that produce no type, and the references the incomplete pass never visited - parameters,
 /// declared error responses, base types, discriminator branches - each became a CS0234 naming
@@ -27,12 +27,21 @@ internal static class ModelRefs {
     internal readonly struct Handle {
         private readonly Action<string?> _set;
 
-        public Handle(string? value, Action<string?> set) {
+        public Handle(string? value, string location, Action<string?> set) {
             Value = value;
+            Location = location;
             _set = set;
         }
 
         public string? Value { get; }
+
+        /// <summary>Where the reference was made, for a message the author can act on.</summary>
+        /// <remarks>
+        /// Carried rather than derived: the two passes that rewrite references do not need it, and
+        /// the one that reports a reference naming nothing cannot reconstruct it - by then the
+        /// handle is all there is.
+        /// </remarks>
+        public string Location { get; }
 
         public void Set(string? value) => _set(value);
     }
@@ -41,34 +50,44 @@ internal static class ModelRefs {
         foreach (var schema in model.Schemas) {
             var captured = schema;
 
-            yield return new Handle(schema.BaseRef, value => captured.BaseRef = value);
-            yield return new Handle(schema.ArrayItemsRef, value => captured.ArrayItemsRef = value);
+            yield return new Handle(
+                schema.BaseRef, schema.Name + " (base type)", value => captured.BaseRef = value);
+            yield return new Handle(
+                schema.ArrayItemsRef, schema.Name + " (items)",
+                value => captured.ArrayItemsRef = value);
 
             foreach (var branch in schema.OneOf) {
                 var branchCaptured = branch;
 
-                yield return new Handle(branch.Ref, value => branchCaptured.Ref = value);
+                yield return new Handle(
+                    branch.Ref, schema.Name + " (oneOf branch)", value => branchCaptured.Ref = value);
             }
 
             foreach (var mapping in schema.DiscriminatorMapping) {
                 var mappingCaptured = mapping;
 
-                yield return new Handle(mapping.Ref, value => mappingCaptured.Ref = value ?? "");
+                yield return new Handle(
+                    mapping.Ref, schema.Name + " (discriminator mapping)",
+                    value => mappingCaptured.Ref = value ?? "");
             }
 
             foreach (var property in schema.Properties) {
                 var propertyCaptured = property;
+                var where = schema.Name + "." + property.Name;
 
-                yield return new Handle(property.Ref, value => propertyCaptured.Ref = value);
+                yield return new Handle(property.Ref, where, value => propertyCaptured.Ref = value);
                 yield return new Handle(
-                    property.ArrayItemsRef, value => propertyCaptured.ArrayItemsRef = value);
+                    property.ArrayItemsRef, where + " (items)",
+                    value => propertyCaptured.ArrayItemsRef = value);
                 yield return new Handle(
-                    property.DictionaryValueRef, value => propertyCaptured.DictionaryValueRef = value);
+                    property.DictionaryValueRef, where + " (values)",
+                    value => propertyCaptured.DictionaryValueRef = value);
 
                 foreach (var branch in property.OneOf) {
                     var branchCaptured = branch;
 
-                    yield return new Handle(branch.Ref, value => branchCaptured.Ref = value);
+                    yield return new Handle(
+                        branch.Ref, where + " (oneOf branch)", value => branchCaptured.Ref = value);
                 }
             }
         }
@@ -76,26 +95,57 @@ internal static class ModelRefs {
         foreach (var service in model.Services) {
             foreach (var operation in service.Operations) {
                 var captured = operation;
+                var where = operation.HttpMethod + " " + operation.Path;
 
                 yield return new Handle(
-                    operation.RequestBodyRef, value => captured.RequestBodyRef = value);
+                    operation.RequestBodyRef, where + " (request body)",
+                    value => captured.RequestBodyRef = value);
+
+                // The success responses were not here, and every pass that walks references needs
+                // all of them: a schema renamed by the allocator left a success case pointing at
+                // the old name, which is the shape this class exists to stop happening again.
+                foreach (var success in operation.SuccessResponses) {
+                    var successCaptured = success;
+                    var status = where + " (" + success.StatusCode + ")";
+
+                    yield return new Handle(
+                        success.Ref, status, value => successCaptured.Ref = value);
+                    yield return new Handle(
+                        success.ArrayItemsRef, status + " items",
+                        value => successCaptured.ArrayItemsRef = value);
+                }
+
+                // The flat fields mirror the primary success - the lowest declared 2xx - so they
+                // are labelled as it rather than as somewhere of their own. A caller reporting one
+                // reference per place reports these once, because the document declares them once.
+                // They are still yielded: a pass that rewrites references has to rewrite both
+                // copies or the two disagree.
+                var primary = where + " (" + operation.SuccessStatusCode + ")";
+
                 yield return new Handle(
-                    operation.ResponseRef, value => captured.ResponseRef = value);
+                    operation.ResponseRef, primary, value => captured.ResponseRef = value);
                 yield return new Handle(
-                    operation.ResponseArrayItemsRef, value => captured.ResponseArrayItemsRef = value);
+                    operation.ResponseArrayItemsRef, primary + " items",
+                    value => captured.ResponseArrayItemsRef = value);
 
                 foreach (var error in operation.ErrorResponses) {
                     var errorCaptured = error;
 
-                    yield return new Handle(error.Ref, value => errorCaptured.Ref = value);
+                    yield return new Handle(
+                        error.Ref, where + " (" + error.StatusCode + ")",
+                        value => errorCaptured.Ref = value);
                 }
 
                 foreach (var parameter in operation.Parameters) {
                     var parameterCaptured = parameter;
 
-                    yield return new Handle(parameter.Ref, value => parameterCaptured.Ref = value);
                     yield return new Handle(
-                        parameter.ArrayItemsRef, value => parameterCaptured.ArrayItemsRef = value);
+                        parameter.Ref, where + " parameter '" + parameter.Name + "'",
+                        value => parameterCaptured.Ref = value);
+                    yield return new Handle(
+                        parameter.ArrayItemsRef,
+                        where + " parameter '" + parameter.Name + "' (items)",
+                        value => parameterCaptured.ArrayItemsRef = value);
                 }
             }
         }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
@@ -14,7 +14,7 @@ namespace Hardened.Idl;
 /// with a message that never mentions the document that caused it.
 /// </para>
 /// <para>
-/// Codes are the front end's prefix plus 020-025, one number per finder. The prefix is a
+/// Codes are the front end's prefix plus 020-025 and 027, one number per finder. The prefix is a
 /// parameter because this pass runs for every front end and a finding belongs to the document
 /// that caused it: a Smithy model's mixed enum reported as HOAT anything sends its author to the
 /// OpenAPI documentation. 020 up is this pass's block; everything below it belongs to the task
@@ -192,9 +192,38 @@ internal static class SpecDiagnostics {
     /// </summary>
     internal const string MixedEnumType = "mixed-enum";
 
+    /// <summary>
+    /// References the description makes to something it never declares.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Fatal, unlike everything else in the 020 block that resolves to a workable answer. There is
+    /// no answer here: a dangling reference in a response degraded the success case to a bodyless
+    /// one, so a handler written against the generated interface compiled and answered 200 with an
+    /// empty body. The only errors were CS0246s a hop away in application code that happened to
+    /// name the missing model, or nothing at all.
+    /// </para>
+    /// <para>
+    /// One report per reference rather than per name: a document referencing a schema it dropped
+    /// usually does so from several places, and each is a separate edit.
+    /// </para>
+    /// </remarks>
+    private static void FindDanglingReferences(
+        ServiceSpecModel model, string prefix, List<Problem> problems) {
+        foreach (var dangling in model.DanglingReferences) {
+            problems.Add(new Problem(
+                prefix + "027",
+                $"'{dangling.Location}' references '{dangling.Reference}', which the description " +
+                "does not declare. Nothing is generated for it, so the member it types would be " +
+                "absent and a response body would be dropped. Declare the schema, or point the " +
+                "reference at one that exists."));
+        }
+    }
+
     public static IReadOnlyList<Problem> Find(ServiceSpecModel model, string diagnosticPrefix) {
         var problems = new List<Problem>();
 
+        FindDanglingReferences(model, diagnosticPrefix, problems);
         FindDuplicateSchemaNames(model, diagnosticPrefix, problems);
         FindUnresolvableChoices(model, diagnosticPrefix, problems);
         FindMixedEnums(model, diagnosticPrefix, problems);

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DanglingReferenceTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DanglingReferenceTests.cs
@@ -1,0 +1,246 @@
+using System.Linq;
+using System.Threading;
+using Hardened.Idl;
+using Hardened.Generation;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// A reference the description makes to something it never declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// OR-07. <c>$ref: '#/components/schemas/DoesNotExist'</c> in a response produced no diagnostic at
+/// all: the success case became a bodyless record, so a handler written against the generated
+/// interface compiled and answered 200 with an empty body. The only errors were CS0246s a hop away
+/// in application code that happened to name the missing model, or - where nothing named it -
+/// nothing.
+/// </para>
+/// <para>
+/// The check has to run in the parser, for the reason the unmapped-keyword check does: every
+/// reference pass after it clears what it cannot resolve, and afterwards a reference naming
+/// nothing is indistinguishable from one naming something the parser deliberately resolved to a
+/// different shape.
+/// </para>
+/// </remarks>
+public class DanglingReferenceTests {
+
+    private static string Document(string responseSchema, string components) => $$"""
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /products:
+            get:
+              operationId: listProducts
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: {{responseSchema}}
+        components:
+          schemas:
+        {{components}}
+        """;
+
+    private const string Product = """
+            Product:
+              type: object
+              properties:
+                sku: { type: string }
+        """;
+
+    private static ServiceSpecModel Parse(string yaml) {
+        var model = OpenApiSpecParser.Parse(yaml, "depot", CancellationToken.None);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static SpecDiagnostics.Problem[] Problems(ServiceSpecModel model) =>
+        SpecDiagnostics.Find(model, "HOAT").ToArray();
+
+    /// <summary>The exact repro.</summary>
+    [Fact]
+    public void AReferenceToAnUndeclaredSchemaIsRecorded() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("#/components/schemas/DoesNotExist", dangling.Reference);
+    }
+
+    [Fact]
+    public void ItStopsTheBuild() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var problem = Assert.Single(Problems(model), p => p.Code == "HOAT027");
+
+        Assert.True(problem.Fatal);
+    }
+
+    /// <summary>
+    /// The message names the reference and where it was made, because a document referencing a
+    /// dropped schema usually does so from several places and each is a separate edit.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheReferenceAndWhereItWasMade() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var message = Assert.Single(Problems(model), p => p.Code == "HOAT027").Message;
+
+        Assert.Contains("#/components/schemas/DoesNotExist", message);
+        Assert.Contains("/products", message);
+        Assert.Contains("(200)", message);
+    }
+
+    /// <summary>A reference from a property carries the member it was made from.</summary>
+    /// <summary>
+    /// A request body reference names the operation it was made from.
+    /// </summary>
+    [Fact]
+    public void ARequestBodyReferenceNamesTheOperation() {
+        var model = Parse("""
+            openapi: 3.0.0
+            info: { title: Depot, version: '1.0' }
+            paths:
+              /products:
+                post:
+                  operationId: createProduct
+                  requestBody:
+                    content:
+                      application/json:
+                        schema: { $ref: '#/components/schemas/Missing' }
+                  responses:
+                    '201': { description: created }
+            components:
+              schemas:
+                Product:
+                  type: object
+                  properties:
+                    sku: { type: string }
+            """);
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("#/components/schemas/Missing", dangling.Reference);
+        Assert.Contains("request body", dangling.Location);
+    }
+
+    /// <summary>
+    /// What this does not catch, pinned so nobody reads the check as complete.
+    /// </summary>
+    /// <remarks>
+    /// A <c>$ref</c> on a schema property is resolved by the reader before this parser sees it, and
+    /// an unresolvable one is discarded there: the property arrives carrying no reference, no type
+    /// and no shape, and becomes <c>JsonElement</c>. The reader reports nothing about it either -
+    /// its own diagnostics are empty. There is no record left in the model to report from, so
+    /// catching this needs the raw document rather than the object model, which is a separate
+    /// piece of work.
+    /// </remarks>
+    [Fact]
+    public void APropertyReferenceTheReaderDiscardsIsNotCaught() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/Product' }", """
+            Product:
+              type: object
+              properties:
+                supplier: { $ref: '#/components/schemas/Missing' }
+        """));
+
+        var property = Assert.Single(Assert.Single(model.Schemas).Properties);
+
+        Assert.Null(property.Ref);
+        Assert.Null(property.Type);
+        Assert.Empty(model.DanglingReferences);
+    }
+
+    /// <summary>
+    /// A schema that is declared and produces no type is not this. A top-level array alias is read,
+    /// used, and resolved into the property that names it - which is the parser working, not
+    /// failing.
+    /// </summary>
+    [Fact]
+    public void AnArrayAliasIsNotDangling() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/ProductList' }", """
+            ProductList:
+              type: array
+              items: { $ref: '#/components/schemas/Product' }
+            Product:
+              type: object
+              properties:
+                sku: { type: string }
+        """));
+
+        Assert.Empty(model.DanglingReferences);
+        Assert.DoesNotContain(Problems(model), p => p.Code == "HOAT027");
+    }
+
+    /// <summary>A document that declares what it references says nothing at all.</summary>
+    [Fact]
+    public void ADocumentThatResolvesIsSilent() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/Product' }", Product));
+
+        Assert.Empty(model.DanglingReferences);
+        Assert.Empty(Problems(model));
+    }
+
+    /// <summary>
+    /// Every place the reference was made, not the first: two operations naming one missing schema
+    /// are two edits.
+    /// </summary>
+    [Fact]
+    public void EveryReferenceToTheMissingSchemaIsReported() {
+        var model = Parse("""
+            openapi: 3.0.0
+            info: { title: Depot, version: '1.0' }
+            paths:
+              /products:
+                get:
+                  operationId: listProducts
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema: { $ref: '#/components/schemas/Missing' }
+              /suppliers:
+                get:
+                  operationId: listSuppliers
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema: { $ref: '#/components/schemas/Missing' }
+            components:
+              schemas:
+                Product:
+                  type: object
+                  properties:
+                    sku: { type: string }
+            """);
+
+        Assert.Equal(2, model.DanglingReferences.Count);
+        Assert.Equal(2, Problems(model).Count(p => p.Code == "HOAT027"));
+    }
+
+    /// <summary>
+    /// Not serialized, and absent from the model's equality: the build stops on one of these, so
+    /// no model carrying any is ever read back, and a diagnostic in a cache key is a cache miss
+    /// for a build that generates identical code.
+    /// </summary>
+    [Fact]
+    public void ItDoesNotTravelInTheModelFile() {
+        var model = Parse(Document("{ $ref: '#/components/schemas/DoesNotExist' }", Product));
+
+        var restored = SpecModelSerializer.Read(SpecModelSerializer.Write(model));
+
+        Assert.NotNull(restored);
+        Assert.Empty(restored!.DanglingReferences);
+        Assert.Equal(model, restored);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -212,6 +212,7 @@ internal static class OpenApiSpecParser {
         // allocator never names a type nothing will emit; base types are dropped before that
         // because a dropped base changes which members a type declares. Choices go first of all,
         // because dropping one is another way a reference stops naming something.
+        RecordDanglingReferences(model);
         DropUndecidableChoices(model);
         InlineNonObjectRefs(model);
         DropIncompatibleBaseTypes(model);
@@ -361,6 +362,49 @@ internal static class OpenApiSpecParser {
                 dropped.Contains(TypeMapper.GetRefName(reference.Value))) {
                 reference.Set(null);
             }
+        }
+    }
+
+    /// <summary>
+    /// References the document makes to schemas it never declares.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// First of the reference passes, because every one after it clears references, and a
+    /// <c>$ref</c> naming nothing is indistinguishable afterwards from one naming something the
+    /// parser deliberately resolved to a different shape. A dangling reference in a response
+    /// degraded the success case to a bodyless one, so a handler written against the broken
+    /// interface compiled and answered 200 with an empty body - and the only errors were CS0246s
+    /// in application code that happened to name the missing model, or nothing at all.
+    /// </para>
+    /// <para>
+    /// Compared against the schemas the reader produced rather than against the ones that will be
+    /// emitted. A top-level array alias, an <c>anyOf</c> with no shape of its own and an
+    /// undecidable <c>oneOf</c> are all declared and all resolved to something else on purpose;
+    /// what this is looking for is a name the document does not contain.
+    /// </para>
+    /// </remarks>
+    private static void RecordDanglingReferences(ServiceSpecModel model) {
+        var declared = new HashSet<string>();
+
+        foreach (var schema in model.Schemas) {
+            declared.Add(schema.Name);
+        }
+
+        // One report per place the document makes the reference, and the primary success is one
+        // place: the operation's flat response fields mirror it, and reporting both would make one
+        // edit look like two.
+        var reported = new HashSet<string>();
+
+        foreach (var reference in ModelRefs.All(model)) {
+            if (string.IsNullOrEmpty(reference.Value) ||
+                declared.Contains(TypeMapper.GetRefName(reference.Value!)) ||
+                !reported.Add(reference.Location + "\u0000" + reference.Value)) {
+                continue;
+            }
+
+            model.DanglingReferences.Add(
+                new DanglingReferenceModel(reference.Value!, reference.Location));
         }
     }
 

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/DanglingTargetTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/DanglingTargetTests.cs
@@ -1,0 +1,144 @@
+using Hardened.Generation.Models;
+using Hardened.Idl;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// A target the model references and does not declare.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Smithy half of the OpenAPI front end's dangling <c>$ref</c>. These were warnings that named
+/// what the parser did instead - <c>JsonElement</c> for a member, a dropped operation - and one of
+/// them, an error shape bound to an operation, said nothing at all: the interface simply never
+/// declared that error and the status the model promised was answered by nothing.
+/// </para>
+/// <para>
+/// The CLI refuses an undeclared target before this parser ever sees it, so a model built from
+/// sources cannot reach here. A committed AST can, which is exactly the case with no other check
+/// in front of it.
+/// </para>
+/// </remarks>
+public class DanglingTargetTests {
+
+    private static ServiceSpecModel Parse(string shapes) {
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(
+            $$"""
+              { "smithy": "2.0", "shapes": { {{shapes}} } }
+              """, "depot", diagnostics);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static SpecDiagnostics.Problem[] Problems(ServiceSpecModel model) =>
+        SpecDiagnostics.Find(model, "HSMT").ToArray();
+
+    private const string Service = """
+        "com.example#Svc": {
+          "type": "service", "version": "1",
+          "operations": [ { "target": "com.example#Op" } ] }
+        """;
+
+    /// <summary>An error shape bound to an operation that the model never declares.</summary>
+    [Fact]
+    public void AnUndeclaredErrorShapeIsRecorded() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "errors": [ { "target": "com.example#NoSuchError" } ],
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } }
+            """);
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("com.example#NoSuchError", dangling.Reference);
+        Assert.Contains("declares error", dangling.Location);
+    }
+
+    [Fact]
+    public void AnUndeclaredInputShapeIsRecorded() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "input": { "target": "com.example#NoSuchInput" },
+              "traits": { "smithy.api#http": { "method": "POST", "uri": "/x", "code": 200 } } }
+            """);
+
+        Assert.Equal(
+            "com.example#NoSuchInput", Assert.Single(model.DanglingReferences).Reference);
+    }
+
+    [Fact]
+    public void AnUndeclaredOutputShapeIsRecorded() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "output": { "target": "com.example#NoSuchOutput" },
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } }
+            """);
+
+        Assert.Equal(
+            "com.example#NoSuchOutput", Assert.Single(model.DanglingReferences).Reference);
+    }
+
+    /// <summary>
+    /// An operation the service binds and the model never declares, beside one it does. A service
+    /// with no readable operation at all fails earlier, as a model that describes no service.
+    /// </summary>
+    private const string OneGoodOneMissing = """
+        "com.example#Svc": {
+          "type": "service", "version": "1",
+          "operations": [
+            { "target": "com.example#Good" },
+            { "target": "com.example#Missing" } ] },
+        "com.example#Good": {
+          "type": "operation",
+          "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } }
+        """;
+
+    [Fact]
+    public void AnUndeclaredOperationIsRecorded() {
+        var model = Parse(OneGoodOneMissing);
+
+        var dangling = Assert.Single(model.DanglingReferences);
+
+        Assert.Equal("com.example#Missing", dangling.Reference);
+        Assert.Contains("binds operation", dangling.Location);
+    }
+
+    /// <summary>It stops the build, under the front end that read the model.</summary>
+    [Fact]
+    public void ItStopsTheBuildUnderTheSmithyPrefix() {
+        var problem = Assert.Single(
+            Problems(Parse(OneGoodOneMissing)), p => p.Code == "HSMT027");
+
+        Assert.True(problem.Fatal);
+        Assert.Contains("com.example#Missing", problem.Message);
+    }
+
+    /// <summary>A model that declares what it references says nothing.</summary>
+    [Fact]
+    public void AModelThatResolvesIsSilent() {
+        var model = Parse($$"""
+            {{Service}},
+            "com.example#Op": {
+              "type": "operation",
+              "output": { "target": "com.example#Out" },
+              "traits": { "smithy.api#http": { "method": "GET", "uri": "/x", "code": 200 } } },
+            "com.example#Out": {
+              "type": "structure",
+              "members": { "sku": { "target": "smithy.api#String" } } }
+            """);
+
+        Assert.Empty(model.DanglingReferences);
+        Assert.DoesNotContain(Problems(model), p => p.Code == "HSMT027");
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -200,8 +200,8 @@ internal static class SmithySpecParser {
 
         foreach (var operationId in Operations(context, service)) {
             if (!context.Ast.TryGetShape(operationId, out var operation)) {
-                context.Diagnostics.Add(
-                    $"service '{tag}' binds operation '{operationId}', which the model does not declare.");
+                Dangling(context, operationId, "service '" + tag + "' binds operation");
+
                 continue;
             }
 
@@ -525,8 +525,7 @@ internal static class SmithySpecParser {
         }
 
         if (!context.Ast.TryGetShape(inputId, out var input)) {
-            context.Diagnostics.Add(
-                $"operation '{operationName}' takes '{inputId}', which the model does not declare.");
+            Dangling(context, inputId, "operation '" + operationName + "' takes");
 
             return;
         }
@@ -674,8 +673,7 @@ internal static class SmithySpecParser {
         }
 
         if (!context.Ast.TryGetShape(outputId, out var output)) {
-            context.Diagnostics.Add(
-                $"operation '{operationName}' returns '{outputId}', which the model does not declare.");
+            Dangling(context, outputId, "operation '" + operationName + "' returns");
 
             return headers;
         }
@@ -804,6 +802,11 @@ internal static class SmithySpecParser {
         ParseContext context, JsonElement operation, OperationModel model, ProtocolBinding protocol) {
         foreach (var errorId in SmithyAst.TargetList(operation, "errors")) {
             if (!context.Ast.TryGetShape(errorId, out var error)) {
+                // Dropped in silence until now, which is the quietest of the four: the operation
+                // keeps its other errors, the generated interface simply never declares this one,
+                // and the status the model promised is answered by nothing.
+                Dangling(context, errorId, "operation '" + model.OperationId + "' declares error");
+
                 continue;
             }
 
@@ -1079,7 +1082,7 @@ internal static class SmithySpecParser {
         }
 
         if (!context.Ast.TryGetShape(target, out var shape)) {
-            context.Diagnostics.Add($"'{target}' is referenced but not declared; it becomes JsonElement.");
+            Dangling(context, target, "member");
 
             return;
         }
@@ -1384,6 +1387,26 @@ internal static class SmithySpecParser {
 
         return SmithyAst.Kind(shape) is "list" or "set" or "map";
     }
+
+    /// <summary>
+    /// Records a shape the model references and does not declare.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These were warnings that named what the parser did instead - JsonElement for a member, a
+    /// dropped operation, an error the interface never declares. Every one of them is the shape
+    /// the OpenAPI front end's dangling <c>$ref</c> takes, and it is an error there: a reference
+    /// naming nothing is not a degrade the author chose, it is a model that says one thing and
+    /// generates another.
+    /// </para>
+    /// <para>
+    /// The CLI refuses an undeclared target before this parser ever sees it, so a model built from
+    /// sources cannot reach here. A committed AST can, which is exactly the case with no other
+    /// check in front of it.
+    /// </para>
+    /// </remarks>
+    private static void Dangling(ParseContext context, string target, string where) =>
+        context.Model.DanglingReferences.Add(new DanglingReferenceModel(target, where));
 
     /// <summary>Records every trait a shape carries, for the report at the end.</summary>
     private static void Note(ParseContext context, JsonElement shape) {


### PR DESCRIPTION
A5 / H-07 from the 0.19 work order, with the Smithy sweep the item asks for.

A dangling `$ref` in a response produced no diagnostic at all. The success case became a bodyless record, so a handler written against the generated interface compiled and answered 200 with an empty body; the only errors were CS0246s a hop away in application code that happened to name the missing model — or nothing, where nothing named it. New `HOAT027`/`HSMT027` is fatal and names the reference and where it was made:

```
'GET /events (200)' references '#/components/schemas/DoesNotExist', which the description
does not declare. Nothing is generated for it, so the member it types would be absent and a
response body would be dropped. Declare the schema, or point the reference at one that exists.
```

**Recorded in the parser**, which is the only place with both halves in hand: every reference pass after it clears what it cannot resolve, and afterwards a reference naming nothing is indistinguishable from one naming something the parser deliberately resolved to a different shape. A top-level array alias, an `anyOf` with no shape of its own and an undecidable `oneOf` are all declared, read, and resolved on purpose — this is about a name the document does not contain. `ServiceSpecModel.DanglingReferences` rides the model on exactly the terms `UnmappedKeywords` does: unserialized, outside the model's equality, because the build stops before anything reads it.

**The Smithy sweep** found the same shape in four places. Three warned and named what the parser did instead — `JsonElement` for a member, a dropped operation; the fourth, an error shape bound to an operation, said nothing at all: the generated interface simply never declared that error and the status the model promised was answered by nothing. All four now report under `HSMT027`. The CLI refuses an undeclared target before the parser sees it, so only a committed AST reaches this.

**`ModelRefs` was missing the success responses**, and its own remarks say every pass that walks references needs all of them — a schema renamed by the allocator left a success case pointing at the old name. They are in it now. Handles also carry where the reference was made, and the operation's flat response fields are labelled as the primary success they mirror, so one declaration in the document is reported once rather than twice.

**What this does not catch, pinned by a test that says so.** A `$ref` on a schema property is resolved by the reader before the parser sees it, and an unresolvable one is discarded there: the property arrives with no reference, no type and no shape, and becomes `JsonElement`. Nothing in the object model records that the reference was made, and the reader's own diagnostics are empty. Catching that needs the raw document rather than the object model — a separate piece of work, and it is in the docs entry and my handoff notes.

Validated:

- CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors.
- `dotnet test` on the solution — 31 suites green, with 8 new OpenAPI cases and 7 new Smithy ones. The conformance suite and the OpenAPI/Smithy integration SUTs still build, so nothing correct started failing.
- `scripts/verify-templates.sh` — green across all seven default rows; Smithy rows self-skip on this machine (CLI 1.56.0 against the 1.73.0 pin).

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
