### PR TITLE
Read money as decimal, in both spellings a contract can use

### DIFF
--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -54,6 +54,46 @@ serving the source verbatim where that is wanted.
   against what the handler actually throws - the declared response models are where the compiler
   holds the set.
 
+## Numbers, and money
+
+`format` is an open-valued property. OpenAPI names four numeric formats - `int32`, `int64`,
+`float`, `double` - and says a document may use others, so anything else is a convention rather
+than a standard. What the build reads:
+
+| declared | C# |
+|---|---|
+| `number` / `float` | `float` |
+| `number` / `double` | `double` |
+| `number` / `decimal` | `decimal` |
+| `string` / `number` | `decimal` |
+| `number` / anything else, or no format | `double` |
+| `integer` / `int64` | `long` |
+| `integer` / `uint32` | `uint` |
+| `integer` / anything else | `int`, widened to `long` where a declared bound exceeds it |
+
+Two spellings for a decimal because the ecosystem has two and neither is in the specification.
+`number` + `decimal` is NSwag's, measured against 14.1.0: it answers `decimal` for that pair and
+`double` for a formatless `number`. `string` + `number` is openapi-generator's, whose
+`ModelUtils.isDecimalSchema` tests exactly that pair and whose language generators map it to
+`BigDecimal`, `Decimal`, `decimal.Decimal` and so on.
+
+What neither spelling can be is the *absence* of a format. openapi-generator's C# target maps
+every formatless `number` to `decimal`, so a document written against it means a decimal by
+saying nothing - and saying nothing is how every other document means `double`. That one is not
+readable and stays `double`.
+
+A bound on a decimal member is emitted as `Range(Min = "0.01")` rather than as a number.
+`decimal` is not a legal attribute argument type in C#, and ValidationModules parses a string
+bound invariantly against the property's own type at generation time - so the bound stays exact
+instead of going through the `double` the member exists to avoid, and a malformed one is still a
+build error.
+
+Smithy's `BigDecimal` and `BigInteger` still degrade to `double` and `long` under `HSMT006`.
+Arbitrary precision has no C# type; `decimal` would be closer than `double` and is not the same
+thing, which is its own change.
+
+Code-first, a `decimal` property publishes `number` / `decimal`, so it reads back as one.
+
 ## The vocabulary
 
 | Declaration | Where | What it does |

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Hardened.Requests.Runtime.Validation;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
@@ -212,6 +213,83 @@ public class ValidationTests {
             ValidOrder, "/orders", request => request.Headers["Idempotency-Key"] = "0f9ac3b2");
 
         response.Assert.Ok();
+    }
+
+    #endregion
+
+    #region money
+
+    /// <summary>
+    /// H-10. Every <c>number</c> became a <c>double</c>, so money was a double end to end and the
+    /// framework never said so.
+    /// </summary>
+    /// <remarks>
+    /// Both spellings, because the ecosystem uses two and neither is in the OpenAPI specification:
+    /// <c>number</c> + <c>decimal</c> is NSwag's, and <c>string</c> + <c>number</c> is
+    /// openapi-generator's - its <c>ModelUtils.isDecimalSchema</c> tests exactly that pair.
+    /// </remarks>
+    [HardenedTest]
+    public async Task MoneySurvivesTheRoundTripExactly(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":3,"unitPrice":19.99,"discount":0.1}]}""",
+            "/orders");
+
+        response.Assert.Ok();
+
+        var line = response.Deserialize<OrderRequest>().Lines![0];
+
+        // The value a double cannot hold: 19.99 * 3 is 59.97 in decimal and 59.970000000000006 in
+        // binary floating point.
+        Assert.Equal(19.99m, line.UnitPrice);
+        Assert.Equal(59.97m, line.UnitPrice!.Value * 3);
+        Assert.Equal(0.1m, line.Discount);
+    }
+
+    /// <summary>
+    /// And the declared bound still runs. It is emitted as Range(Min = "0.01") - the string form
+    /// ValidationModules parses against the property's own type - because rendering it through
+    /// double is the one thing a decimal member exists to avoid.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABoundOnMoneyIsEnforced(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":3,"unitPrice":0.001}]}""",
+            "/orders");
+
+        Assert.Equal(400, response.StatusCode);
+        Assert.Contains(
+            response.Deserialize<RequestValidationError>().Errors,
+            e => e.Field.Contains("unitPrice") && e.Code == "range");
+    }
+
+    /// <summary>
+    /// The published document keeps the spelling the contract used, so a client generator reads
+    /// back what the author wrote.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheDocumentPublishesBothSpellings(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/openapi.json");
+
+        response.Assert.Ok();
+        response.Body.Position = 0;
+
+        // Served gzipped, because the harness asks for it by default the way a client does.
+        await using var gzip = new System.IO.Compression.GZipStream(
+            response.Body, System.IO.Compression.CompressionMode.Decompress);
+
+        using var document = JsonDocument.Parse(await new StreamReader(gzip).ReadToEndAsync());
+
+        var properties = document.RootElement
+            .GetProperty("components").GetProperty("schemas")
+            .GetProperty("OrderLine").GetProperty("properties");
+
+        var unitPrice = properties.GetProperty("unitPrice");
+        var discount = properties.GetProperty("discount");
+
+        Assert.Equal("number", unitPrice.GetProperty("type").GetString());
+        Assert.Equal("decimal", unitPrice.GetProperty("format").GetString());
+        Assert.Equal("string", discount.GetProperty("type").GetString());
+        Assert.Equal("number", discount.GetProperty("format").GetString());
     }
 
     #endregion

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -531,6 +531,17 @@ components:
           type: integer
           format: int32
           minimum: 1
+        # Money, in the two spellings the ecosystem uses, with a bound a double cannot hold
+        # exactly. Both reach C# decimal, and the bound goes on the attribute as a string because
+        # rendering it through double is what the type exists to avoid.
+        unitPrice:
+          type: number
+          format: decimal
+          minimum: 0.01
+        discount:
+          type: string
+          format: number
+          minimum: 0.1
     PetSpecies:
       type: string
       enum:

--- a/src/SourceGenerators/Hardened.Generation.Shared/TypeMapper.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/TypeMapper.cs
@@ -19,6 +19,15 @@ internal static class TypeMapper {
             ("string", "date") => "DateOnly",
             ("string", "uuid") => "string",
             ("string", "byte") => "byte[]",
+            // Money as an exact decimal, in the two spellings the ecosystem actually uses. Neither
+            // is in the OpenAPI specification, which names int32, int64, float and double and
+            // nothing else - format is an open-valued property, so both are legal and both are
+            // conventions rather than standards.
+            //
+            // "string" + "number" is openapi-generator's: ModelUtils.isDecimalSchema tests exactly
+            // that pair, and around thirty of its language generators map it to a decimal type.
+            // Ahead of ("string", _) or it would go on being a string.
+            ("string", "number") => "decimal",
             ("string", "binary") => "byte[]",
             ("string", _) => "string",
             ("integer", "int64") => "long",
@@ -26,6 +35,12 @@ internal static class TypeMapper {
             ("integer", _) => "int",
             ("number", "float") => "float",
             ("number", "double") => "double",
+            // "number" + "decimal" is NSwag's, measured against 14.1.0: it answers decimal for this
+            // pair and double for a formatless number. openapi-generator warns "Unknown `format`
+            // decimal" and discards it, so a document written for that tool means a decimal by
+            // leaving the format off - which is the one reading this cannot take, because the same
+            // absence is how every other document says double.
+            ("number", "decimal") => "decimal",
             ("number", _) => "double",
             ("boolean", _) => "bool",
             _ => "JsonElement"

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -587,19 +587,20 @@ internal static class JsonTypeInfoEmitter {
             ns, TypeMapper.MapToCSharpType(prop.DictionaryValueType, null), false);
     }
 
+    /// <summary>
+    /// Whether an optional member of this type needs the nullable form in its property info.
+    /// </summary>
+    /// <remarks>
+    /// The primitive half is <c>TypeMapper.IsNonNullableValueType</c> rather than a list of its
+    /// own. It was a list of its own, and it had drifted: <c>decimal</c> was missing, so an
+    /// optional decimal member emitted <c>CreatePropertyInfo&lt;decimal&gt;</c> over a
+    /// <c>decimal?</c> property and the generated file did not compile. That was invisible while
+    /// no mapping produced a decimal, which is the way a duplicated list fails - not when it is
+    /// written, but when something upstream finally reaches the case it forgot.
+    /// </remarks>
     private static bool IsValueType(string csType, PropertyModel prop, List<SchemaModel> allSchemas) {
-        switch (csType) {
-            case "int":
-            case "uint":
-            case "long":
-            case "float":
-            case "double":
-            case "bool":
-            case "DateTimeOffset":
-            case "DateTime":
-            case "DateOnly":
-            case "JsonElement":
-                return true;
+        if (TypeMapper.IsNonNullableValueType(csType)) {
+            return true;
         }
 
         // Check if it's an enum reference

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
@@ -109,11 +109,11 @@ internal static class ConstraintAttributes {
             var arguments = new List<string>();
 
             if (minimum.HasValue) {
-                arguments.Add("Min = " + Literal(minimum.Value));
+                arguments.Add("Min = " + Literal(minimum.Value, csType));
             }
 
             if (maximum.HasValue) {
-                arguments.Add("Max = " + Literal(maximum.Value));
+                arguments.Add("Max = " + Literal(maximum.Value, csType));
             }
 
             if (exclusiveMinimum) {
@@ -169,12 +169,25 @@ internal static class ConstraintAttributes {
     }
 
     /// <summary>
-    /// A bound as a C# literal for Range's <c>object?</c> properties. Rendered through double
-    /// because decimal is not a legal attribute argument type; a whole-number bound renders as
-    /// the integer it is.
+    /// A bound as a C# literal for Range's <c>object?</c> properties.
     /// </summary>
-    private static string Literal(decimal value) =>
-        ((double)value).ToString("R", CultureInfo.InvariantCulture);
+    /// <remarks>
+    /// <para>
+    /// Rendered through double, because decimal is not a legal attribute argument type; a
+    /// whole-number bound renders as the integer it is.
+    /// </para>
+    /// <para>
+    /// Except on a decimal member, where going through double is the one thing the type was chosen
+    /// to avoid - a bound of 0.1 would arrive at the comparison as 0.1000000000000000055511151231.
+    /// <c>Range</c> takes <c>object?</c> and ValidationModules parses a string bound invariantly
+    /// against the property's own type at generation time, which its remarks give decimal as the
+    /// first reason for. So the bound stays exact and a malformed one is still a build error.
+    /// </para>
+    /// </remarks>
+    private static string Literal(decimal value, string csType) =>
+        csType == "decimal"
+            ? Quote(value.ToString(CultureInfo.InvariantCulture))
+            : ((double)value).ToString("R", CultureInfo.InvariantCulture);
 
     private static string Quote(string value) =>
         "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
@@ -329,7 +329,12 @@ public static class JsonSchemaWriter {
                 "{\"type\":\"integer\",\"format\":\"int64\"}",
             SpecialType.System_Single => "{\"type\":\"number\",\"format\":\"float\"}",
             SpecialType.System_Double => "{\"type\":\"number\",\"format\":\"double\"}",
-            SpecialType.System_Decimal => "{\"type\":\"number\"}",
+            // The format is written, so the document says decimal rather than leaving a reader to
+            // guess from a bare "number" - which this framework reads back as double, so a
+            // code-first decimal did not survive its own contract. NSwag reads the pair as decimal
+            // too; openapi-generator ignores the format and defaults number to decimal in C#
+            // anyway, so naming it costs that reader nothing.
+            SpecialType.System_Decimal => "{\"type\":\"number\",\"format\":\"decimal\"}",
             SpecialType.System_DateTime => "{\"type\":\"string\",\"format\":\"date-time\"}",
             SpecialType.System_Object => "{}",
             _ => ByName(type)


### PR DESCRIPTION
C1 / H-10, the OpenAPI half. Both conventions, as you asked.

`TypeMapper` mapped `("number", _)` to `double`, so `format: decimal` became a double end to end with nothing said — money as binary floating point, from a contract that asked for the opposite. `type: string` with `format: number` stayed a string.

| declared | before | now |
|---|---|---|
| `number` / `decimal` | `double`, silently | `decimal` |
| `string` / `number` | `string` | `decimal` |
| `number` / no format | `double` | `double`, unchanged |

Neither spelling is in the OpenAPI specification — it names `int32`, `int64`, `float` and `double` and nothing else, and `format` is open-valued, so both are conventions. `number` + `decimal` is NSwag's; I ran 14.1.0 and it answers `decimal` for that pair and `double` for a formatless `number`. `string` + `number` is openapi-generator's, whose `ModelUtils.isDecimalSchema` tests exactly that pair and whose generators map it to `BigDecimal`, `Decimal`, `decimal.Decimal` per target.

**The absence of a format stays `double`, deliberately.** openapi-generator's C# target maps every formatless `number` to `decimal`, so a document written against it means a decimal by saying nothing — and saying nothing is how every other document means `double`. That one is not readable both ways, so it is not read.

**Two things the type had to travel through, and both were broken.**

Bounds were rendered through `double`, which on a decimal member is the one thing the type is chosen to avoid: `minimum: 0.1` would have reached the comparison as `0.1000000000000000055511151231`, a stricter rule than the contract wrote. `Range` takes `object?` and ValidationModules parses a string bound invariantly against the property's own type at generation time — its remarks give `decimal` as the first reason that overload exists — so a decimal bound is emitted as `Range(Min = "0.01")`. Exact, and a malformed bound is still a build error.

`JsonTypeInfoEmitter.IsValueType` kept a second list of value types and `decimal` was missing from it, so an optional decimal member emitted `CreatePropertyInfo<decimal>` over a `decimal?` property and the generated file did not compile. It reads `TypeMapper.IsNonNullableValueType` now, which is the complete list. That list had been wrong since it was written; nothing reached the case until this mapping did, which is how a duplicated list fails — not when it is written, but when something upstream finally arrives at what it forgot.

Code-first, a `decimal` property publishes `number` + `decimal` instead of a bare `number`, so it reads back as the type it was. That was a round-trip hole: your own document did not describe your own type.

Tests — the petstore fixture's `OrderLine` gains a `unitPrice` (`number`/`decimal`) and a `discount` (`string`/`number`), both with bounds a double cannot hold exactly:

- money survives the round trip, asserting `19.99m` and that `× 3` is `59.97m` rather than `59.970000000000006`;
- the declared bound refuses `0.001` with a `range` error naming `unitPrice`;
- the served document publishes each property in the spelling its contract used.

Validated: CI-style Release build 0 warnings 0 errors; 31 suites green; coverage gate 21 assemblies at or above baseline.

**Not in this PR:** Smithy's `BigDecimal`, which still degrades to `double` under HSMT006. Arbitrary precision has no C# type — `decimal` is 28–29 significant digits — so mapping it is a narrowing of the warning rather than a removal, and it deserves its own change. Say the word and it follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
