### PR TITLE
Derive a code-first operation's validation status from [Throws<T>]

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
@@ -120,4 +120,63 @@ public class RegistrationValidationTests {
 
         response.Assert.Ok();
     }
+
+    #region an operation that declares its validation status
+
+    /// <summary>
+    /// H-08. A spec-first operation declares 422 and the runtime honours it; code-first had no way
+    /// to say the same thing, and the trial's 422 requirement took a marker attribute plus a
+    /// wrapping <c>IExceptionToModelConverter</c> to satisfy - while the served document still
+    /// carried an unreachable 400 beside the hand-declared 422.
+    /// </summary>
+    /// <remarks>
+    /// Derived from <c>[Throws&lt;RequestValidationError&gt;(422)]</c> rather than declared twice.
+    /// The handler has already put that status in the document; reading the same declaration for
+    /// the runtime is what closes the gap without a second source of truth on a verb attribute.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AConstraintFailureAnswersTheDeclaredStatus(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new { Name = "", Age = 30 }, "/registration/declared-422");
+
+        Assert.Equal(422, response.StatusCode);
+        Assert.Contains(
+            response.Deserialize<RequestValidationError>().Errors, e => e.Field == "model.name");
+    }
+
+    /// <summary>A handler validating by hand reaches the same status.</summary>
+    [HardenedTest]
+    public async Task AThrownValidationExceptionAnswersTheDeclaredStatus(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new { Name = "Ada", Age = 30 }, "/registration/declared-422/by-hand");
+
+        Assert.Equal(422, response.StatusCode);
+    }
+
+    /// <summary>
+    /// And so does a body the deserializer refuses, which is the half that split the status in two
+    /// on every spec-first operation declaring 422 until the converter looked it up.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABodyTheDeserializerRefusesAnswersTheDeclaredStatus(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new { Name = "Ada", Age = "not a number" }, "/registration/declared-422");
+
+        Assert.Equal(422, response.StatusCode);
+        Assert.Equal(
+            "ValidationError", response.Deserialize<RequestValidationError>().Type);
+    }
+
+    /// <summary>
+    /// The control. An operation that declares nothing still answers the stock 400, so the
+    /// derivation reaches the operation that asked for it and no other.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOperationDeclaringNothingStillAnswers400(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(new { Name = "", Age = 30 }, "/registration");
+
+        response.Assert.BadRequest();
+    }
+
+    #endregion
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiDocumentTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiDocumentTests.cs
@@ -255,4 +255,38 @@ public class OpenApiDocumentTests {
 
         Assert.Equal("string", response.GetProperty("type").GetString());
     }
+
+    #region the declared validation status
+
+    private static async Task<string[]> Statuses(ITestWebApp testWebApp, string path) {
+        using var document = await Fetch(testWebApp);
+
+        return document.RootElement
+            .GetProperty("paths").GetProperty(path).GetProperty("post").GetProperty("responses")
+            .EnumerateObject().Select(status => status.Name).OrderBy(name => name).ToArray();
+    }
+
+    /// <summary>
+    /// The operation publishes the status it answers, and only that one. The trial's code-first arm
+    /// declared 422 by hand and the document carried the synthesized 400 beside it - a status the
+    /// operation could no longer produce.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOperationDeclaring422PublishesItAndNoSynthesized400(ITestWebApp testWebApp) {
+        var statuses = await Statuses(testWebApp, "/registration/declared-422");
+
+        Assert.Contains("422", statuses);
+        Assert.DoesNotContain("400", statuses);
+    }
+
+    /// <summary>
+    /// And an operation that declares nothing still publishes the 400 it answers, which is what the
+    /// synthesis is for.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOperationDeclaringNothingStillPublishesThe400(ITestWebApp testWebApp) {
+        Assert.Contains("400", await Statuses(testWebApp, "/registration/for/{tenant}"));
+    }
+
+    #endregion
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/RegistrationController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/RegistrationController.cs
@@ -1,5 +1,12 @@
 using Hardened.IntegrationTests.WebApp.SUT.Models;
+using Hardened.Requests.Abstract.Responses;
+using Hardened.Requests.Runtime.Validation;
 using Hardened.Web.Runtime.Attributes;
+using ValidationModules;
+// Both namespaces declare a ValidationException, which is CS0104 without this. Either reaches the
+// same response - ExceptionToModelConverter maps one shape from both - so which is aliased is a
+// choice, and Hardened's is the one this controller means.
+using ValidationException = Hardened.Requests.Runtime.Validation.ValidationException;
 
 namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
 
@@ -34,4 +41,29 @@ public class RegistrationController {
     [Post("/anonymous")]
     public string Unconstrained(MathAddModel model) =>
         string.Join(",", model.Values ?? new List<int>());
+
+    /// <summary>
+    /// The same model on an operation that says what a validation refusal answers.
+    /// </summary>
+    /// <remarks>
+    /// <c>[Throws&lt;RequestValidationError&gt;(422)]</c> puts the 422 in the published document,
+    /// and the same declaration is what the runtime reads: one vocabulary carrying both, rather
+    /// than an assertion on a verb attribute that the document would have to be told about
+    /// separately. A specification-first operation declaring 422 has answered it since 0.18; this
+    /// is how a hand-written one says the same thing.
+    /// </remarks>
+    [Post("/declared-422")]
+    [Throws<RequestValidationError>(422)]
+    public string RegisterDeclaring422(RegistrationModel model) => model.Name ?? "";
+
+    /// <summary>
+    /// A handler validating by hand on an operation that declares 422, so the thrown route to a
+    /// refusal answers what the filter's route does.
+    /// </summary>
+    [Post("/declared-422/by-hand")]
+    [Throws<RequestValidationError>(422)]
+    public string ThrowValidation() =>
+        throw new ValidationException(ValidationResult.FromErrors([
+            new ValidationError("model.name", "required", "model.name is required.")
+        ]));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
@@ -96,9 +96,12 @@ public interface IExecutionRequestHandlerInfo {
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Set only from a described operation declaring 422. A contract that publishes a 422 for its
-    /// validation error is a promise the converter has to keep; a hand-written handler has no
-    /// source of truth behind such an assertion, which is why no attribute carries this.
+    /// Set from a described operation declaring 422, and from a hand-written handler carrying
+    /// <c>[Throws&lt;RequestValidationError&gt;(422)]</c>. A contract that publishes a 422 for its
+    /// validation error is a promise the converter has to keep, and that attribute is how a
+    /// code-first handler publishes the same one - so the status is derived from the declaration
+    /// the document already reads rather than asserted a second time on a verb attribute, which is
+    /// what those attributes dropped it for.
     /// </para>
     /// <para>
     /// Every refusal that answers the validation envelope, not only the ones a generated filter

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ThrowsAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ThrowsAttribute.cs
@@ -26,6 +26,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// means, and the generator refuses a declaration that names neither.
 /// </para>
 /// <para>
+/// <b>One declaration it also decides.</b> <c>[Throws&lt;RequestValidationError&gt;(422)]</c> says
+/// the operation answers validation failures with 422, so that is the status the runtime answers
+/// them with - the filter's refusal, a handler's own <c>ValidationException</c>, and a body the
+/// deserializer could not read alike. A described operation declaring 422 has behaved this way
+/// since 0.18; this is how a hand-written one says it, without a second place to write it down.
+/// </para>
+/// <para>
 /// <b>What this deliberately does not promise.</b> It does not assert that the handler throws this,
 /// nor that it throws nothing else. An unmapped exception is unplanned by definition and the runtime
 /// already has somewhere to put it. Verifying completeness is the road ASP.NET went down with its

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ThrowsAttributeTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ThrowsAttributeTests.cs
@@ -136,6 +136,101 @@ public class ThrowsAttributeTests {
     /// source searches compressed bytes and finds nothing - which is exactly the false negative this
     /// suite hit first time round.
     /// </remarks>
+    #region the validation status it derives
+
+    /// <summary>
+    /// A handler declaring that it answers 422 with the validation envelope has stated the
+    /// operation's validation status; the same declaration sets it for the runtime.
+    /// </summary>
+    /// <remarks>
+    /// H-08. Spec-first has declared this since 0.18 and code-first had nothing, deliberately - the
+    /// verb attributes dropped <c>ValidationErrorStatus</c> on the grounds that no hand-written
+    /// assertion should be a second source of truth beside the document. Deriving it from a
+    /// declaration the document already reads keeps that: there is still one place to write it.
+    /// </remarks>
+    [Fact]
+    public void DeclaringTheValidationEnvelopeSetsTheHandlersValidationStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class PetController {
+                [Post("/pets")]
+                [Throws<Hardened.Requests.Runtime.Validation.RequestValidationError>(422)]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        result.AssertNoErrors();
+
+        Assert.Contains("validationErrorStatus: 422", HandlerInfo(result));
+    }
+
+    /// <summary>
+    /// Another thrown type does not, however it is declared. This derives one status from one
+    /// vocabulary, not a status from every declaration.
+    /// </summary>
+    [Fact]
+    public void DeclaringAnotherThrownTypeSetsNoValidationStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class PetController {
+                [Post("/pets")]
+                [Throws<RateLimited>]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        result.AssertNoErrors();
+
+        Assert.DoesNotContain("validationErrorStatus", HandlerInfo(result));
+    }
+
+    /// <summary>
+    /// Matched by full name. An application is entitled to a <c>RequestValidationError</c> of its
+    /// own, and one that happens to share the name says nothing about how this framework's
+    /// validation answers.
+    /// </summary>
+    [Fact]
+    public void ATypeMerelySharingTheNameSetsNoValidationStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            [HttpStatus(422)]
+            public class RequestValidationError { }
+
+            public class PetController {
+                [Post("/pets")]
+                [Throws<RequestValidationError>]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        result.AssertNoErrors();
+
+        Assert.DoesNotContain("validationErrorStatus", HandlerInfo(result));
+    }
+
+    /// <summary>
+    /// The declaration still reaches the document, which is the half it already did.
+    /// </summary>
+    /// <remarks>
+    /// Whether the synthesized 400 stands down beside it is not assertable here - this handler
+    /// constrains nothing, so no 400 is synthesized either way. <c>OpenApiDocumentTests</c> covers
+    /// that over an application whose model carries real constraints.
+    /// </remarks>
+    [Fact]
+    public void TheDocumentCarriesTheDeclaredStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class PetController {
+                [Post("/pets")]
+                [Throws<Hardened.Requests.Runtime.Validation.RequestValidationError>(422)]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        Assert.Contains("\"422\"", Document(result));
+    }
+
+    private static string HandlerInfo(GeneratorResult result) =>
+        result.GeneratedSources.First(candidate => candidate.Key.Contains("PetController")).Value;
+
+    #endregion
+
     private static string Document(GeneratorResult result) {
         var source = result.GeneratedSources
             .First(candidate => candidate.Key.Contains("OpenApiDocument")).Value;

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -24,14 +24,11 @@ public abstract class BaseRequestModelGenerator {
 
         var parameters = GetParameters(context, methodDeclaration, nameModel, cancellationToken);
 
-        // Read before Compose, because the unresolved ones ride on the response model and the
-        // emit step is where there is a context to report them into.
-        var unresolved = new List<string>();
-        var thrown = ThrownResponseSelector.Read(context, methodDeclaration, unresolved, cancellationToken);
-
-        if (unresolved.Count > 0) {
-            response.ThrowsDiagnostic = string.Join(",", unresolved);
-        }
+        // Read before Compose, because two things it derives ride on the response model: the
+        // declarations naming no status, which the emit step has a context to report, and the
+        // validation status a [Throws<RequestValidationError>(422)] states.
+        var thrown = ThrownResponseSelector.Read(
+            context, methodDeclaration, response, cancellationToken);
 
         var model = Compose(
             nameModel,

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/ThrownResponseSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/ThrownResponseSelector.cs
@@ -29,6 +29,9 @@ public static class ThrownResponseSelector {
     private const string AttributeSuffix = "Attribute";
     private const string HttpStatusAttribute = "HttpStatusAttribute";
 
+    /// <summary>The envelope every validation refusal answers with.</summary>
+    private const string ValidationErrorType = "Hardened.Requests.Runtime.Validation.RequestValidationError";
+
     /// <summary>The id reported when a declaration names no status.</summary>
     public const string DiagnosticId = "HRDT001";
 
@@ -64,15 +67,17 @@ public static class ThrownResponseSelector {
     }
 
     /// <summary>
-    /// Reads every <c>[Throws&lt;T&gt;]</c> on the method, collecting into <paramref name="unresolved"/>
-    /// the ones naming no status.
+    /// Reads every <c>[Throws&lt;T&gt;]</c> on the method, recording onto
+    /// <paramref name="response"/> the declarations naming no status and the validation status one
+    /// of them derives.
     /// </summary>
     public static IReadOnlyList<ResponseSchemaModel> Read(
         GeneratorSyntaxContext context,
         MethodDeclarationSyntax method,
-        List<string> unresolved,
+        ResponseInformationModel response,
         CancellationToken cancellationToken) {
         List<ResponseSchemaModel>? declared = null;
+        List<string>? unresolved = null;
 
         foreach (var attributeList in method.AttributeLists) {
             foreach (var attribute in attributeList.Attributes) {
@@ -87,9 +92,19 @@ public static class ThrownResponseSelector {
                 var status = StatedStatus(context, attribute) ?? DeclaredStatus(errorType);
 
                 if (status == null) {
-                    unresolved.Add(errorType.Name);
+                    (unresolved ??= new List<string>()).Add(errorType.Name);
 
                     continue;
+                }
+
+                // Derived rather than declared twice. A handler saying it answers 422 with the
+                // validation envelope has stated the operation's validation status into the
+                // document already; reading the same declaration for the runtime is what lets
+                // code-first reach the parity spec-first has had, without a second source of truth
+                // on any attribute. The verb attributes dropped ValidationErrorStatus on exactly
+                // those grounds.
+                if (response.ValidationErrorStatus == null && IsValidationEnvelope(errorType)) {
+                    response.ValidationErrorStatus = status;
                 }
 
                 declared ??= new List<ResponseSchemaModel>();
@@ -106,8 +121,23 @@ public static class ThrownResponseSelector {
             }
         }
 
+        if (unresolved != null) {
+            response.ThrowsDiagnostic = string.Join(",", unresolved);
+        }
+
         return (IReadOnlyList<ResponseSchemaModel>?)declared ?? System.Array.Empty<ResponseSchemaModel>();
     }
+
+    /// <summary>
+    /// Whether the declared type is the envelope every validation refusal answers with.
+    /// </summary>
+    /// <remarks>
+    /// By full name rather than by simple name: an application is entitled to a
+    /// <c>RequestValidationError</c> of its own, and one that happens to share the name is not a
+    /// statement about how this framework's validation answers.
+    /// </remarks>
+    private static bool IsValidationEnvelope(INamedTypeSymbol errorType) =>
+        errorType.ToDisplayString() == ValidationErrorType;
 
     /// <summary>The type argument of a <c>[Throws&lt;T&gt;]</c>, or null for any other attribute.</summary>
     private static INamedTypeSymbol? ThrownType(GeneratorSyntaxContext context, AttributeSyntax attribute) {


### PR DESCRIPTION
B3 / H-08 from the 0.19 work order, built on the mechanism you signed off: derive it, do not declare it twice.

Spec-first declares 422 per operation and the runtime honours it. Code-first had nothing, deliberately — the verb attributes dropped `ValidationErrorStatus` on the recorded grounds that no hand-written assertion should be a second source of truth beside the document. So the trial's 422 requirement took a marker attribute plus a wrapping `IExceptionToModelConverter`, and the served document still carried the now-unreachable synthesized 400 beside the hand-declared 422.

A handler carrying `[Throws<RequestValidationError>(422)]` has already declared that status into the document. The same declaration now sets `HandlerInfo.ValidationErrorStatus`:

```csharp
[Post("/registration/declared-422")]
[Throws<RequestValidationError>(422)]
public string Register(RegistrationModel model) => model.Name ?? "";
```

One vocabulary carrying the runtime and the document together, and no new property on any attribute — which is what keeps the grounds those attributes were built on.

Matched by full name. An application is entitled to a `RequestValidationError` of its own, and one that happens to share the name says nothing about how this framework's validation answers.

**The document needed no change.** `WriteValidationResponse` already skips the synthesis where a validation status is declared, so the operation publishes the 422 it answers and no orphaned 400.

Tests:

- Four integration tests over the real pipeline: a constraint failure answers 422, a handler's own `ValidationException` answers 422, a body the deserializer refuses answers 422, and an operation declaring nothing still answers 400.
- Two document tests: the declaring operation publishes 422 and no 400; a sibling declaring nothing still publishes its 400.
- Four generator tests: the derived emission, another thrown type deriving nothing, a type merely sharing the name deriving nothing, and the declaration reaching the document. The first fails against the old selector.

The fixture's `[Throws]` handler also demonstrates the using-alias that H-11 is about, since two namespaces declare a `ValidationException` and the controller needs both.

**Stacked on #227**, which the deserialization case needs: without it that request answers 400 whatever the operation declares.

Validated: CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green; public API baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
