### PR TITLE
Name a parameter failure the way the caller spelt it

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
@@ -177,4 +177,42 @@ public class ValidationTests {
 
         response.Assert.Ok();
     }
+
+    #region the name a caller can act on
+
+    private const string ValidOrder =
+        """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":2}]}""";
+
+    /// <summary>
+    /// OR-04. <c>Idempotency-Key</c> failing its pattern reported <c>"field": "idempotencyKey"</c>
+    /// - a name that appears nowhere in the request or the contract. Body failures already used
+    /// wire names with indexed paths; header and query failures leaked the C# identifier the
+    /// generator allocated.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHeaderFailureNamesTheHeader(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            ValidOrder, "/orders", request => request.Headers["Idempotency-Key"] = "not-hex");
+
+        Assert.Equal(400, response.StatusCode);
+
+        var error = response.Deserialize<RequestValidationError>();
+
+        Assert.Contains(error.Errors, e => e.Field == "Idempotency-Key");
+        Assert.DoesNotContain(error.Errors, e => e.Field == "idempotencyKey");
+    }
+
+    /// <summary>
+    /// A valid key gets through, so the constraint is the thing being tested rather than the
+    /// parameter merely being present.
+    /// </summary>
+    [HardenedTest]
+    public async Task AValidHeaderIsAccepted(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            ValidOrder, "/orders", request => request.Headers["Idempotency-Key"] = "0f9ac3b2");
+
+        response.Assert.Ok();
+    }
+
+    #endregion
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OrderServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/OrderServiceImpl.cs
@@ -10,9 +10,11 @@ namespace Hardened.IntegrationTests.OpenApi.SUT;
 /// <remarks>
 /// Deliberately does no checking of its own. The point of the route is that a request reaching this
 /// method at all is a failure of validation - both defects it covers ended with the handler running
-/// on a body the caller never sent.
+/// on a body the caller never sent. The idempotency key is taken and ignored for the same reason:
+/// what is under test is the refusal it never reaches.
 /// </remarks>
 [Handler]
 public class OrderServiceImpl : IOrderService {
-    public Task<OrderRequest> PlaceOrder(OrderRequest body) => Task.FromResult(body);
+    public Task<OrderRequest> PlaceOrder(string? idempotencyKey, OrderRequest body) =>
+        Task.FromResult(body);
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -135,6 +135,15 @@ paths:
       tags:
         - Order
       operationId: placeOrder
+      parameters:
+        # A wire name no C# identifier can be. The member becomes IdempotencyKey and the failure
+        # has to still name the header the caller sent.
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            pattern: '^[0-9a-f]{8}$'
       requestBody:
         required: true
         content:

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
@@ -30,10 +30,15 @@ internal static class OperationParameters {
     internal sealed record Model(string OperationId, string InterfaceName, IReadOnlyList<Member> Members);
 
     /// <param name="Name">The C# name, matching what the handler's Parameters class declares.</param>
+    /// <param name="WireName">
+    /// What the caller calls it - the header, query or path name the contract declares - or null
+    /// where that is already the C# name.
+    /// </param>
     /// <param name="Type">Its type.</param>
     /// <param name="Attributes">Constraints, already rendered.</param>
     internal sealed record Member(
-        string Name, ITypeDefinition Type, IReadOnlyList<ConstraintAttributes.Model> Attributes);
+        string Name, string? WireName, ITypeDefinition Type,
+        IReadOnlyList<ConstraintAttributes.Model> Attributes);
 
     public static Model? Build(
         OperationModel operation, ServiceSpecModel spec, string modelsNamespace, PatternRegistry patterns) {
@@ -67,6 +72,7 @@ internal static class OperationParameters {
 
             members.Add(new Member(
                 parameter.MemberName,
+                parameter.Name == parameter.MemberName ? null : parameter.Name,
                 TypeMapper.GetTypeDefinition(modelsNamespace, csType, parameter.IsCSharpNullable),
                 attributes));
         }
@@ -96,7 +102,7 @@ internal static class OperationParameters {
 
             constrained |= attributes.Length > 0;
 
-            members.Add(new Member("body", bodyType, attributes));
+            members.Add(new Member("body", null, bodyType, attributes));
         }
 
         return constrained

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/ValidationEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/ValidationEmitter.cs
@@ -57,6 +57,17 @@ internal static class ValidationEmitter {
 
             property.Set = null;
 
+            // What the caller calls it, where that is not the C# name. ValidationModules reads
+            // [JsonPropertyName] to spell a failure's field, so Idempotency-Key failing its pattern
+            // reports "Idempotency-Key" rather than "idempotencyKey" - a name that appears nowhere
+            // in the request or the contract. Nothing serializes this interface; the attribute is
+            // here as the field-naming vocabulary the validator already reads.
+            if (member.WireName != null) {
+                property.AddAttribute(
+                    TypeDefinition.Get("System.Text.Json.Serialization", "JsonPropertyNameAttribute"),
+                    new CodeOutputComponent($"\"{member.WireName}\"") { Indented = false });
+            }
+
             foreach (var attribute in member.Attributes) {
                 Apply(property, attribute);
             }


### PR DESCRIPTION
B4 / H-19.

`Idempotency-Key` failing its pattern reported `"field": "idempotencyKey"` — a name that appears nowhere in the request or the contract, so a client reading the error has nothing to act on. Body failures already used wire names with indexed paths (`body.priceTiers[0].code`); header, query and cookie failures leaked the C# identifier the generator allocated for the member.

The parameter interface the build task emits now carries the wire name as `[JsonPropertyName]` wherever it differs from the member name. That is the vocabulary ValidationModules already reads to spell a failure's field, so nothing new decides the name and the two cannot drift. Nothing serializes that interface — it exists to carry constraints onto the handler's `Parameters` class — so the attribute is there for the naming and nothing else.

**The code-first path already did this.** `HandlerValidationFrontEnd.FieldNameFor` prefers the binding name over the identifier; this is the spec-first half of the same rule.

Tests: the petstore fixture's `POST /orders` gains an optional `Idempotency-Key` header constrained to eight hex characters — a wire name no C# identifier can be. One test sends a bad key and asserts the error names `Idempotency-Key` and not `idempotencyKey`; the other sends a valid one and is admitted, so the constraint is what is under test rather than the parameter merely existing. The first fails without the change. Every existing `/orders` test is untouched, which is why the header is optional.

Validated: CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green.

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
