### PR TITLE
Register TimeProvider so an application does not write a clock

### DIFF
--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -170,7 +170,35 @@ Every test project is already created and registered in the solution. If you fin
 editing them conflict. `coverage-baseline.json` is the one shared file you are expected to touch,
 and only to raise your own assembly's floor.
 
-## 12. xunit version
+## 12. Moving time
+
+`HardenedCoreModule` registers `TimeProvider.System`, so an application takes `TimeProvider` and a
+test substitutes it:
+
+```csharp
+[Get("/holds/{id}")]
+public Hold? Get([FromServices] TimeProvider timeProvider, string id) =>
+    _store.Get(id) is { } hold && hold.ExpiresAt > timeProvider.GetUtcNow() ? hold : null;
+```
+
+```csharp
+[HardenedTest]
+public async Task AHoldExpires(ITestWebApp app, [Mock] TimeProvider timeProvider) {
+    timeProvider.GetUtcNow().Returns(DateTimeOffset.UtcNow.AddHours(1));
+
+    (await app.Get($"/holds/{id}")).Assert.NotFound();
+}
+```
+
+`[FromServices]` rather than a bare parameter: `TimeProvider` is an abstract class, and the
+convention that resolves a parameter from the container reads interfaces — a concrete type falls
+through to the body branch.
+
+Registered with `TryAdd`, so an application that registers its own keeps it. Nothing in the
+framework reads time through it; it is registered because every application needs a clock and none
+should have to write one — three trial arms wrote the same ten lines independently.
+
+## 13. xunit version
 
 New test projects use **xunit.v3**.
 

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ClockTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ClockTests.cs
@@ -1,0 +1,44 @@
+using NSubstitute;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// Movable time, without an application writing the seam for it.
+/// </summary>
+/// <remarks>
+/// H-22. All three arms of the 0.18 trial hand-rolled an <c>IClock</c> and a <c>SystemClock</c>,
+/// ten identical lines each, because nothing in the framework or the harness provided one. The
+/// core module registers <c>TimeProvider.System</c> now, so an application injects the BCL's own
+/// abstraction and a test substitutes it with <c>[Mock]</c> like any other singleton.
+/// </remarks>
+public class ClockTests {
+
+    [HardenedTest]
+    public async Task TheRegisteredClockIsTheSystemOne(ITestWebApp testWebApp) {
+        var before = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        var response = await testWebApp.Get("/clock/now");
+
+        response.Assert.Ok();
+
+        Assert.InRange(
+            response.Deserialize<DateTimeOffset>(), before, DateTimeOffset.UtcNow.AddMinutes(1));
+    }
+
+    /// <summary>
+    /// A test moves time by substituting the provider, with no application-defined seam between
+    /// the two.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATestCanMoveTime(ITestWebApp testWebApp, [Mock] TimeProvider timeProvider) {
+        var moon = new DateTimeOffset(1969, 7, 20, 20, 17, 0, TimeSpan.Zero);
+
+        timeProvider.GetUtcNow().Returns(moon);
+
+        var response = await testWebApp.Get("/clock/now");
+
+        response.Assert.Ok();
+
+        Assert.Equal(moon, response.Deserialize<DateTimeOffset>());
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ClockController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ClockController.cs
@@ -1,0 +1,26 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Web.Runtime.Attributes;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// A handler that reads the time from the container rather than from <c>DateTimeOffset.UtcNow</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every arm of the last two trials hand-rolled an <c>IClock</c> and a <c>SystemClock</c> to drive
+/// expiry from a test. <c>TimeProvider</c> is the BCL's own abstraction for it and the core module
+/// registers <c>TimeProvider.System</c>, so an application injects it and a test substitutes it.
+/// </para>
+/// <para>
+/// <c>[FromServices]</c> rather than a bare parameter, because <c>TimeProvider</c> is an abstract
+/// class and the convention that resolves a parameter from the container reads interfaces - a
+/// concrete type falls through to the body branch.
+/// </para>
+/// </remarks>
+[BasePath("/clock")]
+public class ClockController {
+
+    [Get("/now")]
+    public DateTimeOffset Now([FromServices] TimeProvider timeProvider) => timeProvider.GetUtcNow();
+}

--- a/src/Shared/Hardened.Shared.Runtime/DependencyInjection/HardenedCoreModule.cs
+++ b/src/Shared/Hardened.Shared.Runtime/DependencyInjection/HardenedCoreModule.cs
@@ -26,5 +26,28 @@ public partial class HardenedCoreModule : IServiceCollectionConfiguration {
 
         services.TryAddSingleton<IItemPool<MD5>>(_ =>
             new ItemPool<MD5>(MD5.Create, _ => { }, md5 => md5.Dispose()));
+
+        RegisterTimeProvider(services);
+    }
+
+    /// <summary>
+    /// The clock, as the BCL's own abstraction.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every arm of the last two trials hand-rolled an <c>IClock</c> and a <c>SystemClock</c> to
+    /// drive expiry from a test, and every one of them was the same ten lines. <c>TimeProvider</c>
+    /// is what .NET 8 added for it, so there is nothing here to invent: an application injects
+    /// <c>TimeProvider</c> and a test substitutes it with <c>[Mock]</c> like any other singleton.
+    /// </para>
+    /// <para>
+    /// <c>TryAdd</c>, so an application that registers its own - a fake, or one of
+    /// <c>Microsoft.Extensions.TimeProvider.Testing</c>'s - keeps it. The framework reads no time
+    /// through this; it is here because every application needs one and none should have to write
+    /// it.
+    /// </para>
+    /// </remarks>
+    private static void RegisterTimeProvider(IServiceCollection services) {
+        services.TryAddSingleton(TimeProvider.System);
     }
 }


### PR DESCRIPTION
C2 / H-22.

All three arms of the 0.18 trial hand-rolled an `IClock` and a `SystemClock` to drive expiry from a test — ten identical lines each — because nothing in the framework or the harness provided movable time. `TimeProvider` is what .NET 8 added for exactly this, so there is nothing here to invent: `HardenedCoreModule` registers `TimeProvider.System`, an application injects the BCL's own abstraction, and a test substitutes it with `[Mock]` like any other singleton.

`TryAdd`, so an application that registers its own — a fake, or one of `Microsoft.Extensions.TimeProvider.Testing`'s — keeps it. The framework reads no time through this; it is registered because every application needs a clock and none should have to write one.

Two integration tests over a real host: the registered provider is the system one, and a test moves time to 1969 by substituting it with no application-defined seam between the two.

`docs/testing-conventions.md` gains a section showing both halves, including why a handler takes it with `[FromServices]` — `TimeProvider` is an abstract class, and the convention that resolves a parameter from the container reads interfaces, so a bare parameter falls through to the body branch.

Validated: CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green; public API baseline unchanged, since `TimeProvider` is the BCL's type and the registration is not surface.

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
