### PR TITLE
Give the pipeline room between its stages

### DIFF
--- a/docs/response-caching.md
+++ b/docs/response-caching.md
@@ -121,7 +121,7 @@ guards, and applied to every handler nobody read anything.
 ## What is not cached
 
 **A handler whose authorization reads the request.** The filter runs at
-`FilterOrder.BeforeSerialization`, which is after authorization over grants alone and before
+`FilterOrder.ResponseCache`, which is after authorization over grants alone and before
 authorization that reads bound parameters. A stored answer to "may this caller edit *this* pet"
 served to a second caller is a data leak, so the filter is not installed at all — decided once per
 handler from `IExecutionRequestHandlerInfo.Requirement.RequiresContext`. A requirement over grants

--- a/docs/validation-system.md
+++ b/docs/validation-system.md
@@ -23,7 +23,7 @@ Order  1000  DefaultValue (user filters)
 Order  2000  EndPointInvoke (calls the endpoint method)
 ```
 
-The `ValidationFilter` runs at `FilterOrder.Validation` (= `Serialization + 1` = 6), ensuring parameters are already deserialized and bound before validation occurs.
+The `ValidationFilter` runs at `FilterOrder.Validation`, one stage behind `Serialization`, so parameters are already deserialized and bound before validation occurs.
 
 ### Components
 

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -317,19 +317,6 @@ namespace Hardened.Requests.Abstract.Execution
         public System.Collections.Generic.IReadOnlyList<string> Keys { get; }
         public string? Get(string key) { }
     }
-    public enum ExecutionFilterOrder
-    {
-        Init = -10000,
-        FullRequestMetrics = -7000,
-        RetryFilter = -5000,
-        BeforeSerialize = -1,
-        BindParameters = 0,
-        First = 1,
-        Second = 2,
-        Third = 3,
-        Normal = 100,
-        Last = 2147483647,
-    }
     public interface IExecutionChain
     {
         Hardened.Requests.Abstract.Execution.IExecutionContext Context { get; }
@@ -678,24 +665,29 @@ namespace Hardened.Requests.Abstract.RequestFilter
 {
     public static class FilterOrder
     {
-        public const int Authentication = 2;
-        public const int Authorization = 7;
-        public const int BeforeSerialization = 4;
-        public const int DefaultValue = 1000;
-        public const int EndPointHandlers = 2000;
-        public const int EndPointInvoke = 2000;
-        public const int HandlerCreation = -1000;
-        public const int RateLimitPrincipal = 9;
-        public const int RateLimitTransport = 1;
-        public const int Retry = 8;
-        public const int Serialization = 5;
-        public const int Validation = 6;
+        public const int After = 500;
+        public const int Authentication = 2000;
+        public const int Authorization = 9000;
+        public const int Before = -500;
+        public const int BeforeSerialization = 6500;
+        public const int Conditional = 5000;
+        public const int DefaultValue = 100000;
+        public const int EndPointHandlers = 200000;
+        public const int EndPointInvoke = 200000;
+        public const int GrantAuthorization = 4000;
+        public const int HandlerCreation = -10000;
+        public const int RateLimitPrincipal = 3000;
+        public const int RateLimitTransport = 1000;
+        public const int ResponseCache = 6000;
+        public const int Retry = 10000;
+        public const int Serialization = 7000;
+        public const int Validation = 8000;
     }
     public interface IGlobalFilterRegistry
     {
         System.Collections.Generic.List<Hardened.Requests.Abstract.RequestFilter.RequestFilterInfo> GetFilters(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo requestHandlerInfo);
         void RegisterFilter(System.Func<Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo, Hardened.Requests.Abstract.RequestFilter.RequestFilterInfo?> filterFunc);
-        void RegisterFilter(Hardened.Requests.Abstract.Execution.IExecutionFilter filter, int order = 1000);
+        void RegisterFilter(Hardened.Requests.Abstract.Execution.IExecutionFilter filter, int order = 100000);
     }
     public interface IIOFilterProvider
     {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -380,7 +380,7 @@ namespace Hardened.Requests.Runtime.Filters
         public GlobalFilterRegistry(System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders) { }
         public System.Collections.Generic.List<Hardened.Requests.Abstract.RequestFilter.RequestFilterInfo> GetFilters(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo requestHandlerInfo) { }
         public void RegisterFilter(System.Func<Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo, Hardened.Requests.Abstract.RequestFilter.RequestFilterInfo?> filterFunc) { }
-        public void RegisterFilter(Hardened.Requests.Abstract.Execution.IExecutionFilter filter, int order = 1000) { }
+        public void RegisterFilter(Hardened.Requests.Abstract.Execution.IExecutionFilter filter, int order = 100000) { }
     }
     public static class GlobalFilterServiceCollectionExtensions
     {

--- a/src/Requests/Hardened.Requests.Abstract.Tests/RequestFilter/FilterOrderTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/RequestFilter/FilterOrderTests.cs
@@ -27,13 +27,17 @@ public class FilterOrderTests {
     }
 
     /// <summary>
-    /// A requirement over grants alone is authorized at <c>Authentication + 1</c>, so that slot has
-    /// to exist and still be ahead of serialization. This is why the gap is two rather than one -
-    /// the arithmetic, not the literal, is the thing that matters.
+    /// A requirement over grants alone is authorized at <see cref="FilterOrder.GrantAuthorization"/>,
+    /// which has to be after a caller exists and still ahead of serialization.
     /// </summary>
+    /// <remarks>
+    /// This was spelled <c>Authentication + 1</c> on both sides until the stage got a name. A
+    /// position documented in three files and expressed nowhere is one nothing can sit beside.
+    /// </remarks>
     [Fact]
-    public void TheSlotAfterAuthenticationIsStillAheadOfSerialization() {
-        Assert.True(FilterOrder.Authentication + 1 < FilterOrder.BeforeSerialization);
+    public void GrantAuthorizationRunsAfterAuthenticationAndAheadOfSerialization() {
+        Assert.True(FilterOrder.GrantAuthorization > FilterOrder.Authentication);
+        Assert.True(FilterOrder.GrantAuthorization < FilterOrder.Serialization);
     }
 
     /// <summary>
@@ -52,7 +56,7 @@ public class FilterOrderTests {
     /// </summary>
     [Fact]
     public void BothAuthorizationPositionsRunBeforeTheHandler() {
-        Assert.True(FilterOrder.Authentication + 1 < FilterOrder.EndPointInvoke);
+        Assert.True(FilterOrder.GrantAuthorization < FilterOrder.EndPointInvoke);
         Assert.True(FilterOrder.Authorization < FilterOrder.EndPointInvoke);
     }
 
@@ -66,23 +70,30 @@ public class FilterOrderTests {
     }
 
     /// <summary>
-    /// Neither new value collides with an existing one. A collision is not an error - the sort is
-    /// stable and both filters would run - but it makes the relative order an accident of
-    /// registration rather than a decision.
+    /// Neither authorization slot collides with another stage. A collision is not an error - the
+    /// sort is stable, so both filters run in registration order - but between two <em>stages</em>
+    /// it would make the relative order an accident of registration rather than a decision. Two
+    /// filters deliberately sharing a position through <see cref="FilterOrder.Before"/> or
+    /// <see cref="FilterOrder.After"/> is the case that is fine.
     /// </summary>
     [Fact]
     public void NeitherAuthorizationSlotCollidesWithAnExistingStage() {
         int[] existing = [
             FilterOrder.HandlerCreation,
+            FilterOrder.RateLimitTransport,
+            FilterOrder.RateLimitPrincipal,
+            FilterOrder.Conditional,
+            FilterOrder.ResponseCache,
             FilterOrder.BeforeSerialization,
             FilterOrder.Serialization,
             FilterOrder.Validation,
+            FilterOrder.Retry,
             FilterOrder.DefaultValue,
             FilterOrder.EndPointInvoke,
         ];
 
         Assert.DoesNotContain(FilterOrder.Authentication, existing);
-        Assert.DoesNotContain(FilterOrder.Authentication + 1, existing);
+        Assert.DoesNotContain(FilterOrder.GrantAuthorization, existing);
         Assert.DoesNotContain(FilterOrder.Authorization, existing);
     }
 }

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionFilter.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionFilter.cs
@@ -1,27 +1,16 @@
-﻿namespace Hardened.Requests.Abstract.Execution;
+namespace Hardened.Requests.Abstract.Execution;
 
-public enum ExecutionFilterOrder {
-    Init = -10000,
-    
-    FullRequestMetrics = -7000,
-    
-    RetryFilter = -5000,
-    
-    BeforeSerialize = -1,
-
-    BindParameters = 0,
-
-    First = 1,
-
-    Second = 2,
-
-    Third = 3,
-
-    Normal = 100,
-
-    Last = int.MaxValue,
-}
-
+/// <summary>
+/// One step of a request pipeline. It does its work around <c>chain.Next()</c>; returning without
+/// calling it short-circuits everything ordered after.
+/// </summary>
+/// <remarks>
+/// Where a filter runs is <c>FilterOrder</c>, which is the only ordering vocabulary there is.
+/// <c>ExecutionFilterOrder</c> used to be a second one and was removed: it named positions relative
+/// to parameter binding and serialization that had stopped being where it said they were, most
+/// plainly at <c>RetryFilter = -5000</c> against <c>FilterOrder.Retry</c> behind serialization.
+/// Nothing shipped ever named a member of it.
+/// </remarks>
 public interface IExecutionFilter {
     Task Execute(IExecutionChain chain);
 }

--- a/src/Requests/Hardened.Requests.Abstract/RequestFilter/FilterOrder.cs
+++ b/src/Requests/Hardened.Requests.Abstract/RequestFilter/FilterOrder.cs
@@ -1,53 +1,211 @@
-﻿namespace Hardened.Requests.Abstract.RequestFilter;
+namespace Hardened.Requests.Abstract.RequestFilter;
 
+/// <summary>
+/// Where each stage of the request pipeline runs, and how to sit between two of them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The gaps are the feature.</b> These were consecutive integers, which left an application
+/// nowhere to put a filter of its own: the natural spelling of "just after authentication" is
+/// <c>FilterOrder.Authentication + 100</c>, and on the old scale that was 102, landing past
+/// serialization, validation, resource authorization and the retry filter. It compiled, it ran, and
+/// it meant close to the opposite of what was written. A thousand between stages makes that
+/// expression true, and <see cref="Before"/> and <see cref="After"/> make it readable.
+/// </para>
+/// <para>
+/// <b>Every value is a relationship rather than a literal.</b> One anchor at
+/// <see cref="Serialization"/> and each stage a gap from its neighbour, so the reason a stage sits
+/// where it does stays in the file instead of in whoever last renumbered it.
+/// </para>
+/// <para>
+/// <b>They are <c>const</c>, so a consumer inlines them.</b> An assembly compiled against one set
+/// of values keeps using those values until it is rebuilt, and a filter at a stale position is a
+/// silent behaviour change rather than an error. That is why the scale is wide enough never to move
+/// again rather than only wide enough for what is here now.
+/// </para>
+/// <para>
+/// Everything ahead of <see cref="Serialization"/> can refuse a request before its body has been
+/// read, and the stages there are in cheapest-refusal-first order. A filter on that side of the
+/// line refuses by recording the failure and continuing, so the serialization filter can write the
+/// response; behind it, an ordinary short circuit is what stops the handler.
+/// </para>
+/// </remarks>
 public static class FilterOrder {
-    public const int HandlerCreation = -1000;
+
+    /// <summary>The distance between two stages.</summary>
+    private const int Gap = 1000;
 
     /// <summary>
-    /// Refusing a request on volume, before anyone has asked who is making it - 1.
+    /// Half a gap earlier: a position between two stages, ahead of the named one.
     /// </summary>
     /// <remarks>
-    /// Ahead of <see cref="Authentication"/>, because a limiter meant to blunt a credential-stuffing
-    /// flood cannot wait for the credential to be examined, and ahead of
-    /// <see cref="Serialization"/> for the reason <see cref="Authentication"/> is: a request about
-    /// to be refused must not cost a 10 MB deserialization first. Being on that side of the line
-    /// means a filter here refuses by recording the failure and continuing, not by returning.
+    /// <para>
+    /// <c>Before + Serialization</c> and <c>After + ResponseCache</c> are the same position, which
+    /// is what both of them mean.
+    /// </para>
+    /// <para>
+    /// <b>It does not compose.</b> <c>Before + Before + Serialization</c> is a whole gap and lands
+    /// exactly on <see cref="ResponseCache"/>. Name the earlier stage instead.
+    /// </para>
     /// </remarks>
-    public const int RateLimitTransport = Authentication - 1;
+    public const int Before = -(Gap / 2);
 
     /// <summary>
-    /// Establishing who the caller is - 2.
+    /// Half a gap later: a position between two stages, behind the named one. See
+    /// <see cref="Before"/>, including for why it does not compose.
+    /// </summary>
+    public const int After = Gap / 2;
+
+    /// <summary>
+    /// Creating the handler instance - the outermost position there is.
     /// </summary>
     /// <remarks>
-    /// Before <see cref="BeforeSerialization"/>, and deliberately: a request carrying no credential
-    /// must not cause a 10 MB body to be deserialized before it is rejected. Authentication needs
-    /// nothing but headers, so nothing is lost by settling it this early.
-    ///
-    /// Two below rather than one, because a requirement over grants alone is authorized at
-    /// <c>Authentication + 1</c> and that slot must still land before serialization.
+    /// Before <see cref="Authentication"/>, which reads the handler's metadata for the schemes the
+    /// operation accepts and so needs a handler to read it from. Far outside the pipeline band
+    /// rather than one gap from it, so a filter that has to wrap even this has somewhere to go.
     /// </remarks>
-    public const int Authentication = BeforeSerialization - 2;
-
-    public const int BeforeSerialization = Serialization - 1;
-
-    public const int Serialization = 5;
-
-    public const int Validation = Serialization + 1;
+    public const int HandlerCreation = -(Gap * 10);
 
     /// <summary>
-    /// Deciding whether the caller may proceed - 7.
+    /// Refusing a request on volume, before anyone has asked who is making it.
+    /// </summary>
+    /// <remarks>
+    /// Ahead of <see cref="Authentication"/>, and that is the whole reason this position is
+    /// separate from <see cref="RateLimitPrincipal"/>: a limiter meant to blunt a credential-stuffing
+    /// flood cannot wait for the credential to be examined, because examining it is the work being
+    /// flooded. It keys on whatever identifies the transport, since there is nothing else to key on
+    /// this early.
+    /// </remarks>
+    public const int RateLimitTransport = Authentication - Gap;
+
+    /// <summary>
+    /// Establishing who the caller is.
+    /// </summary>
+    /// <remarks>
+    /// Before <see cref="Serialization"/>, and deliberately: a request carrying no credential must
+    /// not cause a 10 MB body to be deserialized before it is rejected. Authentication needs nothing
+    /// but headers, so nothing is lost by settling it this early.
+    /// </remarks>
+    public const int Authentication = RateLimitPrincipal - Gap;
+
+    /// <summary>
+    /// Refusing a request on volume, once it is known whose volume it is.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After <see cref="Authentication"/> for the obvious reason: a limit keyed on the caller needs
+    /// a caller.
+    /// </para>
+    /// <para>
+    /// Ahead of <see cref="GrantAuthorization"/>, because resolving a caller's grants can reach a
+    /// permissions store, and bounding work like that is what a limiter is for. The cost is that a
+    /// caller who would have been refused anyway still spends a permit, which is the right way
+    /// round: a caller sending requests they hold no grant for is the case worth limiting.
+    /// </para>
+    /// <para>
+    /// This sat behind <see cref="Retry"/> until the scale was widened, not by choice but because
+    /// the integers either side of serialization were taken. The consequence was that a limiter
+    /// keyed on the caller read the whole request body before refusing it, which is most of what a
+    /// limiter exists to avoid.
+    /// </para>
+    /// </remarks>
+    public const int RateLimitPrincipal = GrantAuthorization - Gap;
+
+    /// <summary>
+    /// Deciding whether the caller may proceed, from grants alone.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A requirement naming only grants can be settled from the caller, so it is settled here,
+    /// before a body is read. One that reads bound parameters cannot and waits for
+    /// <see cref="Authorization"/>. Which of the two applies is decided from the requirement tree
+    /// once per handler, not per request.
+    /// </para>
+    /// <para>
+    /// This is a stage rather than <c>Authentication + 1</c>, which is how
+    /// <c>AuthorizationFilterProvider</c> used to spell it. A position documented in three files and
+    /// expressed nowhere is one nothing can sit beside: with a name, "resolve the tenant from the
+    /// token, then check grants" has somewhere to go.
+    /// </para>
+    /// </remarks>
+    public const int GrantAuthorization = Conditional - Gap;
+
+    /// <summary>
+    /// Answering a conditional request from a validator the caller already holds.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Nothing occupies this yet.</b> <c>EntityTagHeader</c> can format and weakly compare
+    /// validators and <c>StaticContentWriter</c> is its only caller, so a client revalidating a
+    /// handler's response is still sent a full body. The slot is reserved because the position is
+    /// already decided and moving a <c>const</c> later is a silent break for anything compiled
+    /// against it.
+    /// </para>
+    /// <para>
+    /// Ahead of <see cref="ResponseCache"/>, and that ordering is the design rather than a
+    /// preference. A 304 costs no body at all, so it is the cheaper answer and belongs first; and a
+    /// validator filter placed inside the cache would never run on a hit, so a cached response could
+    /// never be revalidated.
+    /// </para>
+    /// </remarks>
+    public const int Conditional = ResponseCache - Gap;
+
+    /// <summary>
+    /// Serving a stored response instead of running the handler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Its position is a correctness requirement rather than a convenience, which is what earns it
+    /// a stage instead of an offset. Ahead of <see cref="Serialization"/>, so a hit skips the bind,
+    /// the handler and the serialize rather than only the handler. Behind
+    /// <see cref="GrantAuthorization"/> and ahead of <see cref="Authorization"/>, which is why a
+    /// handler guarded by a requirement over bound parameters is never cached: a stored answer to
+    /// "may this caller edit <em>this</em> pet" served to a second caller is a data leak.
+    /// </para>
+    /// <para>
+    /// <c>[CacheControl]</c> sits at <see cref="BeforeSerialization"/> instead, one half-gap behind,
+    /// so it runs inside the cache. On a hit it does not run at all and the header it wrote on the
+    /// miss is replayed with the rest of them.
+    /// </para>
+    /// </remarks>
+    public const int ResponseCache = Serialization - Gap;
+
+    /// <summary>
+    /// The ordinary slot for work that has to happen just before the response is serialized.
+    /// </summary>
+    /// <remarks>
+    /// Not a stage. It is the position <c>Before + Serialization</c> names, kept as a constant
+    /// because it is a common one and because <c>[CacheControl]</c> and Hardened.Amz both reference
+    /// it. Anything else wanting to sit between two stages writes the expression.
+    /// </remarks>
+    public const int BeforeSerialization = Before + Serialization;
+
+    /// <summary>
+    /// Binding the request on the way in, and serializing the response on the way out.
+    /// </summary>
+    /// <remarks>
+    /// The anchor every other stage is measured from, and the line either side of which a filter
+    /// refuses differently. See the remarks on <see cref="FilterOrder"/>.
+    /// </remarks>
+    public const int Serialization = Gap * 7;
+
+    /// <summary>
+    /// Checking the constraints the contract declared, over the parameters that were just bound.
+    /// </summary>
+    public const int Validation = Serialization + Gap;
+
+    /// <summary>
+    /// Deciding whether the caller may proceed, from the resource as well as the caller.
     /// </summary>
     /// <remarks>
     /// After <see cref="Validation"/>, because a requirement over the resource - "may this caller
     /// edit <em>this</em> pet" - reads bound parameters, and they do not exist until then. A
-    /// requirement over grants alone does not wait: it runs at <see cref="Authentication"/> + 1.
-    /// Which of the two applies is decided from the requirement tree once per handler, not per
-    /// request.
+    /// requirement over grants alone does not wait: it runs at <see cref="GrantAuthorization"/>.
     /// </remarks>
-    public const int Authorization = Validation + 1;
+    public const int Authorization = Validation + Gap;
 
     /// <summary>
-    /// Re-running the handler after a failure - 9.
+    /// Re-running the handler after a failure.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -68,30 +226,24 @@ public static class FilterOrder {
     /// per-request state on itself is not one that can be retried.
     /// </para>
     /// </remarks>
-    public const int Retry = Authorization + 1;
+    public const int Retry = Authorization + Gap;
 
     /// <summary>
-    /// Refusing a request on volume, once it is known whose volume it is - 9.
+    /// Where a filter that states no order lands: after every stage, before the handler.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// After <see cref="Authentication"/> for the obvious reason: a limit keyed on the caller needs
-    /// a caller. There is no room for it between authentication and
-    /// <see cref="Serialization"/> - 3 and 4 are taken and a tie sorts unpredictably - so it sits
-    /// here, which means the body has already been read by the time it refuses. That is the cost of
-    /// the position and the reason <see cref="RateLimitTransport"/> exists: a limiter that must
-    /// refuse before reading a body keys on the transport instead.
-    /// </para>
-    /// <para>
-    /// Behind <see cref="Serialization"/>, so a filter here refuses by returning rather than by
-    /// recording and continuing.
-    /// </para>
+    /// Far above <see cref="Retry"/> rather than one gap from it, so stages can still be added
+    /// without this moving. Moving it would be worse than moving a stage, because it is the default
+    /// parameter value on <c>IGlobalFilterRegistry.RegisterFilter</c> and those are inlined at every
+    /// call site.
     /// </remarks>
-    public const int RateLimitPrincipal = Retry + 1;
-
-    public const int DefaultValue = 1000;
+    public const int DefaultValue = Gap * 100;
 
     public const int EndPointHandlers = DefaultValue * 2;
 
+    /// <summary>
+    /// The handler. Terminal: it never calls <c>Next</c>, so a filter ordered above this is built
+    /// into the chain and never reached.
+    /// </summary>
     public const int EndPointInvoke = DefaultValue * 2;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Serializer/IResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Serializer/IResponseSerializer.cs
@@ -4,7 +4,7 @@ namespace Hardened.Requests.Abstract.Serializer;
 
 /// <summary>
 /// Where a response serializer sits relative to the others. Lower runs first, matching
-/// <c>ExecutionFilterOrder</c>.
+/// <c>FilterOrder</c>.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthorizationFilterProviderTests.cs
@@ -307,7 +307,7 @@ public class AuthorizationFilterProviderTests {
     public void AGrantOnlyRequirementRunsAheadOfSerialization() {
         var filter = Filter(false, new AuthorizeGrantsAttribute("pets:read"))!;
 
-        Assert.Equal(FilterOrder.Authentication + 1, filter.Order);
+        Assert.Equal(FilterOrder.GrantAuthorization, filter.Order);
         Assert.True(filter.Order < FilterOrder.Serialization);
     }
 

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheResponseAttributeTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheResponseAttributeTests.cs
@@ -15,14 +15,21 @@ namespace Hardened.Requests.Runtime.Tests.Caching;
 /// </summary>
 public class CacheResponseAttributeTests {
 
+    /// <summary>
+    /// The cache has a stage of its own rather than sharing the pre-serialization slot, because its
+    /// position is a correctness requirement: ahead of serialization so a hit skips the bind and the
+    /// handler, and behind grant authorization so it never answers for a caller who was refused.
+    /// </summary>
     [Fact]
-    public void TheFilterIsInstalledAheadOfSerialization() {
+    public void TheFilterIsInstalledAtTheResponseCacheStage() {
         var attribute = new CacheResponseAttribute<CacheTestSupport.FixedKey>();
         var handler = CacheTestSupport.Handler([attribute]);
 
         var filter = Assert.Single(attribute.GetFilters(handler));
 
-        Assert.Equal(FilterOrder.BeforeSerialization, filter.Order);
+        Assert.Equal(FilterOrder.ResponseCache, filter.Order);
+        Assert.True(filter.Order < FilterOrder.Serialization);
+        Assert.True(filter.Order > FilterOrder.GrantAuthorization);
         Assert.IsType<ResponseCacheFilter>(filter.FilterFunc(null!));
     }
 

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterOrderingTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterOrderingTests.cs
@@ -87,66 +87,126 @@ public class FilterOrderingTests {
     }
 
     /// <summary>
-    /// Every value on <see cref="ExecutionFilterOrder"/>, registered at once and in reverse so
-    /// the sort has to do the work. The pipeline's own three filters interleave with them at
-    /// their documented positions, which is the point: a filter author picks an
-    /// <c>ExecutionFilterOrder</c> to land on a particular side of parameter binding and
-    /// handler invocation.
+    /// Every named stage, registered at once and in reverse so the sort has to do the work, with
+    /// the pipeline's own three filters interleaved at their documented positions.
     ///
     /// <para>
-    /// <see cref="ExecutionFilterOrder.Last"/> is absent from the expected sequence because it
-    /// sorts above <see cref="FilterOrder.EndPointInvoke"/>, and the invoke filter is terminal
-    /// - see <see cref="AFilterOrderedAfterTheHandlerNeverRuns"/>.
+    /// This is the whole ordering contract in one assertion. It replaced a test over
+    /// <c>ExecutionFilterOrder</c>, a second ordering vocabulary whose names had stopped describing
+    /// where its values landed - <c>RetryFilter = -5000</c> against a retry stage behind
+    /// serialization - and which nothing shipped ever used.
     /// </para>
     /// </summary>
     [Fact]
-    public async Task TheWholeExecutionFilterOrderRangeRunsInAscendingOrder() {
+    public async Task EveryStageRunsInPipelineOrder() {
         var log = new List<string>();
 
+        // Name and order together, so a stage that moves fails here rather than being reordered
+        // silently. The three the pipeline pins itself are not registered.
+        var stages = new (string Name, int Order)[] {
+            ("rate-limit-transport", FilterOrder.RateLimitTransport),
+            ("authentication",       FilterOrder.Authentication),
+            ("rate-limit-principal", FilterOrder.RateLimitPrincipal),
+            ("grant-authorization",  FilterOrder.GrantAuthorization),
+            ("conditional",          FilterOrder.Conditional),
+            ("response-cache",       FilterOrder.ResponseCache),
+            ("before-serialization", FilterOrder.BeforeSerialization),
+            ("validation",           FilterOrder.Validation),
+            ("authorization",        FilterOrder.Authorization),
+            ("retry",                FilterOrder.Retry),
+            ("default",              FilterOrder.DefaultValue),
+        };
+
         await Run(log, registry => {
-            foreach (var value in Enum.GetValues<ExecutionFilterOrder>().OrderByDescending(v => v)) {
-                registry.RegisterFilter(new Pipeline.Recording(log, value.ToString()), (int)value);
+            foreach (var stage in stages.Reverse()) {
+                registry.RegisterFilter(new Pipeline.Recording(log, stage.Name), stage.Order);
             }
         });
 
         Assert.Equal(new[] {
-            nameof(ExecutionFilterOrder.Init),               // -10000
-            nameof(ExecutionFilterOrder.FullRequestMetrics), //  -7000
-            nameof(ExecutionFilterOrder.RetryFilter),        //  -5000
-            Instance,                                        //  -1000  FilterOrder.HandlerCreation
-            nameof(ExecutionFilterOrder.BeforeSerialize),    //     -1
-            nameof(ExecutionFilterOrder.BindParameters),     //      0
-            nameof(ExecutionFilterOrder.First),              //      1
-            nameof(ExecutionFilterOrder.Second),             //      2
-            nameof(ExecutionFilterOrder.Third),              //      3
-            Io,                                              //      5  FilterOrder.Serialization
-            nameof(ExecutionFilterOrder.Normal),             //    100
-            Invoke                                           //   2000  FilterOrder.EndPointInvoke
+            Instance,                 //  -10000  HandlerCreation
+            "rate-limit-transport",   //    1000
+            "authentication",         //    2000
+            "rate-limit-principal",   //    3000
+            "grant-authorization",    //    4000
+            "conditional",            //    5000
+            "response-cache",         //    6000
+            "before-serialization",   //    6500  Before + Serialization
+            Io,                       //    7000  Serialization
+            "validation",             //    8000
+            "authorization",          //    9000
+            "retry",                  //   10000
+            "default",                //  100000
+            Invoke                    //  200000  EndPointInvoke
         }, log);
     }
 
     /// <summary>
-    /// A filter registered before parameter binding sees the request ahead of the IO filter;
-    /// one registered after it does not. Table-driven across the range because each value is
-    /// a separate branch through the same comparison.
+    /// A limiter keyed on the caller refuses before the body is read.
+    /// </summary>
+    /// <remarks>
+    /// It did not until the scale was widened. The stage sat behind <c>Retry</c> because the
+    /// integers either side of serialization were taken, so a request that was about to be refused
+    /// on volume was deserialized first - which is most of what a limiter exists to avoid.
+    /// </remarks>
+    [Fact]
+    public void PrincipalRateLimitingRefusesAheadOfTheBodyRead() {
+        Assert.True(FilterOrder.RateLimitPrincipal < FilterOrder.Serialization);
+        Assert.True(FilterOrder.RateLimitPrincipal > FilterOrder.Authentication);
+    }
+
+    /// <summary>
+    /// Every stage has room either side of it for a filter an application writes.
+    /// </summary>
+    /// <remarks>
+    /// The reason the scale is wide. On consecutive integers the natural spelling of "just after
+    /// authentication" - <c>Authentication + 100</c> - landed past serialization, validation,
+    /// authorization and retry, and there was no spelling that did not.
+    /// </remarks>
+    [Fact]
+    public async Task AFilterCanSitBetweenTwoStages() {
+        var log = new List<string>();
+
+        await Run(log, registry => {
+            registry.RegisterFilter(
+                new Pipeline.Recording(log, "after-auth"),
+                FilterOrder.After + FilterOrder.Authentication);
+            registry.RegisterFilter(
+                new Pipeline.Recording(log, "before-auth"),
+                FilterOrder.Before + FilterOrder.Authentication);
+            registry.RegisterFilter(
+                new Pipeline.Recording(log, "authentication"), FilterOrder.Authentication);
+        });
+
+        Assert.Equal(
+            new[] { Instance, "before-auth", "authentication", "after-auth", Io, Invoke }, log);
+    }
+
+    /// <summary>
+    /// A filter registered before serialization sees the request ahead of the IO filter; one
+    /// registered after it does not. Table-driven across the stages, because each is a separate
+    /// branch through the same comparison.
     /// </summary>
     [Theory]
-    [InlineData(ExecutionFilterOrder.Init, true)]
-    [InlineData(ExecutionFilterOrder.FullRequestMetrics, true)]
-    [InlineData(ExecutionFilterOrder.RetryFilter, true)]
-    [InlineData(ExecutionFilterOrder.BeforeSerialize, true)]
-    [InlineData(ExecutionFilterOrder.BindParameters, true)]
-    [InlineData(ExecutionFilterOrder.First, true)]
-    [InlineData(ExecutionFilterOrder.Second, true)]
-    [InlineData(ExecutionFilterOrder.Third, true)]
-    [InlineData(ExecutionFilterOrder.Normal, false)]
+    [InlineData(FilterOrder.HandlerCreation, true)]
+    [InlineData(FilterOrder.RateLimitTransport, true)]
+    [InlineData(FilterOrder.Authentication, true)]
+    [InlineData(FilterOrder.RateLimitPrincipal, true)]
+    [InlineData(FilterOrder.GrantAuthorization, true)]
+    [InlineData(FilterOrder.Conditional, true)]
+    [InlineData(FilterOrder.ResponseCache, true)]
+    [InlineData(FilterOrder.BeforeSerialization, true)]
+    [InlineData(FilterOrder.Validation, false)]
+    [InlineData(FilterOrder.Authorization, false)]
+    [InlineData(FilterOrder.Retry, false)]
+    [InlineData(FilterOrder.DefaultValue, false)]
     public async Task AFilterRunsBeforeSerializationExactlyWhenItsOrderIsLower(
-        ExecutionFilterOrder order, bool expectedBeforeIo) {
+        int order, bool expectedBeforeIo) {
 
         var log = new List<string>();
 
         var result = await Run(log, registry =>
-            registry.RegisterFilter(new Pipeline.Recording(log, "subject"), (int)order));
+            registry.RegisterFilter(new Pipeline.Recording(log, "subject"), order));
 
         Assert.Contains("subject", result);
         Assert.Equal(expectedBeforeIo, result.IndexOf("subject") < result.IndexOf(Io));
@@ -155,9 +215,7 @@ public class FilterOrderingTests {
     /// <summary>
     /// The invoke filter is terminal - it never calls <c>Next</c> - so a filter sorted above
     /// <see cref="FilterOrder.EndPointInvoke"/> is built into the chain and then silently
-    /// never reached. <see cref="ExecutionFilterOrder.Last"/> is <c>int.MaxValue</c> and is
-    /// therefore unreachable in a standard handler pipeline, which is worth pinning because
-    /// nothing reports it: the filter simply does not run.
+    /// never reached. Worth pinning because nothing reports it: the filter simply does not run.
     /// </summary>
     [Theory]
     [InlineData(FilterOrder.EndPointInvoke + 1)]
@@ -174,8 +232,8 @@ public class FilterOrderingTests {
 
     /// <summary>
     /// A <see cref="RequestFilterInfo"/> with no order is sorted as
-    /// <see cref="FilterOrder.DefaultValue"/>, which puts it after everything at
-    /// <see cref="ExecutionFilterOrder.Normal"/> and before the handler.
+    /// <see cref="FilterOrder.DefaultValue"/>, which puts it after every stage and before the
+    /// handler.
     /// </summary>
     [Fact]
     public async Task AFilterWithNoOrderSortsAtTheDefaultValue() {
@@ -234,19 +292,24 @@ public class FilterOrderingTests {
     public async Task AttributeFiltersAndGlobalFiltersShareOneOrdering() {
         var log = new List<string>();
 
+        // Positions named as stages rather than as literals. The literals this used to carry were
+        // picked to straddle the old consecutive integers and stopped meaning anything the moment
+        // the scale changed, which is the failure the named constants exist to prevent.
         var result = await Run(
             log,
             registry => {
-                registry.RegisterFilter(new Pipeline.Recording(log, "global-early"), -6000);
-                registry.RegisterFilter(new Pipeline.Recording(log, "global-late"), 500);
+                registry.RegisterFilter(
+                    new Pipeline.Recording(log, "global-early"), FilterOrder.Authentication);
+                registry.RegisterFilter(
+                    new Pipeline.Recording(log, "global-late"), FilterOrder.Retry);
             },
-            AtOrder(log, "attribute-earliest", -9000),
-            AtOrder(log, "attribute-middle", 200));
+            AtOrder(log, "attribute-earliest", FilterOrder.HandlerCreation - 100),
+            AtOrder(log, "attribute-middle", FilterOrder.Validation));
 
         Assert.Equal(new[] {
             "attribute-earliest",
-            "global-early",
             Instance,
+            "global-early",
             Io,
             "attribute-middle",
             "global-late",

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/ShortCircuitTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/ShortCircuitTests.cs
@@ -130,7 +130,7 @@ public class ShortCircuitTests {
 
         var registry = new GlobalFilterRegistry(Array.Empty<IRequestFilterProvider>());
         registry.RegisterFilter(new Pipeline.ShortCircuiting(log, "gate"),
-            (int)ExecutionFilterOrder.Init);
+            FilterOrder.HandlerCreation - 1);
 
         var context = Pipeline.Context(configureServices: services => {
             services.AddSingleton<IGlobalFilterRegistry>(registry);

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/GlobalFilterRegistryTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/GlobalFilterRegistryTests.cs
@@ -63,11 +63,12 @@ public class GlobalFilterRegistryTests {
     }
 
     [Theory]
-    [InlineData((int)ExecutionFilterOrder.Init)]
-    [InlineData((int)ExecutionFilterOrder.RetryFilter)]
+    [InlineData(FilterOrder.HandlerCreation)]
+    [InlineData(FilterOrder.Authentication)]
     [InlineData(FilterOrder.Serialization)]
     [InlineData(FilterOrder.Validation)]
-    [InlineData((int)ExecutionFilterOrder.Normal)]
+    [InlineData(FilterOrder.Before + FilterOrder.Serialization)]
+    [InlineData(FilterOrder.DefaultValue)]
     public void AnExplicitOrderIsCarriedThroughToTheFilterInfo(int order) {
         var registry = Registry();
 

--- a/src/Requests/Hardened.Requests.Runtime.Tests/RateLimiting/RateLimitFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/RateLimiting/RateLimitFilterTests.cs
@@ -257,7 +257,8 @@ public class RateLimitFilterTests {
     [Fact]
     public void RateLimitAttribute_UsesOrdersNothingElseClaims() {
         var taken = new[] {
-            FilterOrder.HandlerCreation, FilterOrder.Authentication, FilterOrder.BeforeSerialization,
+            FilterOrder.HandlerCreation, FilterOrder.Authentication, FilterOrder.GrantAuthorization,
+            FilterOrder.Conditional, FilterOrder.ResponseCache, FilterOrder.BeforeSerialization,
             FilterOrder.Serialization, FilterOrder.Validation, FilterOrder.Authorization,
             FilterOrder.Retry, FilterOrder.DefaultValue, FilterOrder.EndPointInvoke
         };

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizationFilterProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizationFilterProvider.cs
@@ -60,7 +60,7 @@ public class AuthorizationFilterProvider {
         // cannot. Decided here, once per handler, rather than per request.
         var order = requirement.RequiresContext
             ? FilterOrder.Authorization
-            : FilterOrder.Authentication + 1;
+            : FilterOrder.GrantAuthorization;
 
         var filter = new AuthorizationFilter(
             requirement, beforeSerialization: order < FilterOrder.Serialization);

--- a/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
@@ -32,7 +32,7 @@ namespace Hardened.Requests.Runtime.Caching;
 ///
 /// <para>
 /// <b>A resource-scoped handler is never cached.</b> The filter runs at
-/// <see cref="FilterOrder.BeforeSerialization"/>, which is after authorization over grants alone
+/// <see cref="FilterOrder.ResponseCache"/>, which is after authorization over grants alone
 /// and before authorization that reads bound parameters - so a stored response for "may this caller
 /// edit <em>this</em> pet" would be served to a caller the resource check would refuse. ASP.NET
 /// Core ships that hazard as a documentation note telling you to call <c>UseOutputCache</c> after
@@ -100,7 +100,7 @@ public sealed class CacheResponseAttribute<TProvider> :
 
         var filter = ResponseCacheFilter.Compose(handlerInfo, declarations);
 
-        yield return new RequestFilterInfo(_ => filter, FilterOrder.BeforeSerialization);
+        yield return new RequestFilterInfo(_ => filter, FilterOrder.ResponseCache);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -12,9 +12,9 @@ namespace Hardened.Requests.Runtime.Caching;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Installed at <see cref="Abstract.RequestFilter.FilterOrder.BeforeSerialization"/>, one position
-/// ahead of <c>IoFilter</c>. That is what makes a hit skip the bind, the handler and the serialize
-/// rather than only the handler - the whole point of storing bytes instead of the value the handler
+/// Installed at <see cref="Abstract.RequestFilter.FilterOrder.ResponseCache"/>, one stage ahead of
+/// <c>IoFilter</c>. That is what makes a hit skip the bind, the handler and the serialize rather
+/// than only the handler - the whole point of storing bytes instead of the value the handler
 /// returned.
 /// </para>
 /// <para>

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
@@ -225,10 +225,20 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
             filterList.AddRange(requestFilterProvider.GetFilters(handlerInfo));
         }
 
-        filterList.Sort((x, y) =>
-            Comparer<int>.Default.Compare(x.Order ?? FilterOrder.DefaultValue, y.Order ?? FilterOrder.DefaultValue));
-
-        return new ExecutionHandlerSetup(handlerInfo, filterList.Select(f => f.FilterFunc).ToArray());
+        // OrderBy rather than List.Sort, because it is stable and List.Sort is not.
+        //
+        // Two filters at one order is not a mistake to be designed out: FilterOrder.Before and
+        // FilterOrder.After name a position rather than a stage, so two registrations asking for
+        // the same place get the same integer, which is correct - they asked for the same place.
+        // What was wrong was the tie breaking differently between runs, which for anything
+        // straddling serialization decides whether a body is written. Registration order is now
+        // what settles it, and registration order is deterministic.
+        return new ExecutionHandlerSetup(
+            handlerInfo,
+            filterList
+                .OrderBy(filter => filter.Order ?? FilterOrder.DefaultValue)
+                .Select(filter => filter.FilterFunc)
+                .ToArray());
     }
 
     /// <summary>


### PR DESCRIPTION
`FilterOrder` was consecutive integers, and the problem is not that it was untidy. It is that the natural spelling of "just after authentication" was silently wrong.

```csharp
FilterOrder.Authentication + 100   // 102 — past serialization, validation,
                                   // resource authorization and both rate limiters
```

That compiles, it runs, and there was no spelling that did not. `2`, `3`, `4` and `5` were authentication, grant authorization, the pre-serialization slot and serialization, so an application had nowhere to put a filter of its own between any two stages.

## The new scale

A thousand between stages, every value still a relationship rather than a literal.

| | Stage | |
|---:|---|---|
| `-10000` | `HandlerCreation` | |
| `1000` | `RateLimitTransport` | |
| `2000` | `Authentication` | |
| `3000` | `RateLimitPrincipal` | **moved** |
| `4000` | `GrantAuthorization` | **new name** |
| `5000` | `Conditional` | **new, unoccupied** |
| `6000` | `ResponseCache` | **new name** |
| `6500` | `BeforeSerialization` | now `Before + Serialization` |
| `7000` | `Serialization` | |
| `8000` | `Validation` | |
| `9000` | `Authorization` | |
| `10000` | `Retry` | |
| `100000` | `DefaultValue` | |
| `200000` | `EndPointInvoke` | |

`Before` and `After` are `-500` and `500`, so `Before + Serialization` and `After + ResponseCache` are the same position, which is what both of them mean. They are consts rather than methods deliberately: a method call cannot go in an attribute argument, a default parameter value or a `switch` case, and `Before + X` can.

They do not compose. `Before + Before + Serialization` is a whole gap and lands exactly on `ResponseCache`. The doc comment says so at the call site, where someone would read it.

## The crowding had been shaping the design

`RateLimitPrincipal` sat behind `Retry` because 3 and 4 were taken, and its own doc comment recorded what that cost: a limiter keyed on the caller read the whole request body before refusing it, which is most of what a limiter exists to avoid. It now sits between authentication and grant authorization, ahead of grant resolution because that can reach a permissions store and bounding work like that is the point.

This turned out to be free. `RateLimitFilter` already carries the record-and-continue mode that a position ahead of serialization requires, and `RateLimitAttribute` computes `beforeSerialization` from the order, so the behaviour change is the constant moving.

`RateLimitTransport`'s rationale needed rewriting either way. It used to justify itself partly by principal limiting reading the body first; it exists because it needs no identity at all.

## Two stages get names they should have had

`GrantAuthorization` was `FilterOrder.Authentication + 1` in `AuthorizationFilterProvider`. A position documented in three files and expressible nowhere is one nothing can sit beside; with a name, "resolve the tenant from the token, then check grants" has somewhere to go.

`ResponseCache` was sharing the pre-serialization slot. Its position is a correctness requirement rather than a convenience — ahead of serialization so a hit skips the bind and the handler, behind grant authorization so it never answers for a caller who was refused — and that is what earns a stage instead of an offset. `[CacheControl]` stays at `BeforeSerialization`, one half-gap behind, so it runs inside the cache; on a hit it does not run and the header it wrote on the miss is replayed with the rest.

`Conditional` is reserved and nothing occupies it. `EntityTagHeader` can already format and weakly compare validators and `StaticContentWriter` is its only caller, so a client revalidating a handler's response still gets a full body. The slot is declared now because the position is decided and moving a `const` later is a silent break for anything compiled against it.

## The sort is stable now

`ExecutionHelper` used `List<T>.Sort`, which is not. Two filters at one order is not a mistake to design out — `Before` and `After` name a position, so two registrations asking for the same place get the same integer, correctly. What was wrong was the tie breaking differently between runs, which for anything straddling serialization decides whether a body is written. Registration order settles it now, and registration order is deterministic. It also makes `FilterOrderTests`'s existing "the sort is stable" comment true.

## `ExecutionFilterOrder` is removed

**The one call worth vetoing if you disagree**, and it is a single revert.

It was a second public ordering vocabulary landing in the same `RequestFilterInfo.Order` field, and its names had already stopped describing where its values went: `RetryFilter = -5000` against a retry stage sitting behind serialization at 8. Widening the scale takes that from mostly wrong to entirely wrong — every member except `Last` would sort ahead of the whole pipeline, so `Normal` would run before transport rate limiting.

Nothing shipped in either repository names a member of it; only tests did. Keeping it meant either rewriting those tests to assert a meaningless interleaving, which `docs/testing-conventions.md` §6 forbids, or rescaling it into a parallel vocabulary that agrees with `FilterOrder` by hand. The tests it anchored are rewritten against the real stages and are better for it: `EveryStageRunsInPipelineOrder` now pins the entire pipeline in one assertion, which is what the old test was reaching for with the wrong nouns.

## What consumers have to do

These are `public const int`, so they are inlined at the call site. `Hardened.Amz.Function.Lambda.Runtime`'s `ThrowExceptionAttribute` reads `FilterOrder.BeforeSerialization` and needs rebuilding against this rather than changing — the name is still there. Until it is rebuilt its filter sits at 4 while authentication has moved to 2000, so this wants a release note and the two repositories moving on one line.

That is also the argument for the scale being wider than anything here needs. The next stage that gets added should not cost a second coordinated break.

## Verified

- `dotnet build --configuration Release -p:ContinuousIntegrationBuild=true` clean, with the pinned Smithy CLI on PATH.
- `dotnet test` in Release: 32 assemblies, 0 failures, 0 skipped.
- `FilterOrderTests` asserts relationships rather than values and passed the renumber unmodified; the edits to it name `GrantAuthorization` where it was describing `Authentication + 1`, and extend the collision list to the stages added since it was written.
- Public surface re-approved. The diff is the values, the two new stages, `Before`/`After`, and the `ExecutionFilterOrder` removal.
- `docs/response-caching.md` and `docs/validation-system.md` had stale positions in prose; both fixed. The pipeline page on Hardened.Docs names the old integers and will need the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
