### PR TITLE
Take a shared node's route constraint from every route through it

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
@@ -1,3 +1,5 @@
+using Hardened.Requests.Testing;
+
 namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
 
 /// <summary>
@@ -70,4 +72,50 @@ public class DescribedSecurityTests {
 
         response.Assert.Ok();
     }
+
+    #region the caller, in a handler
+
+    /// <summary>
+    /// H-03. A specification-first handler implements a generated interface, so the code-first
+    /// escape - an <c>IExecutionContext</c> parameter - does not exist, and nothing scoped exposed
+    /// the caller. Ownership checks and grant-dependent filtering could not be written without
+    /// hand-rolled plumbing, and both spec-first arms of the trial invented the same bridge
+    /// independently. <c>ICurrentCaller</c> is that bridge, shipped and injected by constructor.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerReadsTheCallerAndAdmitsTheOwner(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/secured/owned/integration-test", Holding("pets:read"));
+
+        Assert.Equal(200, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The refusal the contract cannot express. Both requests hold the grant the description asks
+    /// for and pass authorization; only the handler can tell which of them owns the row.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerReadsTheCallerAndRefusesSomebodyElse(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/owned/somebody-else", Holding("pets:read"));
+
+        Assert.Equal(403, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Present on every request, empty where nothing authenticated - so a handler reads the same
+    /// shape either way and never checks for null. Authorization refuses this one first, which is
+    /// the arrangement: what a caller may do is judged before the handler runs.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnAnonymousRequestIsRefusedBeforeTheHandlerReadsAnything(
+        ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/owned/integration-test");
+
+        Assert.Equal(401, response.StatusCode);
+    }
+
+    private static Action<TestWebRequest> Holding(string grants) =>
+        request => request.Headers[TestGrantsPrincipalSource.GrantsHeader] = grants;
+
+    #endregion
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
@@ -14,6 +14,9 @@
     <ItemGroup>
         <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
         <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <!-- TestGrantsPrincipalSource, the shipped testing source. A fixture states its caller
+             through the same seam a production application authenticates through. -->
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
         <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OpenApiTestApp.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OpenApiTestApp.cs
@@ -1,10 +1,14 @@
+using DependencyModules.Runtime.Interfaces;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Testing;
 using Hardened.Shared.Runtime.Attributes;
 using Hardened.Web.Runtime.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT;
 
 /// <summary>
-/// A specification-first application, which registers nothing of its own.
+/// A specification-first application, whose one registration is a caller for its tests to state.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -20,6 +24,18 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// emitter back in the path that exists to have none.
 /// </para>
 /// </remarks>
+/// <remarks>
+/// <para>
+/// <c>TestGrantsPrincipalSource</c> is the shipped testing source, through the same seam a
+/// production one uses. It declines every request that does not carry <c>X-Test-Grants</c>, so
+/// every route in this fixture answers exactly as it did before it was registered - and a test
+/// that wants a caller now has one to name.
+/// </para>
+/// </remarks>
 [HardenedModule]
 [HardenedWebModule]
-public partial class OpenApiTestApp { }
+public partial class OpenApiTestApp : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddSingleton<IPrincipalSource, TestGrantsPrincipalSource>();
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
@@ -1,5 +1,7 @@
 using Hardened.IntegrationTests.OpenApi.SUT.Services;
 using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Errors;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT;
 
@@ -7,12 +9,26 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// Handlers that exist to be refused.
 /// </summary>
 /// <remarks>
-/// Neither carries an authorization attribute. Everything guarding them came from the description,
-/// which is the point: reaching either method at all is the failure these routes test for.
+/// <para>
+/// None carries an authorization attribute. Everything guarding them came from the description,
+/// which is the point: reaching one of these methods at all is the failure these routes test for.
+/// </para>
+/// <para>
+/// <c>SecuredOwned</c> is the other half. A contract can say the caller must hold a grant and
+/// cannot say the row must be theirs, so the ownership check belongs to the handler - which needs
+/// to know who the caller is. A specification-first handler implements a generated interface, so
+/// it cannot take <c>IExecutionContext</c> as a parameter; <see cref="ICurrentCaller"/> is what it
+/// takes instead, by plain constructor injection with nothing wired by hand.
+/// </para>
 /// </remarks>
 [Handler]
-public class SecuredServiceImpl : ISecuredService {
+public class SecuredServiceImpl(ICurrentCaller caller) : ISecuredService {
     public Task<string> SecuredScoped() => Task.FromResult("reached");
 
     public Task<string> SecuredEither() => Task.FromResult("reached");
+
+    public Task<string> SecuredOwned(string ownerId) =>
+        ownerId == caller.Principal.Subject
+            ? Task.FromResult(ownerId)
+            : throw new StatusCodeException(403);
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -115,6 +115,31 @@ paths:
             application/json:
               schema:
                 type: string
+  # An ownership check, which is the decision only the handler can make: the contract says the
+  # caller must hold pets:read, and nothing in a document can say "and the row must be theirs".
+  # The handler takes ICurrentCaller and compares.
+  /secured/owned/{ownerId}:
+    get:
+      tags:
+        - Secured
+      operationId: securedOwned
+      security:
+        - petstoreOAuth: ["pets:read"]
+      parameters:
+        - name: ownerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The caller owns it.
+          content:
+            application/json:
+              schema:
+                type: string
+        '403':
+          description: The caller is not the owner.
   /secured/either:
     get:
       tags:

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -202,6 +202,10 @@ namespace Hardened.Requests.Abstract.Authorization
         string? Subject { get; }
         bool TryGetClaim(string name, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out string value);
     }
+    public interface ICurrentCaller
+    {
+        Hardened.Requests.Abstract.Authorization.ICallerPrincipal Principal { get; }
+    }
     public interface IPrincipalSource
     {
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.ICallerPrincipal?> Authenticate(Hardened.Requests.Abstract.Execution.IExecutionContext context);

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/ICurrentCaller.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/ICurrentCaller.cs
@@ -1,0 +1,46 @@
+namespace Hardened.Requests.Abstract.Authorization;
+
+/// <summary>
+/// The caller of the request being handled, as a service a handler can take.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>IExecutionContext.CallerPrincipal</c> is where the principal lives, and a code-first handler
+/// reaches it by taking an <see cref="Execution.IExecutionContext"/> parameter. A specification-first
+/// handler implements a generated interface, so its signature is fixed and that escape does not
+/// exist - which left ownership checks and grant-dependent filtering unwritable without
+/// hand-rolled plumbing. Both spec-first arms of the 0.18 trial invented the same scoped holder
+/// independently; this is it, shipped.
+/// </para>
+/// <code>
+/// [Handler]
+/// public class OrderService(ICurrentCaller caller, IOrderStore store) : IOrderService {
+///     public async Task&lt;Order&gt; GetOrder(string orderId) {
+///         var order = await store.Get(orderId);
+///
+///         if (order.OwnerSubject != caller.Principal.Subject) {
+///             throw new ForbiddenException();
+///         }
+///
+///         return order;
+///     }
+/// }
+/// </code>
+/// <para>
+/// Scoped, and present on every request. A request no principal source answered for carries
+/// <see cref="AnonymousCallerPrincipal.Instance"/>, so a handler reads the same shape either way
+/// and never checks for null.
+/// </para>
+/// <para>
+/// Registered by <c>HardenedRequestModule</c>, so plain constructor injection works with nothing
+/// wired by hand. It is not a substitute for <c>[Authorize]</c> and its friends: what a caller may
+/// do is declared on the operation and judged before the handler runs. This is for the decisions
+/// only the handler can make - whether this caller owns this row.
+/// </para>
+/// </remarks>
+public interface ICurrentCaller {
+    /// <summary>
+    /// The caller this request established, or <see cref="AnonymousCallerPrincipal.Instance"/>.
+    /// </summary>
+    ICallerPrincipal Principal { get; }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationMiddlewareTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationMiddlewareTests.cs
@@ -1,7 +1,9 @@
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.DependencyInjection;
 using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
 
@@ -95,4 +97,79 @@ public class AuthenticationMiddlewareTests {
 
         Assert.Equal("one", seen?.Subject);
     }
+
+    #region the caller, on the request scope
+
+    /// <summary>
+    /// A context whose services are an application's - the request module's own registrations,
+    /// which is what puts the holder there.
+    /// </summary>
+    private static IExecutionContext ApplicationContext() =>
+        Pipeline.Context(
+            configureServices: services => new HardenedRequestModule().ConfigureServices(services));
+
+    private static ICallerPrincipal Resolved(IExecutionContext context) =>
+        context.RequestServices.GetRequiredService<ICurrentCaller>().Principal;
+
+    /// <summary>
+    /// H-03. A specification-first handler implements a generated interface, so it cannot take
+    /// <c>IExecutionContext</c> as a parameter and had no way to read the caller at all. The
+    /// middleware puts the answer on the request scope as well as on the context, which is what
+    /// makes <see cref="ICurrentCaller"/> resolvable in one.
+    /// </summary>
+    [Fact]
+    public async Task TheEstablishedCallerIsPutOnTheRequestScope() {
+        var context = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(context));
+
+        Assert.Equal("ada", Resolved(context).Subject);
+    }
+
+    /// <summary>
+    /// Written from the context rather than from the source's return value, so a request no source
+    /// answered for reads what the context holds - the anonymous principal, present rather than
+    /// null.
+    /// </summary>
+    [Fact]
+    public async Task ARequestNoSourceAnsweredForReadsTheAnonymousPrincipal() {
+        var context = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(null)]).Execute(Chain(context));
+
+        Assert.Same(AnonymousCallerPrincipal.Instance, Resolved(context));
+        Assert.False(Resolved(context).IsAuthenticated);
+    }
+
+    /// <summary>
+    /// One request's caller is not another's, which is the whole reason the holder is scoped.
+    /// </summary>
+    [Fact]
+    public async Task OneRequestsCallerDoesNotReachAnother() {
+        var authenticated = ApplicationContext();
+        var untouched = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(authenticated));
+
+        Assert.Equal("ada", Resolved(authenticated).Subject);
+        Assert.Same(AnonymousCallerPrincipal.Instance, Resolved(untouched));
+    }
+
+    /// <summary>
+    /// Asked for rather than required: a host that composed this middleware without the request
+    /// module's registrations still has a caller to establish.
+    /// </summary>
+    [Fact]
+    public async Task AContextWithoutTheHolderStillAuthenticates() {
+        var context = Pipeline.Context();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(context));
+
+        Assert.Equal("ada", context.CallerPrincipal.Subject);
+    }
+
+    #endregion
 }

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationMiddleware.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationMiddleware.cs
@@ -1,5 +1,6 @@
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.Requests.Runtime.Authorization;
 
@@ -23,6 +24,13 @@ namespace Hardened.Requests.Runtime.Authorization;
 /// Installed by <see cref="AuthenticationStartupService"/> only when at least one source is
 /// registered, so an application using none carries no per-request cost at all.
 /// </para>
+/// <para>
+/// The answer is put on the request scope as well as on the context, which is what makes
+/// <see cref="ICurrentCaller"/> resolvable in a specification-first handler - one whose signature a
+/// generated interface fixes, so it cannot take the context as a parameter. Written from the
+/// context rather than from the source's return value, so a request no source answered for reads
+/// whatever the context holds.
+/// </para>
 /// </remarks>
 public sealed class AuthenticationMiddleware : IExecutionFilter {
     private readonly IPrincipalSource[] _sources;
@@ -42,6 +50,13 @@ public sealed class AuthenticationMiddleware : IExecutionFilter {
 
                 break;
             }
+        }
+
+        // One resolve per request of an application that opted into authentication. Asked for
+        // rather than required, because a host that composed this middleware without the request
+        // module's registrations still has a caller to establish.
+        if (context.RequestServices?.GetService<CurrentCaller>() is { } caller) {
+            caller.Principal = context.CallerPrincipal;
         }
 
         await chain.Next();

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/CurrentCaller.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/CurrentCaller.cs
@@ -1,0 +1,26 @@
+using Hardened.Requests.Abstract.Authorization;
+
+namespace Hardened.Requests.Runtime.Authorization;
+
+/// <summary>
+/// The scoped holder <see cref="ICurrentCaller"/> resolves to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written by <see cref="AuthenticationMiddleware"/>, which runs ahead of the whole handler chain
+/// inside the request's own scope, and read by whatever the handler was resolved with. A mutable
+/// holder rather than a factory over the execution context, because the container has no per-request
+/// instance of the context to hand one.
+/// </para>
+/// <para>
+/// <b>What it reflects, exactly.</b> The principal the authentication seam established. An
+/// application with no <see cref="IPrincipalSource"/> installs no middleware and every request
+/// reads <see cref="AnonymousCallerPrincipal.Instance"/> - which is the same answer
+/// <c>IExecutionContext.CallerPrincipal</c> gives, at no per-request cost. A principal assigned to
+/// the context by something else after the middleware has run is not reflected here; nothing else
+/// is asked to run, which is what keeps this free for the applications that use none of it.
+/// </para>
+/// </remarks>
+internal sealed class CurrentCaller : ICurrentCaller {
+    public ICallerPrincipal Principal { get; set; } = AnonymousCallerPrincipal.Instance;
+}

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using DependencyModules.Runtime.Attributes;
 using DependencyModules.Runtime.Interfaces;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Runtime.Authorization;
 using Hardened.Requests.Runtime.Configuration;
 using Hardened.Requests.Runtime.Links;
@@ -44,6 +45,13 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         services.AddSingleton(
             s => Options.Create(s.GetRequiredService<IConfigurationManager>()
                 .GetConfiguration<IAuthorizationConfiguration>()));
+
+        // The caller, as a service a handler can take. Scoped rather than resolved from the
+        // context, because the container has no per-request instance of the context to build one
+        // from. Two registrations rather than one: the middleware fills the holder and everything
+        // else reads the interface, which is what keeps the setter off the contract.
+        services.AddScoped<CurrentCaller>();
+        services.AddScoped<ICurrentCaller>(provider => provider.GetRequiredService<CurrentCaller>());
 
         // Always installed. It costs one call per handler at startup and returns null for a handler
         // that carries no authorization attribute, so an application that has not opted in to

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTreeGenerator.cs
@@ -130,14 +130,41 @@ public class RouteTreeGenerator<T> {
 
             // Per continuation rather than across the whole position: /users/{id:int} and
             // /users/{id}/posts become two nodes here - grouped by what follows the token - and only
-            // routes sharing a continuation have to agree. Two that do and disagree is HRDR001,
-            // reported before this runs.
-            node.WildCardConstraint = RouteTokens.Constraint(group.Value[0].WildCardTokens, wildCardDepth);
+            // routes sharing a continuation have to agree. Two that do and declare different
+            // constraints is HRDR001, reported before this runs.
+            //
+            // Read across the group rather than from its first entry, for the reason the catch-all
+            // above is. One path is one node however many verbs answer at it, and a description
+            // routinely declares the same path parameter twice: the petstore fixture gives
+            // /pets/{petId} a pattern on GET and a bare string on PATCH, PUT and DELETE. Taking the
+            // first entry meant the segment was constrained or not according to which operation the
+            // table happened to reach first - so adding an unrelated route elsewhere in the
+            // document silently turned a 404 into a 400.
+            node.WildCardConstraint = Constraint(group.Value, wildCardDepth);
 
             returnList.Add(node);
         }
 
         return returnList;
+    }
+
+    /// <summary>
+    /// The constraint the routes through this continuation declare, or null where none does.
+    /// </summary>
+    /// <remarks>
+    /// A segment either names a resource or does not, and that is a fact about the path rather than
+    /// about the verb - so one route declaring a constraint constrains the node. The alternative,
+    /// applying it only where every route agrees, would let a document loosen a declared constraint
+    /// by describing the same parameter twice and leaving it off the second time.
+    /// </remarks>
+    private static string? Constraint(List<Entry> entries, int wildCardDepth) {
+        foreach (var entry in entries) {
+            if (RouteTokens.Constraint(entry.WildCardTokens, wildCardDepth) is { } constraint) {
+                return constraint;
+            }
+        }
+
+        return null;
     }
 
     private IReadOnlyList<RouteTreeLeafNode<T>> CreateLeafNodes(List<Entry> entries, int stringIndex) {

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteConstraintTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteConstraintTests.cs
@@ -337,4 +337,98 @@ public class RouteConstraintTests {
             Generate(route).GeneratorDiagnostics,
             diagnostic => diagnostic.Id == DiagnosticId);
     }
+
+    #region one path, several verbs
+
+    /// <summary>
+    /// One path is one node however many verbs answer at it, so a constraint declared on any of
+    /// them constrains the segment.
+    /// </summary>
+    /// <remarks>
+    /// A description routinely declares the same path parameter twice - the petstore fixture gives
+    /// <c>/pets/{petId}</c> a pattern on GET and a bare string on PATCH, PUT and DELETE - and the
+    /// tree took the constraint from whichever entry it reached first. So the segment was
+    /// constrained or not according to the order the operations happened to arrive in, and adding
+    /// an unrelated route elsewhere in the document silently turned a 404 into a 400.
+    /// </remarks>
+    private static GeneratedRoutingTable TwoVerbs(string first, string second) =>
+        GeneratedRoutingTable.For($$"""
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class ItemController {
+                [Get("/items/{{first}}")]
+                public string Read(string id) => id;
+
+                [Delete("/items/{{second}}")]
+                public string Remove(string id) => id;
+            }
+            """);
+
+    [Fact]
+    public void AConstraintDeclaredOnTheFirstVerbConstrainsTheSegment() {
+        var routing = TwoVerbs("{id:int}", "{id}");
+
+        Assert.Equal("Read", routing.Handler("GET", "/items/42").InvokeMethod);
+        Assert.Null(routing.Route("GET", "/items/abc"));
+        Assert.Null(routing.Route("DELETE", "/items/abc"));
+    }
+
+    /// <summary>
+    /// And on the second, which is the half that was order-dependent.
+    /// </summary>
+    [Fact]
+    public void AConstraintDeclaredOnTheSecondVerbConstrainsTheSegmentToo() {
+        var routing = TwoVerbs("{id}", "{id:int}");
+
+        Assert.Equal("Read", routing.Handler("GET", "/items/42").InvokeMethod);
+        Assert.Null(routing.Route("GET", "/items/abc"));
+        Assert.Null(routing.Route("DELETE", "/items/abc"));
+    }
+
+    /// <summary>
+    /// Neither declaring one leaves the segment unconstrained, which is where the binder answers.
+    /// </summary>
+    [Fact]
+    public void NoVerbDeclaringOneLeavesTheSegmentUnconstrained() {
+        var routing = TwoVerbs("{id}", "{id}");
+
+        Assert.Equal("Read", routing.Handler("GET", "/items/abc").InvokeMethod);
+    }
+
+    /// <summary>
+    /// Per continuation, not across the whole position: <c>/items/{id:int}</c> and
+    /// <c>/items/{id}/parts</c> are two nodes, and the first's constraint does not reach the
+    /// second.
+    /// </summary>
+    [Fact]
+    public void AConstraintDoesNotLeakToADifferentContinuation() {
+        var routing = GeneratedRoutingTable.For("""
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class ItemController {
+                [Get("/items/{id:int}")]
+                public string Item(string id) => id;
+
+                [Get("/items/{id}/parts")]
+                public string Parts(string id) => id;
+            }
+            """);
+
+        Assert.Null(routing.Route("GET", "/items/abc"));
+        Assert.Equal("Parts", routing.Handler("GET", "/items/abc/parts").InvokeMethod);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Not on the work order. Found while building B2's fixture: adding one unrelated operation to `petstore.yaml` made `GET /pets/NOT_A_VALID_ID` answer 400 instead of 404, and the constraint call had disappeared from the emitted routing table.

One path is one node however many verbs answer at it, and `ProcessWildCardNodes` read the token's constraint from `group.Value[0]` — whichever entry it reached first. A description routinely declares the same path parameter twice: the petstore fixture gives `/pets/{petId}` a `pattern` on GET and a bare string on PATCH, PUT and DELETE. So the segment was constrained or not according to the order the operations happened to arrive in, and adding a route elsewhere in the document silently changed the answer for one that had not been touched.

The catch-all flag two lines above already reads across the group, and says why: "the node is shared and they may not agree".

**One route declaring a constraint constrains the node.** A segment either names a resource or does not, which is a fact about the path rather than about the verb. The alternative — applying it only where every route agrees — would let a document loosen a declared constraint by describing the same parameter twice and leaving it off the second time.

Per continuation, unchanged: `/items/{id:int}` and `/items/{id}/parts` are two nodes, and the first's constraint does not reach the second. Two routes sharing a continuation and declaring *different* constraints is still HRDR001's business; whether that is actually reported when they differ only by verb is a separate question, and it is in my handoff notes rather than in this change.

Four tests in `RouteConstraintTests`: the constraint declared on the first verb, on the second, on neither, and not leaking across a continuation. The second-verb case fails against the old selection — it is the order-dependent half — and the other three pass either way.

Validated: CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green.

Based on #226. B2 is stacked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
