### PR TITLE
Refuse a build whose routes nothing is compiling

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -54,6 +54,32 @@ public class CatalogHandler : HandlerBase, ICatalogService { }
 C# requires the base class to come first, and the base list is searched by name, so HOAG031 fires
 only when *no* entry matches a described service.
 
+## Routing
+
+### HRDR006 — no routing generator is compiling this assembly's routes
+
+A module declaring routes with nothing turning them into a routing table. It compiled without a
+warning into an application that answered 404 to every route it declared, and the template's
+`AGENTS.md` documented the trap without the build ever mentioning it.
+
+```
+'Depot.EventsController' declares routes and nothing in this project turns them into a routing
+table, so every one of them answers 404 at run time. Reference Hardened.Web.SourceGenerator as
+an analyzer, or drop the route attributes if this assembly is not meant to serve them.
+```
+
+The build cannot see a missing analyzer from inside the analyzer that is missing, so the question
+is asked from one that is still there. `Hardened.Web.SourceGenerator` and
+`Hardened.Idl.SourceGenerator` each declare `Hardened.Web.Generated.WebRoutingGeneratorMarker` as
+post-initialization output — the one kind of generated source another generator can see — and
+`Hardened.Library.SourceGenerator`, which every Hardened project references, reports its absence.
+
+Triggered by a route declaration rather than by `[HardenedWebModule]`. That attribute means "bring
+the web pipeline", which is a thing an assembly with no routes of its own legitimately does — the
+framework's own `AspNetCoreRuntime` is one.
+
+One report per assembly, not one per route: there is a single thing to fix.
+
 ## Other diagnostics
 
 | Id | Meaning |
@@ -62,7 +88,7 @@ only when *no* entry matches a described service.
 | `HOAG002` | The description could not be parsed; the build task's message is passed through. |
 | `HOAG010` | A handler was skipped because a parameter type did not resolve. Other handlers are unaffected. |
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
-| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. |
+| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. `HRDR006` is above. |
 
 ## Description build tasks (HOAT, HSMT)
 

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
@@ -47,6 +47,14 @@ namespace Hardened.Idl.SourceGenerator;
 public class SpecSourceGenerator : IIncrementalGenerator {
 
     public void Initialize(IncrementalGeneratorInitializationContext context) {
+        // Says "a routing generator is running" to the library generator, which reports its
+        // absence. A specification-first project carries no attribute routes of its own, but one
+        // may declare a code-first module beside its contract - and it is this generator that
+        // would compile the routes if it did.
+        context.RegisterPostInitializationOutput(static production => production.AddSource(
+            "Hardened.Web.Marker.g.cs",
+            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+
         // Read the models the build task wrote, keeping both successes and errors for diagnostics
         var parseResults = context.AdditionalTextsProvider
             .Where(IsSpecModelFile)

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Hardened.SourceGenerator.Configuration;
 using Hardened.SourceGenerator.DependencyInjection;
@@ -20,5 +22,53 @@ public class LibrarySourceGenerator : IIncrementalGenerator {
             SourceGeneratorWrapper.Wrap<EntryPointSelector.Model>(generator.GenerateFile));
 
         ConfigurationIncrementalGenerator.Setup(context, applicationModel);
+
+        ReportAMissingRoutingGenerator(context);
+    }
+
+    /// <summary>
+    /// Says so when this project declares routes and nothing is compiling them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A module with handlers and no routing generator built without a warning into an application
+    /// that answered 404 to everything - the trial arm deleted one PackageReference and lost an
+    /// afternoon to it. The build cannot see a missing analyzer from inside the analyzer that is
+    /// missing, so the question is asked here: this generator is referenced by every Hardened
+    /// project, and the routing generators declare a marker type saying they ran.
+    /// </para>
+    /// <para>
+    /// The route declarations are found through <c>ForAttributeWithMetadataName</c>, which is
+    /// Roslyn's attribute index rather than a walk over every node - the same cost discipline
+    /// DependencyModules' own generator is built around.
+    /// </para>
+    /// </remarks>
+    private static void ReportAMissingRoutingGenerator(
+        IncrementalGeneratorInitializationContext context) {
+        IncrementalValueProvider<ImmutableArray<string>>? routes = null;
+
+        foreach (var attribute in RoutingGeneratorPresence.VerbAttributes) {
+            var declared = context.SyntaxProvider.ForAttributeWithMetadataName(
+                    attribute,
+                    static (node, _) => node is Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax,
+                    static (target, _) =>
+                        target.TargetSymbol.ContainingType?.ToDisplayString() ?? "")
+                .Where(static name => name.Length > 0)
+                .Collect();
+
+            routes = routes == null
+                ? declared
+                : routes.Value.Combine(declared).Select(
+                    static (pair, _) => pair.Left.AddRange(pair.Right));
+        }
+
+        if (routes == null) {
+            return;
+        }
+
+        context.RegisterSourceOutput(
+            context.CompilationProvider.Combine(routes.Value),
+            static (production, pair) => RoutingGeneratorPresence.Report(
+                production, pair.Left, pair.Right.Distinct().OrderBy(name => name).ToArray()));
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorPresence.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorPresence.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// Whether anything in this compilation is turning route declarations into a routing table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A module with handlers and no routing generator compiles without a warning into an application
+/// that answers 404 to everything. The build cannot see a missing analyzer from inside the analyzer
+/// that is missing, so the question is asked from one that is still there: the routing generators
+/// declare <see cref="MarkerTypeName"/> as post-initialization output - the one kind of generated
+/// source another generator can see - and the library generator reports its absence.
+/// </para>
+/// <para>
+/// The same arrangement <c>ValidationGeneratorMarker</c> uses, and for a related reason: a
+/// generator cannot observe another's regular output, so a marker is the only channel between two
+/// of them.
+/// </para>
+/// </remarks>
+public static class RoutingGeneratorPresence {
+
+    /// <summary>The type a routing generator declares to say it is running.</summary>
+    public const string MarkerTypeName = "Hardened.Web.Generated.WebRoutingGeneratorMarker";
+
+    /// <summary>
+    /// Deliberately plain C#: block-scoped namespace, ordinary class body. This lands in whatever
+    /// project references the generator, and a marker that needs a language version to compile
+    /// would fail the builds it exists to keep working.
+    /// </summary>
+    /// <remarks>
+    /// Written without the generated-file header so <c>GeneratedSource.Header</c> adds it - that
+    /// method leaves a source that already opens with the marker alone, which would mean this file
+    /// carrying the marker and neither the nullable context nor the CS1591 pragma that travel with
+    /// it.
+    /// </remarks>
+    public const string MarkerSource =
+        "namespace Hardened.Web.Generated {\n" +
+        "    /// <summary>Declared by a Hardened routing generator so other generators can tell\n" +
+        "    /// whether route declarations are being compiled for this compilation.</summary>\n" +
+        "    internal static class WebRoutingGeneratorMarker {\n" +
+        "    }\n" +
+        "}\n";
+
+    /// <summary>The attributes a hand-written route is declared with.</summary>
+    public static readonly string[] VerbAttributes = {
+        "Hardened.Web.Runtime.Attributes.GetAttribute",
+        "Hardened.Web.Runtime.Attributes.PostAttribute",
+        "Hardened.Web.Runtime.Attributes.PutAttribute",
+        "Hardened.Web.Runtime.Attributes.PatchAttribute",
+        "Hardened.Web.Runtime.Attributes.DeleteAttribute"
+    };
+
+    /// <summary>
+    /// <c>HRDR006</c>. <c>HRDR002</c> and <c>HRDR005</c> are about one route; this is about every
+    /// route in the assembly at once.
+    /// </summary>
+    public const string DiagnosticId = "HRDR006";
+
+    /// <summary>
+    /// Built per call rather than held in a static field: RS2008 looks for the field, and these
+    /// projects set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "No routing generator is compiling this assembly's routes",
+        messageFormat:
+        "'{0}' declares routes and nothing in this project turns them into a routing table, so " +
+        "every one of them answers 404 at run time. Reference Hardened.Web.SourceGenerator as an " +
+        "analyzer, or drop the route attributes if this assembly is not meant to serve them.",
+        category: "Hardened.Routing",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports the absence, having been handed the route declarations the compilation carries.
+    /// </summary>
+    /// <param name="declaringTypes">
+    /// The types carrying route attributes, in the order they were found. One report for the first
+    /// of them rather than one per route: there is a single thing to fix, and an assembly with
+    /// forty routes would otherwise produce forty copies of it.
+    /// </param>
+    public static void Report(
+        SourceProductionContext context, Compilation compilation,
+        IReadOnlyList<string> declaringTypes) {
+        if (declaringTypes.Count == 0 ||
+            compilation.GetTypeByMetadataName(MarkerTypeName) is not null) {
+            return;
+        }
+
+        // Location.None, as everywhere else models are reported from: a syntax location would
+        // travel through the incremental caches, which compare for equality to decide whether to
+        // regenerate. The message carries the type instead.
+        context.ReportDiagnostic(Diagnostic.Create(
+            Descriptor(), Location.None, declaringTypes[0]));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Authorization/RequireAuthorizationTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Authorization/RequireAuthorizationTests.cs
@@ -355,12 +355,19 @@ public class RequireAuthorizationTests {
         Assert.Equal(result.FirstRun, result.SecondRun);
 
         // And nothing it emitted was rebuilt to find that out: as many outputs were served from
-        // cache as there are generated files. The steps that did run are the diagnostic ones, which
-        // emit no source.
+        // cache as there are generated files with a step behind them. The steps that did run are
+        // the diagnostic ones, which emit no source.
+        //
+        // The routing-generator marker is not one of them. Post-initialization output is written
+        // once for the compilation and has no incremental step at all, which is better than cached
+        // rather than worse - so it is taken out of the count rather than expected in it.
         var cached = result.OutputReasons.Count(
             reason => reason == IncrementalStepRunReason.Cached);
 
-        Assert.Equal(result.FirstRun.Count, cached);
+        var fromSteps = result.FirstRun.Count(
+            source => !source.Key.Contains("Hardened.Web.Marker"));
+
+        Assert.Equal(fromSteps, cached);
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
@@ -39,6 +39,15 @@
         <ProjectReference Include="..\Hardened.DependencyModules.SourceGenerator\Hardened.DependencyModules.SourceGenerator.csproj"/>
 
         <!--
+            For the routing-generator-absent diagnostic, which is decided in the library generator
+            because that is the one still referenced when the web generator is not. Same terms as
+            the reference above: this assembly compiles its own copy of the shared source, so every
+            shared type is ambiguous across the two, and the tests that touch it name only
+            LibrarySourceGenerator and the diagnostic's id.
+        -->
+        <ProjectReference Include="..\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj"/>
+
+        <!--
             The same OpenAPI reader the build task parses specifications with, so the round trip can
             check the emitted document against something other than the code that wrote it. Reading
             it back with Hardened's own parser would let a misunderstanding shared by the writer and

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/MissingRoutingGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/MissingRoutingGeneratorTests.cs
@@ -1,0 +1,160 @@
+using Hardened.Library.SourceGenerator;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// A module with handlers and nothing compiling them into a routing table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CS-10. Removing <c>Hardened.Web.SourceGenerator</c> built without a warning into an application
+/// that answered 404 to every route it declared. The template's AGENTS.md documented the trap and
+/// the build said nothing, which is the worst of both: written down where you look after you have
+/// already lost the afternoon.
+/// </para>
+/// <para>
+/// The build cannot see a missing analyzer from inside the analyzer that is missing, so the
+/// question is asked from one that is still there. <c>Hardened.Library.SourceGenerator</c> is
+/// referenced by every Hardened project and by the template, and the routing generators declare a
+/// marker type saying they ran - post-initialization output being the one kind of generated source
+/// another generator can see.
+/// </para>
+/// <para>
+/// The diagnostic is named by its id rather than through <c>RoutingGeneratorPresence</c>: this test
+/// assembly compiles the shared source that type lives in, so the constant is ambiguous across the
+/// three generator assemblies referenced here.
+/// </para>
+/// </remarks>
+public class MissingRoutingGeneratorTests {
+    private const string DiagnosticId = "HRDR006";
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)   // Hardened.Requests.Abstract
+    ];
+
+    private const string WithRoutes = """
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        [HardenedWebModule]
+        public partial class TestApplication { }
+
+        public class ItemController {
+            [Get("/items/{id}")]
+            public string Item(string id) => id;
+        }
+        """;
+
+    private const string WithNoRoutes = """
+        using Hardened.Shared.Runtime.Attributes;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        public partial class TestApplication { }
+
+        public class ItemService {
+            public string Item(string id) => id;
+        }
+        """;
+
+    private static GeneratorResult Generate(string source, params IIncrementalGenerator[] generators) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Test.cs"] = source }, generators, Anchors);
+
+    private static bool Reported(GeneratorResult result) =>
+        result.GeneratorDiagnostics.Any(diagnostic => diagnostic.Id == DiagnosticId);
+
+    /// <summary>The repro: routes declared, and only the library generator running.</summary>
+    [Fact]
+    public void RoutesWithNoRoutingGeneratorAreAnError() {
+        var result = Generate(WithRoutes, new LibrarySourceGenerator());
+
+        var diagnostic = Assert.Single(
+            result.GeneratorDiagnostics.Where(reported => reported.Id == DiagnosticId));
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    /// <summary>
+    /// The message names the type that declared them, what it costs, and both ways out - the
+    /// second of which is the one an assembly that never meant to serve them wants.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheTypeAndTheGenerator() {
+        var message = Generate(WithRoutes, new LibrarySourceGenerator()).GeneratorDiagnostics
+            .Single(reported => reported.Id == DiagnosticId).GetMessage();
+
+        Assert.Contains("TestApp.ItemController", message);
+        Assert.Contains("404", message);
+        Assert.Contains("Hardened.Web.SourceGenerator", message);
+    }
+
+    /// <summary>With the routing generator beside it, nothing is reported.</summary>
+    [Fact]
+    public void RoutesWithTheRoutingGeneratorAreNotReported() {
+        Assert.False(Reported(
+            Generate(WithRoutes, new LibrarySourceGenerator(), new WebLibrarySourceGenerator())));
+    }
+
+    /// <summary>
+    /// Order does not matter. The marker is post-initialization output, which every generator sees
+    /// whichever ran first.
+    /// </summary>
+    [Fact]
+    public void TheOrderTheGeneratorsRunInDoesNotMatter() {
+        Assert.False(Reported(
+            Generate(WithRoutes, new WebLibrarySourceGenerator(), new LibrarySourceGenerator())));
+    }
+
+    /// <summary>
+    /// An assembly that declares no routes needs no routing generator - which is what the
+    /// framework's own web runtime assemblies are, and the reason the check is not on
+    /// <c>[HardenedWebModule]</c>: <c>AspNetCoreRuntime</c> declares that attribute to bring the
+    /// pipeline and carries no routes at all.
+    /// </summary>
+    [Fact]
+    public void AnAssemblyWithNoRoutesIsNotReported() {
+        Assert.False(Reported(Generate(WithNoRoutes, new LibrarySourceGenerator())));
+    }
+
+    /// <summary>
+    /// One report for an assembly, not one per route. There is a single thing to fix.
+    /// </summary>
+    [Fact]
+    public void EveryRouteInTheAssemblyProducesOneReport() {
+        var result = Generate("""
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class ItemController {
+                [Get("/items/{id}")]
+                public string Item(string id) => id;
+
+                [Post("/items")]
+                public string Create(string body) => body;
+            }
+
+            public class PartController {
+                [Delete("/parts/{id}")]
+                public string Remove(string id) => id;
+            }
+            """, new LibrarySourceGenerator());
+
+        Assert.Single(result.GeneratorDiagnostics.Where(reported => reported.Id == DiagnosticId));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
@@ -7,6 +7,14 @@ namespace Hardened.Web.SourceGenerator;
 [Generator]
 public class WebLibrarySourceGenerator : IIncrementalGenerator {
     public void Initialize(IncrementalGeneratorInitializationContext context) {
+        // Says "a routing generator is running" to the library generator, which reports its
+        // absence - a module with handlers and no routing generator builds clean into an
+        // application that answers 404 to everything. Post-init because that is the only generated
+        // source another generator can see.
+        context.RegisterPostInitializationOutput(static production => production.AddSource(
+            "Hardened.Web.Marker.g.cs",
+            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+
         var applicationModel = context.SyntaxProvider.CreateSyntaxProvider(
             EntryPointSelector.UsingAttribute(),
             EntryPointSelector.TransformModel(false)


### PR DESCRIPTION
A3 / H-05, the last of the P0 items in this repository.

A module with handlers and no routing generator built without a warning into an application that answered 404 to every route it declared. The template's `AGENTS.md` documented the trap and the build said nothing — the worst arrangement of the two, since it is written down where you look after you have already lost the afternoon.

**The build cannot see a missing analyzer from inside the analyzer that is missing**, so the question is asked from one that is still there. `Hardened.Web.SourceGenerator` and `Hardened.Idl.SourceGenerator` each declare `Hardened.Web.Generated.WebRoutingGeneratorMarker` as post-initialization output — the one kind of generated source another generator can see — and `Hardened.Library.SourceGenerator` reports its absence as `HRDR006`. That generator is referenced by every Hardened project and by the template, and it is still there when the web generator's `PackageReference` is deleted, which is CS-10's exact repro.

```
'Depot.EventsController' declares routes and nothing in this project turns them into a routing
table, so every one of them answers 404 at run time. Reference Hardened.Web.SourceGenerator as
an analyzer, or drop the route attributes if this assembly is not meant to serve them.
```

**A build-time check rather than a startup one**, which the work order left to me to pick and justify. The targets-level alternative it names inspects `@(Analyzer)`, and this repository's own `AGENTS.md` says that is unreliable: "`project.assets.json` and `-getItem:Analyzer` both report a package that never reaches `csc`". A marker the generator itself emits reports what actually ran, in the IDE and on the command line alike, and it fails the build rather than the first request.

**Triggered by a route declaration rather than by `[HardenedWebModule]`.** That attribute means "bring the web pipeline", which an assembly with no routes of its own legitimately does — the framework's own `AspNetCoreRuntime` declares it and carries none, so keying on it would fail this repository's own build. The declarations are found through `ForAttributeWithMetadataName`, Roslyn's attribute index rather than a walk over every node.

Six tests: the repro is an error, the message names the type and both ways out, the pairing is quiet, generator order does not matter, an assembly with no routes is quiet, and an assembly with three routes reports once.

One existing test moved: `RequireAuthorizationTests`' caching assertion counted every generated file as one with an incremental step behind it. Post-initialization output has no step at all — better than cached rather than worse — so the marker is taken out of that count and the comment says why.

Validated:

- CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors. The whole solution builds clean, which is the check's own false-positive test: several framework assemblies declare `[HardenedWebModule]` and reference no routing generator.
- `dotnet test` on the solution — 31 suites green.
- `scripts/verify-templates.sh` — green across all seven default rows; Smithy rows self-skip on this machine (CLI 1.56.0 against the 1.73.0 pin).

`HRDR006` follows `HRDR005` from #229; both add a section to `docs/generator-diagnostics.md` and will conflict there on merge, which is a one-line resolution.

Based on #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
