### PR TITLE
Map Smithy's BigDecimal to decimal, and say which member narrowed

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -176,7 +176,7 @@ the other.
 | `003` | The description was declared as the wrong item kind. `HOAT003`: a spec left in `AdditionalFiles`, which the generator no longer reads. `HSMT003`: a `.smithy` IDL file pointed at `HardenedSmithyAst`, which takes a JSON AST. |
 | `004` | A model or generated source the extract step should have written is missing. Delete the model directory and rebuild. |
 | `005` | The targets file was imported before the specs were declared, so no generated source reached the compilation. Move the `<Import>` below the item group. |
-| `006` | Warning. The reader parsed the document and had something to say about it, including what a degraded trait promises that the code does not enforce. |
+| `006` | Warning. The reader parsed the document and had something to say about it, including what a degraded trait promises that the code does not enforce. Under `HSMT`, this is also where a prelude shape with no exact C# type is reported - `BigDecimal` becomes `decimal`, `BigInteger` becomes `long` - once per member, naming it. |
 | `007` | A slice selected no operations, so nothing would be generated. |
 | `008` | Warning. A slice removed a schema that is still referenced; the reference degrades to `JsonElement`. |
 | `009` | Warning. The spec is sliced but its document is embedded whole, so the served description claims operations the application does not implement. |

--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -88,9 +88,11 @@ bound invariantly against the property's own type at generation time - so the bo
 instead of going through the `double` the member exists to avoid, and a malformed one is still a
 build error.
 
-Smithy's `BigDecimal` and `BigInteger` still degrade to `double` and `long` under `HSMT006`.
-Arbitrary precision has no C# type; `decimal` would be closer than `double` and is not the same
-thing, which is its own change.
+Smithy's `BigDecimal` maps to `decimal` and `BigInteger` to `long`, both under an `HSMT006`
+naming the member and what it cost - arbitrary precision has no C# type, so the choice is which
+half to keep. `decimal` keeps exactness and runs out at 28 significant digits; `double` kept
+neither, since 19.99 is not 19.99 in binary floating point at any magnitude, and a model reaching
+for `BigDecimal` has almost always reached for exactness.
 
 Code-first, a `decimal` property publishes `number` / `decimal`, so it reads back as one.
 

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/BigDecimalTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/BigDecimalTests.cs
@@ -1,0 +1,129 @@
+using Hardened.Generation;
+using Hardened.Generation.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// The two prelude shapes with no exact C# type, and what the build says about them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>BigDecimal</c> used to become <c>double</c>. Both narrow, and they narrow differently: a
+/// double loses the value's exactness at any magnitude, so 19.99 stops being 19.99 and money stops
+/// adding up, while a decimal is exact and runs out at 28 significant digits. A model reaching for
+/// <c>BigDecimal</c> has almost always reached for exactness rather than for range.
+/// </para>
+/// <para>
+/// H-31 is the other half: three <c>BigDecimal</c> members produced three byte-identical warnings
+/// naming none of them, so the count told you how many and nothing told you which.
+/// </para>
+/// </remarks>
+public class BigDecimalTests {
+
+    private static string Model(string members) =>
+        $$"""
+          { "smithy": "2.0", "shapes": {
+              "com.example#Svc": {
+                "type": "service", "version": "1",
+                "operations": [ { "target": "com.example#Charge" } ] },
+              "com.example#Charge": {
+                "type": "operation",
+                "input": { "target": "com.example#Money" },
+                "traits": {
+                  "smithy.api#http": { "method": "POST", "uri": "/charges", "code": 200 } } },
+              "com.example#Money": {
+                "type": "structure",
+                "members": { {{members}} } } } }
+          """;
+
+    private static SchemaModel Parse(string members, out List<string> diagnostics) {
+        diagnostics = new List<string>();
+
+        var model = SmithySpecParser.Parse(Model(members), "money", diagnostics);
+
+        Assert.NotNull(model);
+
+        return Assert.Single(model!.Schemas, s => s.Name == "Money");
+    }
+
+    [Fact]
+    public void ABigDecimalMemberReachesCSharpDecimal() {
+        var schema = Parse("""
+            "amount": { "target": "smithy.api#BigDecimal" }
+            """, out _);
+
+        var amount = Assert.Single(schema.Properties);
+
+        Assert.Equal("number", amount.Type);
+        Assert.Equal("decimal", amount.Format);
+        Assert.Equal("decimal", TypeMapper.MapPropertyToCSharpType(amount));
+    }
+
+    /// <summary>Float and Double are exact mappings and say nothing.</summary>
+    [Theory]
+    [InlineData("smithy.api#Float", "float")]
+    [InlineData("smithy.api#Double", "double")]
+    public void AnExactlyMappedShapeIsSilent(string shape, string csType) {
+        var schema = Parse($$"""
+            "amount": { "target": "{{shape}}" }
+            """, out var diagnostics);
+
+        Assert.Equal(csType, TypeMapper.MapPropertyToCSharpType(Assert.Single(schema.Properties)));
+        Assert.Empty(diagnostics);
+    }
+
+    /// <summary>
+    /// The narrowing is still reported, because 28 digits is not arbitrarily many - and the
+    /// message says what it became rather than that no type exists.
+    /// </summary>
+    [Fact]
+    public void TheNarrowingIsReportedAndNamesWhatItBecame() {
+        Parse("""
+            "amount": { "target": "smithy.api#BigDecimal" }
+            """, out var diagnostics);
+
+        var warning = Assert.Single(diagnostics);
+
+        Assert.Contains("'Money.amount'", warning);
+        Assert.Contains("BigDecimal", warning);
+        Assert.Contains("decimal", warning);
+        Assert.Contains("28 significant digits", warning);
+    }
+
+    /// <summary>BigInteger narrows too, and says what it costs rather than the same sentence.</summary>
+    [Fact]
+    public void ABigIntegerSaysWhatItCosts() {
+        var schema = Parse("""
+            "count": { "target": "smithy.api#BigInteger" }
+            """, out var diagnostics);
+
+        Assert.Equal("long", TypeMapper.MapPropertyToCSharpType(Assert.Single(schema.Properties)));
+
+        var warning = Assert.Single(diagnostics);
+
+        Assert.Contains("'Money.count'", warning);
+        Assert.Contains("64 bits", warning);
+    }
+
+    /// <summary>
+    /// H-31. One warning per member, each naming its own - three members used to produce three
+    /// copies of one sentence naming none. Qualified by the shape, because two structures may each
+    /// hold an <c>amount</c>.
+    /// </summary>
+    [Fact]
+    public void EveryNarrowedMemberIsNamedOnce() {
+        Parse("""
+            "unitPrice": { "target": "smithy.api#BigDecimal" },
+            "discount":  { "target": "smithy.api#BigDecimal" },
+            "total":     { "target": "smithy.api#BigDecimal" }
+            """, out var diagnostics);
+
+        Assert.Equal(3, diagnostics.Count);
+        Assert.Equal(3, diagnostics.Distinct().Count());
+        Assert.Contains(diagnostics, d => d.Contains("'Money.unitPrice'"));
+        Assert.Contains(diagnostics, d => d.Contains("'Money.discount'"));
+        Assert.Contains(diagnostics, d => d.Contains("'Money.total'"));
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyPrelude.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyPrelude.cs
@@ -65,15 +65,19 @@ internal static class SmithyPrelude {
             case "smithy.api#PrimitiveDouble":
                 type = "number"; format = "double"; return true;
 
-            // Neither has a C# type that both holds every value and survives the JSON type-info
-            // emitter - see the decimal note on TypeMapper. Mapped to the widest thing that does,
-            // and reported, because silently narrowing a value the model calls valid is the failure
+            // Neither has a C# type that holds every value the model calls valid, so both are
+            // mapped to the closest one that does and reported - silently narrowing is the failure
             // worth naming.
             case "smithy.api#BigInteger":
                 type = "integer"; format = "int64"; return true;
 
+            // decimal rather than double. Both narrow, and they narrow differently: double loses
+            // the value's exactness at any magnitude, so 19.99 is not 19.99 and money stops
+            // adding up, while decimal is exact and runs out at 28 significant digits. A model
+            // reaching for BigDecimal has almost always reached for exactness rather than for
+            // range, and that is the half decimal keeps.
             case "smithy.api#BigDecimal":
-                type = "number"; format = "double"; return true;
+                type = "number"; format = "decimal"; return true;
 
             // RFC 3339 by default, which is what DateTimeOffset holds. @timestampFormat can say
             // otherwise and is read by the parser, not here.
@@ -93,6 +97,23 @@ internal static class SmithyPrelude {
     /// <summary>Whether the shape loses precision on the way to C#, for a diagnostic.</summary>
     internal static bool IsLossy(string shapeId) =>
         shapeId is "smithy.api#BigInteger" or "smithy.api#BigDecimal";
+
+    /// <summary>
+    /// What the narrowing costs, for the message. Null where the shape narrows nothing.
+    /// </summary>
+    /// <remarks>
+    /// Names the C# type and the limit rather than saying "no exact type", because the two shapes
+    /// lose different things and an author's next move differs: a BigDecimal that needed more than
+    /// 28 digits has nowhere to go, and one that needed exactness has arrived.
+    /// </remarks>
+    internal static string? LossDescription(string shapeId) => shapeId switch {
+        "smithy.api#BigInteger" =>
+            "becomes long, so a value outside 64 bits does not round-trip",
+        "smithy.api#BigDecimal" =>
+            "becomes decimal, which is exact but holds 28 significant digits rather than " +
+            "arbitrarily many",
+        _ => null
+    };
 
     /// <summary>Whether the id names a prelude shape at all.</summary>
     internal static bool IsPrelude(string shapeId) =>

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -604,7 +604,11 @@ internal static class SmithySpecParser {
                 };
 
                 foreach (var member in bodyMembers) {
-                    var schemaProperty = BuildProperty(context, member.Key, member.Value);
+                    // Named for the diagnostic as the model spells it rather than as the body
+                    // schema does: one member of one Smithy structure, whatever the reader
+                    // materialises it into.
+                    var schemaProperty = BuildProperty(
+                        context, member.Key, member.Value, SmithyPrelude.LocalName(inputId));
 
                     bodySchema.Properties.Add(schemaProperty);
 
@@ -620,7 +624,8 @@ internal static class SmithySpecParser {
         }
 
         foreach (var member in bodyMembers) {
-            var property = BuildProperty(context, member.Key, member.Value);
+            var property = BuildProperty(
+                context, member.Key, member.Value, SmithyPrelude.LocalName(inputId));
 
             model.RequestBodyProperties.Add(property);
 
@@ -916,7 +921,8 @@ internal static class SmithySpecParser {
         // reaches C# as `verbose`: the wire name is the contract, and the alternative would be a
         // second naming authority, which is the exact defect NameAllocator was built to remove.
         if (target != null) {
-            Describe(context, target, out var type, out var format, out var reference, out var array);
+            Describe(context, target, out var type, out var format, out var reference, out var array,
+                model.OperationId + "." + parameter.Name);
 
             parameter.Type = type;
             parameter.Format = format;
@@ -931,8 +937,12 @@ internal static class SmithySpecParser {
         model.Parameters.Add(parameter);
     }
 
+    /// <param name="owner">
+    /// The shape the member belongs to, so a narrowing diagnostic names which one - two structures
+    /// may each hold an <c>amount</c>, and "'amount' narrows" says nothing about where to look.
+    /// </param>
     private static PropertyModel BuildProperty(
-        ParseContext context, string name, JsonElement member) {
+        ParseContext context, string name, JsonElement member, string owner) {
         var property = new PropertyModel {
             Name = JsonName(member) ?? name,
             IsRequired = SmithyAst.HasTrait(member, SmithyTraits.Required),
@@ -944,7 +954,8 @@ internal static class SmithySpecParser {
         var target = SmithyAst.Target(member);
 
         if (target != null) {
-            Describe(context, target, out var type, out var format, out var reference, out var shape);
+            Describe(context, target, out var type, out var format, out var reference, out var shape,
+                owner + "." + property.Name);
 
             property.Type = type;
             property.Format = format;
@@ -1056,13 +1067,18 @@ internal static class SmithySpecParser {
     /// <c>List&lt;T&gt;</c>. That mirrors what <c>InlineNonObjectRefs</c> does on the OpenAPI side,
     /// and keeps the generated surface to the shapes a caller actually names.
     /// </remarks>
+    /// <param name="memberName">
+    /// The member being described, for a narrowing diagnostic. Null where the caller has no name
+    /// to give - a payload targeting a prelude shape directly, say.
+    /// </param>
     private static void Describe(
         ParseContext context,
         string target,
         out string? type,
         out string? format,
         out string? reference,
-        out ShapeFacts facts) {
+        out ShapeFacts facts,
+        string? memberName = null) {
         type = null;
         format = null;
         reference = null;
@@ -1072,10 +1088,21 @@ internal static class SmithySpecParser {
             type = preludeType;
             format = preludeFormat;
 
-            if (SmithyPrelude.IsLossy(target)) {
-                context.Diagnostics.Add(
-                    $"'{SmithyPrelude.LocalName(target)}' has no exact C# type; " +
-                    "values outside the mapped range will not round-trip.");
+            if (SmithyPrelude.LossDescription(target) is { } loss) {
+                // Once per member, naming it. Three BigDecimal members used to produce three
+                // byte-identical warnings naming none of them, so the count was the only way to
+                // tell how many there were and no way to tell which - and a set of identical
+                // strings deduplicates itself, which is why the name has to be in the message
+                // rather than beside it.
+                var where = memberName == null ? "" : $"'{memberName}' ";
+
+                var message = $"{where}targets {SmithyPrelude.LocalName(target)}, which {loss}.";
+
+                // A structure is walked twice - once as a schema, once as an operation's body - so
+                // without this every narrowed member is reported twice.
+                if (!context.Diagnostics.Contains(message)) {
+                    context.Diagnostics.Add(message);
+                }
             }
 
             return;
@@ -1249,7 +1276,7 @@ internal static class SmithySpecParser {
                 foreach (var member in SmithyAst.Members(shape)) {
                     Note(context, member.Value);
 
-                    var property = BuildProperty(context, member.Key, member.Value);
+                    var property = BuildProperty(context, member.Key, member.Value, schema.Name);
 
                     schema.Properties.Add(property);
 


### PR DESCRIPTION
#245's content never reached `response-default`. It merged into `decimal-support`, its own base branch, after that branch had already been squashed in as #244 — so the squash carried #244 and nothing after it. `origin/response-default` still has `BigDecimal` mapping to `double` and no `BigDecimalTests`.

Same commit, cherry-picked onto the current `response-default`. No conflicts; the content is unchanged from what you reviewed on #245.

`BigDecimal` maps to `decimal` rather than `double`. Both narrow, differently: a `double` loses the value's exactness at any magnitude, so `19.99` is not `19.99` and money stops adding up, while a `decimal` is exact and runs out at 28 significant digits. A model reaching for `BigDecimal` has almost always reached for exactness. `BigInteger` still becomes `long` — there is no C# integer without a ceiling either.

HSMT006 stays, since 28 digits is not arbitrarily many, and now names the member and what it cost, with a different sentence per shape:

```
'Money.unitPrice' targets BigDecimal, which becomes decimal, which is exact but holds
28 significant digits rather than arbitrarily many.

'Ledger.sequence' targets BigInteger, which becomes long, so a value outside 64 bits
does not round-trip.
```

That is B7/H-31's naming half, which this does not subsume — the warning survives the mapping, so its faults do. Members are qualified by the Smithy shape rather than the generated C# type, because one member materialises into both a schema and an operation's body schema and is still one member. Its position is still the AST rather than the `.smithy` line, which needs the source locations HSMT012 gets from the CLI.

Validated on this branch, not carried over from #245: CI-style Release build 0 warnings 0 errors, 31 suites green.

Worth a look at the merge order generally — this is the second time a stacked PR has landed in its base after the base was squashed. #233 and #234 did the same thing earlier; their content survived only because the squash happened to come after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
