### PR TITLE
Ship the caller as a service a spec-first handler can take

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
@@ -1,3 +1,5 @@
+using Hardened.Requests.Testing;
+
 namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
 
 /// <summary>
@@ -70,4 +72,50 @@ public class DescribedSecurityTests {
 
         response.Assert.Ok();
     }
+
+    #region the caller, in a handler
+
+    /// <summary>
+    /// H-03. A specification-first handler implements a generated interface, so the code-first
+    /// escape - an <c>IExecutionContext</c> parameter - does not exist, and nothing scoped exposed
+    /// the caller. Ownership checks and grant-dependent filtering could not be written without
+    /// hand-rolled plumbing, and both spec-first arms of the trial invented the same bridge
+    /// independently. <c>ICurrentCaller</c> is that bridge, shipped and injected by constructor.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerReadsTheCallerAndAdmitsTheOwner(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/secured/owned/integration-test", Holding("pets:read"));
+
+        Assert.Equal(200, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The refusal the contract cannot express. Both requests hold the grant the description asks
+    /// for and pass authorization; only the handler can tell which of them owns the row.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerReadsTheCallerAndRefusesSomebodyElse(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/owned/somebody-else", Holding("pets:read"));
+
+        Assert.Equal(403, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Present on every request, empty where nothing authenticated - so a handler reads the same
+    /// shape either way and never checks for null. Authorization refuses this one first, which is
+    /// the arrangement: what a caller may do is judged before the handler runs.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnAnonymousRequestIsRefusedBeforeTheHandlerReadsAnything(
+        ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/owned/integration-test");
+
+        Assert.Equal(401, response.StatusCode);
+    }
+
+    private static Action<TestWebRequest> Holding(string grants) =>
+        request => request.Headers[TestGrantsPrincipalSource.GrantsHeader] = grants;
+
+    #endregion
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
@@ -14,6 +14,9 @@
     <ItemGroup>
         <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
         <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <!-- TestGrantsPrincipalSource, the shipped testing source. A fixture states its caller
+             through the same seam a production application authenticates through. -->
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
         <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OpenApiTestApp.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OpenApiTestApp.cs
@@ -1,10 +1,14 @@
+using DependencyModules.Runtime.Interfaces;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Testing;
 using Hardened.Shared.Runtime.Attributes;
 using Hardened.Web.Runtime.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT;
 
 /// <summary>
-/// A specification-first application, which registers nothing of its own.
+/// A specification-first application, whose one registration is a caller for its tests to state.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -20,6 +24,18 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// emitter back in the path that exists to have none.
 /// </para>
 /// </remarks>
+/// <remarks>
+/// <para>
+/// <c>TestGrantsPrincipalSource</c> is the shipped testing source, through the same seam a
+/// production one uses. It declines every request that does not carry <c>X-Test-Grants</c>, so
+/// every route in this fixture answers exactly as it did before it was registered - and a test
+/// that wants a caller now has one to name.
+/// </para>
+/// </remarks>
 [HardenedModule]
 [HardenedWebModule]
-public partial class OpenApiTestApp { }
+public partial class OpenApiTestApp : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddSingleton<IPrincipalSource, TestGrantsPrincipalSource>();
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/SecuredServiceImpl.cs
@@ -1,5 +1,7 @@
 using Hardened.IntegrationTests.OpenApi.SUT.Services;
 using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Errors;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT;
 
@@ -7,12 +9,26 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// Handlers that exist to be refused.
 /// </summary>
 /// <remarks>
-/// Neither carries an authorization attribute. Everything guarding them came from the description,
-/// which is the point: reaching either method at all is the failure these routes test for.
+/// <para>
+/// None carries an authorization attribute. Everything guarding them came from the description,
+/// which is the point: reaching one of these methods at all is the failure these routes test for.
+/// </para>
+/// <para>
+/// <c>SecuredOwned</c> is the other half. A contract can say the caller must hold a grant and
+/// cannot say the row must be theirs, so the ownership check belongs to the handler - which needs
+/// to know who the caller is. A specification-first handler implements a generated interface, so
+/// it cannot take <c>IExecutionContext</c> as a parameter; <see cref="ICurrentCaller"/> is what it
+/// takes instead, by plain constructor injection with nothing wired by hand.
+/// </para>
 /// </remarks>
 [Handler]
-public class SecuredServiceImpl : ISecuredService {
+public class SecuredServiceImpl(ICurrentCaller caller) : ISecuredService {
     public Task<string> SecuredScoped() => Task.FromResult("reached");
 
     public Task<string> SecuredEither() => Task.FromResult("reached");
+
+    public Task<string> SecuredOwned(string ownerId) =>
+        ownerId == caller.Principal.Subject
+            ? Task.FromResult(ownerId)
+            : throw new StatusCodeException(403);
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -115,6 +115,31 @@ paths:
             application/json:
               schema:
                 type: string
+  # An ownership check, which is the decision only the handler can make: the contract says the
+  # caller must hold pets:read, and nothing in a document can say "and the row must be theirs".
+  # The handler takes ICurrentCaller and compares.
+  /secured/owned/{ownerId}:
+    get:
+      tags:
+        - Secured
+      operationId: securedOwned
+      security:
+        - petstoreOAuth: ["pets:read"]
+      parameters:
+        - name: ownerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The caller owns it.
+          content:
+            application/json:
+              schema:
+                type: string
+        '403':
+          description: The caller is not the owner.
   /secured/either:
     get:
       tags:

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -202,6 +202,10 @@ namespace Hardened.Requests.Abstract.Authorization
         string? Subject { get; }
         bool TryGetClaim(string name, [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out string value);
     }
+    public interface ICurrentCaller
+    {
+        Hardened.Requests.Abstract.Authorization.ICallerPrincipal Principal { get; }
+    }
     public interface IPrincipalSource
     {
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.ICallerPrincipal?> Authenticate(Hardened.Requests.Abstract.Execution.IExecutionContext context);

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/ICurrentCaller.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/ICurrentCaller.cs
@@ -1,0 +1,46 @@
+namespace Hardened.Requests.Abstract.Authorization;
+
+/// <summary>
+/// The caller of the request being handled, as a service a handler can take.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>IExecutionContext.CallerPrincipal</c> is where the principal lives, and a code-first handler
+/// reaches it by taking an <see cref="Execution.IExecutionContext"/> parameter. A specification-first
+/// handler implements a generated interface, so its signature is fixed and that escape does not
+/// exist - which left ownership checks and grant-dependent filtering unwritable without
+/// hand-rolled plumbing. Both spec-first arms of the 0.18 trial invented the same scoped holder
+/// independently; this is it, shipped.
+/// </para>
+/// <code>
+/// [Handler]
+/// public class OrderService(ICurrentCaller caller, IOrderStore store) : IOrderService {
+///     public async Task&lt;Order&gt; GetOrder(string orderId) {
+///         var order = await store.Get(orderId);
+///
+///         if (order.OwnerSubject != caller.Principal.Subject) {
+///             throw new ForbiddenException();
+///         }
+///
+///         return order;
+///     }
+/// }
+/// </code>
+/// <para>
+/// Scoped, and present on every request. A request no principal source answered for carries
+/// <see cref="AnonymousCallerPrincipal.Instance"/>, so a handler reads the same shape either way
+/// and never checks for null.
+/// </para>
+/// <para>
+/// Registered by <c>HardenedRequestModule</c>, so plain constructor injection works with nothing
+/// wired by hand. It is not a substitute for <c>[Authorize]</c> and its friends: what a caller may
+/// do is declared on the operation and judged before the handler runs. This is for the decisions
+/// only the handler can make - whether this caller owns this row.
+/// </para>
+/// </remarks>
+public interface ICurrentCaller {
+    /// <summary>
+    /// The caller this request established, or <see cref="AnonymousCallerPrincipal.Instance"/>.
+    /// </summary>
+    ICallerPrincipal Principal { get; }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationMiddlewareTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationMiddlewareTests.cs
@@ -1,7 +1,9 @@
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.DependencyInjection;
 using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
 
@@ -95,4 +97,79 @@ public class AuthenticationMiddlewareTests {
 
         Assert.Equal("one", seen?.Subject);
     }
+
+    #region the caller, on the request scope
+
+    /// <summary>
+    /// A context whose services are an application's - the request module's own registrations,
+    /// which is what puts the holder there.
+    /// </summary>
+    private static IExecutionContext ApplicationContext() =>
+        Pipeline.Context(
+            configureServices: services => new HardenedRequestModule().ConfigureServices(services));
+
+    private static ICallerPrincipal Resolved(IExecutionContext context) =>
+        context.RequestServices.GetRequiredService<ICurrentCaller>().Principal;
+
+    /// <summary>
+    /// H-03. A specification-first handler implements a generated interface, so it cannot take
+    /// <c>IExecutionContext</c> as a parameter and had no way to read the caller at all. The
+    /// middleware puts the answer on the request scope as well as on the context, which is what
+    /// makes <see cref="ICurrentCaller"/> resolvable in one.
+    /// </summary>
+    [Fact]
+    public async Task TheEstablishedCallerIsPutOnTheRequestScope() {
+        var context = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(context));
+
+        Assert.Equal("ada", Resolved(context).Subject);
+    }
+
+    /// <summary>
+    /// Written from the context rather than from the source's return value, so a request no source
+    /// answered for reads what the context holds - the anonymous principal, present rather than
+    /// null.
+    /// </summary>
+    [Fact]
+    public async Task ARequestNoSourceAnsweredForReadsTheAnonymousPrincipal() {
+        var context = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(null)]).Execute(Chain(context));
+
+        Assert.Same(AnonymousCallerPrincipal.Instance, Resolved(context));
+        Assert.False(Resolved(context).IsAuthenticated);
+    }
+
+    /// <summary>
+    /// One request's caller is not another's, which is the whole reason the holder is scoped.
+    /// </summary>
+    [Fact]
+    public async Task OneRequestsCallerDoesNotReachAnother() {
+        var authenticated = ApplicationContext();
+        var untouched = ApplicationContext();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(authenticated));
+
+        Assert.Equal("ada", Resolved(authenticated).Subject);
+        Assert.Same(AnonymousCallerPrincipal.Instance, Resolved(untouched));
+    }
+
+    /// <summary>
+    /// Asked for rather than required: a host that composed this middleware without the request
+    /// module's registrations still has a caller to establish.
+    /// </summary>
+    [Fact]
+    public async Task AContextWithoutTheHolderStillAuthenticates() {
+        var context = Pipeline.Context();
+
+        await new AuthenticationMiddleware([Source(new CallerPrincipal("test", subject: "ada"))])
+            .Execute(Chain(context));
+
+        Assert.Equal("ada", context.CallerPrincipal.Subject);
+    }
+
+    #endregion
 }

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationMiddleware.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationMiddleware.cs
@@ -1,5 +1,6 @@
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Execution;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.Requests.Runtime.Authorization;
 
@@ -23,6 +24,13 @@ namespace Hardened.Requests.Runtime.Authorization;
 /// Installed by <see cref="AuthenticationStartupService"/> only when at least one source is
 /// registered, so an application using none carries no per-request cost at all.
 /// </para>
+/// <para>
+/// The answer is put on the request scope as well as on the context, which is what makes
+/// <see cref="ICurrentCaller"/> resolvable in a specification-first handler - one whose signature a
+/// generated interface fixes, so it cannot take the context as a parameter. Written from the
+/// context rather than from the source's return value, so a request no source answered for reads
+/// whatever the context holds.
+/// </para>
 /// </remarks>
 public sealed class AuthenticationMiddleware : IExecutionFilter {
     private readonly IPrincipalSource[] _sources;
@@ -42,6 +50,13 @@ public sealed class AuthenticationMiddleware : IExecutionFilter {
 
                 break;
             }
+        }
+
+        // One resolve per request of an application that opted into authentication. Asked for
+        // rather than required, because a host that composed this middleware without the request
+        // module's registrations still has a caller to establish.
+        if (context.RequestServices?.GetService<CurrentCaller>() is { } caller) {
+            caller.Principal = context.CallerPrincipal;
         }
 
         await chain.Next();

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/CurrentCaller.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/CurrentCaller.cs
@@ -1,0 +1,26 @@
+using Hardened.Requests.Abstract.Authorization;
+
+namespace Hardened.Requests.Runtime.Authorization;
+
+/// <summary>
+/// The scoped holder <see cref="ICurrentCaller"/> resolves to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written by <see cref="AuthenticationMiddleware"/>, which runs ahead of the whole handler chain
+/// inside the request's own scope, and read by whatever the handler was resolved with. A mutable
+/// holder rather than a factory over the execution context, because the container has no per-request
+/// instance of the context to hand one.
+/// </para>
+/// <para>
+/// <b>What it reflects, exactly.</b> The principal the authentication seam established. An
+/// application with no <see cref="IPrincipalSource"/> installs no middleware and every request
+/// reads <see cref="AnonymousCallerPrincipal.Instance"/> - which is the same answer
+/// <c>IExecutionContext.CallerPrincipal</c> gives, at no per-request cost. A principal assigned to
+/// the context by something else after the middleware has run is not reflected here; nothing else
+/// is asked to run, which is what keeps this free for the applications that use none of it.
+/// </para>
+/// </remarks>
+internal sealed class CurrentCaller : ICurrentCaller {
+    public ICallerPrincipal Principal { get; set; } = AnonymousCallerPrincipal.Instance;
+}

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using DependencyModules.Runtime.Attributes;
 using DependencyModules.Runtime.Interfaces;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Runtime.Authorization;
 using Hardened.Requests.Runtime.Configuration;
 using Hardened.Requests.Runtime.Links;
@@ -44,6 +45,13 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         services.AddSingleton(
             s => Options.Create(s.GetRequiredService<IConfigurationManager>()
                 .GetConfiguration<IAuthorizationConfiguration>()));
+
+        // The caller, as a service a handler can take. Scoped rather than resolved from the
+        // context, because the container has no per-request instance of the context to build one
+        // from. Two registrations rather than one: the middleware fills the holder and everything
+        // else reads the interface, which is what keeps the setter off the contract.
+        services.AddScoped<CurrentCaller>();
+        services.AddScoped<ICurrentCaller>(provider => provider.GetRequiredService<CurrentCaller>());
 
         // Always installed. It costs one call per handler at startup and returns null for a handler
         // that carries no authorization attribute, so an application that has not opted in to


### PR DESCRIPTION
B2 / H-03 from the 0.19 work order, found independently by both spec-first arms.

A generated service interface fixes a handler's signature, so the code-first escape — an `IExecutionContext` parameter — does not exist, and nothing scoped exposed the caller. Ownership 403s and grant-dependent filtering, both mainstream and both in the trial's spec, could not be written without hand-rolled plumbing; both arms invented the same scoped holder, and every spec-first application with ownership rules would have re-derived it.

```csharp
[Handler]
public class OrderService(ICurrentCaller caller, IOrderStore store) : IOrderService {
    public async Task<Order> GetOrder(string orderId) {
        var order = await store.Get(orderId);

        if (order.OwnerSubject != caller.Principal.Subject) {
            throw new StatusCodeException(403);
        }

        return order;
    }
}
```

`ICurrentCaller` lives in `Hardened.Requests.Abstract`, because a function handler needs it and the Lambda runtimes do not reference `Hardened.Web.Runtime`. The authentication middleware fills it — that is where the principal is established, it already runs inside the request's own scope, and writing from the context rather than from the source's return value means a request no source answered for reads what the context holds.

**An application that registered no principal source pays nothing.** No middleware is installed, so nothing writes, and every request reads `AnonymousCallerPrincipal.Instance` — present rather than null, so a handler reads the same shape either way and never checks. The remarks state the limit that buys: a principal assigned to the context by something other than the seam, after the middleware has run, is not reflected.

Two registrations rather than one — the middleware fills the holder, everything else reads the interface — which is what keeps the setter off the contract.

`ICurrentCaller` is not a substitute for `[Authorize]`. What a caller may do is declared on the operation and judged before the handler runs; this is for the decision only the handler can make.

Tests:

- The petstore fixture gains `GET /secured/owned/{ownerId}` — the operation a document cannot express, since a contract can say the caller must hold `pets:read` and cannot say the row must be theirs. `SecuredServiceImpl` does the check by plain constructor injection with nothing wired by hand, and three integration tests drive it over a real host: the owner is admitted, somebody else holding the same grant is refused 403, and an anonymous caller is refused 401 by authorization before the handler reads anything. The fixture registers `TestGrantsPrincipalSource`, which declines every request without `X-Test-Grants`, so every route in it answers exactly as before.
- Four unit tests in `AuthenticationMiddlewareTests`, over a context carrying the request module's own registrations: the established caller reaches the scope, a request nothing answered for reads the anonymous principal, one request's caller does not reach another's, and a context without the holder still authenticates.

Public API baseline: `ICurrentCaller` added to `Hardened.Requests.Abstract`, approved deliberately.

Validated: CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green.

**Stacked on #232**, which the fixture change flushed out: adding an operation to `petstore.yaml` reordered the routing table's entries and silently dropped the route constraint on `/pets/{petId}`. That fix is its own PR; this one is based on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
