### PR TITLE
Register each startup service once however often its module is applied

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -56,13 +56,18 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         // Always installed. It costs one call per handler at startup and returns null for a handler
         // that carries no authorization attribute, so an application that has not opted in to
         // anything pays nothing per request.
-        services.AddSingleton<IStartupService, AuthorizationStartupService>();
+        //
+        // TryAddEnumerable for the reason the CORS one is: a startup service registered twice runs
+        // twice, and this one installs a filter provider.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IStartupService, AuthorizationStartupService>());
 
         // Same footing: one resolve at startup, and no middleware at all unless something
         // registered an IPrincipalSource. Constructed over this collection rather than resolved
         // from the provider, because a source registered as IPrincipalSource<TScheme> is reachable
         // only by its closed service type and a built provider cannot be asked what those are.
-        services.AddSingleton<IStartupService>(new AuthenticationStartupService(services));
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IStartupService>(new AuthenticationStartupService(services)));
     }
 
     /// <summary>

--- a/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsStartupServiceTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Cors/CorsStartupServiceTests.cs
@@ -153,4 +153,52 @@ public class CorsStartupServiceTests {
 
         Assert.Same(provider.GetRequiredService<CorsFilter>(), provider.GetRequiredService<CorsFilter>());
     }
+
+    #region composed twice
+
+    /// <summary>
+    /// H-30. An application composing two web modules logged the "no allowed origins" notice
+    /// twice, byte-identical.
+    /// </summary>
+    /// <remarks>
+    /// The notice was the visible half. The same second registration also put a second CORS filter
+    /// in the middleware chain, so every request ran the filter twice - which is the half worth
+    /// fixing, and which a duplicated log line was the only sign of.
+    /// </remarks>
+    [Fact]
+    public void TheModuleAppliedTwiceRegistersOneStartupService() {
+        var services = new ServiceCollection();
+
+        new HardenedWebModule().ConfigureServices(services);
+        new HardenedWebModule().ConfigureServices(services);
+
+        // Named rather than typed: the startup service is internal, and these reach it the way an
+        // application does - through the module's registrations.
+        Assert.Single(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IStartupService) &&
+                          descriptor.ImplementationType?.Name == "CorsStartupService");
+    }
+
+    /// <summary>And so the filter goes into the chain once.</summary>
+    [Fact]
+    public async Task TheModuleAppliedTwiceInstallsOneFilter() {
+        var services = new ServiceCollection();
+
+        new HardenedWebModule().ConfigureServices(services);
+        new HardenedWebModule().ConfigureServices(services);
+
+        var middleware = Substitute.For<IMiddlewareService>();
+
+        services.AddSingleton(new CorsConfiguration());
+        services.AddSingleton(middleware);
+
+        var provider = services.BuildServiceProvider();
+
+        await RunStartup(provider);
+
+        middleware.Received(1).Use(Arg.Any<Func<IExecutionContext, IExecutionFilter>>());
+    }
+
+    #endregion
 }

--- a/src/Web/Hardened.Web.Runtime/DependencyInjection/HardenedWebModule.cs
+++ b/src/Web/Hardened.Web.Runtime/DependencyInjection/HardenedWebModule.cs
@@ -35,7 +35,13 @@ public partial class HardenedWebModule : IServiceCollectionConfiguration {
             return config;
         });
         services.AddSingleton<CorsFilter>();
-        services.AddSingleton<IStartupService, CorsStartupService>();
+
+        // TryAddEnumerable rather than Add: a startup service registered twice runs twice, and this
+        // one puts the CORS filter in the middleware chain - so a second registration is a second
+        // filter on every request, with the "no allowed origins" notice logged beside it once per
+        // copy. An application composing two web modules saw both.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IStartupService, CorsStartupService>());
 
         services.TryAddSingleton<HealthCheckConfiguration>();
 


### PR DESCRIPTION
An application composing two web modules logged the "CORS has no allowed origins" notice twice,
byte-identical. The notice was the visible half. The same second registration also put a second
CORS filter in the middleware chain, so every request ran the filter twice, and the duplicated
log line was the only sign of it.

`AddSingleton` on a multi-registration service adds a registration every time it runs.
`TryAddEnumerable` deduplicates on the pair of service type and implementation type, which is
what a startup service wants: two copies of one are never the intent, and both of them install
something.

The authorization and authentication startup services beside it get the same treatment for the
same reason. One installs a filter provider, the other the authentication middleware.

Covers H-27, item B6 of the work order.

Replaces #248, which was opened against a topic branch instead of `main` and was closed when that
branch was deleted. Same commit, rebased onto `main`.

Verified on `main`: `dotnet build -c Release -p:ContinuousIntegrationBuild=true` clean with zero
warnings, full `dotnet test` green across 32 test projects. The new test asserts a second
`ConfigureServices` adds no second descriptor, and fails without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
