### PR TITLE
Keep the shared generator source out of assemblies that never run it

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/EncodedPathTests.cs
@@ -50,6 +50,16 @@ public class EncodedPathTests {
         Assert.Equal("a%2Fb", await Token(app, "a%2Fb"));
     }
 
+    /// <summary>
+    /// In either case. An escape is hex, and hex is case-insensitive - Kestrel decodes
+    /// <c>%c3%a9</c> and leaves <c>%2f</c>, exactly as it does the capitals.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheCaseOfAnEscapeDoesNotMatter(ITestWebApp app) {
+        Assert.Equal("a%2fb", await Token(app, "a%2fb"));
+        Assert.Equal("café", await Token(app, "caf%c3%a9"));
+    }
+
     /// <summary>A plus is a plus in a path. Only a query string reads one as a space.</summary>
     [HardenedTest]
     public async Task APlusIsNotASpace(ITestWebApp app) {
@@ -60,5 +70,23 @@ public class EncodedPathTests {
     [HardenedTest]
     public async Task SomethingThatIsNotAnEscapeIsLeftAlone(ITestWebApp app) {
         Assert.Equal("a%zz", await Token(app, "a%zz"));
+    }
+
+    /// <summary>
+    /// And neither is an escape that runs out of path before it has two digits.
+    /// </summary>
+    /// <summary>
+    /// Nor are two characters that sit outside hex on the other side of it.
+    /// </summary>
+    [HardenedTest]
+    public async Task DigitsBelowHexAreNotAnEscapeEither(ITestWebApp app) {
+        Assert.Equal("a%-1b", await Token(app, "a%-1b"));
+        Assert.Equal("a%G0b", await Token(app, "a%G0b"));
+    }
+
+    [HardenedTest]
+    public async Task AnEscapeWithNothingAfterItIsLeftAlone(ITestWebApp app) {
+        Assert.Equal("a%", await Token(app, "a%"));
+        Assert.Equal("a%2", await Token(app, "a%2"));
     }
 }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
@@ -53,7 +53,7 @@ public class SpecSourceGenerator : IIncrementalGenerator {
         // would compile the routes if it did.
         context.RegisterPostInitializationOutput(static production => production.AddSource(
             "Hardened.Web.Marker.g.cs",
-            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+            GeneratedSource.Header(RoutingGeneratorMarker.Source)));
 
         // Read the models the build task wrote, keeping both successes and errors for diagnostics
         var parseResults = context.AdditionalTextsProvider

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/LibrarySourceGenerator.cs
@@ -47,7 +47,7 @@ public class LibrarySourceGenerator : IIncrementalGenerator {
         IncrementalGeneratorInitializationContext context) {
         IncrementalValueProvider<ImmutableArray<string>>? routes = null;
 
-        foreach (var attribute in RoutingGeneratorPresence.VerbAttributes) {
+        foreach (var attribute in MissingRoutingGenerator.VerbAttributes) {
             var declared = context.SyntaxProvider.ForAttributeWithMetadataName(
                     attribute,
                     static (node, _) => node is Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax,
@@ -68,7 +68,7 @@ public class LibrarySourceGenerator : IIncrementalGenerator {
 
         context.RegisterSourceOutput(
             context.CompilationProvider.Combine(routes.Value),
-            static (production, pair) => RoutingGeneratorPresence.Report(
+            static (production, pair) => MissingRoutingGenerator.Report(
                 production, pair.Left, pair.Right.Distinct().OrderBy(name => name).ToArray()));
     }
 }

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/MissingRoutingGenerator.cs
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/MissingRoutingGenerator.cs
@@ -1,48 +1,26 @@
 using System.Collections.Generic;
+using Hardened.SourceGenerator.Shared;
 using Microsoft.CodeAnalysis;
 
-namespace Hardened.SourceGenerator.Shared;
+namespace Hardened.Library.SourceGenerator;
 
 /// <summary>
-/// Whether anything in this compilation is turning route declarations into a routing table.
+/// Routes with nothing compiling them into a routing table.
 /// </summary>
 /// <remarks>
 /// <para>
-/// A module with handlers and no routing generator compiles without a warning into an application
-/// that answers 404 to everything. The build cannot see a missing analyzer from inside the analyzer
-/// that is missing, so the question is asked from one that is still there: the routing generators
-/// declare <see cref="MarkerTypeName"/> as post-initialization output - the one kind of generated
-/// source another generator can see - and the library generator reports its absence.
+/// Reported from this generator because it is the one still referenced when the routing generator
+/// is not - a build cannot see a missing analyzer from inside the analyzer that is missing.
+/// <see cref="RoutingGeneratorMarker"/> is how a routing generator says it ran.
 /// </para>
 /// <para>
-/// The same arrangement <c>ValidationGeneratorMarker</c> uses, and for a related reason: a
-/// generator cannot observe another's regular output, so a marker is the only channel between two
-/// of them.
+/// Here rather than beside the marker in the shared source. Five generator assemblies link that
+/// folder in and one asks this question, so a decision compiled into the other four is dead weight
+/// in each of them - the same reason the library generator's own project file leaves out
+/// <c>Models/Request</c>.
 /// </para>
 /// </remarks>
-public static class RoutingGeneratorPresence {
-
-    /// <summary>The type a routing generator declares to say it is running.</summary>
-    public const string MarkerTypeName = "Hardened.Web.Generated.WebRoutingGeneratorMarker";
-
-    /// <summary>
-    /// Deliberately plain C#: block-scoped namespace, ordinary class body. This lands in whatever
-    /// project references the generator, and a marker that needs a language version to compile
-    /// would fail the builds it exists to keep working.
-    /// </summary>
-    /// <remarks>
-    /// Written without the generated-file header so <c>GeneratedSource.Header</c> adds it - that
-    /// method leaves a source that already opens with the marker alone, which would mean this file
-    /// carrying the marker and neither the nullable context nor the CS1591 pragma that travel with
-    /// it.
-    /// </remarks>
-    public const string MarkerSource =
-        "namespace Hardened.Web.Generated {\n" +
-        "    /// <summary>Declared by a Hardened routing generator so other generators can tell\n" +
-        "    /// whether route declarations are being compiled for this compilation.</summary>\n" +
-        "    internal static class WebRoutingGeneratorMarker {\n" +
-        "    }\n" +
-        "}\n";
+internal static class MissingRoutingGenerator {
 
     /// <summary>The attributes a hand-written route is declared with.</summary>
     public static readonly string[] VerbAttributes = {
@@ -54,8 +32,8 @@ public static class RoutingGeneratorPresence {
     };
 
     /// <summary>
-    /// <c>HRDR006</c>. <c>HRDR002</c> and <c>HRDR005</c> are about one route; this is about every
-    /// route in the assembly at once.
+    /// <c>HRDR006</c>. <c>HRDR002</c> is about one route; this is about every route in the
+    /// assembly at once.
     /// </summary>
     public const string DiagnosticId = "HRDR006";
 
@@ -86,7 +64,7 @@ public static class RoutingGeneratorPresence {
         SourceProductionContext context, Compilation compilation,
         IReadOnlyList<string> declaringTypes) {
         if (declaringTypes.Count == 0 ||
-            compilation.GetTypeByMetadataName(MarkerTypeName) is not null) {
+            compilation.GetTypeByMetadataName(RoutingGeneratorMarker.TypeName) is not null) {
             return;
         }
 

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
@@ -76,6 +76,10 @@ public class SpecFirstDocumentTests {
 
         Assert.Empty(result.Errors);
 
+        return PublishedDocumentFrom(result);
+    }
+
+    private static JsonElement PublishedDocumentFrom(GeneratorResult result) {
         var source = result.GeneratedSources
             .First(pair => pair.Key.Contains("OpenApiDocument")).Value;
 
@@ -347,6 +351,58 @@ public class SpecFirstDocumentTests {
             .GetProperty("RequestValidationError");
 
         Assert.Equal("object", schema.GetProperty("type").GetString());
+    }
+
+    #endregion
+
+    #region what the contract says about itself
+
+    /// <summary>
+    /// An entry point that also declares <c>[OpenApiInfo]</c>, with a comma in its description.
+    /// </summary>
+    private const string EntryPointDeclaringInfo =
+        """
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+
+        namespace TestNamespace;
+
+        [HardenedModule]
+        [OpenApiInfo("Attribute Title", "9.9", "Parcels, pallets and freight")]
+        public partial class TestApp {
+        }
+        """;
+
+    private static JsonElement Info(string spec, string source) {
+        var result = OpenApiGenerator.Run(spec, source);
+
+        Assert.Empty(result.Errors);
+
+        return PublishedDocumentFrom(result).GetProperty("info");
+    }
+
+    /// <summary>
+    /// The contract's own <c>info</c> wins, which is what <c>[OpenApiInfo]</c>'s remarks promise
+    /// and what nothing was driving.
+    /// </summary>
+    [Fact]
+    public void TheContractsInfoWinsOverTheAttribute() {
+        var info = Info(ConstrainedParameters, EntryPointDeclaringInfo);
+
+        Assert.Equal("Pets", info.GetProperty("title").GetString());
+        Assert.Equal("1.0", info.GetProperty("version").GetString());
+    }
+
+    /// <summary>
+    /// A description the contract does not state is taken from the attribute, commas and all - the
+    /// reading is the same on both front ends, so H-16's truncation would have shown here too.
+    /// </summary>
+    [Fact]
+    public void ADescriptionTheContractOmitsComesFromTheAttributeWhole() {
+        var info = Info(ConstrainedParameters, EntryPointDeclaringInfo);
+
+        Assert.True(info.TryGetProperty("description", out var description));
+        Assert.Equal("Parcels, pallets and freight", description.GetString());
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/AttributeArguments.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/AttributeArguments.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Hardened.SourceGenerator.Shared;
+namespace Hardened.SourceGenerator.OpenApiDocument;
 
 /// <summary>
 /// The positional arguments of an attribute, read back out of the source text
 /// <see cref="AttributeModel.Arguments"/> holds.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Beside its only caller rather than in the shared folder. Five generator assemblies link that
+/// folder in, and a reader of attribute arguments compiled into the four that never call one is
+/// dead weight in each of them.
+/// </para>
 /// <para>
 /// The model joins arguments with ", " and keeps each one as it was written, quotes included - so
 /// reading them back is splitting on the commas that separate arguments and no others.

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorMarker.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/RoutingGeneratorMarker.cs
@@ -1,0 +1,48 @@
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// The type a routing generator declares to say it is running.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A module with handlers and no routing generator compiles without a warning into an application
+/// that answers 404 to everything. The build cannot see a missing analyzer from inside the analyzer
+/// that is missing, so the question is asked from one that is still there: the routing generators
+/// emit this as post-initialization output - the one kind of generated source another generator
+/// can see - and <c>Hardened.Library.SourceGenerator</c> reports its absence as HRDR006.
+/// </para>
+/// <para>
+/// The same arrangement <c>ValidationGeneratorMarker</c> uses, and for a related reason: a
+/// generator cannot observe another's regular output, so a marker is the only channel between two
+/// of them.
+/// </para>
+/// <para>
+/// Two constants and no logic, deliberately. This file is linked into five generator assemblies
+/// because three of them declare the marker, and only one asks the question - so what the others
+/// compile in has to be small enough to carry.
+/// </para>
+/// </remarks>
+public static class RoutingGeneratorMarker {
+
+    /// <summary>The metadata name the check looks for.</summary>
+    public const string TypeName = "Hardened.Web.Generated.WebRoutingGeneratorMarker";
+
+    /// <summary>
+    /// Deliberately plain C#: block-scoped namespace, ordinary class body. This lands in whatever
+    /// project references the generator, and a marker that needs a language version to compile
+    /// would fail the builds it exists to keep working.
+    /// </summary>
+    /// <remarks>
+    /// Written without the generated-file header so <c>GeneratedSource.Header</c> adds it - that
+    /// method leaves a source that already opens with the marker alone, which would mean this file
+    /// carrying the marker and neither the nullable context nor the CS1591 pragma that travel with
+    /// it.
+    /// </remarks>
+    public const string Source =
+        "namespace Hardened.Web.Generated {\n" +
+        "    /// <summary>Declared by a Hardened routing generator so other generators can tell\n" +
+        "    /// whether route declarations are being compiled for this compilation.</summary>\n" +
+        "    internal static class WebRoutingGeneratorMarker {\n" +
+        "    }\n" +
+        "}\n";
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator/WebLibrarySourceGenerator.cs
@@ -13,7 +13,7 @@ public class WebLibrarySourceGenerator : IIncrementalGenerator {
         // source another generator can see.
         context.RegisterPostInitializationOutput(static production => production.AddSource(
             "Hardened.Web.Marker.g.cs",
-            GeneratedSource.Header(RoutingGeneratorPresence.MarkerSource)));
+            GeneratedSource.Header(RoutingGeneratorMarker.Source)));
 
         var applicationModel = context.SyntaxProvider.CreateSyntaxProvider(
             EntryPointSelector.UsingAttribute(),


### PR DESCRIPTION
#226's `build` check is failing on the coverage gate. This is the fix; it is my regression, from #236 and #240.

```
Hardened.Idl.SourceGenerator branch:        48.3% below 49.0  (-0.7)
Hardened.Validation.SourceGenerator line:   23.6% below 25.4  (-1.8)
Hardened.Validation.SourceGenerator branch: 13.4% below 15.4  (-2.0)
Hardened.Web.Testing line:                  97.7% below 98.9  (-1.2)
Hardened.Web.Testing branch:                95.4% below 100.0 (-4.6)
```

**Most of it is denominator, not testing.** Both PRs put a file in `Hardened.SourceGenerator/Shared`, and five generator assemblies link that folder in through `Compile Include`. Only one of them calls either file, so Validation, Idl and Library each gained a few hundred lines they can never execute. `Hardened.Validation.SourceGenerator` sits at 25% because it is mostly linked source already; another 300 lines moves it two points.

Both files move to where their callers are. `AttributeArguments` goes beside `OpenApiDocumentGenerator`, its only caller, which takes it out of Validation and Library entirely — and is where it belonged anyway. `RoutingGeneratorPresence` splits: the marker's name and source stay in `Shared`, because three generators declare it and two constants cost nothing, while the diagnostic that reads it moves into `Hardened.Library.SourceGenerator`, the only generator that asks the question. Library's own coverage rises nine points as a result, because the decision is now compiled where its tests are.

That is the same move the library generator's project file already makes for `Models/Request`, and its comment says why: "purely as coverage denominator".

**Two of them were real gaps.**

`RequestPathDecoder` cost `Hardened.Web.Testing` a perfect branch score, and fairly — the end-to-end cases I wrote skipped lowercase hex, an escape truncated by the end of the path, and two characters sitting outside hex on either side of it. Those are cases now.

`AttributeArguments` was never executed in the Idl assembly at all: no spec-first test drove `[OpenApiInfo]` through a published document. `SpecFirstDocumentTests` now pins the two things the attribute's own remarks promise and nothing was checking — the contract's `info` wins over it, and a description the contract omits is taken from the attribute whole, commas included. That is the H-16 fix proved on the second front end.

Validated:

- Coverage gate run locally the way `build-package.yaml` runs it: **21 assemblies at or above baseline, no floor moved.** `Hardened.Idl.SourceGenerator` line comes out above its floor as well. No baseline is re-written here — AGENTS.md says that number comes from CI.
- CI-style Release build with `ContinuousIntegrationBuild=true` — 0 warnings, 0 errors; `dotnet test` on the solution — 31 suites green.
- `scripts/verify-templates.sh` green across all seven default rows, since this moves source that ships in the packaged generators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
