### PR TITLE
Hand the harness a path and a body the way a transport does

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
@@ -1,0 +1,64 @@
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// A percent-encoded path, through the harness, answering what a socket answers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SU-07. <c>app.Get("/binding/path/%20")</c> reached the handler as the literal three characters
+/// while the same request over Kestrel decoded to whitespace - so a test could pass here and the
+/// application behave differently in production, which is the one thing a harness exists not to
+/// do.
+/// </para>
+/// <para>
+/// Every expectation below was measured against the Kestrel integration application over a real
+/// socket rather than reasoned about: the separator that stays encoded and the plus that is not a
+/// space are both surprises.
+/// </para>
+/// </remarks>
+public class EncodedPathTests {
+
+    private static async Task<string> Token(ITestWebApp app, string encoded) {
+        var response = await app.Get("/binding/path/" + encoded);
+
+        response.Assert.Ok();
+
+        return response.Deserialize<string>();
+    }
+
+    [HardenedTest]
+    public async Task AnEscapedSpaceReachesTheHandlerAsASpace(ITestWebApp app) {
+        Assert.Equal(" ", await Token(app, "%20"));
+    }
+
+    [HardenedTest]
+    public async Task AMultiByteCharacterIsDecodedWhole(ITestWebApp app) {
+        Assert.Equal("café", await Token(app, "caf%C3%A9"));
+    }
+
+    [HardenedTest]
+    public async Task AnEscapedPercentIsAPercent(ITestWebApp app) {
+        Assert.Equal("a%b", await Token(app, "a%25b"));
+    }
+
+    /// <summary>
+    /// The one escape that stays. Decoding it would put a separator inside a segment, changing how
+    /// many segments the path has.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnEscapedSeparatorStaysEncoded(ITestWebApp app) {
+        Assert.Equal("a%2Fb", await Token(app, "a%2Fb"));
+    }
+
+    /// <summary>A plus is a plus in a path. Only a query string reads one as a space.</summary>
+    [HardenedTest]
+    public async Task APlusIsNotASpace(ITestWebApp app) {
+        Assert.Equal("a+b", await Token(app, "a+b"));
+    }
+
+    /// <summary>Two characters that are not hex are not an escape.</summary>
+    [HardenedTest]
+    public async Task SomethingThatIsNotAnEscapeIsLeftAlone(ITestWebApp app) {
+        Assert.Equal("a%zz", await Token(app, "a%zz"));
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
@@ -120,4 +120,37 @@ public class RegistrationValidationTests {
 
         response.Assert.Ok();
     }
+
+    #region a body the harness sends as it is
+
+    /// <summary>
+    /// H-29. Every <c>Post</c> overload takes <c>object</c>, and everything that is not a string
+    /// was serialized - so a body that is not text at all could only be exercised against a live
+    /// socket. Bytes go as themselves now.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABodySentAsBytesGoesOnTheWireAsItself(ITestWebApp testWebApp) {
+        var body = System.Text.Encoding.UTF8.GetBytes(
+            """{"name":"Ada","age":36,"address":{"city":"London","country":"GB"}}""");
+
+        var response = await testWebApp.Post(body, "/registration");
+
+        response.Assert.Ok();
+        Assert.Equal("Ada", response.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// And a malformed one is refused rather than serialized into something well formed, which is
+    /// what makes the JSON-reader refusal testable in process.
+    /// </summary>
+    [HardenedTest]
+    public async Task MalformedBytesReachTheDeserializerAsMalformed(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            System.Text.Encoding.UTF8.GetBytes("{\"name\":"), "/registration");
+
+        response.Assert.BadRequest();
+        Assert.Equal("ValidationError", response.Deserialize<RequestValidationError>().Type);
+    }
+
+    #endregion
 }

--- a/src/Web/Hardened.Web.Testing/ITestWebApp.cs
+++ b/src/Web/Hardened.Web.Testing/ITestWebApp.cs
@@ -8,7 +8,12 @@ public interface ITestWebApp : ITestContext {
     /// <summary>
     /// Get method
     /// </summary>
-    /// <param name="path">request path</param>
+    /// <param name="path">
+    /// The request path, percent-encoded as a client would send it. It is decoded before the
+    /// pipeline sees it, the way a transport decodes one - so <c>"/events/%20"</c> reaches the
+    /// handler as a space, and <c>%2F</c> alone stays as written because decoding it would put a
+    /// separator inside a segment.
+    /// </param>
     /// <param name="webRequest">web request configuration</param>
     /// <returns></returns>
     Task<TestWebResponse> Get(string path, Action<TestWebRequest>? webRequest = null);
@@ -16,9 +21,16 @@ public interface ITestWebApp : ITestContext {
     /// <summary>
     /// Post value to path
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="path"></param>
-    /// <param name="webRequest"></param>
+    /// <param name="value">
+    /// The body. A <c>string</c> or a <c>byte[]</c> goes on the wire as itself; anything else is
+    /// serialized as JSON. That is how a malformed body is sent - <c>Post("{", path)</c> is a
+    /// request the deserializer refuses - and how a body that is not text at all is.
+    /// </param>
+    /// <param name="path">
+    /// The request path, percent-encoded as a client would send it. It is decoded before the
+    /// pipeline sees it, the way a transport decodes one.
+    /// </param>
+    /// <param name="webRequest">Headers and cancellation for the request.</param>
     /// <returns></returns>
     Task<TestWebResponse> Post(object value, string path, Action<TestWebRequest>? webRequest = null);
 

--- a/src/Web/Hardened.Web.Testing/RequestPathDecoder.cs
+++ b/src/Web/Hardened.Web.Testing/RequestPathDecoder.cs
@@ -1,0 +1,91 @@
+using System.Text;
+
+namespace Hardened.Web.Testing;
+
+/// <summary>
+/// Percent-decodes a request path the way a transport hands one over.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The harness's whole value is that it drives the real pipeline, so a request that answers 404
+/// here and 400 on Kestrel is worse than no harness for that case. <c>app.Get("/events/%20")</c>
+/// reached the handler as the literal <c>%20</c> and matched nothing, while the same request over
+/// a socket decoded to whitespace and reached the validator.
+/// </para>
+/// <para>
+/// <b>The rule is Kestrel's, measured rather than assumed.</b> Probed against the Kestrel
+/// integration application over a real socket:
+/// </para>
+/// <code>
+/// /echo/path/%20         -> " "
+/// /echo/path/caf%C3%A9   -> "café"
+/// /echo/path/a%5Cb       -> "a\b"
+/// /echo/path/a%25b       -> "a%b"
+/// /echo/path/a%2Fb       -> "a%2Fb"   the one escape that stays
+/// /echo/path/a+b         -> "a+b"     a plus is a plus in a path
+/// /echo/path/a%zz        -> "a%zz"    not an escape at all
+/// </code>
+/// <para>
+/// <c>%2F</c> survives because decoding it would put a separator inside a segment, which would
+/// change how many segments the path has. <c>Uri.UnescapeDataString</c> decodes it, which is why
+/// this is written out rather than delegated.
+/// </para>
+/// </remarks>
+internal static class RequestPathDecoder {
+
+    public static string Decode(string path) {
+        if (path.IndexOf('%') < 0) {
+            return path;
+        }
+
+        var builder = new StringBuilder(path.Length);
+        List<byte>? pending = null;
+
+        for (var index = 0; index < path.Length; index++) {
+            if (path[index] == '%' && index + 2 < path.Length &&
+                Hex(path[index + 1]) is { } high && Hex(path[index + 2]) is { } low) {
+                var value = (byte)((high << 4) | low);
+
+                // A separator inside a segment would change how many segments the path has, so
+                // this one escape is left as the caller wrote it.
+                if (value == (byte)'/') {
+                    Flush(builder, ref pending);
+                    builder.Append(path, index, 3);
+                }
+                else {
+                    (pending ??= new List<byte>()).Add(value);
+                }
+
+                index += 2;
+
+                continue;
+            }
+
+            Flush(builder, ref pending);
+            builder.Append(path[index]);
+        }
+
+        Flush(builder, ref pending);
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Decoded bytes become characters together, because one character may take several of them.
+    /// </summary>
+    private static void Flush(StringBuilder builder, ref List<byte>? pending) {
+        if (pending == null || pending.Count == 0) {
+            return;
+        }
+
+        builder.Append(Encoding.UTF8.GetString(pending.ToArray()));
+        pending.Clear();
+    }
+
+    private static int? Hex(char character) => character switch {
+        >= '0' and <= '9' => character - '0',
+        >= 'a' and <= 'f' => character - 'a' + 10,
+        >= 'A' and <= 'F' => character - 'A' + 10,
+        _ => null
+    };
+}

--- a/src/Web/Hardened.Web.Testing/TestWebApp.cs
+++ b/src/Web/Hardened.Web.Testing/TestWebApp.cs
@@ -130,6 +130,17 @@ public class TestWebApp : TestContext, ITestWebApp {
             return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(raw));
         }
 
+        // And bytes go as themselves too, for a body that is not text at all. Without this they
+        // serialized as a JSON array of numbers, so an upload, a truncated payload or a byte
+        // sequence that is not valid UTF-8 could only be exercised against a live socket.
+        if (bodyValue is byte[] bytes) {
+            return new MemoryStream(bytes);
+        }
+
+        if (bodyValue is ReadOnlyMemory<byte> memory) {
+            return new MemoryStream(memory.ToArray());
+        }
+
         // Resolve IJsonSerializer first so its constructor populates the
         // shared JsonSerializerConfiguration.Options TypeInfoResolverChain
         // with the source-gen contexts the application has registered. The
@@ -164,6 +175,13 @@ public class TestWebApp : TestContext, ITestWebApp {
         if (questionMark > -1) {
             pathMinusQuery = path.Substring(0, questionMark);
         }
+
+        // Decoded, because a transport hands one over decoded. Passing it through undecoded made
+        // /events/%20 reach the handler as the literal three characters and match nothing, while
+        // the same request over a socket decoded to whitespace and reached the validator - which
+        // is the divergence a harness exists not to have. See RequestPathDecoder for the rule and
+        // where it was measured.
+        pathMinusQuery = RequestPathDecoder.Decode(pathMinusQuery);
 
         // Read from the headers the caller set rather than passed as "", which is what it used to
         // be. TestExecutionRequest takes Accept as a constructor argument instead of parsing it, so


### PR DESCRIPTION
C3 / H-21 and C4 / H-29. Two divergences between the in-process client and a real socket, in one PR because they are the same claim: the harness hands the pipeline what a transport would.

**The path went through undecoded.** `app.Get("/binding/path/%20")` reached the handler as the literal three characters and matched nothing, while the same request over Kestrel decoded to whitespace and reached the validator's 400. A test could pass here and the application behave differently in production.

`RequestPathDecoder` decodes it to **Kestrel's rule, measured rather than assumed** — I ran the probes against the Kestrel integration application over a real socket:

```
/echo/path/%20         -> " "
/echo/path/caf%C3%A9   -> "café"
/echo/path/a%5Cb       -> "a\b"
/echo/path/a%25b       -> "a%b"
/echo/path/a%2Fb       -> "a%2Fb"   the one escape that stays
/echo/path/a+b         -> "a+b"     a plus is a plus in a path
/echo/path/a%zz        -> "a%zz"    not an escape at all
```

`%2F` survives because decoding it would put a separator inside a segment and change how many segments the path has. `Uri.UnescapeDataString` decodes it, which is why the decoder is written out rather than delegated.

**A body that was not a string was serialized.** A `byte[]` became a JSON array of numbers, so an upload, a truncated payload or a sequence that is not valid UTF-8 could only be exercised against a live host. Bytes go as themselves now, beside the string that already did.

That string behaviour is the other half of H-29: it has worked since 0.10 and the SU arm did not find it, which is fair — the parameter is typed `object` and nothing said so. `ITestWebApp` now does, on both the body and the path.

Tests: six encoded-path cases and two raw-body cases, driven end to end through a real host in the web SUT. Four of the eight fail without the change; the other four pass either way and are there to pin the surprises.

Validated: CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green; public API baseline unchanged.

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
