### PR TITLE
Re-land seven pull requests lost with the response-default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,15 @@ public partial class TodosLibrary;
 
 public class TodoController {
     [Get("/{id}")]
-    public Response<Todo, NotFound> ById(ITodoStore store, int id) =>
-        store.Find(id) ?? new NotFound("todo", $"No todo has id {id}.").AsResponse<Todo, NotFound>();
+    public Response<Todo, NotFound> ById(ITodoStore store, int id) {
+        var todo = store.Find(id);
+
+        if (todo is null) {
+            return new NotFound("todo", $"No todo has id {id}.");
+        }
+
+        return todo;
+    }
 }
 ```
 
@@ -123,14 +130,27 @@ public class TodoService : ITodosService {
 
     public TodoService(ITodoStore store) => _store = store;
 
-    // The ? is generated from the declared 404: returning null answers it, with the body the
-    // document names. Without a declared 404 there is no ?, and the compiler says so.
-    public Task<Todo?> GetTodo(int id) => Task.FromResult(_store.Find(id));
+    // GetTodoResponse, GetTodoOk and GetTodoNotFound are generated from the two declared
+    // statuses, one case each. The set is the return type, so a 404 the contract declares and the
+    // handler never returns is a compiler error rather than a document nothing answers to.
+    public Task<GetTodoResponse> GetTodo(int id) {
+        var todo = _store.Find(id);
+
+        if (todo is null) {
+            return Task.FromResult<GetTodoResponse>(
+                new GetTodoNotFound(new Problem { Detail = $"No todo has id {id}." }));
+        }
+
+        return Task.FromResult<GetTodoResponse>(new GetTodoOk(todo));
+    }
 }
 ```
 
-`Todo`, `Problem` and `ITodosService` are all written by the build, and `minimum: 1` becomes a
-validation filter in front of the handler.
+`Todo`, `Problem`, `ITodosService` and the response set are all written by the build, and
+`minimum: 1` becomes a validation filter in front of the handler. That shape is the `response`
+model, which is what the template scaffolds; the [three return models](#three-return-models) below
+are the choice, and in `throws` mode the same operation is a `Task<Todo?>` whose null answers the
+declared 404.
 
 There are no route attributes anywhere in the project. Add an operation to the contract and the
 build writes the model, the route and the validation, then stops compiling until your service
@@ -199,32 +219,10 @@ three work side by side.
 | **Throws** | one success type | thrown | any SDK |
 | **Union** | the whole set, as a C# `union` | in the return type | .NET 11, `LangVersion` preview |
 
-**Response** is the default: the declared set is where the compiler's checking and the document's
-truthfulness come from, so it is the mode the template reaches for when you say nothing.
-
-**Throws** names the success type and throws every other status. It was called **standard** until
-0.19.0, and it is not a legacy mode - a team that wants errors decided in filters and handlers kept
-lean chooses it deliberately. Nothing in the signature says the route can answer a 404, so nothing
-checks that you handled it, and the document describes only the 200 unless the handler declares the
-rest with `[Throws<NotFound>]` - the attribute the mode is named for.
-
-```csharp
-[Get("/{id}")]
-public Todo ById(ITodoStore store, int id) {
-    var todo = store.Find(id);
-
-    if (todo is null) {
-        throw new NotFound("todo", $"No todo has id {id}.").AsException();
-    }
-
-    return todo;
-}
-```
-
-**Response** puts the whole set in the return type. `Response<T1..Tn>` is an ordinary struct with an
-implicit conversion per case, so the handler returns payloads and never names the wrapper. The
-compiler knows the set and the document describes all of it. In throws mode the same handler names
-`Todo` alone and throws the `NotFound`.
+**Response** is what the template scaffolds, and what the examples above and elsewhere in this
+README use: the declared set is where the compiler's checking and the document's truthfulness come
+from. It puts the whole set in the return type. `Response<T1..Tn>` is an ordinary struct with an
+implicit conversion per case, so the handler returns payloads and never names the wrapper.
 
 ```csharp
 [Get("/{id}")]
@@ -239,8 +237,34 @@ public Response<Todo, NotFound> ById(ITodoStore store, int id) {
 }
 ```
 
+**An application that says nothing still gets throws**, and will until 1.0, so nothing built
+before 0.19.0 moves when its packages do. `response` is the template's default rather than the
+framework's. Code-first there is nothing to set - a handler's return type is the declaration, and
+the template writes no attribute. Spec-first the template writes `<HardenedResponseModel>` out for
+every mode, so the project file says which one it is rather than leaving you to know the default.
+
+**Throws** names the success type and throws every other status. It was called **standard** until
+0.19.0, and it is not a legacy mode - a team that wants errors decided in filters and handlers kept
+lean chooses it deliberately. Nothing in the signature says the route can answer a 404, so nothing
+checks that you handled it, and the document describes only the 200 unless the handler declares the
+rest with `[Throws<NotFound>]` - the attribute the mode is named for.
+
+```csharp
+[Get("/{id}")]
+[Throws<NotFound>]
+public Todo ById(ITodoStore store, int id) {
+    var todo = store.Find(id);
+
+    if (todo is null) {
+        throw new NotFound("todo", $"No todo has id {id}.").AsException();
+    }
+
+    return todo;
+}
+```
+
 **Union** declares the same set as a C# language union, which adds exhaustiveness wherever you
-pattern-match on the result. The handler body is identical to the `Response` version.
+pattern-match on the result. The handler body is identical to the `Response` version above.
 
 ```csharp
 public union TodoResult(Todo, NotFound);

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -176,7 +176,7 @@ the other.
 | `003` | The description was declared as the wrong item kind. `HOAT003`: a spec left in `AdditionalFiles`, which the generator no longer reads. `HSMT003`: a `.smithy` IDL file pointed at `HardenedSmithyAst`, which takes a JSON AST. |
 | `004` | A model or generated source the extract step should have written is missing. Delete the model directory and rebuild. |
 | `005` | The targets file was imported before the specs were declared, so no generated source reached the compilation. Move the `<Import>` below the item group. |
-| `006` | Warning. The reader parsed the document and had something to say about it, including what a degraded trait promises that the code does not enforce. |
+| `006` | Warning. The reader parsed the document and had something to say about it, including what a degraded trait promises that the code does not enforce. Under `HSMT`, this is also where a prelude shape with no exact C# type is reported - `BigDecimal` becomes `decimal`, `BigInteger` becomes `long` - once per member, naming it. |
 | `007` | A slice selected no operations, so nothing would be generated. |
 | `008` | Warning. A slice removed a schema that is still referenced; the reference degrades to `JsonElement`. |
 | `009` | Warning. The spec is sliced but its document is embedded whole, so the served description claims operations the application does not implement. |

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -56,6 +56,47 @@ only when *no* entry matches a described service.
 
 ## Routing
 
+### HRDR002 — unsupported route token syntax
+
+A brace form the template accepts and Hardened does not compile, or a template that is not
+well formed at all. Both compile and route today, and neither does what it was written to do.
+
+| Written | What it actually means |
+|---|---|
+| `{id?}` | A mandatory segment named `id?`. The path it was meant to make optional does not match at all. |
+| `{id=5}` | A mandatory segment named `id=5`. Nothing binds to `id`; give the C# parameter the default. |
+| `{id:isbn}` | A constraint nothing declares. Declare it with `[RouteConstraint("isbn")]`, or drop it and let the parameter type refuse a bad value. |
+| `{id` | A brace with no partner. The rest is matched as literal text, so the route answers nothing anyone sends. |
+| `}` | The same, from the other end. |
+| `{}`, `{:int}` | A token with no name, which binds nothing. |
+| `{id}/x/{id}` | One name declared twice. Only one of the two segments a request sends could reach the parameter. |
+
+Every offending token in a route is reported, and the handler is still emitted — the routing table
+filters on unresolved parameters rather than on token syntax, so dropping it would bury this
+diagnostic under CS0246s.
+
+### HRDR005 — route token binds no parameter
+
+A token the template compiles that no parameter binds, beside a parameter that fell onto the
+request body because of it.
+
+```
+Route '/events/{eventid}' on 'EventController.Get' declares '{eventid}', which no parameter
+binds. 'eventId' differs from it only by case, so it is read from the request body instead.
+Route tokens bind by exact name: spell the token '{eventId}', or rename the parameter to
+'eventid'.
+```
+
+Both halves are required. A token that binds nothing is not a mistake on its own — one declared in
+a shared `[BasePath]` binds nothing on the handlers under it that do not need it. What makes it a
+defect is the parameter that went somewhere else because of it: onto a body a `GET`, `HEAD`,
+`OPTIONS` or `TRACE` does not carry, or — whatever the verb — onto a body when its name differs
+from the token only by case. `DELETE` is not treated as bodyless: HTTP permits a body on one and
+some APIs send it.
+
+A described parameter binds by the wire name its contract declares, not by the C# identifier
+allocated for it.
+
 ### HRDR006 — no routing generator is compiling this assembly's routes
 
 A module declaring routes with nothing turning them into a routing table. It compiled without a

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -80,6 +80,36 @@ framework's own `AspNetCoreRuntime` is one.
 
 One report per assembly, not one per route: there is a single thing to fix.
 
+## Validation
+
+### HRDV004 — nested constraints are never reached
+
+A generated validator descends into a member only where `[ValidateNested]` says to, so omitting it
+switches off every constraint on the child type. Nothing said so at build time or at run time: the
+trial's price tiers stored as 201 with an empty code and a negative price, from a model whose
+constraints were all declared and all correct.
+
+```
+'CreateEvent.PriceTiers' does not declare [ValidateNested] and its element type 'PriceTier'
+declares constraints, so none of them run and an invalid 'PriceTier' is accepted with no
+error. Add [ValidateNested] to the property, or set <NoWarn>$(NoWarn);HRDV004</NoWarn> if the
+skip is intended.
+```
+
+A warning rather than an error, because not descending is sometimes what was meant — a member
+validated by a later step, a shared type whose constraints belong to another operation. The
+`NoWarn` is what makes that choice deliberate rather than silent.
+
+Reported on a property of a type that constrains something itself, whose member, array element,
+collection element or dictionary value is a type declared in the same compilation carrying
+constraints in either vocabulary. A type that constrains nothing is not a model this generator
+validates — a data seed holding a list of records, a response case wrapping a body — and its
+validator was never going to descend anywhere.
+
+Descending by default is the better answer and is on the table for 1.0. It cannot be the answer in
+a 0.x release: it changes what an existing application answers, from 201 to 400, on payloads it
+accepts today.
+
 ## Other diagnostics
 
 | Id | Meaning |
@@ -88,7 +118,7 @@ One report per assembly, not one per route: there is a single thing to fix.
 | `HOAG002` | The description could not be parsed; the build task's message is passed through. |
 | `HOAG010` | A handler was skipped because a parameter type did not resolve. Other handlers are unaffected. |
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
-| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. `HRDR006` is above. |
+| `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. The ones with an entry have a section above. |
 
 ## Description build tasks (HOAT, HSMT)
 

--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -54,6 +54,46 @@ serving the source verbatim where that is wanted.
   against what the handler actually throws - the declared response models are where the compiler
   holds the set.
 
+## Numbers, and money
+
+`format` is an open-valued property. OpenAPI names four numeric formats - `int32`, `int64`,
+`float`, `double` - and says a document may use others, so anything else is a convention rather
+than a standard. What the build reads:
+
+| declared | C# |
+|---|---|
+| `number` / `float` | `float` |
+| `number` / `double` | `double` |
+| `number` / `decimal` | `decimal` |
+| `string` / `number` | `decimal` |
+| `number` / anything else, or no format | `double` |
+| `integer` / `int64` | `long` |
+| `integer` / `uint32` | `uint` |
+| `integer` / anything else | `int`, widened to `long` where a declared bound exceeds it |
+
+Two spellings for a decimal because the ecosystem has two and neither is in the specification.
+`number` + `decimal` is NSwag's, measured against 14.1.0: it answers `decimal` for that pair and
+`double` for a formatless `number`. `string` + `number` is openapi-generator's, whose
+`ModelUtils.isDecimalSchema` tests exactly that pair and whose language generators map it to
+`BigDecimal`, `Decimal`, `decimal.Decimal` and so on.
+
+What neither spelling can be is the *absence* of a format. openapi-generator's C# target maps
+every formatless `number` to `decimal`, so a document written against it means a decimal by
+saying nothing - and saying nothing is how every other document means `double`. That one is not
+readable and stays `double`.
+
+A bound on a decimal member is emitted as `Range(Min = "0.01")` rather than as a number.
+`decimal` is not a legal attribute argument type in C#, and ValidationModules parses a string
+bound invariantly against the property's own type at generation time - so the bound stays exact
+instead of going through the `double` the member exists to avoid, and a malformed one is still a
+build error.
+
+Smithy's `BigDecimal` and `BigInteger` still degrade to `double` and `long` under `HSMT006`.
+Arbitrary precision has no C# type; `decimal` would be closer than `double` and is not the same
+thing, which is its own change.
+
+Code-first, a `decimal` property publishes `number` / `decimal`, so it reads back as one.
+
 ## The vocabulary
 
 | Declaration | Where | What it does |

--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -88,9 +88,11 @@ bound invariantly against the property's own type at generation time - so the bo
 instead of going through the `double` the member exists to avoid, and a malformed one is still a
 build error.
 
-Smithy's `BigDecimal` and `BigInteger` still degrade to `double` and `long` under `HSMT006`.
-Arbitrary precision has no C# type; `decimal` would be closer than `double` and is not the same
-thing, which is its own change.
+Smithy's `BigDecimal` maps to `decimal` and `BigInteger` to `long`, both under an `HSMT006`
+naming the member and what it cost - arbitrary precision has no C# type, so the choice is which
+half to keep. `decimal` keeps exactness and runs out at 28 significant digits; `double` kept
+neither, since 19.99 is not 19.99 in binary floating point at any magnitude, and a model reaching
+for `BigDecimal` has almost always reached for exactness.
 
 Code-first, a `decimal` property publishes `number` / `decimal`, so it reads back as one.
 

--- a/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT.Tests/DefaultDenyTests.cs
+++ b/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT.Tests/DefaultDenyTests.cs
@@ -1,3 +1,4 @@
+using Hardened.IntegrationTests.Authorization.SUT;
 using Hardened.Requests.Testing;
 
 namespace Hardened.IntegrationTests.Authorization.SUT.Tests;
@@ -130,6 +131,50 @@ public class DefaultDenyTests {
 
         response.Assert.Ok();
     }
+
+    #endregion
+
+    #region the typed source
+
+    /// <summary>
+    /// CS-01 and SU-04, end to end. <c>ApiKeyPrincipalSource</c> implements only
+    /// <c>IPrincipalSource&lt;ApiKeyScheme&gt;</c> and carries the plain <c>[SingletonService]</c>,
+    /// so the generated registration names the closed generic and nothing else. Nothing but a real
+    /// application can show that such a source reaches the middleware: the whole failure was that
+    /// it was registered, resolvable, and never asked.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATypedSourceAuthenticatesARealRequest(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/guarded/implicit", WithApiKey());
+
+        response.Assert.Ok();
+    }
+
+    /// <summary>
+    /// And the principal it built is the one authorization judges, grants included.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATypedSourcesGrantsAreTheOnesJudged(ITestWebApp testWebApp) {
+        var admitted = await testWebApp.Get("/guarded/pets", WithApiKey());
+        var refused = await testWebApp.Get("/guarded/pets-manage", WithApiKey());
+
+        admitted.Assert.Ok();
+        refused.Assert.Forbidden();
+    }
+
+    /// <summary>
+    /// The two forms are one ordered list. A typed source that declines leaves the request to the
+    /// plain source registered beside it, rather than ending it.
+    /// </summary>
+    [HardenedTest]
+    public async Task ATypedSourceDecliningFallsThroughToThePlainOne(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/guarded/implicit", Authenticated());
+
+        response.Assert.Ok();
+    }
+
+    private static Action<TestWebRequest> WithApiKey() =>
+        request => request.Headers[ApiKeyPrincipalSource.KeyHeader] = ApiKeyPrincipalSource.KnownKey;
 
     #endregion
 }

--- a/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT/ApiKeyPrincipalSource.cs
+++ b/src/IntegrationTests/Authorization/Hardened.IntegrationTests.Authorization.SUT/ApiKeyPrincipalSource.cs
@@ -1,0 +1,44 @@
+using DependencyModules.Runtime.Attributes;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.IntegrationTests.Authorization.SUT;
+
+/// <summary>A scheme, named as a type, the way <c>[Authorize&lt;TScheme&gt;]</c> names one.</summary>
+public class ApiKeyScheme : IAuthenticationScheme;
+
+/// <summary>
+/// A source written against the typed interface and registered with the plain attribute.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CS-01 and SU-04, as a fixture. A registration attribute registers a class as the interface it
+/// declares, so this lands in the container under <c>IPrincipalSource&lt;ApiKeyScheme&gt;</c> and
+/// under nothing else - and while the startup service resolved the non-generic interface alone,
+/// an application whose only source looked like this installed no middleware, answered 401 to
+/// every protected route, and said nothing about why. Two arms lost a debugging session to it.
+/// </para>
+/// <para>
+/// Declines every request that does not carry its own header, so the fixture's other source
+/// answers for every test written before this one.
+/// </para>
+/// </remarks>
+[SingletonService]
+public class ApiKeyPrincipalSource : IPrincipalSource<ApiKeyScheme> {
+    public const string KeyHeader = "X-Api-Key";
+
+    /// <summary>The one key this fixture knows, and the grant it carries.</summary>
+    public const string KnownKey = "open-sesame";
+
+    public const string KeyGrant = "pets:read";
+
+    public ValueTask<ICallerPrincipal?> Authenticate(IExecutionContext context) {
+        if (!context.Request.Headers.TryGetValue(KeyHeader, out var header) ||
+            header.ToString() != KnownKey) {
+            return new ValueTask<ICallerPrincipal?>((ICallerPrincipal?)null);
+        }
+
+        return new ValueTask<ICallerPrincipal?>(
+            new CallerPrincipal("api-key", [KeyGrant], subject: "api-key-caller"));
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ValidationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Hardened.Requests.Runtime.Validation;
 
 namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
@@ -212,6 +213,83 @@ public class ValidationTests {
             ValidOrder, "/orders", request => request.Headers["Idempotency-Key"] = "0f9ac3b2");
 
         response.Assert.Ok();
+    }
+
+    #endregion
+
+    #region money
+
+    /// <summary>
+    /// H-10. Every <c>number</c> became a <c>double</c>, so money was a double end to end and the
+    /// framework never said so.
+    /// </summary>
+    /// <remarks>
+    /// Both spellings, because the ecosystem uses two and neither is in the OpenAPI specification:
+    /// <c>number</c> + <c>decimal</c> is NSwag's, and <c>string</c> + <c>number</c> is
+    /// openapi-generator's - its <c>ModelUtils.isDecimalSchema</c> tests exactly that pair.
+    /// </remarks>
+    [HardenedTest]
+    public async Task MoneySurvivesTheRoundTripExactly(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":3,"unitPrice":19.99,"discount":0.1}]}""",
+            "/orders");
+
+        response.Assert.Ok();
+
+        var line = response.Deserialize<OrderRequest>().Lines![0];
+
+        // The value a double cannot hold: 19.99 * 3 is 59.97 in decimal and 59.970000000000006 in
+        // binary floating point.
+        Assert.Equal(19.99m, line.UnitPrice);
+        Assert.Equal(59.97m, line.UnitPrice!.Value * 3);
+        Assert.Equal(0.1m, line.Discount);
+    }
+
+    /// <summary>
+    /// And the declared bound still runs. It is emitted as Range(Min = "0.01") - the string form
+    /// ValidationModules parses against the property's own type - because rendering it through
+    /// double is the one thing a decimal member exists to avoid.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABoundOnMoneyIsEnforced(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            """{"species":"cat","weightGrams":3000,"lines":[{"sku":"TLS-0001","quantity":3,"unitPrice":0.001}]}""",
+            "/orders");
+
+        Assert.Equal(400, response.StatusCode);
+        Assert.Contains(
+            response.Deserialize<RequestValidationError>().Errors,
+            e => e.Field.Contains("unitPrice") && e.Code == "range");
+    }
+
+    /// <summary>
+    /// The published document keeps the spelling the contract used, so a client generator reads
+    /// back what the author wrote.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheDocumentPublishesBothSpellings(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/openapi.json");
+
+        response.Assert.Ok();
+        response.Body.Position = 0;
+
+        // Served gzipped, because the harness asks for it by default the way a client does.
+        await using var gzip = new System.IO.Compression.GZipStream(
+            response.Body, System.IO.Compression.CompressionMode.Decompress);
+
+        using var document = JsonDocument.Parse(await new StreamReader(gzip).ReadToEndAsync());
+
+        var properties = document.RootElement
+            .GetProperty("components").GetProperty("schemas")
+            .GetProperty("OrderLine").GetProperty("properties");
+
+        var unitPrice = properties.GetProperty("unitPrice");
+        var discount = properties.GetProperty("discount");
+
+        Assert.Equal("number", unitPrice.GetProperty("type").GetString());
+        Assert.Equal("decimal", unitPrice.GetProperty("format").GetString());
+        Assert.Equal("string", discount.GetProperty("type").GetString());
+        Assert.Equal("number", discount.GetProperty("format").GetString());
     }
 
     #endregion

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -531,6 +531,17 @@ components:
           type: integer
           format: int32
           minimum: 1
+        # Money, in the two spellings the ecosystem uses, with a bound a double cannot hold
+        # exactly. Both reach C# decimal, and the bound goes on the attribute as a string because
+        # rendering it through double is what the type exists to avoid.
+        unitPrice:
+          type: number
+          format: decimal
+          minimum: 0.01
+        discount:
+          type: string
+          format: number
+          minimum: 0.1
     PetSpecies:
       type: string
       enum:

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
@@ -153,4 +153,63 @@ public class RegistrationValidationTests {
     }
 
     #endregion
+
+    #region an operation that declares its validation status
+
+    /// <summary>
+    /// H-08. A spec-first operation declares 422 and the runtime honours it; code-first had no way
+    /// to say the same thing, and the trial's 422 requirement took a marker attribute plus a
+    /// wrapping <c>IExceptionToModelConverter</c> to satisfy - while the served document still
+    /// carried an unreachable 400 beside the hand-declared 422.
+    /// </summary>
+    /// <remarks>
+    /// Derived from <c>[Throws&lt;RequestValidationError&gt;(422)]</c> rather than declared twice.
+    /// The handler has already put that status in the document; reading the same declaration for
+    /// the runtime is what closes the gap without a second source of truth on a verb attribute.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AConstraintFailureAnswersTheDeclaredStatus(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new { Name = "", Age = 30 }, "/registration/declared-422");
+
+        Assert.Equal(422, response.StatusCode);
+        Assert.Contains(
+            response.Deserialize<RequestValidationError>().Errors, e => e.Field == "model.name");
+    }
+
+    /// <summary>A handler validating by hand reaches the same status.</summary>
+    [HardenedTest]
+    public async Task AThrownValidationExceptionAnswersTheDeclaredStatus(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new { Name = "Ada", Age = 30 }, "/registration/declared-422/by-hand");
+
+        Assert.Equal(422, response.StatusCode);
+    }
+
+    /// <summary>
+    /// And so does a body the deserializer refuses, which is the half that split the status in two
+    /// on every spec-first operation declaring 422 until the converter looked it up.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABodyTheDeserializerRefusesAnswersTheDeclaredStatus(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new { Name = "Ada", Age = "not a number" }, "/registration/declared-422");
+
+        Assert.Equal(422, response.StatusCode);
+        Assert.Equal(
+            "ValidationError", response.Deserialize<RequestValidationError>().Type);
+    }
+
+    /// <summary>
+    /// The control. An operation that declares nothing still answers the stock 400, so the
+    /// derivation reaches the operation that asked for it and no other.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOperationDeclaringNothingStillAnswers400(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(new { Name = "", Age = 30 }, "/registration");
+
+        response.Assert.BadRequest();
+    }
+
+    #endregion
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiDocumentTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiDocumentTests.cs
@@ -255,4 +255,38 @@ public class OpenApiDocumentTests {
 
         Assert.Equal("string", response.GetProperty("type").GetString());
     }
+
+    #region the declared validation status
+
+    private static async Task<string[]> Statuses(ITestWebApp testWebApp, string path) {
+        using var document = await Fetch(testWebApp);
+
+        return document.RootElement
+            .GetProperty("paths").GetProperty(path).GetProperty("post").GetProperty("responses")
+            .EnumerateObject().Select(status => status.Name).OrderBy(name => name).ToArray();
+    }
+
+    /// <summary>
+    /// The operation publishes the status it answers, and only that one. The trial's code-first arm
+    /// declared 422 by hand and the document carried the synthesized 400 beside it - a status the
+    /// operation could no longer produce.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOperationDeclaring422PublishesItAndNoSynthesized400(ITestWebApp testWebApp) {
+        var statuses = await Statuses(testWebApp, "/registration/declared-422");
+
+        Assert.Contains("422", statuses);
+        Assert.DoesNotContain("400", statuses);
+    }
+
+    /// <summary>
+    /// And an operation that declares nothing still publishes the 400 it answers, which is what the
+    /// synthesis is for.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOperationDeclaringNothingStillPublishesThe400(ITestWebApp testWebApp) {
+        Assert.Contains("400", await Statuses(testWebApp, "/registration/for/{tenant}"));
+    }
+
+    #endregion
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/RegistrationController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/RegistrationController.cs
@@ -1,5 +1,12 @@
 using Hardened.IntegrationTests.WebApp.SUT.Models;
+using Hardened.Requests.Abstract.Responses;
+using Hardened.Requests.Runtime.Validation;
 using Hardened.Web.Runtime.Attributes;
+using ValidationModules;
+// Both namespaces declare a ValidationException, which is CS0104 without this. Either reaches the
+// same response - ExceptionToModelConverter maps one shape from both - so which is aliased is a
+// choice, and Hardened's is the one this controller means.
+using ValidationException = Hardened.Requests.Runtime.Validation.ValidationException;
 
 namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
 
@@ -34,4 +41,29 @@ public class RegistrationController {
     [Post("/anonymous")]
     public string Unconstrained(MathAddModel model) =>
         string.Join(",", model.Values ?? new List<int>());
+
+    /// <summary>
+    /// The same model on an operation that says what a validation refusal answers.
+    /// </summary>
+    /// <remarks>
+    /// <c>[Throws&lt;RequestValidationError&gt;(422)]</c> puts the 422 in the published document,
+    /// and the same declaration is what the runtime reads: one vocabulary carrying both, rather
+    /// than an assertion on a verb attribute that the document would have to be told about
+    /// separately. A specification-first operation declaring 422 has answered it since 0.18; this
+    /// is how a hand-written one says the same thing.
+    /// </remarks>
+    [Post("/declared-422")]
+    [Throws<RequestValidationError>(422)]
+    public string RegisterDeclaring422(RegistrationModel model) => model.Name ?? "";
+
+    /// <summary>
+    /// A handler validating by hand on an operation that declares 422, so the thrown route to a
+    /// refusal answers what the filter's route does.
+    /// </summary>
+    [Post("/declared-422/by-hand")]
+    [Throws<RequestValidationError>(422)]
+    public string ThrowValidation() =>
+        throw new ValidationException(ValidationResult.FromErrors([
+            new ValidationError("model.name", "required", "model.name is required.")
+        ]));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/IPrincipalSource.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/IPrincipalSource.cs
@@ -41,12 +41,21 @@ public interface IPrincipalSource {
 /// A principal source for one declared authentication scheme.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The scheme type is the same one <c>[Authorize&lt;TScheme&gt;]</c> names and the published
 /// document keys its <c>securitySchemes</c> entry by, so "find references" connects the
 /// operations requiring a scheme with the source that implements it. The runtime does not
 /// dispatch on the type parameter - every registered source is asked in order - so implementing
 /// the plain <see cref="IPrincipalSource"/> works identically; this form exists to state the
 /// tie.
+/// </para>
+/// <para>
+/// A registration attribute registers a class as the interface it declares, so a source written
+/// this way is in the container under the closed generic rather than under
+/// <see cref="IPrincipalSource"/>. <c>AuthenticationStartupService</c> collects both, in one
+/// registration order, which is what makes "works identically" true of registration as well as
+/// of dispatch.
+/// </para>
 /// </remarks>
 public interface IPrincipalSource<TScheme> : IPrincipalSource
     where TScheme : IAuthenticationScheme;

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
@@ -95,9 +95,20 @@ public interface IExecutionRequestHandlerInfo {
     /// The status a validation failure answers with, or null for the stock 400.
     /// </summary>
     /// <remarks>
-    /// Set only from a described operation declaring 422. A contract that publishes a 422 for its
-    /// validation error is a promise the converter has to keep; a hand-written handler has no
-    /// source of truth behind such an assertion, which is why no attribute carries this.
+    /// <para>
+    /// Set from a described operation declaring 422, and from a hand-written handler carrying
+    /// <c>[Throws&lt;RequestValidationError&gt;(422)]</c>. A contract that publishes a 422 for its
+    /// validation error is a promise the converter has to keep, and that attribute is how a
+    /// code-first handler publishes the same one - so the status is derived from the declaration
+    /// the document already reads rather than asserted a second time on a verb attribute, which is
+    /// what those attributes dropped it for.
+    /// </para>
+    /// <para>
+    /// Every refusal that answers the validation envelope, not only the ones a generated filter
+    /// raises: an undeclared enum value and malformed JSON are caught inside deserialization and
+    /// answer this too. Which layer caught the value is not visible to the caller, so it cannot
+    /// decide the status.
+    /// </para>
     /// </remarks>
     int? ValidationErrorStatus => null;
 

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ThrowsAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ThrowsAttribute.cs
@@ -26,6 +26,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// means, and the generator refuses a declaration that names neither.
 /// </para>
 /// <para>
+/// <b>One declaration it also decides.</b> <c>[Throws&lt;RequestValidationError&gt;(422)]</c> says
+/// the operation answers validation failures with 422, so that is the status the runtime answers
+/// them with - the filter's refusal, a handler's own <c>ValidationException</c>, and a body the
+/// deserializer could not read alike. A described operation declaring 422 has behaved this way
+/// since 0.18; this is how a hand-written one says it, without a second place to write it down.
+/// </para>
+/// <para>
 /// <b>What this deliberately does not promise.</b> It does not assert that the handler throws this,
 /// nor that it throws nothing else. An unmapped exception is unplanned by definition and the runtime
 /// already has somewhere to put it. Verifying completeness is the road ASP.NET went down with its

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationStartupServiceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Authorization/AuthenticationStartupServiceTests.cs
@@ -1,0 +1,224 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.DependencyInjection;
+using Hardened.Requests.Runtime.Tests.Support;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Authorization;
+
+/// <summary>
+/// Whether an application has authentication at all. A source the startup service does not find is
+/// a source that never runs, and every caller stays anonymous with nothing said.
+///
+/// <para>
+/// The startup service itself is <c>internal</c>, so it is reached the way an application reaches
+/// it - through <c>HardenedRequestModule</c>'s registrations.
+/// </para>
+/// </summary>
+public class AuthenticationStartupServiceTests {
+
+    private sealed class BearerScheme : IAuthenticationScheme;
+
+    private sealed class CookieScheme : IAuthenticationScheme;
+
+    /// <summary>
+    /// Records what it was asked, so a source that was collected and never reached is
+    /// distinguishable from one that was not collected at all.
+    /// </summary>
+    private class RecordingSource : IPrincipalSource {
+        private readonly string? _subject;
+
+        protected RecordingSource(string? subject) => _subject = subject;
+
+        public int Calls { get; private set; }
+
+        public ValueTask<ICallerPrincipal?> Authenticate(IExecutionContext context) {
+            Calls++;
+
+            return new ValueTask<ICallerPrincipal?>(
+                _subject == null ? null : new CallerPrincipal("test", subject: _subject));
+        }
+    }
+
+    /// <summary>
+    /// Written against the typed interface alone, which is what an application following the
+    /// <c>[Authorize&lt;TScheme&gt;]</c> vocabulary writes.
+    /// </summary>
+    private sealed class BearerSource(string? subject = "ada")
+        : RecordingSource(subject), IPrincipalSource<BearerScheme>;
+
+    private sealed class CookieSource(string? subject = "grace")
+        : RecordingSource(subject), IPrincipalSource<CookieScheme>;
+
+    private sealed class PlainSource(string? subject = null) : RecordingSource(subject);
+
+    private sealed class OpenSource<TScheme>(string? subject = null)
+        : RecordingSource(subject), IPrincipalSource<TScheme>
+        where TScheme : IAuthenticationScheme;
+
+    /// <summary>
+    /// Composes the module, lets <paramref name="register"/> state the application's sources, runs
+    /// every startup service, and hands back the middleware that was installed.
+    /// </summary>
+    /// <remarks>
+    /// The authorization startup service runs alongside and installs into the filter registry
+    /// rather than the middleware service, so what comes back is authentication's alone. Its
+    /// configuration is registered after the module so it wins the resolve, the way the CORS
+    /// fixture does it - the module's own factory reads a configuration manager a test must not
+    /// depend on.
+    /// </remarks>
+    private static async Task<IReadOnlyList<IExecutionFilter>> Installed(
+        Action<IServiceCollection> register) {
+        var services = new ServiceCollection();
+
+        new HardenedRequestModule().ConfigureServices(services);
+
+        register(services);
+
+        var installed = new List<IExecutionFilter>();
+        var middlewareService = Substitute.For<IMiddlewareService>();
+
+        middlewareService
+            .When(m => m.Use(Arg.Any<Func<IExecutionContext, IExecutionFilter>>()))
+            .Do(call => installed.Add(
+                call.Arg<Func<IExecutionContext, IExecutionFilter>>()(
+                    Substitute.For<IExecutionContext>())));
+
+        services.AddSingleton(middlewareService);
+        services.AddSingleton(Substitute.For<IGlobalFilterRegistry>());
+        services.AddSingleton<IOptions<IAuthorizationConfiguration>>(
+            Options.Create(Substitute.For<IAuthorizationConfiguration>()));
+
+        var provider = services.BuildServiceProvider();
+
+        foreach (var startupService in provider.GetServices<IStartupService>()) {
+            Assert.True(await startupService.Startup(provider));
+        }
+
+        return installed;
+    }
+
+    /// <summary>
+    /// The caller a request comes out of the installed middleware with.
+    /// </summary>
+    private static async Task<string?> Caller(IExecutionFilter middleware) {
+        var context = Pipeline.Context();
+        var chain = Substitute.For<IExecutionChain>();
+
+        chain.Context.Returns(context);
+        chain.Next().Returns(Task.CompletedTask);
+
+        await middleware.Execute(chain);
+
+        return context.CallerPrincipal.Subject;
+    }
+
+    /// <summary>
+    /// CS-01 and SU-04. Two arms registered a source by attribute, got the typed interface as its
+    /// service type, and lost a debugging session to an application where every protected route
+    /// answered 401 and nothing said why.
+    /// </summary>
+    [Fact]
+    public async Task ATypedSourceInstallsTheMiddleware() {
+        var installed = await Installed(
+            services => services.AddSingleton<IPrincipalSource<BearerScheme>, BearerSource>());
+
+        Assert.IsType<AuthenticationMiddleware>(Assert.Single(installed));
+    }
+
+    [Fact]
+    public async Task ATypedSourceAuthenticatesTheRequest() {
+        var installed = await Installed(
+            services => services.AddSingleton<IPrincipalSource<BearerScheme>, BearerSource>());
+
+        Assert.Equal("ada", await Caller(Assert.Single(installed)));
+    }
+
+    /// <summary>
+    /// The workaround the arms found, which has to keep working.
+    /// </summary>
+    [Fact]
+    public async Task ASourceRegisteredAsThePlainInterfaceStillInstallsTheMiddleware() {
+        var installed = await Installed(
+            services => services.AddSingleton<IPrincipalSource, BearerSource>());
+
+        Assert.Single(installed);
+    }
+
+    /// <summary>
+    /// Two schemes are two service types, and one closed generic is not the whole of what the
+    /// application registered.
+    /// </summary>
+    [Fact]
+    public async Task EverySchemeIsCollected() {
+        var bearer = new BearerSource(subject: null);
+        var cookie = new CookieSource();
+
+        var installed = await Installed(services => {
+            services.AddSingleton<IPrincipalSource<BearerScheme>>(bearer);
+            services.AddSingleton<IPrincipalSource<CookieScheme>>(cookie);
+        });
+
+        Assert.Equal("grace", await Caller(Assert.Single(installed)));
+        Assert.Equal(1, bearer.Calls);
+        Assert.Equal(1, cookie.Calls);
+    }
+
+    /// <summary>
+    /// First answer wins in registration order, and a plain source declining falls through to a
+    /// typed one registered after it. The two forms are one ordered list, not two.
+    /// </summary>
+    [Fact]
+    public async Task RegistrationOrderHoldsAcrossBothForms() {
+        var installed = await Installed(services => {
+            services.AddSingleton<IPrincipalSource, PlainSource>();
+            services.AddSingleton<IPrincipalSource<CookieScheme>, CookieSource>();
+        });
+
+        Assert.Equal("grace", await Caller(Assert.Single(installed)));
+    }
+
+    /// <summary>
+    /// One instance registered under both interfaces is asked once. Asking it twice would only
+    /// cost a request a second read of a credential it has already declined.
+    /// </summary>
+    [Fact]
+    public async Task ASourceRegisteredUnderBothInterfacesIsAskedOnce() {
+        var source = new BearerSource(subject: null);
+
+        var installed = await Installed(services => {
+            services.AddSingleton<IPrincipalSource>(source);
+            services.AddSingleton<IPrincipalSource<BearerScheme>>(source);
+        });
+
+        await Caller(Assert.Single(installed));
+
+        Assert.Equal(1, source.Calls);
+    }
+
+    /// <summary>
+    /// An application that registered nothing gets no middleware, which is what keeps the anonymous
+    /// default free.
+    /// </summary>
+    [Fact]
+    public async Task NoSourceInstallsNoMiddleware() {
+        Assert.Empty(await Installed(_ => { }));
+    }
+
+    /// <summary>
+    /// An open generic registration is passed over rather than resolved: nothing implements the
+    /// source for every scheme, and asking the container for an unbound type throws.
+    /// </summary>
+    [Fact]
+    public async Task AnOpenGenericRegistrationIsPassedOver() {
+        Assert.Empty(await Installed(
+            services => services.AddSingleton(typeof(IPrincipalSource<>), typeof(OpenSource<>))));
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Hardened.Requests.Abstract.Errors;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Runtime.Errors;
+using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.Validation;
 using Microsoft.Extensions.Primitives;
 using NSubstitute;
@@ -21,12 +22,24 @@ public class ExceptionToModelConverterTests {
     /// Carries a real header dictionary, because an exception that names its own status may also
     /// name headers to send with it.
     /// </summary>
-    private static IExecutionContext Context() {
+    /// <param name="validationErrorStatus">
+    /// The status the operation's contract declared for validation failures, or null for an
+    /// operation that declared none.
+    /// </param>
+    private static IExecutionContext Context(int? validationErrorStatus = null) {
         var response = Substitute.For<IExecutionResponse>();
         response.Headers.Returns(new Dictionary<string, StringValues>());
 
         var context = Substitute.For<IExecutionContext>();
         context.Response.Returns(response);
+
+        if (validationErrorStatus != null) {
+            // The type the pipeline carries, rather than a substitute: ValidationErrorStatus is a
+            // default interface member, and a stub for it would prove the stub works.
+            context.HandlerInfo.Returns(new ExecutionRequestHandlerInfo(
+                "/events", "POST", typeof(ExceptionToModelConverterTests), "Handle",
+                validationErrorStatus: validationErrorStatus));
+        }
 
         return context;
     }
@@ -408,6 +421,104 @@ public class ExceptionToModelConverterTests {
 
         Assert.Equal(400, status);
         Assert.IsType<RequestValidationError>(model);
+    }
+
+    #endregion
+
+    #region the declared validation status
+
+    /// <summary>
+    /// An operation whose contract declares 422 for validation answers 422 from the deserializer,
+    /// not only from the filter.
+    /// </summary>
+    /// <remarks>
+    /// Two spec-first trial arms declared 422 and were answered 400 for an undeclared enum value,
+    /// because this branch hardcoded the status the validation branch above it looks up. Which
+    /// layer caught the value is not something a caller can see, so it cannot be something the
+    /// status depends on - and the 400 it answered was absent from the document the operation
+    /// published.
+    /// </remarks>
+    [Fact]
+    public void AnUndeclaredEnumValueAnswersTheDeclaredValidationStatus() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(validationErrorStatus: 422),
+            new JsonException("'cooking' is not a value Genre declares."));
+
+        Assert.Equal(422, status);
+        Assert.IsType<RequestValidationError>(model);
+    }
+
+    /// <summary>
+    /// Malformed JSON is the same refusal from the same layer, so it answers the same status.
+    /// </summary>
+    [Fact]
+    public void MalformedJsonAnswersTheDeclaredValidationStatus() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(validationErrorStatus: 422), ThrownReading("{\"genre\":5}", "$.genre"));
+
+        Assert.Equal(422, status);
+        Assert.Equal("body.genre", Assert.Single(
+            Assert.IsType<RequestValidationError>(model).Errors).Field);
+    }
+
+    /// <summary>
+    /// So does an omitted required member, which the deserializer refuses on the validator's behalf
+    /// and this converter already answers in the validator's own shape.
+    /// </summary>
+    [Fact]
+    public void AMissingRequiredMemberAnswersTheDeclaredValidationStatus() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(validationErrorStatus: 422),
+            new JsonException(
+                "JSON deserialization for type 'CreateEvent' was missing required properties: 'genre'."));
+
+        Assert.Equal(422, status);
+        Assert.Equal("required", Assert.Single(
+            Assert.IsType<RequestValidationError>(model).Errors).Code);
+    }
+
+    /// <summary>
+    /// Both routes to a refused body agree, which is the whole point: one operation, one validation
+    /// status.
+    /// </summary>
+    [Fact]
+    public void AConstraintFailureAndAnUnreadableBodyAnswerTheSameStatus() {
+        var context = Context(validationErrorStatus: 422);
+
+        var (fromFilter, _) = Converter.ConvertExceptionToModel(
+            context,
+            new ValidationException(ValidationModules.ValidationResult.FromErrors(new[] {
+                new ValidationModules.ValidationError("body.name", "required", "name is required"),
+            })));
+
+        var (fromDeserializer, _) = Converter.ConvertExceptionToModel(
+            context, new JsonException("'cooking' is not a value Genre declares."));
+
+        Assert.Equal(fromFilter, fromDeserializer);
+    }
+
+    /// <summary>
+    /// An operation that declared nothing still answers the stock 400, which is what every
+    /// code-first handler does.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableBodyStillAnswers400WhereNothingDeclaredAStatus() {
+        var (status, _) = Converter.ConvertExceptionToModel(
+            Context(), new JsonException("'cooking' is not a value Genre declares."));
+
+        Assert.Equal(400, status);
+    }
+
+    /// <summary>
+    /// The declared status is for validation, not for everything the operation can fail at. A
+    /// server fault on an operation declaring 422 is still a 500.
+    /// </summary>
+    [Fact]
+    public void TheDeclaredValidationStatusDoesNotMoveAnUnrelatedFailure() {
+        var (status, _) = Converter.ConvertExceptionToModel(
+            Context(validationErrorStatus: 422), new InvalidOperationException("disk on fire"));
+
+        Assert.Equal(500, status);
     }
 
     #endregion

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationStartupService.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthenticationStartupService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Middleware;
 using Hardened.Shared.Runtime.Application;
@@ -9,21 +10,99 @@ namespace Hardened.Requests.Runtime.Authorization;
 /// Installs the authentication middleware at startup, when anything registered a source.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The sources are resolved once and the middleware instance is shared: a source establishes a
 /// caller from a request, so it holds no per-request state, and resolving per request would put
 /// a container lookup on every request of every application that opted in. An application that
 /// registered no source gets no middleware, which is what keeps the anonymous default free.
+/// </para>
+/// <para>
+/// <b>Both interfaces, which is why the collection is held.</b> A registration attribute registers
+/// a class as the interface it declares, so a source written against
+/// <see cref="IPrincipalSource{TScheme}"/> sits in the container under the closed generic and
+/// under nothing else. Resolving <see cref="IPrincipalSource"/> alone found none of them,
+/// installed no middleware, and left every caller anonymous with nothing said - the typed form's
+/// own remarks promise it works identically, and this is what makes that true. The service types
+/// cannot be reached from a built provider, so the collection the module configured is read here
+/// instead, once, after everything has registered into it.
+/// </para>
 /// </remarks>
 internal class AuthenticationStartupService : IStartupService {
-    public Task<bool> Startup(IServiceProvider rootProvider) {
-        var sources = rootProvider.GetServices<IPrincipalSource>().ToArray();
+    private readonly IServiceCollection _services;
 
-        if (sources.Length > 0) {
+    public AuthenticationStartupService(IServiceCollection services) {
+        _services = services;
+    }
+
+    public Task<bool> Startup(IServiceProvider rootProvider) {
+        var sources = Sources(rootProvider);
+
+        if (sources.Count > 0) {
             var middleware = new AuthenticationMiddleware(sources);
 
             rootProvider.GetRequiredService<IMiddlewareService>().Use(_ => middleware);
         }
 
         return Task.FromResult(true);
+    }
+
+    /// <summary>
+    /// Every registered source, in registration order, whichever interface it was registered as.
+    /// </summary>
+    /// <remarks>
+    /// A source registered under both interfaces is one source: the middleware asks each in turn
+    /// until one answers, and asking the same instance twice would only cost the request a second
+    /// read of a credential it already declined.
+    /// </remarks>
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Every service type read here is an interface, so the IEnumerable<T> the " +
+                        "container builds shares the canonical reference-type instantiation and " +
+                        "needs no native code of its own. The closed types are not constructed - " +
+                        "they are read from registrations the application already made.")]
+    private List<IPrincipalSource> Sources(IServiceProvider rootProvider) {
+        var sources = new List<IPrincipalSource>();
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+
+        foreach (var serviceType in SourceServiceTypes()) {
+            foreach (var resolved in rootProvider.GetServices(serviceType)) {
+                if (resolved is IPrincipalSource source && seen.Add(source)) {
+                    sources.Add(source);
+                }
+            }
+        }
+
+        return sources;
+    }
+
+    /// <summary>
+    /// The service types a principal source can be registered under, in the order they were
+    /// registered: <see cref="IPrincipalSource"/> itself, and every closed
+    /// <see cref="IPrincipalSource{TScheme}"/> anything asked for.
+    /// </summary>
+    /// <remarks>
+    /// An open generic is skipped rather than resolved. Nothing can implement
+    /// <c>IPrincipalSource&lt;TScheme&gt;</c> for every scheme, and asking the container for an
+    /// unbound type throws.
+    /// </remarks>
+    private IEnumerable<Type> SourceServiceTypes() {
+        var seen = new HashSet<Type>();
+
+        foreach (var descriptor in _services) {
+            var serviceType = descriptor.ServiceType;
+
+            if (serviceType.ContainsGenericParameters) {
+                continue;
+            }
+
+            if (serviceType != typeof(IPrincipalSource) &&
+                !(serviceType.IsGenericType &&
+                  serviceType.GetGenericTypeDefinition() == typeof(IPrincipalSource<>))) {
+                continue;
+            }
+
+            if (seen.Add(serviceType)) {
+                yield return serviceType;
+            }
+        }
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -59,8 +59,10 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         services.AddSingleton<IStartupService, AuthorizationStartupService>();
 
         // Same footing: one resolve at startup, and no middleware at all unless something
-        // registered an IPrincipalSource.
-        services.AddSingleton<IStartupService, AuthenticationStartupService>();
+        // registered an IPrincipalSource. Constructed over this collection rather than resolved
+        // from the provider, because a source registered as IPrincipalSource<TScheme> is reachable
+        // only by its closed service type and a built provider cannot be asked what those are.
+        services.AddSingleton<IStartupService>(new AuthenticationStartupService(services));
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -64,8 +64,15 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
         // this one answered 500, which told a client its own typo was a server fault. Shaped as a
         // validation error rather than an ErrorModel so one malformed field reads the same however
         // it was caught.
+        //
+        // Under the operation's declared validation status for that same reason. An operation
+        // declaring 422 answered 422 from its filter and 400 from its deserializer - one refusal
+        // split across two statuses by which layer happened to catch the value, and the 400 was
+        // absent from the document the operation published.
         if (exp is JsonException jsonException) {
-            return (400, BodyReadError(jsonException, BodyField(context)));
+            return (
+                context.HandlerInfo?.ValidationErrorStatus ?? 400,
+                BodyReadError(jsonException, BodyField(context)));
         }
 
         // Client errors are identified by type, not by the shape of the type's name.

--- a/src/SourceGenerators/Hardened.Generation.Shared/TypeMapper.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/TypeMapper.cs
@@ -19,6 +19,15 @@ internal static class TypeMapper {
             ("string", "date") => "DateOnly",
             ("string", "uuid") => "string",
             ("string", "byte") => "byte[]",
+            // Money as an exact decimal, in the two spellings the ecosystem actually uses. Neither
+            // is in the OpenAPI specification, which names int32, int64, float and double and
+            // nothing else - format is an open-valued property, so both are legal and both are
+            // conventions rather than standards.
+            //
+            // "string" + "number" is openapi-generator's: ModelUtils.isDecimalSchema tests exactly
+            // that pair, and around thirty of its language generators map it to a decimal type.
+            // Ahead of ("string", _) or it would go on being a string.
+            ("string", "number") => "decimal",
             ("string", "binary") => "byte[]",
             ("string", _) => "string",
             ("integer", "int64") => "long",
@@ -26,6 +35,12 @@ internal static class TypeMapper {
             ("integer", _) => "int",
             ("number", "float") => "float",
             ("number", "double") => "double",
+            // "number" + "decimal" is NSwag's, measured against 14.1.0: it answers decimal for this
+            // pair and double for a formatless number. openapi-generator warns "Unknown `format`
+            // decimal" and discards it, so a document written for that tool means a decimal by
+            // leaving the format off - which is the one reading this cannot take, because the same
+            // absence is how every other document says double.
+            ("number", "decimal") => "decimal",
             ("number", _) => "double",
             ("boolean", _) => "bool",
             _ => "JsonElement"

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -587,19 +587,20 @@ internal static class JsonTypeInfoEmitter {
             ns, TypeMapper.MapToCSharpType(prop.DictionaryValueType, null), false);
     }
 
+    /// <summary>
+    /// Whether an optional member of this type needs the nullable form in its property info.
+    /// </summary>
+    /// <remarks>
+    /// The primitive half is <c>TypeMapper.IsNonNullableValueType</c> rather than a list of its
+    /// own. It was a list of its own, and it had drifted: <c>decimal</c> was missing, so an
+    /// optional decimal member emitted <c>CreatePropertyInfo&lt;decimal&gt;</c> over a
+    /// <c>decimal?</c> property and the generated file did not compile. That was invisible while
+    /// no mapping produced a decimal, which is the way a duplicated list fails - not when it is
+    /// written, but when something upstream finally reaches the case it forgot.
+    /// </remarks>
     private static bool IsValueType(string csType, PropertyModel prop, List<SchemaModel> allSchemas) {
-        switch (csType) {
-            case "int":
-            case "uint":
-            case "long":
-            case "float":
-            case "double":
-            case "bool":
-            case "DateTimeOffset":
-            case "DateTime":
-            case "DateOnly":
-            case "JsonElement":
-                return true;
+        if (TypeMapper.IsNonNullableValueType(csType)) {
+            return true;
         }
 
         // Check if it's an enum reference

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
@@ -109,11 +109,11 @@ internal static class ConstraintAttributes {
             var arguments = new List<string>();
 
             if (minimum.HasValue) {
-                arguments.Add("Min = " + Literal(minimum.Value));
+                arguments.Add("Min = " + Literal(minimum.Value, csType));
             }
 
             if (maximum.HasValue) {
-                arguments.Add("Max = " + Literal(maximum.Value));
+                arguments.Add("Max = " + Literal(maximum.Value, csType));
             }
 
             if (exclusiveMinimum) {
@@ -169,12 +169,25 @@ internal static class ConstraintAttributes {
     }
 
     /// <summary>
-    /// A bound as a C# literal for Range's <c>object?</c> properties. Rendered through double
-    /// because decimal is not a legal attribute argument type; a whole-number bound renders as
-    /// the integer it is.
+    /// A bound as a C# literal for Range's <c>object?</c> properties.
     /// </summary>
-    private static string Literal(decimal value) =>
-        ((double)value).ToString("R", CultureInfo.InvariantCulture);
+    /// <remarks>
+    /// <para>
+    /// Rendered through double, because decimal is not a legal attribute argument type; a
+    /// whole-number bound renders as the integer it is.
+    /// </para>
+    /// <para>
+    /// Except on a decimal member, where going through double is the one thing the type was chosen
+    /// to avoid - a bound of 0.1 would arrive at the comparison as 0.1000000000000000055511151231.
+    /// <c>Range</c> takes <c>object?</c> and ValidationModules parses a string bound invariantly
+    /// against the property's own type at generation time, which its remarks give decimal as the
+    /// first reason for. So the bound stays exact and a malformed one is still a build error.
+    /// </para>
+    /// </remarks>
+    private static string Literal(decimal value, string csType) =>
+        csType == "decimal"
+            ? Quote(value.ToString(CultureInfo.InvariantCulture))
+            : ((double)value).ToString("R", CultureInfo.InvariantCulture);
 
     private static string Quote(string value) =>
         "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/BigDecimalTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/BigDecimalTests.cs
@@ -1,0 +1,129 @@
+using Hardened.Generation;
+using Hardened.Generation.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// The two prelude shapes with no exact C# type, and what the build says about them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>BigDecimal</c> used to become <c>double</c>. Both narrow, and they narrow differently: a
+/// double loses the value's exactness at any magnitude, so 19.99 stops being 19.99 and money stops
+/// adding up, while a decimal is exact and runs out at 28 significant digits. A model reaching for
+/// <c>BigDecimal</c> has almost always reached for exactness rather than for range.
+/// </para>
+/// <para>
+/// H-31 is the other half: three <c>BigDecimal</c> members produced three byte-identical warnings
+/// naming none of them, so the count told you how many and nothing told you which.
+/// </para>
+/// </remarks>
+public class BigDecimalTests {
+
+    private static string Model(string members) =>
+        $$"""
+          { "smithy": "2.0", "shapes": {
+              "com.example#Svc": {
+                "type": "service", "version": "1",
+                "operations": [ { "target": "com.example#Charge" } ] },
+              "com.example#Charge": {
+                "type": "operation",
+                "input": { "target": "com.example#Money" },
+                "traits": {
+                  "smithy.api#http": { "method": "POST", "uri": "/charges", "code": 200 } } },
+              "com.example#Money": {
+                "type": "structure",
+                "members": { {{members}} } } } }
+          """;
+
+    private static SchemaModel Parse(string members, out List<string> diagnostics) {
+        diagnostics = new List<string>();
+
+        var model = SmithySpecParser.Parse(Model(members), "money", diagnostics);
+
+        Assert.NotNull(model);
+
+        return Assert.Single(model!.Schemas, s => s.Name == "Money");
+    }
+
+    [Fact]
+    public void ABigDecimalMemberReachesCSharpDecimal() {
+        var schema = Parse("""
+            "amount": { "target": "smithy.api#BigDecimal" }
+            """, out _);
+
+        var amount = Assert.Single(schema.Properties);
+
+        Assert.Equal("number", amount.Type);
+        Assert.Equal("decimal", amount.Format);
+        Assert.Equal("decimal", TypeMapper.MapPropertyToCSharpType(amount));
+    }
+
+    /// <summary>Float and Double are exact mappings and say nothing.</summary>
+    [Theory]
+    [InlineData("smithy.api#Float", "float")]
+    [InlineData("smithy.api#Double", "double")]
+    public void AnExactlyMappedShapeIsSilent(string shape, string csType) {
+        var schema = Parse($$"""
+            "amount": { "target": "{{shape}}" }
+            """, out var diagnostics);
+
+        Assert.Equal(csType, TypeMapper.MapPropertyToCSharpType(Assert.Single(schema.Properties)));
+        Assert.Empty(diagnostics);
+    }
+
+    /// <summary>
+    /// The narrowing is still reported, because 28 digits is not arbitrarily many - and the
+    /// message says what it became rather than that no type exists.
+    /// </summary>
+    [Fact]
+    public void TheNarrowingIsReportedAndNamesWhatItBecame() {
+        Parse("""
+            "amount": { "target": "smithy.api#BigDecimal" }
+            """, out var diagnostics);
+
+        var warning = Assert.Single(diagnostics);
+
+        Assert.Contains("'Money.amount'", warning);
+        Assert.Contains("BigDecimal", warning);
+        Assert.Contains("decimal", warning);
+        Assert.Contains("28 significant digits", warning);
+    }
+
+    /// <summary>BigInteger narrows too, and says what it costs rather than the same sentence.</summary>
+    [Fact]
+    public void ABigIntegerSaysWhatItCosts() {
+        var schema = Parse("""
+            "count": { "target": "smithy.api#BigInteger" }
+            """, out var diagnostics);
+
+        Assert.Equal("long", TypeMapper.MapPropertyToCSharpType(Assert.Single(schema.Properties)));
+
+        var warning = Assert.Single(diagnostics);
+
+        Assert.Contains("'Money.count'", warning);
+        Assert.Contains("64 bits", warning);
+    }
+
+    /// <summary>
+    /// H-31. One warning per member, each naming its own - three members used to produce three
+    /// copies of one sentence naming none. Qualified by the shape, because two structures may each
+    /// hold an <c>amount</c>.
+    /// </summary>
+    [Fact]
+    public void EveryNarrowedMemberIsNamedOnce() {
+        Parse("""
+            "unitPrice": { "target": "smithy.api#BigDecimal" },
+            "discount":  { "target": "smithy.api#BigDecimal" },
+            "total":     { "target": "smithy.api#BigDecimal" }
+            """, out var diagnostics);
+
+        Assert.Equal(3, diagnostics.Count);
+        Assert.Equal(3, diagnostics.Distinct().Count());
+        Assert.Contains(diagnostics, d => d.Contains("'Money.unitPrice'"));
+        Assert.Contains(diagnostics, d => d.Contains("'Money.discount'"));
+        Assert.Contains(diagnostics, d => d.Contains("'Money.total'"));
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyPrelude.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyPrelude.cs
@@ -65,15 +65,19 @@ internal static class SmithyPrelude {
             case "smithy.api#PrimitiveDouble":
                 type = "number"; format = "double"; return true;
 
-            // Neither has a C# type that both holds every value and survives the JSON type-info
-            // emitter - see the decimal note on TypeMapper. Mapped to the widest thing that does,
-            // and reported, because silently narrowing a value the model calls valid is the failure
+            // Neither has a C# type that holds every value the model calls valid, so both are
+            // mapped to the closest one that does and reported - silently narrowing is the failure
             // worth naming.
             case "smithy.api#BigInteger":
                 type = "integer"; format = "int64"; return true;
 
+            // decimal rather than double. Both narrow, and they narrow differently: double loses
+            // the value's exactness at any magnitude, so 19.99 is not 19.99 and money stops
+            // adding up, while decimal is exact and runs out at 28 significant digits. A model
+            // reaching for BigDecimal has almost always reached for exactness rather than for
+            // range, and that is the half decimal keeps.
             case "smithy.api#BigDecimal":
-                type = "number"; format = "double"; return true;
+                type = "number"; format = "decimal"; return true;
 
             // RFC 3339 by default, which is what DateTimeOffset holds. @timestampFormat can say
             // otherwise and is read by the parser, not here.
@@ -93,6 +97,23 @@ internal static class SmithyPrelude {
     /// <summary>Whether the shape loses precision on the way to C#, for a diagnostic.</summary>
     internal static bool IsLossy(string shapeId) =>
         shapeId is "smithy.api#BigInteger" or "smithy.api#BigDecimal";
+
+    /// <summary>
+    /// What the narrowing costs, for the message. Null where the shape narrows nothing.
+    /// </summary>
+    /// <remarks>
+    /// Names the C# type and the limit rather than saying "no exact type", because the two shapes
+    /// lose different things and an author's next move differs: a BigDecimal that needed more than
+    /// 28 digits has nowhere to go, and one that needed exactness has arrived.
+    /// </remarks>
+    internal static string? LossDescription(string shapeId) => shapeId switch {
+        "smithy.api#BigInteger" =>
+            "becomes long, so a value outside 64 bits does not round-trip",
+        "smithy.api#BigDecimal" =>
+            "becomes decimal, which is exact but holds 28 significant digits rather than " +
+            "arbitrarily many",
+        _ => null
+    };
 
     /// <summary>Whether the id names a prelude shape at all.</summary>
     internal static bool IsPrelude(string shapeId) =>

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -604,7 +604,11 @@ internal static class SmithySpecParser {
                 };
 
                 foreach (var member in bodyMembers) {
-                    var schemaProperty = BuildProperty(context, member.Key, member.Value);
+                    // Named for the diagnostic as the model spells it rather than as the body
+                    // schema does: one member of one Smithy structure, whatever the reader
+                    // materialises it into.
+                    var schemaProperty = BuildProperty(
+                        context, member.Key, member.Value, SmithyPrelude.LocalName(inputId));
 
                     bodySchema.Properties.Add(schemaProperty);
 
@@ -620,7 +624,8 @@ internal static class SmithySpecParser {
         }
 
         foreach (var member in bodyMembers) {
-            var property = BuildProperty(context, member.Key, member.Value);
+            var property = BuildProperty(
+                context, member.Key, member.Value, SmithyPrelude.LocalName(inputId));
 
             model.RequestBodyProperties.Add(property);
 
@@ -916,7 +921,8 @@ internal static class SmithySpecParser {
         // reaches C# as `verbose`: the wire name is the contract, and the alternative would be a
         // second naming authority, which is the exact defect NameAllocator was built to remove.
         if (target != null) {
-            Describe(context, target, out var type, out var format, out var reference, out var array);
+            Describe(context, target, out var type, out var format, out var reference, out var array,
+                model.OperationId + "." + parameter.Name);
 
             parameter.Type = type;
             parameter.Format = format;
@@ -931,8 +937,12 @@ internal static class SmithySpecParser {
         model.Parameters.Add(parameter);
     }
 
+    /// <param name="owner">
+    /// The shape the member belongs to, so a narrowing diagnostic names which one - two structures
+    /// may each hold an <c>amount</c>, and "'amount' narrows" says nothing about where to look.
+    /// </param>
     private static PropertyModel BuildProperty(
-        ParseContext context, string name, JsonElement member) {
+        ParseContext context, string name, JsonElement member, string owner) {
         var property = new PropertyModel {
             Name = JsonName(member) ?? name,
             IsRequired = SmithyAst.HasTrait(member, SmithyTraits.Required),
@@ -944,7 +954,8 @@ internal static class SmithySpecParser {
         var target = SmithyAst.Target(member);
 
         if (target != null) {
-            Describe(context, target, out var type, out var format, out var reference, out var shape);
+            Describe(context, target, out var type, out var format, out var reference, out var shape,
+                owner + "." + property.Name);
 
             property.Type = type;
             property.Format = format;
@@ -1056,13 +1067,18 @@ internal static class SmithySpecParser {
     /// <c>List&lt;T&gt;</c>. That mirrors what <c>InlineNonObjectRefs</c> does on the OpenAPI side,
     /// and keeps the generated surface to the shapes a caller actually names.
     /// </remarks>
+    /// <param name="memberName">
+    /// The member being described, for a narrowing diagnostic. Null where the caller has no name
+    /// to give - a payload targeting a prelude shape directly, say.
+    /// </param>
     private static void Describe(
         ParseContext context,
         string target,
         out string? type,
         out string? format,
         out string? reference,
-        out ShapeFacts facts) {
+        out ShapeFacts facts,
+        string? memberName = null) {
         type = null;
         format = null;
         reference = null;
@@ -1072,10 +1088,21 @@ internal static class SmithySpecParser {
             type = preludeType;
             format = preludeFormat;
 
-            if (SmithyPrelude.IsLossy(target)) {
-                context.Diagnostics.Add(
-                    $"'{SmithyPrelude.LocalName(target)}' has no exact C# type; " +
-                    "values outside the mapped range will not round-trip.");
+            if (SmithyPrelude.LossDescription(target) is { } loss) {
+                // Once per member, naming it. Three BigDecimal members used to produce three
+                // byte-identical warnings naming none of them, so the count was the only way to
+                // tell how many there were and no way to tell which - and a set of identical
+                // strings deduplicates itself, which is why the name has to be in the message
+                // rather than beside it.
+                var where = memberName == null ? "" : $"'{memberName}' ";
+
+                var message = $"{where}targets {SmithyPrelude.LocalName(target)}, which {loss}.";
+
+                // A structure is walked twice - once as a schema, once as an operation's body - so
+                // without this every narrowed member is reported twice.
+                if (!context.Diagnostics.Contains(message)) {
+                    context.Diagnostics.Add(message);
+                }
             }
 
             return;
@@ -1249,7 +1276,7 @@ internal static class SmithySpecParser {
                 foreach (var member in SmithyAst.Members(shape)) {
                     Note(context, member.Value);
 
-                    var property = BuildProperty(context, member.Key, member.Value);
+                    var property = BuildProperty(context, member.Key, member.Value, schema.Name);
 
                     schema.Properties.Add(property);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RouteBindingConflictTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RouteBindingConflictTests.cs
@@ -1,0 +1,135 @@
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Web.Routing;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Requests;
+
+/// <summary>
+/// Which handlers declare a token that binds nothing while a parameter falls onto the body.
+/// </summary>
+/// <remarks>
+/// The decision, not the reporting - the split <c>FormAndBodyConflictTests</c> uses, and for the
+/// same reason. What is covered here rather than through a running generator is the described
+/// front end: a spec-first parameter carries the wire name the route declares and a C# identifier
+/// that may differ from it, so a rule that compared the identifier would report every described
+/// path parameter whose member name was allocated.
+/// </remarks>
+public class RouteBindingConflictTests {
+
+    private static ITypeDefinition Type(string name) => TypeDefinition.Get("System", name);
+
+    private static RequestParameterInformation Parameter(
+        ParameterBindType bindingType, string name, string bindingName = "") =>
+        new(Type("String"), name, true, null, bindingType, bindingName, 0, null);
+
+    private static RequestHandlerModel Handler(
+        string path, string method, params RequestParameterInformation[] parameters) =>
+        new(
+            new RequestHandlerNameModel(path, method),
+            TypeDefinition.Get("TestApp", "EventController"),
+            "Handle",
+            TypeDefinition.Get("TestApp.Generated", "EventController_Handle"),
+            parameters,
+            new ResponseInformationModel { ReturnType = Type("String") },
+            []);
+
+    /// <summary>
+    /// A described parameter binds by its wire name. <c>eventId</c> in the contract becomes the
+    /// member <c>EventId</c>, and the route still declares <c>{eventId}</c>.
+    /// </summary>
+    [Fact]
+    public void ADescribedParameterBindsByItsWireName() {
+        var findings = RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventId}", "GET",
+            Parameter(ParameterBindType.Path, "EventId", "eventId")));
+
+        Assert.Empty(findings);
+    }
+
+    /// <summary>A code-first parameter carries no wire name and binds by its identifier.</summary>
+    [Fact]
+    public void ACodeFirstParameterBindsByItsIdentifier() {
+        var findings = RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventId}", "GET", Parameter(ParameterBindType.Path, "eventId")));
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void ATokenDifferingOnlyByCaseIsFound() {
+        var finding = Assert.Single(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventid}", "GET", Parameter(ParameterBindType.Body, "eventId"))));
+
+        Assert.Equal("eventid", finding.Token);
+        Assert.Equal("eventId", finding.BodyParameter);
+        Assert.True(finding.CaseOnly);
+    }
+
+    [Fact]
+    public void AMisspeltTokenOnABodylessVerbIsFound() {
+        var finding = Assert.Single(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventKey}", "GET", Parameter(ParameterBindType.Body, "eventId"))));
+
+        Assert.False(finding.CaseOnly);
+    }
+
+    /// <summary>
+    /// A POST reads a body because a POST carries one. Only a name that differs by case says the
+    /// author meant the token.
+    /// </summary>
+    [Fact]
+    public void AMisspeltTokenOnABodyCarryingVerbIsNotFound() {
+        Assert.Empty(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventKey}", "POST", Parameter(ParameterBindType.Body, "body"))));
+    }
+
+    /// <summary>
+    /// DELETE is not treated as bodyless. HTTP permits a body on one and some APIs send it, so a
+    /// body parameter there is a choice rather than a mistake.
+    /// </summary>
+    [Fact]
+    public void ADeleteIsNotTreatedAsBodyless() {
+        Assert.Empty(RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventKey}", "DELETE", Parameter(ParameterBindType.Body, "body"))));
+    }
+
+    /// <summary>
+    /// A token nothing binds and nothing displaced is not a defect: a token declared in a shared
+    /// base path binds nothing on the handlers under it that do not need it.
+    /// </summary>
+    [Fact]
+    public void AnUnboundTokenWithNoBodyParameterIsNotFound() {
+        Assert.Empty(RouteBindingDiagnostics.Find(Handler(
+            "/tenants/{tenantId}/events/{eventId}", "GET",
+            Parameter(ParameterBindType.Path, "eventId"))));
+    }
+
+    /// <summary>
+    /// A dispatched handler is selected by an exact token in a header - awsJson sends every
+    /// operation to <c>POST /</c> - so its path declares nothing to bind.
+    /// </summary>
+    [Fact]
+    public void ADispatchedHandlerIsNotConsidered() {
+        var model = new RequestHandlerModel(
+            new RequestHandlerNameModel("/", "POST", "X-Amz-Target", "PetStore.GetPet"),
+            TypeDefinition.Get("TestApp", "EventController"),
+            "Handle",
+            TypeDefinition.Get("TestApp.Generated", "EventController_Handle"),
+            [Parameter(ParameterBindType.Body, "input")],
+            new ResponseInformationModel { ReturnType = Type("String") },
+            []);
+
+        Assert.Empty(RouteBindingDiagnostics.Find(model));
+    }
+
+    /// <summary>One finding per token, so fixing the first is not how you discover the second.</summary>
+    [Fact]
+    public void EveryUnboundTokenIsFound() {
+        var findings = RouteBindingDiagnostics.Find(Handler(
+            "/events/{eventid}/holds/{holdid}", "GET",
+            Parameter(ParameterBindType.Body, "eventId")));
+
+        Assert.Equal(2, findings.Count);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ThrowsAttributeTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/ThrowsAttributeTests.cs
@@ -136,6 +136,101 @@ public class ThrowsAttributeTests {
     /// source searches compressed bytes and finds nothing - which is exactly the false negative this
     /// suite hit first time round.
     /// </remarks>
+    #region the validation status it derives
+
+    /// <summary>
+    /// A handler declaring that it answers 422 with the validation envelope has stated the
+    /// operation's validation status; the same declaration sets it for the runtime.
+    /// </summary>
+    /// <remarks>
+    /// H-08. Spec-first has declared this since 0.18 and code-first had nothing, deliberately - the
+    /// verb attributes dropped <c>ValidationErrorStatus</c> on the grounds that no hand-written
+    /// assertion should be a second source of truth beside the document. Deriving it from a
+    /// declaration the document already reads keeps that: there is still one place to write it.
+    /// </remarks>
+    [Fact]
+    public void DeclaringTheValidationEnvelopeSetsTheHandlersValidationStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class PetController {
+                [Post("/pets")]
+                [Throws<Hardened.Requests.Runtime.Validation.RequestValidationError>(422)]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        result.AssertNoErrors();
+
+        Assert.Contains("validationErrorStatus: 422", HandlerInfo(result));
+    }
+
+    /// <summary>
+    /// Another thrown type does not, however it is declared. This derives one status from one
+    /// vocabulary, not a status from every declaration.
+    /// </summary>
+    [Fact]
+    public void DeclaringAnotherThrownTypeSetsNoValidationStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class PetController {
+                [Post("/pets")]
+                [Throws<RateLimited>]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        result.AssertNoErrors();
+
+        Assert.DoesNotContain("validationErrorStatus", HandlerInfo(result));
+    }
+
+    /// <summary>
+    /// Matched by full name. An application is entitled to a <c>RequestValidationError</c> of its
+    /// own, and one that happens to share the name says nothing about how this framework's
+    /// validation answers.
+    /// </summary>
+    [Fact]
+    public void ATypeMerelySharingTheNameSetsNoValidationStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            [HttpStatus(422)]
+            public class RequestValidationError { }
+
+            public class PetController {
+                [Post("/pets")]
+                [Throws<RequestValidationError>]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        result.AssertNoErrors();
+
+        Assert.DoesNotContain("validationErrorStatus", HandlerInfo(result));
+    }
+
+    /// <summary>
+    /// The declaration still reaches the document, which is the half it already did.
+    /// </summary>
+    /// <remarks>
+    /// Whether the synthesized 400 stands down beside it is not assertable here - this handler
+    /// constrains nothing, so no 400 is synthesized either way. <c>OpenApiDocumentTests</c> covers
+    /// that over an application whose model carries real constraints.
+    /// </remarks>
+    [Fact]
+    public void TheDocumentCarriesTheDeclaredStatus() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class PetController {
+                [Post("/pets")]
+                [Throws<Hardened.Requests.Runtime.Validation.RequestValidationError>(422)]
+                public Task<Pet> Create(Pet pet) => Task.FromResult(pet);
+            }
+            """));
+
+        Assert.Contains("\"422\"", Document(result));
+    }
+
+    private static string HandlerInfo(GeneratorResult result) =>
+        result.GeneratedSources.First(candidate => candidate.Key.Contains("PetController")).Value;
+
+    #endregion
+
     private static string Document(GeneratorResult result) {
         var source = result.GeneratedSources
             .First(candidate => candidate.Key.Contains("OpenApiDocument")).Value;

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RouteTokens.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RouteTokens.cs
@@ -1,4 +1,4 @@
-namespace Hardened.SourceGenerator.Models.Request;
+﻿namespace Hardened.SourceGenerator.Models.Request;
 
 /// <summary>
 /// How much of a path a route token matches, and what it may contain.
@@ -75,6 +75,37 @@ public static class RouteTokens {
         var index = depth - 1;
 
         return index >= 0 && index < tokens.Count ? Constraint(tokens[index]) : null;
+    }
+
+    /// <summary>
+    /// The names every well-formed token in <paramref name="pathTemplate"/> binds to, in order.
+    /// </summary>
+    /// <remarks>
+    /// An unclosed brace ends the walk, the way <see cref="BindsParameter"/> stops looking at one.
+    /// <c>RouteTokenSyntax</c> is what reports it; this only answers what does bind.
+    /// </remarks>
+    public static IReadOnlyList<string> Names(string pathTemplate) {
+        List<string>? names = null;
+
+        var open = pathTemplate.IndexOf('{');
+
+        while (open >= 0) {
+            var close = pathTemplate.IndexOf('}', open);
+
+            if (close < 0) {
+                break;
+            }
+
+            var name = Name(pathTemplate.Substring(open + 1, close - open - 1));
+
+            if (name.Length > 0) {
+                (names ??= new List<string>()).Add(name);
+            }
+
+            open = pathTemplate.IndexOf('{', close + 1);
+        }
+
+        return (IReadOnlyList<string>?)names ?? Array.Empty<string>();
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
@@ -329,7 +329,12 @@ public static class JsonSchemaWriter {
                 "{\"type\":\"integer\",\"format\":\"int64\"}",
             SpecialType.System_Single => "{\"type\":\"number\",\"format\":\"float\"}",
             SpecialType.System_Double => "{\"type\":\"number\",\"format\":\"double\"}",
-            SpecialType.System_Decimal => "{\"type\":\"number\"}",
+            // The format is written, so the document says decimal rather than leaving a reader to
+            // guess from a bare "number" - which this framework reads back as double, so a
+            // code-first decimal did not survive its own contract. NSwag reads the pair as decimal
+            // too; openapi-generator ignores the format and defaults number to decimal in C#
+            // anyway, so naming it costs that reader nothing.
+            SpecialType.System_Decimal => "{\"type\":\"number\",\"format\":\"decimal\"}",
             SpecialType.System_DateTime => "{\"type\":\"string\",\"format\":\"date-time\"}",
             SpecialType.System_Object => "{}",
             _ => ByName(type)

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -24,14 +24,11 @@ public abstract class BaseRequestModelGenerator {
 
         var parameters = GetParameters(context, methodDeclaration, nameModel, cancellationToken);
 
-        // Read before Compose, because the unresolved ones ride on the response model and the
-        // emit step is where there is a context to report them into.
-        var unresolved = new List<string>();
-        var thrown = ThrownResponseSelector.Read(context, methodDeclaration, unresolved, cancellationToken);
-
-        if (unresolved.Count > 0) {
-            response.ThrowsDiagnostic = string.Join(",", unresolved);
-        }
+        // Read before Compose, because two things it derives ride on the response model: the
+        // declarations naming no status, which the emit step has a context to report, and the
+        // validation status a [Throws<RequestValidationError>(422)] states.
+        var thrown = ThrownResponseSelector.Read(
+            context, methodDeclaration, response, cancellationToken);
 
         var model = Compose(
             nameModel,

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/ThrownResponseSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/ThrownResponseSelector.cs
@@ -29,6 +29,9 @@ public static class ThrownResponseSelector {
     private const string AttributeSuffix = "Attribute";
     private const string HttpStatusAttribute = "HttpStatusAttribute";
 
+    /// <summary>The envelope every validation refusal answers with.</summary>
+    private const string ValidationErrorType = "Hardened.Requests.Runtime.Validation.RequestValidationError";
+
     /// <summary>The id reported when a declaration names no status.</summary>
     public const string DiagnosticId = "HRDT001";
 
@@ -64,15 +67,17 @@ public static class ThrownResponseSelector {
     }
 
     /// <summary>
-    /// Reads every <c>[Throws&lt;T&gt;]</c> on the method, collecting into <paramref name="unresolved"/>
-    /// the ones naming no status.
+    /// Reads every <c>[Throws&lt;T&gt;]</c> on the method, recording onto
+    /// <paramref name="response"/> the declarations naming no status and the validation status one
+    /// of them derives.
     /// </summary>
     public static IReadOnlyList<ResponseSchemaModel> Read(
         GeneratorSyntaxContext context,
         MethodDeclarationSyntax method,
-        List<string> unresolved,
+        ResponseInformationModel response,
         CancellationToken cancellationToken) {
         List<ResponseSchemaModel>? declared = null;
+        List<string>? unresolved = null;
 
         foreach (var attributeList in method.AttributeLists) {
             foreach (var attribute in attributeList.Attributes) {
@@ -87,9 +92,19 @@ public static class ThrownResponseSelector {
                 var status = StatedStatus(context, attribute) ?? DeclaredStatus(errorType);
 
                 if (status == null) {
-                    unresolved.Add(errorType.Name);
+                    (unresolved ??= new List<string>()).Add(errorType.Name);
 
                     continue;
+                }
+
+                // Derived rather than declared twice. A handler saying it answers 422 with the
+                // validation envelope has stated the operation's validation status into the
+                // document already; reading the same declaration for the runtime is what lets
+                // code-first reach the parity spec-first has had, without a second source of truth
+                // on any attribute. The verb attributes dropped ValidationErrorStatus on exactly
+                // those grounds.
+                if (response.ValidationErrorStatus == null && IsValidationEnvelope(errorType)) {
+                    response.ValidationErrorStatus = status;
                 }
 
                 declared ??= new List<ResponseSchemaModel>();
@@ -106,8 +121,23 @@ public static class ThrownResponseSelector {
             }
         }
 
+        if (unresolved != null) {
+            response.ThrowsDiagnostic = string.Join(",", unresolved);
+        }
+
         return (IReadOnlyList<ResponseSchemaModel>?)declared ?? System.Array.Empty<ResponseSchemaModel>();
     }
+
+    /// <summary>
+    /// Whether the declared type is the envelope every validation refusal answers with.
+    /// </summary>
+    /// <remarks>
+    /// By full name rather than by simple name: an application is entitled to a
+    /// <c>RequestValidationError</c> of its own, and one that happens to share the name is not a
+    /// statement about how this framework's validation answers.
+    /// </remarks>
+    private static bool IsValidationEnvelope(INamedTypeSymbol errorType) =>
+        errorType.ToDisplayString() == ValidationErrorType;
 
     /// <summary>The type argument of a <c>[Throws&lt;T&gt;]</c>, or null for any other attribute.</summary>
     private static INamedTypeSymbol? ThrownType(GeneratorSyntaxContext context, AttributeSyntax attribute) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteBindingDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteBindingDiagnostics.cs
@@ -1,0 +1,190 @@
+using Hardened.SourceGenerator.Models.Request;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Web.Routing;
+
+/// <summary>
+/// A route token that binds nothing, beside a parameter read from a body the request does not
+/// carry.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>[Get("/{eventid}")]</c> against a parameter called <c>eventId</c> built with zero warnings.
+/// The token bound nothing, the parameter fell through to the body branch, and a GET answered 400
+/// "input does not contain any JSON tokens" at request time - from a route that matched perfectly.
+/// The generator has both lists in hand.
+/// </para>
+/// <para>
+/// <b>Both halves are required, which is deliberate.</b> A token that binds nothing is not a
+/// mistake on its own: a token declared in a <c>[BasePath]</c> and used by only some of the
+/// handlers under it binds nothing on the rest, and that is a route matching more than one handler
+/// needs, not a defect. What makes it a defect is the parameter that fell somewhere else because
+/// of it - either onto a body the verb does not carry, or, whatever the verb, onto a body when its
+/// name differs from the token only by case. A case-only difference is never what anyone meant.
+/// </para>
+/// </remarks>
+public static class RouteBindingDiagnostics {
+
+    /// <summary>
+    /// <c>HRDR005</c>. <c>HRDR002</c> reports a token Hardened does not compile; this reports one
+    /// it compiles and nothing binds.
+    /// </summary>
+    public const string DiagnosticId = "HRDR005";
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the reason
+    /// <c>FormAndBodyDiagnostics.Descriptor</c> is: RS2008 looks for the field, and these projects
+    /// set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "Route token binds no parameter",
+        messageFormat: "Route '{0}' on '{1}.{2}' declares '{{{3}}}', which no parameter binds. {4}",
+        category: "Hardened.Routing",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>The token that binds nothing, and the parameter that went to the body instead.</summary>
+    public readonly struct Finding {
+        public Finding(string token, string bodyParameter, bool caseOnly) {
+            Token = token;
+            BodyParameter = bodyParameter;
+            CaseOnly = caseOnly;
+        }
+
+        /// <summary>The token's name, braces and any constraint stripped.</summary>
+        public string Token { get; }
+
+        /// <summary>The parameter being read from the request body.</summary>
+        public string BodyParameter { get; }
+
+        /// <summary>Whether the two differ only by case.</summary>
+        public bool CaseOnly { get; }
+    }
+
+    /// <summary>Verbs whose requests carry no body to read a parameter out of.</summary>
+    /// <remarks>
+    /// DELETE is not among them. HTTP permits a body on one and some APIs send it, so a body
+    /// parameter there is a choice rather than a mistake - and a DELETE with the trial's typo is
+    /// still reported, through the case-only half of the rule.
+    /// </remarks>
+    private static readonly HashSet<string> BodylessVerbs =
+        new(StringComparer.OrdinalIgnoreCase) { "GET", "HEAD", "OPTIONS", "TRACE" };
+
+    /// <summary>
+    /// Every token that binds nothing while a parameter is read from the body it displaced.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Report"/> because a <c>SourceProductionContext</c> only exists
+    /// inside a running generator, and the decision this makes is worth testing on its own. Same
+    /// split as <c>FormAndBodyDiagnostics.FindConflict</c>.
+    /// </remarks>
+    public static IReadOnlyList<Finding> Find(RequestHandlerModel model) {
+        // A dispatched handler is selected by an exact token in a header, so its path declares
+        // nothing to bind - awsJson sends every operation to POST /.
+        if (model.Name.IsDispatched) {
+            return Array.Empty<Finding>();
+        }
+
+        var tokens = RouteTokens.Names(model.Name.Path);
+
+        if (tokens.Count == 0) {
+            return Array.Empty<Finding>();
+        }
+
+        List<string>? unbound = null;
+
+        foreach (var token in tokens) {
+            if (!Binds(model, token)) {
+                (unbound ??= new List<string>()).Add(token);
+            }
+        }
+
+        if (unbound == null) {
+            return Array.Empty<Finding>();
+        }
+
+        var bodyless = BodylessVerbs.Contains(model.Name.Method);
+        List<Finding>? findings = null;
+
+        foreach (var token in unbound) {
+            foreach (var parameter in model.RequestParameterInformationList) {
+                if (parameter.BindingType != ParameterBindType.Body) {
+                    continue;
+                }
+
+                var caseOnly = string.Equals(parameter.Name, token, StringComparison.OrdinalIgnoreCase);
+
+                if (!caseOnly && !bodyless) {
+                    continue;
+                }
+
+                (findings ??= new List<Finding>()).Add(new Finding(token, parameter.Name, caseOnly));
+
+                break;
+            }
+        }
+
+        return (IReadOnlyList<Finding>?)findings ?? Array.Empty<Finding>();
+    }
+
+    /// <summary>
+    /// Whether any parameter binds this token. Read the way the binder reads it: a described
+    /// parameter carries the wire name the route declares and a C# identifier that may differ, and
+    /// a code-first one carries only the identifier.
+    /// </summary>
+    private static bool Binds(RequestHandlerModel model, string token) {
+        foreach (var parameter in model.RequestParameterInformationList) {
+            if (parameter.BindingType != ParameterBindType.Path) {
+                continue;
+            }
+
+            var bound = string.IsNullOrEmpty(parameter.BindingName)
+                ? parameter.Name
+                : parameter.BindingName;
+
+            if (string.Equals(bound, token, StringComparison.Ordinal)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// What to tell the author, built here rather than in the message format so it can carry both
+    /// identifiers.
+    /// </summary>
+    public static string Advice(RequestHandlerModel model, Finding finding) {
+        if (finding.CaseOnly) {
+            return
+                $"'{finding.BodyParameter}' differs from it only by case, so it is read from the " +
+                $"request body instead. Route tokens bind by exact name: spell the token " +
+                $"'{{{finding.BodyParameter}}}', or rename the parameter to '{finding.Token}'.";
+        }
+
+        return
+            $"'{finding.BodyParameter}' matches no token either, so it is read from the request " +
+            $"body - and a {model.Name.Method} carries none, so every request is refused before " +
+            $"the handler runs. Name a parameter '{finding.Token}', or bind " +
+            $"'{finding.BodyParameter}' with [FromQueryString] or [FromHeader].";
+    }
+
+    /// <summary>Reports every finding, if the handler has any.</summary>
+    public static void Report(SourceProductionContext context, RequestHandlerModel model) {
+        foreach (var finding in Find(model)) {
+            // Location.None, as everywhere else models are reported from: a syntax location would
+            // travel with the model through the incremental caches, which compare models for
+            // equality to decide whether to regenerate. The message carries the route and handler
+            // instead.
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptor(),
+                Location.None,
+                model.Name.Path,
+                model.ControllerType.Name,
+                model.HandlerMethod,
+                finding.Token,
+                Advice(model, finding)));
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTokenSyntax.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTokenSyntax.cs
@@ -25,6 +25,13 @@ namespace Hardened.SourceGenerator.Web.Routing;
 /// the application, so a declaration that does not mean what it says has to stop the build rather
 /// than reach production.
 /// </para>
+///
+/// <para>
+/// The template itself is read strictly for the same reason. An unbalanced brace, a token with no
+/// name, and one name declared twice each produced a route that compiled and matched nothing the
+/// author meant it to match — <c>[Get("/{eventId")]</c> built with zero warnings and answered 400
+/// to every request shape.
+/// </para>
 /// </summary>
 public static class RouteTokenSyntax {
 
@@ -39,7 +46,16 @@ public static class RouteTokenSyntax {
         Optional,
 
         /// <summary><c>{id=5}</c> — a default value.</summary>
-        Default
+        Default,
+
+        /// <summary><c>{id</c>, or a stray <c>}</c> — a brace with no partner.</summary>
+        Unbalanced,
+
+        /// <summary><c>{}</c> or <c>{:int}</c> — a token with nothing to bind to.</summary>
+        Unnamed,
+
+        /// <summary>The same token name twice in one route.</summary>
+        Duplicate
     }
 
     public readonly struct Finding {
@@ -77,33 +93,66 @@ public static class RouteTokenSyntax {
     public static IReadOnlyList<Finding> Scan(
         string pathTemplate, IReadOnlyCollection<string>? declaredConstraints = null) {
         List<Finding>? findings = null;
+        HashSet<string>? seen = null;
 
         var open = pathTemplate.IndexOf('{');
+        var stray = pathTemplate.IndexOf('}');
+
+        // A closing brace before any opening one is as unbalanced as the reverse, and reads the
+        // same way to whoever typed it.
+        if (stray >= 0 && (open < 0 || stray < open)) {
+            Add(ref findings, new Finding(
+                pathTemplate.Substring(stray, 1), Form.Unbalanced, "", null));
+        }
 
         while (open >= 0) {
             var close = pathTemplate.IndexOf('}', open);
 
+            // A brace that is never closed used to end the scan silently, which is how
+            // [Get("/{eventId")] built with zero warnings: the rest of the template became literal
+            // text, the route matched nothing anybody sent, and the parameter it was written to
+            // bind was read from the request body instead.
             if (close < 0) {
+                Add(ref findings, new Finding(
+                    pathTemplate.Substring(open), Form.Unbalanced,
+                    Name(pathTemplate.Substring(open + 1)), null));
+
                 break;
             }
 
             var body = pathTemplate.Substring(open + 1, close - open - 1);
-            var form = Classify(body, declaredConstraints);
+            var token = pathTemplate.Substring(open, close - open + 1);
+            var name = Name(body);
 
-            if (form != Form.Supported) {
-                findings ??= new List<Finding>();
+            // A second '{' inside a token is the same mistake seen from the other end: one of the
+            // two braces has no partner.
+            if (body.IndexOf('{') >= 0) {
+                Add(ref findings, new Finding(token, Form.Unbalanced, name, null));
+            }
+            else if (name.Length == 0) {
+                Add(ref findings, new Finding(token, Form.Unnamed, name, null));
+            }
+            else if (!(seen ??= new HashSet<string>(StringComparer.Ordinal)).Add(name)) {
+                Add(ref findings, new Finding(token, Form.Duplicate, name, null));
+            }
+            else {
+                var form = Classify(body, declaredConstraints);
 
-                findings.Add(new Finding(
-                    pathTemplate.Substring(open, close - open + 1),
-                    form,
-                    Name(body),
-                    RouteTokens.Constraint(body)));
+                if (form != Form.Supported) {
+                    Add(ref findings, new Finding(token, form, name, RouteTokens.Constraint(body)));
+                }
             }
 
             open = pathTemplate.IndexOf('{', close + 1);
         }
 
         return (IReadOnlyList<Finding>?)findings ?? Array.Empty<Finding>();
+    }
+
+    private static void Add(ref List<Finding>? findings, Finding finding) {
+        findings ??= new List<Finding>();
+
+        findings.Add(finding);
     }
 
     /// <summary>
@@ -143,6 +192,23 @@ public static class RouteTokenSyntax {
                     $"the token name, so nothing binds to '{name}'. Give the handler's '{name}' " +
                     $"parameter a C# default instead; the template controls matching and C# " +
                     $"supplies the value.";
+
+            case Form.Unbalanced:
+                return
+                    "This brace has no partner, so what was written as a token is matched as " +
+                    "literal text and the parameter it was written to bind is read from the " +
+                    "request body instead. Close the token.";
+
+            case Form.Unnamed:
+                return
+                    "A token with no name binds nothing. Name it, or drop the braces if the " +
+                    "segment is literal.";
+
+            case Form.Duplicate:
+                return
+                    $"'{name}' is declared twice in this route. Two tokens of one name cannot both " +
+                    $"bind the handler's '{name}' parameter, and only one of the two segments a " +
+                    $"request sends would reach it. Give them distinct names.";
 
             default:
                 return "";

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
@@ -49,6 +49,10 @@ public class WebExecutionHandlerCodeGenerator {
         // class that was never written.
         FormAndBodyDiagnostics.Report(sourceProductionContext, requestHandlerModel);
 
+        // And the same treatment again: a token that binds nothing leaves a handler that compiles
+        // and routes, and refuses every request once it is running.
+        RouteBindingDiagnostics.Report(sourceProductionContext, requestHandlerModel);
+
         var sourceFile = GenerateFile(requestHandlerModel, sourceProductionContext.CancellationToken, excludeFromCoverage);
 
         sourceProductionContext.AddSource(requestHandlerModel.InvokeHandlerType.Name, GeneratedSource.Header(sourceFile));

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator.Tests/ValidationGeneratorTests.cs
@@ -556,6 +556,246 @@ public class ValidationGeneratorTests {
 
     #endregion
 
+
+    // ---------------------------------------- nested constraints nothing reaches
+
+    /// <summary>
+    /// A parent that validates, a child that declares constraints, and the one attribute that
+    /// connects them.
+    /// </summary>
+    private static string Nested(string property) => $$"""
+        using System.Collections.Generic;
+        using ValidationModules.Constraints;
+
+        namespace TestApp.Models;
+
+        public class PriceTier {
+            [Pattern("^[A-Z]+$")]
+            public string Code { get; set; } = "";
+
+            [Range(1, 1000)]
+            public int Price { get; set; }
+        }
+
+        public class CreateEvent {
+            [Required]
+            [StringLength(Min = 1, Max = 200)]
+            public string Title { get; set; } = "";
+
+            {{property}}
+        }
+        """;
+
+    /// <summary>
+    /// CS-11. Removing <c>[ValidateNested]</c> from the collection stopped every constraint on
+    /// <c>PriceTier</c> from running, and invalid tiers stored as 201 with no build or runtime
+    /// signal - though the generator compiled those constraints itself and can see the property
+    /// that no longer reaches them.
+    /// </summary>
+    [Fact]
+    public void ACollectionWithoutValidateNestedIsReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", Nested("public List<PriceTier> PriceTiers { get; set; } = new();")));
+
+        var warning = Assert.Single(Warnings(result, "HRDV004"));
+
+        Assert.Contains("PriceTiers", warning.GetMessage());
+        Assert.Contains("PriceTier", warning.GetMessage());
+        Assert.Contains("element", warning.GetMessage());
+        Assert.Contains("[ValidateNested]", warning.GetMessage());
+    }
+
+    /// <summary>
+    /// The message names both fixes, because not descending is sometimes what was meant.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheSuppressionAsWellAsTheFix() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", Nested("public List<PriceTier> PriceTiers { get; set; } = new();")));
+
+        Assert.Contains("HRDV004", Assert.Single(Warnings(result, "HRDV004")).GetMessage());
+    }
+
+    [Fact]
+    public void AWarningRatherThanAnError() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", Nested("public List<PriceTier> PriceTiers { get; set; } = new();")));
+
+        Assert.Equal(
+            DiagnosticSeverity.Warning, Assert.Single(Warnings(result, "HRDV004")).Severity);
+    }
+
+    /// <summary>Every shape a descent can take, and every one of them stops without the attribute.</summary>
+    [Theory]
+    [InlineData("public PriceTier Tier { get; set; } = new();", "member")]
+    [InlineData("public PriceTier[] Tiers { get; set; } = [];", "element")]
+    [InlineData("public List<PriceTier> Tiers { get; set; } = new();", "element")]
+    [InlineData("public IReadOnlyList<PriceTier> Tiers { get; } = [];", "element")]
+    [InlineData("public Dictionary<string, PriceTier> Tiers { get; set; } = new();", "element")]
+    public void EveryNestedShapeIsReported(string property, string kind) {
+        var result = Run(("Entry.cs", EntryPoint), ("Models.cs", Nested(property)));
+
+        Assert.Contains(kind, Assert.Single(Warnings(result, "HRDV004")).GetMessage());
+    }
+
+    /// <summary>The attribute is the whole of what silences it.</summary>
+    [Theory]
+    [InlineData("[ValidateNested]\n    public PriceTier Tier { get; set; } = new();")]
+    [InlineData("[ValidateNested]\n    public List<PriceTier> Tiers { get; set; } = new();")]
+    public void DeclaringValidateNestedIsNotReported(string property) {
+        var result = Run(("Entry.cs", EntryPoint), ("Models.cs", Nested(property)));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+
+        result.AssertNoErrors();
+    }
+
+    /// <summary>A child with nothing to check has nothing to become unreachable.</summary>
+    [Fact]
+    public void AChildWithNoConstraintsIsNotReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class Address {
+                    public string City { get; set; } = "";
+                }
+
+                public class Customer {
+                    [Required]
+                    public string Name { get; set; } = "";
+
+                    public Address Home { get; set; } = new();
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>
+    /// A parent that constrains nothing is not a model this generator validates - a data seed
+    /// holding a list of records, a response case wrapping a body - and a validator that checks
+    /// nothing was never going to descend anywhere.
+    /// </summary>
+    [Fact]
+    public void AParentThatConstrainsNothingIsNotReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using System.Collections.Generic;
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class PriceTier {
+                    [Pattern("^[A-Z]+$")]
+                    public string Code { get; set; } = "";
+                }
+
+                public class SeedData {
+                    public IReadOnlyList<PriceTier> Tiers { get; } = [];
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>A string is a sequence of characters, not a nested model.</summary>
+    [Fact]
+    public void AStringMemberIsNotADescent() {
+        var result = Run(
+            ("Entry.cs", EntryPoint), ("Customer.cs", Model()));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>
+    /// A type that holds one of itself would otherwise report against its own constraints.
+    /// </summary>
+    [Fact]
+    public void ASelfReferenceIsNotReported() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using ValidationModules.Constraints;
+
+                namespace TestApp.Models;
+
+                public class Node {
+                    [Required]
+                    public string Name { get; set; } = "";
+
+                    public Node? Parent { get; set; }
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>The DataAnnotations vocabulary reaches the same place, on both sides.</summary>
+    [Fact]
+    public void DataAnnotationsConstraintsCountAsConstraints() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using System.Collections.Generic;
+                using System.ComponentModel.DataAnnotations;
+
+                namespace TestApp.Models;
+
+                public class Line {
+                    [Range(1, 100)]
+                    public int Quantity { get; set; }
+                }
+
+                public class Order {
+                    [Required]
+                    public string Reference { get; set; } = "";
+
+                    public List<Line> Lines { get; set; } = new();
+                }
+                """));
+
+        Assert.Single(Warnings(result, "HRDV004"));
+    }
+
+    /// <summary>
+    /// An attribute that names a member rather than constraining it is not a constraint.
+    /// <c>[Display]</c> does not derive from <c>ValidationAttribute</c>, which is what the check
+    /// walks the base chain for rather than listing names.
+    /// </summary>
+    [Fact]
+    public void ANamingAttributeIsNotAConstraint() {
+        var result = Run(
+            ("Entry.cs", EntryPoint),
+            ("Models.cs", """
+                using System.Collections.Generic;
+                using System.ComponentModel.DataAnnotations;
+
+                namespace TestApp.Models;
+
+                public class Line {
+                    [Display(Name = "How many")]
+                    public int Quantity { get; set; }
+                }
+
+                public class Order {
+                    [Required]
+                    public string Reference { get; set; } = "";
+
+                    public List<Line> Lines { get; set; } = new();
+                }
+                """));
+
+        Assert.Empty(Warnings(result, "HRDV004"));
+    }
+
     /// <summary>
     /// The whole arrangement, compiled: entry point, several constrained models, both attribute
     /// vocabularies, and the registration that wires them together.

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator/HardenedValidationGenerator.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator/HardenedValidationGenerator.cs
@@ -180,8 +180,203 @@ public class HardenedValidationGenerator : IIncrementalGenerator {
         var diagnostics = frontEnd.Diagnostics.ToList();
 
         diagnostics.AddRange(RequiredValueTypesThatCannotBeMissed(symbol));
+        diagnostics.AddRange(UnreachableNestedConstraints(symbol, model));
 
         return new ModelResult(model, diagnostics.ToImmutableArray());
+    }
+
+    /// <summary>
+    /// Members whose type declares constraints that this type's validator will never reach.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The generated validator descends into a member only where <c>[ValidateNested]</c> says to,
+    /// so omitting it silently switches off every constraint on the child type. The generator
+    /// compiled those constraints and can see the property that fails to reach them, which is what
+    /// makes this sayable at all.
+    /// </para>
+    /// <para>
+    /// Sited on the symbol rather than the built model for the reason the required-value-type check
+    /// is: what decides it is the member's C# type and the child type's attributes, and the
+    /// validation IR has already resolved both away.
+    /// </para>
+    /// <para>
+    /// Only child types declared in this compilation are considered. Those are the ones this
+    /// generator emits validators for, so "a constraint that just became unreachable" is knowable
+    /// rather than guessed at - a type from a package may have been validated at its own boundary.
+    /// </para>
+    /// <para>
+    /// And only parents that constrain something themselves. Every type declaration in the
+    /// compilation reaches this generator, most of which are not models at all - a data seed
+    /// holding a list of records, a response case wrapping a body - and a validator that checks
+    /// nothing was never going to descend anywhere. What the warning is about is a model that
+    /// validates, with one property the validation stops at.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<Diagnostic> UnreachableNestedConstraints(
+        INamedTypeSymbol symbol, ValidatedTypeModel? model) {
+        if (!Constrains(model)) {
+            yield break;
+        }
+
+        foreach (var member in symbol.GetMembers()) {
+            if (member is not IPropertySymbol property || property.IsStatic ||
+                property.DeclaredAccessibility != Accessibility.Public) {
+                continue;
+            }
+
+            if (DeclaresValidateNested(property)) {
+                continue;
+            }
+
+            var nested = NestedType(property.Type, out var isElement);
+
+            if (nested == null || SymbolEqualityComparer.Default.Equals(nested, symbol) ||
+                !DeclaredInSource(nested) || !CarriesConstraints(nested)) {
+                continue;
+            }
+
+            yield return ValidationGeneratorDiagnostics.UnreachableNestedConstraints(
+                symbol, property, nested, isElement);
+        }
+    }
+
+    /// <summary>Whether the built model checks anything at all.</summary>
+    private static bool Constrains(ValidatedTypeModel? model) {
+        if (model == null) {
+            return false;
+        }
+
+        foreach (var property in model.Properties) {
+            if (property.Constraints.Count > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool DeclaresValidateNested(IPropertySymbol property) {
+        foreach (var attribute in property.GetAttributes()) {
+            if (attribute.AttributeClass?.ToDisplayString()
+                == "ValidationModules.Constraints.ValidateNestedAttribute") {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The type a descent would validate: the element of a collection, the value of a dictionary,
+    /// or the member's own type. Null where there is nothing with structure to descend into.
+    /// </summary>
+    /// <remarks>
+    /// A string is a sequence of characters and never a nested model, which is why it is taken out
+    /// before the enumerable test rather than after it.
+    /// </remarks>
+    private static INamedTypeSymbol? NestedType(ITypeSymbol type, out bool isElement) {
+        isElement = false;
+
+        if (type is IArrayTypeSymbol array) {
+            isElement = true;
+
+            return Model(array.ElementType);
+        }
+
+        if (type.SpecialType == SpecialType.System_String) {
+            return null;
+        }
+
+        if (type is INamedTypeSymbol named) {
+            if (named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T) {
+                return Model(named.TypeArguments[0]);
+            }
+
+            foreach (var candidate in Self(named).Concat(named.AllInterfaces)) {
+                var definition = candidate.OriginalDefinition.ToDisplayString();
+
+                if (definition is "System.Collections.Generic.IDictionary<TKey, TValue>"
+                               or "System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>") {
+                    isElement = true;
+
+                    return Model(candidate.TypeArguments[1]);
+                }
+            }
+
+            foreach (var candidate in Self(named).Concat(named.AllInterfaces)) {
+                if (candidate.OriginalDefinition.ToDisplayString()
+                    == "System.Collections.Generic.IEnumerable<T>") {
+                    isElement = true;
+
+                    return Model(candidate.TypeArguments[0]);
+                }
+            }
+        }
+
+        return Model(type);
+    }
+
+    private static IEnumerable<INamedTypeSymbol> Self(INamedTypeSymbol type) {
+        yield return type;
+    }
+
+    /// <summary>The type as something a validator could be generated for, or null.</summary>
+    private static INamedTypeSymbol? Model(ITypeSymbol type) =>
+        type is INamedTypeSymbol named &&
+        named.TypeKind is TypeKind.Class or TypeKind.Struct &&
+        named.SpecialType == SpecialType.None
+            ? named
+            : null;
+
+    private static bool DeclaredInSource(INamedTypeSymbol type) {
+        foreach (var location in type.Locations) {
+            if (location.IsInSource) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether any member of the type carries a constraint from either vocabulary the front end
+    /// reads.
+    /// </summary>
+    /// <remarks>
+    /// Matched by walking the attribute's base chain to <c>ValidationConstraintAttribute</c> or
+    /// <c>ValidationAttribute</c> rather than by listing names: those two bases are what the front
+    /// end compiles, and a list would go stale the first time either vocabulary gained a
+    /// constraint. It also keeps <c>[Display]</c> and <c>[Key]</c> out, which name a member rather
+    /// than constrain it.
+    /// </remarks>
+    private static bool CarriesConstraints(INamedTypeSymbol type) {
+        foreach (var member in type.GetMembers()) {
+            if (member is not IPropertySymbol property || property.IsStatic) {
+                continue;
+            }
+
+            foreach (var attribute in property.GetAttributes()) {
+                if (IsConstraint(attribute.AttributeClass)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsConstraint(INamedTypeSymbol? attributeClass) {
+        for (var type = attributeClass; type != null; type = type.BaseType) {
+            var name = type.ToDisplayString();
+
+            if (name is "ValidationModules.Constraints.ValidationConstraintAttribute"
+                     or "System.ComponentModel.DataAnnotations.ValidationAttribute") {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Validation.SourceGenerator/ValidationGeneratorDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Validation.SourceGenerator/ValidationGeneratorDiagnostics.cs
@@ -72,6 +72,50 @@ public static class ValidationGeneratorDiagnostics {
         isEnabledByDefault: true);
 
     /// <summary>
+    /// A property whose type carries constraints that nothing will run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A generated validator descends into a member only where <c>[ValidateNested]</c> says to.
+    /// Omit it and every constraint on the child type stops running: the trial's price tiers stored
+    /// as 201 with an empty code and a negative price, from a model whose constraints were all
+    /// declared and all correct. Nothing at build time and nothing at run time said so.
+    /// </para>
+    /// <para>
+    /// <b>A warning rather than an error</b>, because not descending is a legitimate choice - a
+    /// member validated by a later step, a shared type whose constraints belong to another
+    /// operation. The <c>NoWarn</c> is what makes that choice deliberate rather than silent.
+    /// </para>
+    /// <para>
+    /// Reported against the parent's property rather than the child's constraints, because that is
+    /// where the one-word fix goes. The child type is named too: the constraints that go unrun are
+    /// not visible from the line the diagnostic sits on.
+    /// </para>
+    /// </remarks>
+    public static readonly DiagnosticDescriptor UnreachableNestedConstraintsDescriptor = new(
+        "HRDV004",
+        "Nested constraints are never reached",
+        "'{0}.{1}' does not declare [ValidateNested] and its {2} type '{3}' declares constraints, " +
+        "so none of them run and an invalid '{3}' is accepted with no error. Add [ValidateNested] " +
+        "to the property, or set <NoWarn>$(NoWarn);HRDV004</NoWarn> if the skip is intended.",
+        "Hardened.Validation",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports <see cref="UnreachableNestedConstraintsDescriptor"/> against the parent's property.
+    /// </summary>
+    public static Diagnostic UnreachableNestedConstraints(
+        INamedTypeSymbol owner, IPropertySymbol property, ITypeSymbol nested, bool isElement) =>
+        Diagnostic.Create(
+            UnreachableNestedConstraintsDescriptor,
+            property.Locations.Length > 0 ? property.Locations[0] : Location.None,
+            owner.Name,
+            property.Name,
+            isElement ? "element" : "member",
+            nested.Name);
+
+    /// <summary>
     /// Reports <see cref="RequiredValueTypeCannotBeMissedDescriptor"/> against the member.
     /// </summary>
     /// <remarks>

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteBindingDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteBindingDiagnosticsTests.cs
@@ -1,0 +1,163 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// A route token that binds nothing, beside a parameter that fell onto the request body because of
+/// it.
+///
+/// <para>
+/// CS-09. <c>[Get("/{eventid}")]</c> against a parameter called <c>eventId</c> built with zero
+/// warnings and answered 400 "input does not contain any JSON tokens" to every request, from a
+/// route that matched perfectly. Both lists are in the generator's hand.
+/// </para>
+/// </summary>
+public class RouteBindingDiagnosticsTests {
+    private const string DiagnosticId = "HRDR005";
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)   // Hardened.Requests.Abstract
+    ];
+
+    private static GeneratorResult Generate(string verb, string route, string parameters) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Test.cs"] = $$"""
+                    using Hardened.Requests.Abstract.Attributes;
+                    using Hardened.Shared.Runtime.Attributes;
+                    using Hardened.Web.Runtime.Attributes;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    public partial class TestApplication { }
+
+                    public class EventBody {
+                        public string Title { get; set; } = "";
+                    }
+
+                    public class EventController {
+                        [{{verb}}("{{route}}")]
+                        public string Handle({{parameters}}) => "";
+                    }
+                    """
+            },
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors);
+
+    private static Diagnostic Reported(string verb, string route, string parameters) {
+        var result = Generate(verb, route, parameters);
+
+        var diagnostic = result.GeneratorDiagnostics
+            .SingleOrDefault(reported => reported.Id == DiagnosticId);
+
+        Assert.True(diagnostic != null,
+            $"'{verb} {route}' with '{parameters}' reported no {DiagnosticId}. Reported: " +
+            string.Join(", ", result.GeneratorDiagnostics.Select(reported => reported.Id)));
+
+        return diagnostic!;
+    }
+
+    private static void NotReported(string verb, string route, string parameters) {
+        Assert.DoesNotContain(
+            Generate(verb, route, parameters).GeneratorDiagnostics,
+            reported => reported.Id == DiagnosticId);
+    }
+
+    /// <summary>The trial's exact repro.</summary>
+    [Fact]
+    public void ATokenDifferingOnlyByCaseIsAnError() {
+        Assert.Equal(
+            DiagnosticSeverity.Error,
+            Reported("Get", "/events/{eventid}", "string eventId").Severity);
+    }
+
+    /// <summary>
+    /// The message names both identifiers and says which way to fix it. Naming only the token
+    /// leaves the reader to spot a difference of one character.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesBothIdentifiersAndTheCaseDifference() {
+        var message = Reported("Get", "/events/{eventid}", "string eventId").GetMessage();
+
+        Assert.Contains("{eventid}", message);
+        Assert.Contains("eventId", message);
+        Assert.Contains("only by case", message);
+        Assert.Contains("EventController", message);
+        Assert.Contains("Handle", message);
+    }
+
+    /// <summary>
+    /// A case difference is never intentional, so the verb does not matter - a PUT with the same
+    /// typo silently takes two readings of one body.
+    /// </summary>
+    [Fact]
+    public void ACaseDifferenceIsReportedOnABodyCarryingVerbToo() {
+        Assert.Equal(
+            DiagnosticSeverity.Error,
+            Reported("Put", "/events/{eventid}", "string eventId, EventBody body").Severity);
+    }
+
+    /// <summary>
+    /// A misspelling that is not merely a case difference reaches the same place, and the message
+    /// says what the verb costs it.
+    /// </summary>
+    [Fact]
+    public void AMisspeltTokenOnABodylessVerbIsAnError() {
+        var message = Reported("Get", "/events/{eventKey}", "string eventId").GetMessage();
+
+        Assert.Contains("{eventKey}", message);
+        Assert.Contains("eventId", message);
+        Assert.Contains("carries none", message);
+        Assert.Contains("FromQueryString", message);
+    }
+
+    [Theory]
+    [InlineData("Get", "/events/{eventId}", "string eventId")]
+    [InlineData("Get", "/events/{eventId}/holds/{holdId}", "string eventId, string holdId")]
+    [InlineData("Get", "/events/{*path}", "string path")]
+    [InlineData("Get", "/events/{eventId:int}", "int eventId")]
+    [InlineData("Get", "/events", "")]
+    [InlineData("Post", "/events", "EventBody body")]
+    [InlineData("Post", "/events/{eventId}", "string eventId, EventBody body")]
+    public void ARouteThatBindsWhatItDeclaresIsNotReported(
+        string verb, string route, string parameters) {
+        NotReported(verb, route, parameters);
+    }
+
+    /// <summary>
+    /// A GET that reads nothing from the body has nothing to report, however its tokens are spelt -
+    /// which is what a token declared in a shared base path and used by only some handlers under it
+    /// looks like.
+    /// </summary>
+    [Fact]
+    public void AnUnboundTokenWithNoBodyParameterIsNotReported() {
+        NotReported("Get", "/events/{eventId}/holds/{holdId}", "string eventId");
+    }
+
+    /// <summary>
+    /// A parameter the author placed by hand is where the author put it, and the token that binds
+    /// nothing has nowhere else to have sent it.
+    /// </summary>
+    [Fact]
+    public void AParameterBoundFromTheQueryStringIsNotABodyRead() {
+        NotReported("Get", "/events/{eventKey}", "[FromQueryString(\"page\")] int page");
+    }
+
+    /// <summary>
+    /// The handler is still emitted, for the reason an unsupported token leaves it emitted: the
+    /// routing table would otherwise point at a class that was never written, burying the one
+    /// diagnostic that says what is wrong.
+    /// </summary>
+    [Fact]
+    public void TheHandlerIsStillEmitted() {
+        var result = Generate("Get", "/events/{eventid}", "string eventId");
+
+        Assert.Contains(result.GeneratedSources.Keys, key => key.Contains("EventController_Handle"));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteTokenSyntaxTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/RouteTokenSyntaxTests.cs
@@ -66,6 +66,10 @@ public class RouteTokenSyntaxTests {
     [Theory]
     [InlineData("/items/{id?}")]
     [InlineData("/items/{id=5}")]
+    [InlineData("/items/{id")]
+    [InlineData("/items/}")]
+    [InlineData("/items/{}")]
+    [InlineData("/items/{id}/parts/{id}")]
     public void AnUnsupportedTokenFormIsAnError(string route) {
         Assert.Equal(DiagnosticSeverity.Error, Reported(route).Severity);
     }
@@ -77,6 +81,8 @@ public class RouteTokenSyntaxTests {
     [Theory]
     [InlineData("/items/{id?}", "{id?}")]
     [InlineData("/items/{id=5}", "{id=5}")]
+    [InlineData("/items/{id", "{id")]
+    [InlineData("/items/{}", "{}")]
     public void TheMessageNamesTheTokenAsWritten(string route, string token) {
         Assert.Contains(token, Reported(route).GetMessage());
     }
@@ -132,4 +138,61 @@ public class RouteTokenSyntaxTests {
 
         Assert.Contains(result.GeneratedSources.Keys, key => key.Contains("ItemController_ItemById"));
     }
+
+    #region a template that is not well formed
+
+    /// <summary>
+    /// CS-12. <c>[Get("/{eventId")]</c> built with zero warnings: the unclosed token was matched as
+    /// literal text, so the route answered nothing anybody sent, and the parameter it was written
+    /// to bind was read from the request body instead.
+    /// </summary>
+    [Fact]
+    public void AnUnclosedTokenSaysWhatItCostsAndHowToFixIt() {
+        var message = Reported("/items/{id").GetMessage();
+
+        Assert.Contains("no partner", message);
+        Assert.Contains("literal text", message);
+    }
+
+    /// <summary>
+    /// A closing brace with no opening one is the same mistake seen from the other end.
+    /// </summary>
+    [Fact]
+    public void AStrayClosingBraceIsReported() {
+        Assert.Equal(DiagnosticSeverity.Error, Reported("/items/}").Severity);
+    }
+
+    /// <summary>
+    /// A token with no name is not a token. It binds nothing and matches one segment of anything.
+    /// </summary>
+    [Theory]
+    [InlineData("/items/{}")]
+    [InlineData("/items/{:int}")]
+    public void AnUnnamedTokenIsReported(string route) {
+        Assert.Contains("binds nothing", Reported(route).GetMessage());
+    }
+
+    /// <summary>
+    /// One name declared twice cannot bind one parameter twice, so only one of the two segments a
+    /// request sends ever reaches it.
+    /// </summary>
+    [Fact]
+    public void ANameDeclaredTwiceIsReported() {
+        var message = Reported("/items/{id}/parts/{id}").GetMessage();
+
+        Assert.Contains("declared twice", message);
+        Assert.Contains("distinct names", message);
+    }
+
+    /// <summary>
+    /// Two tokens that differ are not a duplicate, which is the ordinary shape of a nested route.
+    /// </summary>
+    [Fact]
+    public void TwoDistinctTokensAreNotADuplicate() {
+        Assert.DoesNotContain(
+            Generate("/items/{id}/parts/{partId}").GeneratorDiagnostics,
+            reported => reported.Id == DiagnosticId);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Seven merged pull requests never reached `main`.

Each was merged into `response-default`, a long-lived branch that accumulated the work order's
first two workstreams. `response-default` was then squashed into `main` as c785a1c and deleted.
The squash carried only the branch's state at the point the first eight PRs had landed; the seven
merged afterwards went with the branch. Their commits survive in the object store, which is what
this branch replays.

Nothing here is new work. Each commit is `git cherry-pick` of the merge commit GitHub already
built and you already approved, in the order they originally merged:

| PR | Item | What it does |
| --- | --- | --- |
| #230 | A4 | HRDV004 when a nested type's constraints are never reached |
| #229 | A2, A6 | HRDR005 when a route token binds nothing; strict template reading |
| #227 | B1, B3 | Deserializer failures answer the declared validation status, derived from `[Throws<T>]` |
| #228 | A1 | Principal sources registered as their scheme's closed interface are collected |
| #243 | — | README says which default is the template's and which is the framework's |
| #244 | — | `decimal` from both spellings a contract can use: `string`+`format: number`, `number`+`format: decimal` |
| #245 | — | Smithy `BigDecimal` maps to `decimal`, and the diagnostic names the member that narrowed |

The replay is not a plain revert-of-a-revert: #241 landed on `main` separately and moved the shared
generator source that #229 and #230 touch, so the two conflicting hunks resolve to `main`'s layout.

Verified on the merged result, not on the individual commits:

- `dotnet build -c Release -p:ContinuousIntegrationBuild=true` — 0 warnings, 0 errors
- `dotnet test` across the solution — 32 test projects, all passing
- `scripts/verify-templates.sh` — passes

Coverage is left to this PR's own CI run. A local summary is not comparable to CI's when sibling
`CSharpAuthor` or `ValidationModules` checkouts are present, as they are here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
