### PR TITLE
Name the service parameter the body convention took

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -121,6 +121,31 @@ framework's own `AspNetCoreRuntime` is one.
 
 One report per assembly, not one per route: there is a single thing to fix.
 
+### HRDR007 — service parameter binds from the request body
+
+A handler parameter typed as its concrete class rather than the interface it is registered against.
+
+```
+Parameter 'store' of 'EventController.Handle' is read from the request body. A parameter that names
+no route token and is not an interface binds from the body, and 'EventStore' has no constructor
+that does not take one, so no body can be read into it. Mark 'store' [FromServices], or type it as
+the interface it is registered against.
+```
+
+The convention is that a parameter naming no route token and typed as an interface comes from the
+container, and anything else is the body. Typing a service as its implementing class therefore
+makes it the body parameter, and the build fails as a `CS7036` inside `obj/**/generated/**` — in a
+file the author did not write, naming neither the convention that decided this nor the parameter
+whose meaning changed.
+
+Reported narrowly, because the two shapes are otherwise indistinguishable: a body model is a
+concrete class too. What separates them is that the deserializer cannot construct an interface, so
+a type whose every public constructor takes one has no reading as a body at all. A body model with
+a parameterless constructor, and an immutable one whose constructor takes its own data, are left
+alone — as is a service the deserializer could construct, which arrives empty instead. Both fixes
+in the message work; `[FromServices]` is the one that does not require the service to have an
+interface.
+
 ## Validation
 
 ### HRDV004 — nested constraints are never reached

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RequestParameterInformationTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RequestParameterInformationTests.cs
@@ -1,0 +1,67 @@
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Requests;
+
+public class RequestParameterInformationTests {
+
+    private static RequestParameterInformation Body(bool requiresServices = false) =>
+        new(TypeDefinition.Get("TestApp", "EventStore"),
+            "store", true, null, ParameterBindType.Body, "store", 0,
+            constructorRequiresServices: requiresServices);
+
+    /// <summary>
+    /// <c>ConstructorRequiresServices</c> rides on the model, so an edit to the type's constructor
+    /// has to break the model's equality. Left out, the cached model keeps the old answer and
+    /// HRDR007 comes and goes with whatever else forced a regeneration.
+    /// </summary>
+    [Fact]
+    public void AServiceShapedBodyDoesNotCompareEqualToAnOrdinaryOne() {
+        var body = Body();
+        var service = new RequestParameterInformation(
+            TypeDefinition.Get("TestApp", "EventStore"),
+            "store", true, null, ParameterBindType.Body, "store", 0,
+            constructorRequiresServices: true);
+
+        Assert.NotEqual(body, service);
+        Assert.NotEqual(body.GetHashCode(), service.GetHashCode());
+    }
+
+    /// <summary>
+    /// Reordering rebuilds every parameter, so the copy has to carry everything the original held.
+    /// It did not, and the parameter that reached the handler stage said its type was an ordinary
+    /// body - which turned HRDR007 off for exactly the handlers it exists to report.
+    /// </summary>
+    [Fact]
+    public void ReindexingCarriesEveryProperty() {
+        var original = new RequestParameterInformation(
+            TypeDefinition.Get("TestApp", "EventStore"),
+            "store", true, "5", ParameterBindType.QueryString, "wire", 0,
+            constructorRequiresServices: true) {
+            Description = "prose"
+        };
+
+        var moved = original.WithIndex(3);
+
+        Assert.Equal(3, moved.ParameterIndex);
+        Assert.Equal(original.ParameterType, moved.ParameterType);
+        Assert.Equal(original.Name, moved.Name);
+        Assert.Equal(original.Required, moved.Required);
+        Assert.Equal(original.DefaultValue, moved.DefaultValue);
+        Assert.Equal(original.BindingType, moved.BindingType);
+        Assert.Equal(original.BindingName, moved.BindingName);
+        Assert.Equal(original.CustomAttribute, moved.CustomAttribute);
+        Assert.Equal(original.Description, moved.Description);
+        Assert.True(moved.ConstructorRequiresServices);
+    }
+
+    [Fact]
+    public void TwoParametersAgreeingOnItCompareEqual() {
+        var left = Body(true);
+        var right = Body(true);
+
+        Assert.Equal(left, right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestParameterInformation.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestParameterInformation.cs
@@ -13,7 +13,12 @@ public class RequestParameterInformation {
         ParameterBindType bindingType,
         string bindingName,
         int parameterIndex,
-        AttributeModel? customAttribute = null) {
+        AttributeModel? customAttribute = null,
+        bool constructorRequiresServices = false) {
+        ConstructorRequiresServices = constructorRequiresServices;
+
+
+
         ParameterType = parameterType;
         Name = name;
         Required = required;
@@ -60,9 +65,46 @@ public class RequestParameterInformation {
     /// </remarks>
     internal ParameterModel? SpecParameter { get; set; }
 
+    /// <summary>
+    /// Whether every public constructor of <see cref="ParameterType"/> takes an interface.
+    /// </summary>
+    /// <remarks>
+    /// Recorded at the syntax transform, where the semantic model is in hand, and read at the
+    /// output stage, where a diagnostic can be reported. A type shaped like that has no reading as
+    /// a request body: the deserializer cannot construct an interface, so a body parameter typed
+    /// this way is a service the author meant to inject. Same carry-forward as
+    /// <see cref="ParameterBindType.Unresolved"/>, for the same reason - a syntax provider cannot
+    /// report a diagnostic.
+    /// </remarks>
+    public bool ConstructorRequiresServices { get; }
+
     public int ParameterIndex {
         get;
     }
+
+    /// <summary>
+    /// The same parameter at a different position, with everything else carried across.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the reason <c>RequestHandlerModel.WithFilters</c> does. Rebuilt by hand this
+    /// dropped the parameter's prose, its contract declaration and whether its type can only be
+    /// constructed from services, and nothing failed when it did - the last of those silently
+    /// turned off the diagnostic that reports it. Adding a property here is now the only place that
+    /// has to change.
+    /// </remarks>
+    public RequestParameterInformation WithIndex(int parameterIndex) =>
+        new(ParameterType,
+            Name,
+            Required,
+            DefaultValue,
+            BindingType,
+            BindingName,
+            parameterIndex,
+            CustomAttribute,
+            ConstructorRequiresServices) {
+            Description = Description,
+            SpecParameter = SpecParameter
+        };
 
     public override bool Equals(object obj) {
         if (obj is not RequestParameterInformation requestParameterInformation) {
@@ -109,6 +151,10 @@ public class RequestParameterInformation {
             return false;
         }
 
+        if (ConstructorRequiresServices != requestParameterInformation.ConstructorRequiresServices) {
+            return false;
+        }
+
         return true;
     }
 
@@ -128,6 +174,8 @@ public class RequestParameterInformation {
             if (CustomAttribute is not null) {
                 hashCode = (hashCode * 397) ^ CustomAttribute.GetHashCode();
             }
+
+            hashCode = (hashCode * 397) ^ ConstructorRequiresServices.GetHashCode();
             
             return hashCode;
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -452,7 +452,62 @@ public abstract class BaseRequestModelGenerator {
                 ParameterBindType.Path,parameterIndex);
         }
 
-        return CreateRequestParameterInformation(parameter, parameterType, ParameterBindType.Body,parameterIndex);
+        return CreateRequestParameterInformation(
+            parameter, parameterType, ParameterBindType.Body, parameterIndex,
+            constructorRequiresServices: ConstructorRequiresServices(generatorSyntaxContext, parameter));
+    }
+
+    /// <summary>
+    /// Whether the type has public constructors and every one of them takes an interface.
+    /// </summary>
+    /// <remarks>
+    /// Asked only of a parameter that has fallen to the body, and answered from the semantic model
+    /// because the syntax alone cannot say what a name resolves to. The rule is narrow on purpose:
+    /// the deserializer cannot construct an interface, so a type whose every constructor demands
+    /// one can never be read from a request body, whatever the author intended. A body model with
+    /// a parameterless constructor, and an immutable one whose constructor takes its own data, both
+    /// fail the test and are left alone.
+    /// </remarks>
+    private static bool ConstructorRequiresServices(
+        GeneratorSyntaxContext generatorSyntaxContext,
+        ParameterSyntax parameter) {
+        if (parameter.Type == null) {
+            return false;
+        }
+
+        if (generatorSyntaxContext.SemanticModel.GetTypeInfo(parameter.Type).Type
+            is not INamedTypeSymbol type) {
+            return false;
+        }
+
+        if (type.TypeKind != TypeKind.Class || type.IsAbstract || type.IsRecord) {
+            return false;
+        }
+
+        var constructors = 0;
+
+        foreach (var constructor in type.InstanceConstructors) {
+            if (constructor.DeclaredAccessibility != Accessibility.Public) {
+                continue;
+            }
+
+            constructors++;
+
+            var takesService = false;
+
+            foreach (var constructorParameter in constructor.Parameters) {
+                if (constructorParameter.Type.TypeKind == TypeKind.Interface) {
+                    takesService = true;
+                    break;
+                }
+            }
+
+            if (!takesService) {
+                return false;
+            }
+        }
+
+        return constructors > 0;
     }
 
     public static RequestParameterInformation CreateRequestParameterInformation(
@@ -462,7 +517,8 @@ public abstract class BaseRequestModelGenerator {
         int parameterIndex,
         bool? required = null,
         string? bindingName = null,
-        AttributeModel? customAttribute = null) {
+        AttributeModel? customAttribute = null,
+        bool constructorRequiresServices = false) {
         if (!parameterType.IsNullable && parameter.ToFullString().Contains("?")) {
             parameterType = parameterType.MakeNullable();
         }
@@ -481,7 +537,8 @@ public abstract class BaseRequestModelGenerator {
             parameterBindType,
             bindingName ?? string.Empty,
             parameterIndex,
-            customAttribute);
+            customAttribute,
+            constructorRequiresServices);
     }
 
     protected abstract RequestParameterInformation? GetParameterInfoFromAttributes(

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/OperationSymbols.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/OperationSymbols.cs
@@ -59,6 +59,18 @@ public sealed class OperationSymbols {
     /// </remarks>
     public string? RequestBodyName { get; set; }
 
+    /// <summary>
+    /// Whether every public constructor of <see cref="RequestBodyType"/> takes an interface.
+    /// </summary>
+    /// <remarks>
+    /// Set only by the code-first front end, which is the only one that can be wrong about this: a
+    /// described body is whatever the description says it is, while a C# parameter becomes the body
+    /// by falling through every other branch. Carried because this builder rebuilds the parameter
+    /// list, so anything the front end worked out and did not put here is lost by the time the
+    /// handler stage reports on it.
+    /// </remarks>
+    public bool RequestBodyRequiresServices { get; set; }
+
     /// <summary>Parameter types by parameter name, for the ones already resolved.</summary>
     public Dictionary<string, ITypeDefinition>? ParameterTypes { get; set; }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -303,7 +303,8 @@ internal static class SpecHandlerModelBuilder {
                 null,
                 ParameterBindType.Body,
                 "",
-                index++));
+                index++,
+                constructorRequiresServices: symbols?.RequestBodyRequiresServices ?? false));
         } else if (operation.RequestBodyRef != null) {
             var bodyTypeName = NamingHelper.ToPascalCase(TypeMapper.GetRefName(operation.RequestBodyRef));
             var bodyType = TypeDefinition.Get(modelsNamespace, bodyTypeName);
@@ -739,9 +740,7 @@ internal static class SpecHandlerModelBuilder {
 
                 return at < 0 ? order.IndexOf(parameter.Name) : at;
             })
-            .Select((parameter, index) => new RequestParameterInformation(
-                parameter.ParameterType, parameter.Name, parameter.Required, parameter.DefaultValue,
-                parameter.BindingType, parameter.BindingName, index, parameter.CustomAttribute))
+            .Select((parameter, index) => parameter.WithIndex(index))
             .ToList();
     }
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/ServiceParameterDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/ServiceParameterDiagnostics.cs
@@ -1,0 +1,94 @@
+using Hardened.SourceGenerator.Models.Request;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Web.Routing;
+
+/// <summary>
+/// A service typed as its concrete class, read from the request body because of it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CS-08. A parameter that is not a route token and not an interface binds from the body. Typing a
+/// service as the class that implements it, rather than the interface it implements, therefore
+/// makes it the body parameter - and the build fails as a CS7036 inside
+/// <c>obj/**/generated/**</c>, in a file the author did not write, naming neither the convention
+/// that decided this nor the parameter whose meaning changed.
+/// </para>
+/// <para>
+/// The rule is narrow because the two shapes are otherwise indistinguishable: a body model is a
+/// concrete class too. What separates them is that the deserializer cannot construct an interface,
+/// so a type whose every public constructor takes one has no reading as a body at all. That test
+/// is made at the syntax transform, where the semantic model is in hand, and carried on
+/// <see cref="RequestParameterInformation.ConstructorRequiresServices"/>.
+/// </para>
+/// </remarks>
+public static class ServiceParameterDiagnostics {
+
+    /// <summary>
+    /// <c>HRDR007</c>. <c>HRDR005</c> reports a parameter displaced onto the body by a route token;
+    /// this reports one that landed there because of its type.
+    /// </summary>
+    public const string DiagnosticId = "HRDR007";
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the reason
+    /// <c>RouteBindingDiagnostics.Descriptor</c> is: RS2008 looks for the field, and these projects
+    /// set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "Service parameter binds from the request body",
+        messageFormat:
+            "Parameter '{0}' of '{1}.{2}' is read from the request body. {3}",
+        category: "Hardened.Routing",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Every body parameter whose type can only be constructed from services.
+    /// </summary>
+    /// <remarks>
+    /// Split from <see cref="Report"/> for the reason <c>RouteBindingDiagnostics.Find</c> is: a
+    /// <c>SourceProductionContext</c> only exists inside a running generator, and the decision is
+    /// worth testing on its own.
+    /// </remarks>
+    public static IReadOnlyList<RequestParameterInformation> Find(RequestHandlerModel model) {
+        List<RequestParameterInformation>? found = null;
+
+        foreach (var parameter in model.RequestParameterInformationList) {
+            if (parameter.BindingType == ParameterBindType.Body &&
+                parameter.ConstructorRequiresServices) {
+                (found ??= new List<RequestParameterInformation>()).Add(parameter);
+            }
+        }
+
+        return (IReadOnlyList<RequestParameterInformation>?)found
+               ?? Array.Empty<RequestParameterInformation>();
+    }
+
+    /// <summary>
+    /// What to tell the author. Built here rather than in the message format so it can name the
+    /// type as well as the parameter.
+    /// </summary>
+    public static string Advice(RequestParameterInformation parameter) =>
+        $"A parameter that names no route token and is not an interface binds from the body, and " +
+        $"'{parameter.ParameterType.Name}' has no constructor that does not take one, so no body " +
+        $"can be read into it. Mark '{parameter.Name}' [FromServices], or type it as the " +
+        $"interface it is registered against.";
+
+    /// <summary>Reports every finding, if the handler has any.</summary>
+    public static void Report(SourceProductionContext context, RequestHandlerModel model) {
+        foreach (var parameter in Find(model)) {
+            // Location.None, as everywhere else models are reported from: a syntax location would
+            // travel with the model through the incremental caches, which compare models for
+            // equality to decide whether to regenerate.
+            context.ReportDiagnostic(Diagnostic.Create(
+                Descriptor(),
+                Location.None,
+                parameter.Name,
+                model.ControllerType.Name,
+                model.HandlerMethod,
+                Advice(parameter)));
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
@@ -53,6 +53,10 @@ public class WebExecutionHandlerCodeGenerator {
         // and routes, and refuses every request once it is running.
         RouteBindingDiagnostics.Report(sourceProductionContext, requestHandlerModel);
 
+        // And again: a service typed as its concrete class binds from the body, which compiles
+        // here and fails in the serializer the emitted code calls into.
+        ServiceParameterDiagnostics.Report(sourceProductionContext, requestHandlerModel);
+
         var sourceFile = GenerateFile(requestHandlerModel, sourceProductionContext.CancellationToken, excludeFromCoverage);
 
         sourceProductionContext.AddSource(requestHandlerModel.InvokeHandlerType.Name, GeneratedSource.Header(sourceFile));

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
@@ -389,6 +389,7 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
                 ResponseInformation = response,
                 RequestBodyType = body?.ParameterType,
                 RequestBodyName = body?.Name,
+                RequestBodyRequiresServices = body?.ConstructorRequiresServices ?? false,
                 ParameterOrder = parameters.OrderBy(p => p.ParameterIndex).Select(Wire).ToList(),
                 ParameterTypes = described.ToDictionary(Wire, p => p.ParameterType, StringComparer.Ordinal),
                 ParameterBindings = described.ToDictionary(Wire, p => p.BindingType, StringComparer.Ordinal),

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/ServiceParameterDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/ServiceParameterDiagnosticsTests.cs
@@ -1,0 +1,111 @@
+using CSharpAuthor;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// A service typed as its concrete class, and the request body it silently became.
+///
+/// <para>
+/// CS-08. The build failed as a CS7036 in a generated file, one hop from the parameter that
+/// changed meaning and naming neither it nor the convention that decided it.
+/// </para>
+/// </summary>
+public class ServiceParameterDiagnosticsTests {
+    private const string DiagnosticId = "HRDR007";
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)   // Hardened.Requests.Abstract
+    ];
+
+    private static GeneratorResult Generate(string types, string parameters) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Test.cs"] = $$"""
+                    using Hardened.Requests.Abstract.Attributes;
+                    using Hardened.Shared.Runtime.Attributes;
+                    using Hardened.Web.Runtime.Attributes;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    public partial class TestApplication { }
+
+                    public interface IClock { }
+
+                    {{types}}
+
+                    public class EventController {
+                        [Post("/events")]
+                        public string Handle({{parameters}}) => "";
+                    }
+                    """
+            },
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors);
+
+    private static Diagnostic? Reported(string types, string parameters) =>
+        Generate(types, parameters).GeneratorDiagnostics
+            .SingleOrDefault(reported => reported.Id == DiagnosticId);
+
+    private const string Store = """
+        public class EventStore {
+            public EventStore(IClock clock) { }
+        }
+        """;
+
+    [Fact]
+    public void AConcreteServiceParameterIsReported() {
+        var diagnostic = Reported(Store, "EventStore store");
+
+        Assert.NotNull(diagnostic);
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    /// <summary>
+    /// The message has to carry what the generated file could not: which parameter, which type,
+    /// which convention, and both ways out.
+    /// </summary>
+    [Fact]
+    public void TheMessageNamesTheParameterTheTypeAndBothFixes() {
+        var message = Reported(Store, "EventStore store")!.GetMessage();
+
+        Assert.Contains("'store'", message);
+        Assert.Contains("EventStore", message);
+        Assert.Contains("EventController", message);
+        Assert.Contains("Handle", message);
+        Assert.Contains("[FromServices]", message);
+        Assert.Contains("interface", message);
+    }
+
+    /// <summary>
+    /// Every shape that is a body and must stay one. A class the deserializer can construct is not
+    /// reported however many services sit beside it in the signature.
+    /// </summary>
+    [Theory]
+    // A plain body model.
+    [InlineData("public class EventBody { public string Title { get; set; } = \"\"; }",
+        "EventBody body")]
+    // An immutable body model, whose constructor takes its own data rather than a service.
+    [InlineData("public class EventBody { public EventBody(string title) { Title = title; } " +
+                "public string Title { get; } }",
+        "EventBody body")]
+    // A record, which System.Text.Json constructs through its primary constructor.
+    [InlineData("public record EventBody(string Title);", "EventBody body")]
+    // One constructor takes a service, another does not.
+    [InlineData("public class EventBody { public EventBody() { } public EventBody(IClock c) { } }",
+        "EventBody body")]
+    // The correct spelling of the reported case: still a service, no longer the body.
+    [InlineData("public class EventStore { public EventStore(IClock clock) { } }",
+        "[FromServices] EventStore store")]
+    // And the same service reached through its interface.
+    [InlineData("public interface IEventStore { }", "IEventStore store")]
+    public void AParameterThatCanBeABodyIsLeftAlone(string types, string parameters) =>
+        Assert.Null(Reported(types, parameters));
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -36,7 +36,8 @@ Change the thing it was generated from.
 | `'Application' does not contain 'PopulateServiceCollection'` | A `*.SourceGenerator` package was removed from a csproj |
 | Duplicate definitions under `obj/**/generated/` | A generator was renamed and its old output is still there. Delete `obj/`. |
 | Builds clean, every route answers 404 | The routing generator is absent. The runtime packages carry no analyzers. |
-| A handler parameter arrives empty, or `CS0128` on `contentSerializationService` | A concrete class as a handler parameter is bound from the request body. Inject an interface, or mark it `[FromServices]`. |
+| `HRDR007` on a handler parameter | A concrete class as a handler parameter is bound from the request body. Type it as an interface, or mark it `[FromServices]`. |
+| A handler parameter arrives empty, or `CS0128` on `contentSerializationService` | The same mistake with a type the deserializer can construct, so `HRDR007` does not fire. Same two fixes. |
 #if (specFirst)
 | `HOAT001` naming a contract that exists | The path in the csproj does not match the file |
 #endif
@@ -91,8 +92,9 @@ method's exact signature.
 
 **Services arrive as handler parameters**, alongside route and body values — `ITodoStore store` in
 every handler here. Ask for an interface. A parameter typed as a concrete class is bound from the
-request body instead, which on a route that also takes a body generates two body reads and does not
-compile.
+request body instead. Where the class can only be constructed from services, that is `HRDR007`;
+where the deserializer could construct it, the parameter simply arrives empty, and on a route that
+also takes a body it generates two body reads and does not compile.
 #endif
 
 ## How this application declares its responses

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -87,7 +87,8 @@ served at `/todos/{id}`. `[Get]`, `[Post]`, `[Put]`, `[Delete]` and `[Patch]` al
 way.
 
 Services arrive as parameters, and you ask for an interface. A parameter typed as a concrete class
-is bound from the request body instead. A service is registered next to the class it belongs to,
+is bound from the request body instead - `HRDR007`, where the class can only be constructed from
+services. A service is registered next to the class it belongs to,
 with `[SingletonService]`, `[ScopedService]` or `[TransientService]` - the module lists nothing, so
 it cannot fall out of step.
 #endif


### PR DESCRIPTION
A handler parameter that names no route token and is not an interface binds from the request body.
Typing a service as the class that implements it, rather than the interface it implements,
therefore makes it the body parameter. The build then fails as a `CS7036` inside
`obj/**/generated/**`, in a file the author did not write, naming neither the convention that
decided this nor the parameter whose meaning changed.

`HRDR007` reports it at the handler:

```
Parameter 'store' of 'EventController.Handle' is read from the request body. A parameter that
names no route token and is not an interface binds from the body, and 'EventStore' has no
constructor that does not take one, so no body can be read into it. Mark 'store' [FromServices],
or type it as the interface it is registered against.
```

The trigger is narrow, because the two shapes are otherwise indistinguishable: a body model is a
concrete class too. What separates them is that the deserializer cannot construct an interface, so
a type whose every public constructor takes one has no reading as a body at all. A body model with
a parameterless constructor, an immutable one whose constructor takes its own data, a record, and a
service the deserializer could construct are all left alone — there is a test for each.

**A second defect turned up while carrying the flag.** `SpecHandlerModelBuilder.Ordered` rebuilt
every parameter by hand to renumber it and carried six of the nine properties, so a reordered
parameter lost its prose, its contract declaration, and this. That is the same shape of defect
`RequestHandlerModel.WithFilters` was written to fix, and it gets the same treatment:
`RequestParameterInformation.WithIndex`, so adding a property is one place rather than two.

The template's trap table predicted `CS0128` for this case, which is what the *other* half of the
mistake produces — a service the deserializer can construct, which arrives empty. Both rows are
there now.

Covers H-17, item A7 of the work order.

Based on #247. GitHub retargets this to `main` once #247 merges. Review the last commit only.

Verified: `dotnet build -c Release -p:ContinuousIntegrationBuild=true` clean, full `dotnet test`
green across 32 test projects, `scripts/verify-templates.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
