### PR TITLE
Close the response-cache defects the 0.19.0-rc1000 trial found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,5 +164,5 @@ function runtimes do not reference it.
 - `docs/generator-diagnostics.md` — every diagnostic the generators raise
 - `docs/described-authorization.md` — what a contract's `security` becomes
 - `docs/validation-usage.md` — constraints, custom validators, the error response
-- `docs/response-caching.md` — `[CacheResponse<T>]`, the store package, what is never cached
+- `docs/response-caching.md` — `[CacheResponse<T>]`, the store package, who a stored answer is for, invalidating by tag
 - Full user documentation: <https://ipjohnson.github.io/Hardened.Docs>

--- a/docs/response-caching.md
+++ b/docs/response-caching.md
@@ -22,9 +22,15 @@ exactly what a trimmer cannot remove, so registering one unconditionally would p
 public partial class Application { }
 ```
 
-Without a store, the first request to a handler declaring `[CacheResponse]` fails with
-`ResponseCacheStoreMissingException` naming the handler. The attribute never silently does
-nothing.
+Without a store, a request to a handler declaring `[CacheResponse]` fails with
+`ResponseCacheStoreMissingException` naming the handler, the package to reference and the attribute
+to add. The attribute never silently does nothing.
+
+The failure is recorded on the response and the chain continues, which is the rule for everything
+ahead of `FilterOrder.Serialization`: the filter that turns a failure into bytes is behind this
+stage, so throwing here unwound past it and answered a 500 with `Content-Length: 0`. The caller
+gets the framework's error envelope like any other server fault, and the message naming the handler
+goes to the log, where an unexpected 500's detail belongs.
 
 ## Declaring it
 
@@ -43,6 +49,9 @@ reached the handler.
 
 `Duration` is in seconds. Omitting it means 60, which is what ASP.NET Core's output cache
 defaults to.
+
+`Scope` says who a stored response may be served to, and a handler that requires anything of its
+caller has to set it. See [Who the answer is for](#who-the-answer-is-for).
 
 ### The strategies in the box
 
@@ -100,8 +109,9 @@ The parts compose into one key, in the order they were declared, and the handler
 rather than one per attribute. `[OutputCache]` is `AllowMultiple = false` and cannot compose at
 all; you write one policy that does everything.
 
-`Duration` may appear on more than one attribute. The first that sets one wins, and two that
-disagree fail as the chain is built, naming the handler.
+`Duration` and `Scope` may each appear on more than one attribute. The first that sets one wins,
+and two that disagree fail as the chain is built, naming the handler. `Tags` accumulate instead:
+every declaration's tags name the one entry, deduped.
 
 ## Applying it everywhere
 
@@ -118,24 +128,100 @@ so explicit beats convention without the registration site saying so.
 than a plain `AddSingleton`: applied to one handler an attribute is read beside the code it
 guards, and applied to every handler nobody read anything.
 
+## Who the answer is for
+
+```csharp
+[Get("/alerts/{alertId}")]
+[Authorize]
+[CacheResponse<VaryByRoute>(Duration = 60, Scope = CacheScope.PerCaller)]
+public Alert Read(string alertId) => _alerts.OwnedBy(_caller.Principal.Subject, alertId);
+```
+
+`CacheScope.PerCaller` puts the caller's issuer and subject in the key, so one caller's answer can
+never be handed to another whatever the handler put in it. `CacheScope.AllCallers` is one entry
+shared by whoever the guard admits, which is what an authorized read of something public wants.
+
+**A handler that requires anything of its caller and states neither fails, naming the handler.** Not
+because the framework cannot pick a default, but because both defaults are wrong. Sharing the entry
+leaks one caller's data the moment the answer depends on who asked; keying per caller is safe and
+silently turns one shared entry into one per caller, so a cache added to shed load stops shedding
+it and grows with the caller count instead.
+
+Nothing on the handler separates the two cases. "Every caller holding `rates:read` gets these same
+bytes" and "each caller gets their own" are both authenticated reads with a grant requirement, and
+the difference is in what the handler does with the caller. A handler that requires nothing of its
+caller states nothing: it has one audience already.
+
+This replaces a rule that read `Requirement.RequiresContext` and claimed a resource-scoped handler
+was never cached. That property is true only for a requirement built from `Requirement.Predicate`,
+and false for grants and for `Authenticated()` — so it covered a shape almost nobody writes and
+missed the two everybody does. An owner-scoped read whose ownership check is handler code answering
+404, which is what a description forces because it can require authentication and cannot require
+ownership, was cached and served to the next caller.
+
+## Invalidating
+
+```csharp
+[Get("/rates/{symbol}")]
+[CacheResponse<VaryByRoute>(Duration = 3600, Tags = ["rates"])]
+public Rate Read(string symbol) => _rates.Latest(symbol);
+```
+
+```csharp
+public async Task Publish(RateSet set, CancellationToken cancellationToken) {
+    await _rates.Save(set, cancellationToken);
+    await _store.EvictByTag("rates", cancellationToken);
+}
+```
+
+`IResponseCacheStore.EvictByTag` drops every entry stored under the tag. Inject the store where you
+change what a cached read reads; without this an application's only way to reach its own entries is
+to wait for them to expire, so a publish is visible within the cache lifetime and never sooner.
+
+A tag rather than a key. The key is the handler's `METHOD path`, a unit separator, the caller when
+the scope is per-caller, and then each strategy's part — a shape nothing publishes and an
+application should not have to rebuild to invalidate its own entries. Composed attributes
+contribute to one set of tags, deduped, in the order they were declared.
+
+Group invalidation is the reason this is `IResponseCacheStore` rather than `IDistributedCache`,
+which has no atomic operation to do it with. A store that cannot do it atomically should still do
+it: entries dropped one at a time is a worse guarantee than all at once, and both are better than a
+publish nobody can see.
+
 ## What is not cached
 
 **A handler whose authorization reads the request.** The filter runs at
 `FilterOrder.ResponseCache`, which is after authorization over grants alone and before
-authorization that reads bound parameters. A stored answer to "may this caller edit *this* pet"
-served to a second caller is a data leak, so the filter is not installed at all — decided once per
-handler from `IExecutionRequestHandlerInfo.Requirement.RequiresContext`. A requirement over grants
-alone settles ahead of the cache and is cached normally.
+authorization that reads bound parameters — so such a requirement does not run on a hit at all, and
+keying per caller would not make it run. The filter is not installed, decided once per handler from
+`Requirement.RequiresContext`.
 
 ASP.NET Core ships the same hazard as a documentation note telling you to call `UseOutputCache`
 after `UseAuthorization`, and the failure is silent.
 
+**A request something already refused.** Authorization and rate limiting sit ahead of this stage
+and refuse by recording the failure and continuing, because the filter that writes a refusal is
+behind them. So a refused request arrives here still travelling, and the cache reads what they
+recorded rather than treating that as permission. It is neither answered from the store nor stored.
+
 **Anything that is not a 200.** A 404 or a 500 is about the moment rather than the resource, and a
 redirect or a 304 carries its meaning in headers this does not model.
 
-**`Set-Cookie`.** Stripped as a response is captured, not as one is replayed, so a store written by
-an older build cannot leak one either. Every other response header is replayed as it was sent,
-which is what carries `Cache-Control`, `ETag` and `Vary` onto a hit.
+## What headers a hit carries
+
+A stored entry holds what this representation is, not what its first request was. Three kinds of
+header are dropped as a response is captured — not as one is replayed, so a store written by an
+older build cannot leak one either:
+
+| Dropped | Why |
+|---|---|
+| `Set-Cookie` | Belongs to a caller. Replaying one hands a second caller the first one's session. |
+| `Transfer-Encoding`, `Connection`, `Keep-Alive`, `TE`, `Trailer`, `Upgrade`, `Proxy-Authenticate`, `Proxy-Authorization`, `Content-Length`, `Date`, `Server` | Belong to a connection or to a moment. A host frames a body with no `Content-Length` as chunked and says so on the response; an entry that kept that header re-declared chunked framing on the hit and then wrote the stored bytes unframed, which is a malformed response on every socket. |
+| Anything the response already carried on the way in | Belongs to this request. Whatever wrote it sits ahead of this stage and runs on a hit as well, so its own value is already there — and storing one froze the first caller's `X-Correlation-Id`, and the first request's `RateLimit-Remaining`, onto everyone else for the whole duration. A header the chain *changed* is kept, because a miss would have changed it the same way. |
+
+What is left is what the handler and the filters inside the cache produced, which is what carries
+`Cache-Control` and `ETag` onto a hit. `Vary` reaches a hit because `VaryByHeader` writes it while
+composing the key, on every request.
 
 ## What it stores
 
@@ -157,7 +243,8 @@ or an external call, and worth nothing when the handler is cheap.
 the moment a caller does pass a tenant or a user id, it is in the payload.
 
 `MemoryCache` is not timer-driven in .NET 8 and checks expiry on read, so the store stays correct
-across a freeze of any length; only reclamation happens late.
+across a freeze of any length; only reclamation happens late. The in-process store decides validity
+on its own `TimeProvider` as well, so a frozen environment and a test both see the same rule.
 
 ## Configuration
 
@@ -173,11 +260,27 @@ rather than on `[HardenedMemoryResponseCache]` because DependencyModules unwraps
 it generates a module attribute, so a `long?` becomes a `long` and would be copied onto the module
 as `0` for anyone who wrote the attribute with no arguments.
 
+## Testing a duration
+
+`[HardenedMemoryResponseCache]` registers `TimeProvider.System` with `TryAddSingleton`, and the
+in-process store decides on it whether an entry is still valid. Register a `TimeProvider` of your
+own and a test moves time instead of waiting for it:
+
+```csharp
+services.AddSingleton<TimeProvider>(clock);   // before the module, or it keeps yours either way
+
+await app.Get("/rates/EUR");
+clock.Advance(TimeSpan.FromHours(2));         // a day-long entry, tested in a millisecond
+```
+
+`MemoryCache`'s own absolute expiration is still set and still runs on the machine clock. That one
+decides when the memory is freed, not what a request is answered with.
+
 ## Not built
 
-- **Tag-based invalidation.** Nothing can say "drop every cached response touching pet 7". ASP.NET
-  Core has `Tags` and `IOutputCacheStore.EvictByTagAsync`; Symfony pushes tags out to Varnish,
-  Fastly and Cloudflare. It is orthogonal to the key design and is the next thing to decide.
+- **Per-resource invalidation.** A tag names a handler's entries, not a row: "drop every cached
+  response touching pet 7" needs the tag to carry the id, which means the declaration cannot be a
+  constant. ASP.NET Core has the same shape and the same limit.
 - **Stampede protection.** ASP.NET Core locks per resource so a cold key is computed once. Here,
   *n* concurrent misses run the handler *n* times and the last one wins.
 - **Conditional GET.** `EntityTagHeader` can format and weakly compare validators and nothing reads

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
@@ -1,4 +1,6 @@
 using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Runtime.Caching;
+using Hardened.Requests.Testing;
 using Microsoft.Extensions.Primitives;
 
 namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
@@ -141,9 +143,73 @@ public class ResponseCacheTests {
         Assert.NotEqual(await warm.ReadTextAsync(), await grantless.ReadTextAsync());
     }
 
+    /// <summary>
+    /// The defect all three trial arms found: a second subscriber served the first subscriber's
+    /// row, with a 200.
+    /// </summary>
+    /// <remarks>
+    /// The guard the framework read was <c>Requirement.RequiresContext</c>, true only for a
+    /// requirement built from a predicate. An ownership check written as handler code answering 404
+    /// - which is what a description forces, because it can require authentication and cannot
+    /// require ownership - was invisible to it. <c>CacheScope.PerCaller</c> is the declaration that
+    /// says so, and it keys the entry on the caller.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnOwnerScopedHandlerAnswersEachCallerTheirOwn(ITestWebApp testWebApp) {
+        var first = await testWebApp.Get(
+            "/response-cache/owned-by-subject", Caller("pets:read", "subscriber-one"));
+
+        var second = await testWebApp.Get(
+            "/response-cache/owned-by-subject", Caller("pets:read", "subscriber-two"));
+
+        Assert.Equal("subscriber-one-1", first.Deserialize<string>());
+        Assert.Equal("subscriber-two-2", second.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// And each caller's own entry is still an entry, so the feature survives being made safe.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOwnerScopedHandlerStillAnswersOneCallerFromTheStore(ITestWebApp testWebApp) {
+        await testWebApp.Get(
+            "/response-cache/owned-by-subject", Caller("pets:read", "subscriber-one"));
+
+        var repeat = await testWebApp.Get(
+            "/response-cache/owned-by-subject", Caller("pets:read", "subscriber-one"));
+
+        Assert.Equal("subscriber-one-1", repeat.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// A guarded handler that says nothing about who may be served its answer fails naming itself,
+    /// rather than picking one of the two readings of silence.
+    /// </summary>
+    /// <remarks>
+    /// Raised as the handler's filter chain is built, which is the first request its route matches -
+    /// so it reaches a test as the exception and a running host as a logged 500. That is where the
+    /// other two failures a declaration can express are raised, and for the same reason: it names
+    /// the handler and is asked once rather than per request.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AGuardedHandlerThatStatesNoScopeFails(ITestWebApp testWebApp) {
+        var failure = await Assert.ThrowsAsync<CacheScopeUndeclaredException>(
+            () => testWebApp.Get(
+                "/response-cache/unstated-scope", Caller("pets:read", "subscriber-one")));
+
+        Assert.Equal("GET /response-cache/unstated-scope", failure.Handler);
+        Assert.Contains("CacheScope.PerCaller", failure.Message);
+    }
+
     private static Action<TestWebRequest> Language(string value) =>
         request => request.Headers["Accept-Language"] = new StringValues(value);
 
     private static Action<TestWebRequest> Grants(string value) =>
-        request => request.Headers["X-Test-Grants"] = new StringValues(value);
+        request => request.Headers[TestGrantsPrincipalSource.GrantsHeader] = new StringValues(value);
+
+    /// <summary>Which caller, for the tests where one caller's data reaching another is the point.</summary>
+    private static Action<TestWebRequest> Caller(string grants, string subject) =>
+        request => {
+            request.Headers[TestGrantsPrincipalSource.GrantsHeader] = new StringValues(grants);
+            request.Headers[TestGrantsPrincipalSource.SubjectHeader] = new StringValues(subject);
+        };
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
@@ -107,6 +107,40 @@ public class ResponseCacheTests {
         Assert.Equal("1", second.Deserialize<string>());
     }
 
+    /// <summary>
+    /// The question no test in this repository asked until the 0.19.0-rc1000 trial: what a caller
+    /// the guard refuses gets from a cache a permitted caller filled.
+    /// </summary>
+    /// <remarks>
+    /// It got the stored 200 and the body with it. The refusal is recorded ahead of this stage and
+    /// written behind it, so the cache has to read it rather than treat "still travelling" as "still
+    /// permitted". <c>AGrantGuardedHandlerIsStillCached</c> above is the other half: warming and
+    /// reading as a permitted caller was all that was ever exercised.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AWarmCacheStillRefusesTheGrantlessCaller(ITestWebApp testWebApp) {
+        var warm = await testWebApp.Get("/response-cache/granted", Grants("pets:read"));
+
+        warm.Assert.Ok();
+
+        var grantless = await testWebApp.Get("/response-cache/granted");
+
+        Assert.True(grantless.StatusCode is 401 or 403,
+            $"a grantless caller was answered {grantless.StatusCode} from the warm cache");
+    }
+
+    /// <summary>
+    /// And the refused caller is answered the refusal rather than nothing, which is what recording
+    /// it and continuing buys over short-circuiting here.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheRefusedCallerIsNotGivenTheStoredBody(ITestWebApp testWebApp) {
+        var warm = await testWebApp.Get("/response-cache/granted", Grants("pets:read"));
+        var grantless = await testWebApp.Get("/response-cache/granted");
+
+        Assert.NotEqual(await warm.ReadTextAsync(), await grantless.ReadTextAsync());
+    }
+
     private static Action<TestWebRequest> Language(string value) =>
         request => request.Headers["Accept-Language"] = new StringValues(value);
 

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
@@ -200,6 +200,24 @@ public class ResponseCacheTests {
         Assert.Contains("CacheScope.PerCaller", failure.Message);
     }
 
+    /// <summary>
+    /// A published change reaches a cached read, which the trial found was impossible: an
+    /// application could not reach its own entries at all, so an hour-long entry meant an hour.
+    /// </summary>
+    [HardenedTest]
+    public async Task APublishReachesACachedRead(ITestWebApp testWebApp) {
+        var first = await testWebApp.Get("/response-cache/tagged");
+        var cached = await testWebApp.Get("/response-cache/tagged");
+
+        await testWebApp.Post("", "/response-cache/publish");
+
+        var afterPublish = await testWebApp.Get("/response-cache/tagged");
+
+        Assert.Equal("1", first.Deserialize<string>());
+        Assert.Equal("1", cached.Deserialize<string>());
+        Assert.Equal("2", afterPublish.Deserialize<string>());
+    }
+
     private static Action<TestWebRequest> Language(string value) =>
         request => request.Headers["Accept-Language"] = new StringValues(value);
 

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ResponseCacheController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ResponseCacheController.cs
@@ -24,10 +24,13 @@ public class ResponseCacheController {
 
     private readonly HandlerCallCounter _counter;
     private readonly ICurrentCaller _currentCaller;
+    private readonly IResponseCacheStore _store;
 
-    public ResponseCacheController(HandlerCallCounter counter, ICurrentCaller currentCaller) {
+    public ResponseCacheController(
+        HandlerCallCounter counter, ICurrentCaller currentCaller, IResponseCacheStore store) {
         _counter = counter;
         _currentCaller = currentCaller;
+        _store = store;
     }
 
     [Get("/catalog")]
@@ -98,6 +101,27 @@ public class ResponseCacheController {
     [CacheResponse<VaryByRoute>(Duration = 60)]
     public string UnstatedScope() =>
         _currentCaller.Principal.Subject + "-" + _counter.Next("unstated-scope");
+
+    /// <summary>
+    /// A read whose entry outlives anything worth waiting for, invalidated by name when the thing
+    /// it read changes.
+    /// </summary>
+    /// <remarks>
+    /// The pair is the whole feature. Without <see cref="Publish"/> an application's only way to
+    /// reach its own entries was to expire them, so a published change appeared within the cache
+    /// lifetime and never sooner.
+    /// </remarks>
+    [Get("/tagged")]
+    [CacheResponse<VaryByRoute>(Duration = 3600, Tags = ["catalog"])]
+    public string Tagged() => _counter.Next("tagged").ToString();
+
+    /// <summary>What an application does where it changes what a cached read reads.</summary>
+    [Post("/publish")]
+    public async Task<string> Publish(CancellationToken cancellationToken) {
+        await _store.EvictByTag("catalog", cancellationToken);
+
+        return "published";
+    }
 }
 
 /// <summary>

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ResponseCacheController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ResponseCacheController.cs
@@ -55,9 +55,15 @@ public class ResponseCacheController {
     public string Owned(string ownerId) => ownerId + "-" + _counter.Next("owned");
 
     /// <summary>
-    /// Guarded by grants alone, which settle before serialization and so ahead of the cache. Safe
-    /// to cache behind, and the case the resource-scoped rule must not also refuse.
+    /// Guarded by grants alone, which settle before serialization and so ahead of the cache, and
+    /// the case the resource-scoped rule must not also refuse.
     /// </summary>
+    /// <remarks>
+    /// This comment used to say "safe to cache behind" and stopped there, which is how the
+    /// authorization bypass shipped. Settling ahead of the cache is not by itself what makes it
+    /// safe: a refusal ahead of serialization is <em>recorded</em> and travels on, so the cache has
+    /// to read it. <c>AWarmCacheStillRefusesTheGrantlessCaller</c> is the test that says so.
+    /// </remarks>
     [Get("/granted")]
     [AuthorizeGrants("pets:read")]
     [CacheResponse<VaryByRoute>(Duration = 60)]

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ResponseCacheController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ResponseCacheController.cs
@@ -1,5 +1,6 @@
 using Hardened.IntegrationTests.WebApp.SUT.Services;
 using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Caching;
 using Hardened.Requests.Runtime.Authorization;
 using Hardened.Requests.Runtime.Caching;
 using Hardened.Web.Runtime.Attributes;
@@ -22,9 +23,11 @@ namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
 public class ResponseCacheController {
 
     private readonly HandlerCallCounter _counter;
+    private readonly ICurrentCaller _currentCaller;
 
-    public ResponseCacheController(HandlerCallCounter counter) {
+    public ResponseCacheController(HandlerCallCounter counter, ICurrentCaller currentCaller) {
         _counter = counter;
+        _currentCaller = currentCaller;
     }
 
     [Get("/catalog")]
@@ -66,8 +69,35 @@ public class ResponseCacheController {
     /// </remarks>
     [Get("/granted")]
     [AuthorizeGrants("pets:read")]
-    [CacheResponse<VaryByRoute>(Duration = 60)]
+    [CacheResponse<VaryByRoute>(Duration = 60, Scope = CacheScope.AllCallers)]
     public string Granted() => _counter.Next("granted").ToString();
+
+    /// <summary>
+    /// The shape three trial arms found one caller's data in: an authenticated read whose ownership
+    /// check is the handler's own code, cached.
+    /// </summary>
+    /// <remarks>
+    /// Nothing on the handler distinguishes this from <see cref="Granted"/>. A description can say
+    /// "the caller must be authenticated" and cannot say "and the row must be theirs", so the check
+    /// is here, answering 404 rather than 403 so the row's existence is not disclosed - and that is
+    /// invisible to anything reading the requirement. <c>CacheScope.PerCaller</c> is the author
+    /// saying what the metadata cannot.
+    /// </remarks>
+    [Get("/owned-by-subject")]
+    [AuthorizeGrants("pets:read")]
+    [CacheResponse<VaryByRoute>(Duration = 60, Scope = CacheScope.PerCaller)]
+    public string OwnedBySubject() =>
+        _currentCaller.Principal.Subject + "-" + _counter.Next("owned-by-subject");
+
+    /// <summary>
+    /// The same read with nothing said about who may be served it, so the first request to it
+    /// fails naming the handler rather than serving one caller's answer to another.
+    /// </summary>
+    [Get("/unstated-scope")]
+    [AuthorizeGrants("pets:read")]
+    [CacheResponse<VaryByRoute>(Duration = 60)]
+    public string UnstatedScope() =>
+        _currentCaller.Principal.Subject + "-" + _counter.Next("unstated-scope");
 }
 
 /// <summary>

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -254,12 +254,13 @@ namespace Hardened.Requests.Abstract.Caching
     }
     public sealed class CachedResponse
     {
-        public CachedResponse(int status, string? contentType, byte[] body, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>> headers) { }
+        public CachedResponse(int status, string? contentType, byte[] body, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>> headers, System.Collections.Generic.IReadOnlyList<string>? tags = null) { }
         public byte[] Body { get; }
         public string? ContentType { get; }
         public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>> Headers { get; }
         public long Size { get; }
         public int Status { get; }
+        public System.Collections.Generic.IReadOnlyList<string> Tags { get; }
     }
     public interface ICacheKeyProvider
     {
@@ -270,10 +271,12 @@ namespace Hardened.Requests.Abstract.Caching
     {
         int Duration { get; }
         Hardened.Requests.Abstract.Caching.CacheScope Scope { get; }
+        System.Collections.Generic.IReadOnlyList<string> Tags { get; }
         Hardened.Requests.Abstract.Caching.ICacheKeyProvider CreateKeyProvider();
     }
     public interface IResponseCacheStore
     {
+        System.Threading.Tasks.ValueTask EvictByTag(string tag, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Caching.CachedResponse?> Get(string key, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.ValueTask Set(string key, Hardened.Requests.Abstract.Caching.CachedResponse response, System.TimeSpan duration, System.Threading.CancellationToken cancellationToken);
     }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -246,6 +246,12 @@ namespace Hardened.Requests.Abstract.Authorization
 }
 namespace Hardened.Requests.Abstract.Caching
 {
+    public enum CacheScope
+    {
+        Unstated = 0,
+        AllCallers = 1,
+        PerCaller = 2,
+    }
     public sealed class CachedResponse
     {
         public CachedResponse(int status, string? contentType, byte[] body, System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues>> headers) { }
@@ -263,6 +269,7 @@ namespace Hardened.Requests.Abstract.Caching
     public interface ICacheResponseDeclaration
     {
         int Duration { get; }
+        Hardened.Requests.Abstract.Caching.CacheScope Scope { get; }
         Hardened.Requests.Abstract.Caching.ICacheKeyProvider CreateKeyProvider();
     }
     public interface IResponseCacheStore
@@ -537,22 +544,32 @@ namespace Hardened.Requests.Abstract.Headers
         public const string AcceptRanges = "Accept-Ranges";
         public const string Allow = "Allow";
         public const string CacheControl = "Cache-Control";
+        public const string Connection = "Connection";
         public const string ContentEncoding = "Content-Encoding";
         public const string ContentLength = "Content-Length";
         public const string ContentRange = "Content-Range";
         public const string ContentType = "Content-Type";
         public const string Cookie = "Cookie";
+        public const string Date = "Date";
         public const string ETag = "ETag";
         public const string IfMatch = "If-Match";
         public const string IfModifiedSince = "If-Modified-Since";
         public const string IfNoneMatch = "If-None-Match";
         public const string IfRange = "If-Range";
+        public const string KeepAlive = "Keep-Alive";
         public const string LastModified = "Last-Modified";
         public const string Location = "Location";
         public const string Origin = "Origin";
+        public const string ProxyAuthenticate = "Proxy-Authenticate";
+        public const string ProxyAuthorization = "Proxy-Authorization";
         public const string Range = "Range";
         public const string RetryAfter = "Retry-After";
+        public const string Server = "Server";
         public const string SetCookie = "Set-Cookie";
+        public const string TE = "TE";
+        public const string Trailer = "Trailer";
+        public const string TransferEncoding = "Transfer-Encoding";
+        public const string Upgrade = "Upgrade";
         public const string Vary = "Vary";
         public static class Cors
         {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Caching.Memory.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Caching.Memory.approved.txt
@@ -36,6 +36,7 @@ namespace Hardened.Requests.Caching.Memory
     {
         public MemoryResponseCacheStore(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Caching.Memory.IMemoryResponseCacheConfiguration> configuration) { }
         public void Dispose() { }
+        public System.Threading.Tasks.ValueTask EvictByTag(string tag, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Caching.CachedResponse?> Get(string key, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask Set(string key, Hardened.Requests.Abstract.Caching.CachedResponse response, System.TimeSpan duration, System.Threading.CancellationToken cancellationToken) { }
     }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Caching.Memory.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Caching.Memory.approved.txt
@@ -34,7 +34,7 @@ namespace Hardened.Requests.Caching.Memory
     }
     public sealed class MemoryResponseCacheStore : Hardened.Requests.Abstract.Caching.IResponseCacheStore, System.IDisposable
     {
-        public MemoryResponseCacheStore(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Caching.Memory.IMemoryResponseCacheConfiguration> configuration) { }
+        public MemoryResponseCacheStore(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Caching.Memory.IMemoryResponseCacheConfiguration> configuration, System.TimeProvider timeProvider) { }
         public void Dispose() { }
         public System.Threading.Tasks.ValueTask EvictByTag(string tag, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Caching.CachedResponse?> Get(string key, System.Threading.CancellationToken cancellationToken) { }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -121,14 +121,20 @@ namespace Hardened.Requests.Runtime.Caching
     {
         public CacheResponseAttribute(params string[] values) { }
         public int Duration { get; set; }
+        public Hardened.Requests.Abstract.Caching.CacheScope Scope { get; set; }
         public string[] Values { get; }
         public Hardened.Requests.Abstract.Caching.ICacheKeyProvider CreateKeyProvider() { }
         public System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.RequestFilterInfo> GetFilters(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo) { }
     }
+    public class CacheScopeUndeclaredException : System.InvalidOperationException
+    {
+        public CacheScopeUndeclaredException(string handler, Hardened.Requests.Abstract.Authorization.Requirement requirement) { }
+        public string Handler { get; }
+    }
     public sealed class ResponseCacheFilter : Hardened.Requests.Abstract.Execution.IExecutionFilter
     {
         public const int DefaultDuration = 60;
-        public ResponseCacheFilter(Hardened.Requests.Abstract.Caching.ICacheKeyProvider[] keyProviders, string handlerKey, int duration) { }
+        public ResponseCacheFilter(Hardened.Requests.Abstract.Caching.ICacheKeyProvider[] keyProviders, string handlerKey, int duration, Hardened.Requests.Abstract.Caching.CacheScope scope = 1) { }
         public System.Threading.Tasks.Task Execute(Hardened.Requests.Abstract.Execution.IExecutionChain chain) { }
         public static Hardened.Requests.Runtime.Caching.ResponseCacheFilter Compose(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Caching.ICacheResponseDeclaration> declarations) { }
     }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -122,6 +122,7 @@ namespace Hardened.Requests.Runtime.Caching
         public CacheResponseAttribute(params string[] values) { }
         public int Duration { get; set; }
         public Hardened.Requests.Abstract.Caching.CacheScope Scope { get; set; }
+        public string[] Tags { get; set; }
         public string[] Values { get; }
         public Hardened.Requests.Abstract.Caching.ICacheKeyProvider CreateKeyProvider() { }
         public System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.RequestFilterInfo> GetFilters(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo) { }
@@ -134,7 +135,7 @@ namespace Hardened.Requests.Runtime.Caching
     public sealed class ResponseCacheFilter : Hardened.Requests.Abstract.Execution.IExecutionFilter
     {
         public const int DefaultDuration = 60;
-        public ResponseCacheFilter(Hardened.Requests.Abstract.Caching.ICacheKeyProvider[] keyProviders, string handlerKey, int duration, Hardened.Requests.Abstract.Caching.CacheScope scope = 1) { }
+        public ResponseCacheFilter(Hardened.Requests.Abstract.Caching.ICacheKeyProvider[] keyProviders, string handlerKey, int duration, Hardened.Requests.Abstract.Caching.CacheScope scope = 1, string[]? tags = null) { }
         public System.Threading.Tasks.Task Execute(Hardened.Requests.Abstract.Execution.IExecutionChain chain) { }
         public static Hardened.Requests.Runtime.Caching.ResponseCacheFilter Compose(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Caching.ICacheResponseDeclaration> declarations) { }
     }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Testing.approved.txt
@@ -192,8 +192,10 @@ namespace Hardened.Requests.Testing
     public sealed class TestGrantsPrincipalSource : Hardened.Requests.Abstract.Authorization.IPrincipalSource
     {
         public const string AnonymousGrantsValue = "-";
+        public const string DefaultSubject = "integration-test";
         public const string GrantsHeader = "X-Test-Grants";
         public const string SchemeName = "test";
+        public const string SubjectHeader = "X-Test-Subject";
         public TestGrantsPrincipalSource() { }
         public System.Threading.Tasks.ValueTask<Hardened.Requests.Abstract.Authorization.ICallerPrincipal?> Authenticate(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
     }

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Caching/CacheResponseDeclarationTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Caching/CacheResponseDeclarationTests.cs
@@ -1,0 +1,47 @@
+using Hardened.Requests.Abstract.Caching;
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.Requests.Abstract.Tests.Caching;
+
+/// <summary>
+/// What a declaration that answers only what the interface always asked for means.
+/// </summary>
+/// <remarks>
+/// <see cref="ICacheResponseDeclaration.Scope"/> and <see cref="ICacheResponseDeclaration.Tags"/>
+/// have default implementations so that a declaration written before either existed still compiles.
+/// These pin what that compiles to: nothing said about who the answer is for, which is a failure
+/// naming the handler on anything guarded, and no tag, which is an entry only its duration removes.
+/// </remarks>
+public class CacheResponseDeclarationTests {
+
+    /// <summary>
+    /// Through the interface, which is the only way a default implementation is reachable and the
+    /// way everything asking a declaration these questions holds one.
+    /// </summary>
+    private static readonly ICacheResponseDeclaration Minimal = new MinimalDeclaration();
+
+    [Fact]
+    public void ADeclarationThatSaysNothingAboutItsAudienceIsUnstated() {
+        Assert.Equal(CacheScope.Unstated, Minimal.Scope);
+    }
+
+    [Fact]
+    public void ADeclarationThatNamesNoTagsHasNone() {
+        Assert.Empty(Minimal.Tags);
+    }
+
+    /// <summary>
+    /// Everything the interface has always required, and nothing it has since added.
+    /// </summary>
+    private sealed class MinimalDeclaration : ICacheResponseDeclaration {
+        public int Duration => 0;
+
+        public ICacheKeyProvider CreateKeyProvider() => new EveryRequest();
+
+        private sealed class EveryRequest : ICacheKeyProvider {
+            public static ICacheKeyProvider Create(string[] values) => new EveryRequest();
+
+            public ValueTask<string?> Key(IExecutionContext context) => new("only");
+        }
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Caching/CacheScope.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Caching/CacheScope.cs
@@ -1,0 +1,71 @@
+namespace Hardened.Requests.Abstract.Caching;
+
+/// <summary>
+/// Who a stored response may be served to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Stated by the author, because nothing else can know.</b> The filter used to decide this from
+/// <c>IExecutionRequestHandlerInfo.Requirement.RequiresContext</c>, which is true only for a
+/// requirement built from <c>Requirement.Predicate</c> - so it covered a shape almost nobody
+/// writes and missed the two everybody does. An owner-scoped read whose ownership check is handler
+/// code answering 404, which is what a description forces anyway because it can say "the caller
+/// must be authenticated" and cannot say "and the row must be theirs", was cached and served to the
+/// next subscriber. Three trial arms hit that independently.
+/// </para>
+/// <para>
+/// No property of the handler distinguishes the two cases. "Every caller holding <c>rates:read</c>
+/// gets these same bytes" and "each caller gets their own" are both authenticated reads with a
+/// grant requirement, and the difference lives in what the handler does with the caller - which is
+/// not on the metadata and cannot be inferred from it. So a handler that requires anything of its
+/// caller has to say, and one that requires nothing is <see cref="AllCallers"/> as it always was.
+/// </para>
+/// <para>
+/// Silently defaulting to <see cref="PerCaller"/> was the alternative, and it is worse than
+/// failing: it is safe, and it turns one shared entry into one per caller, so a cache somebody
+/// added to shed load quietly stops shedding it and grows in proportion to the caller count
+/// instead. A wrong answer that looks like the right one is what this framework raises rather than
+/// guesses.
+/// </para>
+/// </remarks>
+public enum CacheScope {
+
+    /// <summary>
+    /// The declaration did not say.
+    /// </summary>
+    /// <remarks>
+    /// The default, and a failure naming the handler on any handler that requires something of its
+    /// caller. Distinguished from <see cref="AllCallers"/> rather than merged with it so that "the
+    /// author did not say" and "the author said everyone" stay different answers - the same reason
+    /// <c>Duration</c> keeps 0 apart from 60.
+    /// </remarks>
+    Unstated = 0,
+
+    /// <summary>
+    /// One entry, served to whoever the guard admits.
+    /// </summary>
+    /// <remarks>
+    /// What a public read wants, and what an authorized read wants when the answer does not depend
+    /// on who asked. The guard still runs on every request - it sits ahead of the cache and its
+    /// refusals are read there - so this shares a representation among permitted callers rather
+    /// than admitting anyone.
+    /// </remarks>
+    AllCallers,
+
+    /// <summary>
+    /// One entry per caller.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The caller's issuer and subject go into the key, so one caller's answer can never be handed
+    /// to another however the handler decided what to put in it. This is what makes an owner-scoped
+    /// read cacheable at all: the ownership check does not run on a hit, and with this it does not
+    /// need to, because the entry belongs to the caller it was filled for.
+    /// </para>
+    /// <para>
+    /// A caller with no subject is not cached either way. There is nothing to key on, and the entry
+    /// that would result is the shared one this exists to avoid.
+    /// </para>
+    /// </remarks>
+    PerCaller
+}

--- a/src/Requests/Hardened.Requests.Abstract/Caching/CachedResponse.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Caching/CachedResponse.cs
@@ -28,11 +28,13 @@ public sealed class CachedResponse {
         int status,
         string? contentType,
         byte[] body,
-        IReadOnlyList<KeyValuePair<string, StringValues>> headers) {
+        IReadOnlyList<KeyValuePair<string, StringValues>> headers,
+        IReadOnlyList<string>? tags = null) {
         Status = status;
         ContentType = contentType;
         Body = body;
         Headers = headers;
+        Tags = tags ?? [];
     }
 
     public int Status { get; }
@@ -42,6 +44,16 @@ public sealed class CachedResponse {
     public byte[] Body { get; }
 
     public IReadOnlyList<KeyValuePair<string, StringValues>> Headers { get; }
+
+    /// <summary>
+    /// The names this entry can be invalidated by. Empty when the declaration named none.
+    /// </summary>
+    /// <remarks>
+    /// Carried on the entry rather than passed beside it, because a store that persists entries has
+    /// to persist these with them: an index rebuilt from anything else is an index that can be
+    /// wrong about which entries a tag names. See <see cref="IResponseCacheStore.EvictByTag"/>.
+    /// </remarks>
+    public IReadOnlyList<string> Tags { get; }
 
     /// <summary>
     /// What this entry costs a store that caps its size.

--- a/src/Requests/Hardened.Requests.Abstract/Caching/CachedResponse.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Caching/CachedResponse.cs
@@ -13,11 +13,13 @@ namespace Hardened.Requests.Abstract.Caching;
 /// repeated.
 /// </para>
 /// <para>
-/// <b><c>Set-Cookie</c> is not among the headers.</b> It is stripped when a response is captured,
-/// not when one is replayed, so a cookie cannot reach a second caller even from a store written by
-/// an older build. Everything else is replayed as it was sent, which is what carries
-/// <c>Cache-Control</c>, <c>ETag</c> and <c>Vary</c> onto a hit - the filters that wrote them sit
-/// at the same position in the chain as the cache, and a hit returns before they run.
+/// <b>The headers are what this representation is, not what its first request was.</b> Three kinds
+/// are absent, all of them dropped when a response is captured rather than when one is replayed, so
+/// a store written by an older build cannot leak one either: <c>Set-Cookie</c>, which belongs to a
+/// caller; the hop-by-hop and transport-framing headers, which belong to a connection; and anything
+/// the response already carried before the cache's own chain was entered, which the filter that
+/// wrote it writes again on a hit. What is left is what the handler and the filters inside the
+/// cache produced, which is what carries <c>Cache-Control</c> and <c>ETag</c> onto a hit.
 /// </para>
 /// </remarks>
 public sealed class CachedResponse {

--- a/src/Requests/Hardened.Requests.Abstract/Caching/ICacheResponseDeclaration.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Caching/ICacheResponseDeclaration.cs
@@ -25,6 +25,16 @@ public interface ICacheResponseDeclaration {
     int Duration { get; }
 
     /// <summary>
+    /// Who a stored response may be served to.
+    /// </summary>
+    /// <remarks>
+    /// Defaulted so that a declaration written before this existed still compiles. It means
+    /// <see cref="CacheScope.Unstated"/>, which is a failure naming the handler on anything that
+    /// requires something of its caller rather than a quiet reading of it.
+    /// </remarks>
+    CacheScope Scope => CacheScope.Unstated;
+
+    /// <summary>
     /// The strategy this declaration names, built from the values it carries.
     /// </summary>
     /// <remarks>

--- a/src/Requests/Hardened.Requests.Abstract/Caching/ICacheResponseDeclaration.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Caching/ICacheResponseDeclaration.cs
@@ -35,6 +35,15 @@ public interface ICacheResponseDeclaration {
     CacheScope Scope => CacheScope.Unstated;
 
     /// <summary>
+    /// The names an entry from this handler can be invalidated by.
+    /// </summary>
+    /// <remarks>
+    /// Defaulted to none, so a declaration written before this existed still compiles and still
+    /// expires on its duration alone.
+    /// </remarks>
+    IReadOnlyList<string> Tags => [];
+
+    /// <summary>
     /// The strategy this declaration names, built from the values it carries.
     /// </summary>
     /// <remarks>

--- a/src/Requests/Hardened.Requests.Abstract/Caching/IResponseCacheStore.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Caching/IResponseCacheStore.cs
@@ -14,7 +14,7 @@ namespace Hardened.Requests.Abstract.Caching;
 /// <para>
 /// <b>Not <c>IMemoryCache</c> and not <c>IDistributedCache</c>.</b> Microsoft made the same split
 /// with <c>IOutputCacheStore</c>, and their reason for it holds here: <c>IDistributedCache</c> has
-/// no atomic operations, which is what invalidating a group of entries needs.
+/// no atomic operations, which is what <see cref="EvictByTag"/> needs.
 /// <c>IMemoryCache</c> has that problem too, plus an <c>object</c>-keyed API that boxes on the hot
 /// path. Typing against this interface is what lets a Lambda deployment replace one registration
 /// with a shared store and change nothing else.
@@ -43,4 +43,29 @@ public interface IResponseCacheStore {
     /// </remarks>
     ValueTask Set(
         string key, CachedResponse response, TimeSpan duration, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Drops every entry stored under <paramref name="tag"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The only way an application reaches its own entries, and deliberately the only way. A
+    /// <c>Remove(key)</c> would mean composing the key the filter composed - the handler's
+    /// "METHOD path", a unit separator, the caller when the scope is per-caller, then each
+    /// strategy's part - which is a shape nothing publishes and no adopter should have to
+    /// reverse-engineer. A tag is a name the declaration chose.
+    /// </para>
+    /// <para>
+    /// Group invalidation is the reason this interface exists rather than
+    /// <c>IDistributedCache</c>, which has no atomic operation to do it with, so this is the member
+    /// that argument was about. A store that cannot do it atomically should still do it: entries
+    /// dropped one at a time is a worse guarantee than all at once, and both are better than a
+    /// publish nobody can see for a minute.
+    /// </para>
+    /// <para>
+    /// A tag nothing was stored under is not an error. An application invalidating what it just
+    /// wrote does not know whether anything had read it yet.
+    /// </para>
+    /// </remarks>
+    ValueTask EvictByTag(string tag, CancellationToken cancellationToken);
 }

--- a/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
@@ -25,8 +25,8 @@ public static class KnownHeaders {
     /// A cookie the response sets.
     /// </summary>
     /// <remarks>
-    /// Named here because it is the one response header that must never be replayed to a
-    /// second caller. <c>CachedResponse</c> strips it as a response is captured.
+    /// Named here because it must never be replayed to a second caller: it identifies one. The
+    /// response cache drops it as a response is captured, along with the hop-by-hop headers below.
     /// </remarks>
     public const string SetCookie = "Set-Cookie";
 
@@ -93,6 +93,55 @@ public static class KnownHeaders {
 
     /// <summary>How long to wait before trying again. Belongs on a 429 and on a 503.</summary>
     public const string RetryAfter = "Retry-After";
+
+    /// <summary>
+    /// How the body is framed on this connection.
+    /// </summary>
+    /// <remarks>
+    /// Hop-by-hop: it describes one connection rather than the representation travelling over it,
+    /// and RFC 9110 forbids storing or forwarding one. Named here because a stored copy of it is
+    /// what made every response-cache hit malformed - the host declared chunked framing on the way
+    /// in, the entry kept it, and the replayed bytes went out with no chunk header and no
+    /// terminator.
+    /// </remarks>
+    public const string TransferEncoding = "Transfer-Encoding";
+
+    /// <summary>
+    /// What this connection does when the message ends, and the header that names which others are
+    /// hop-by-hop.
+    /// </summary>
+    public const string Connection = "Connection";
+
+    /// <summary>Hop-by-hop. How long an idle connection is held open.</summary>
+    public const string KeepAlive = "Keep-Alive";
+
+    /// <summary>Hop-by-hop. The transfer codings this connection will accept.</summary>
+    public const string TE = "TE";
+
+    /// <summary>Hop-by-hop. Which fields arrive after a chunked body.</summary>
+    public const string Trailer = "Trailer";
+
+    /// <summary>Hop-by-hop. The protocol this connection could switch to.</summary>
+    public const string Upgrade = "Upgrade";
+
+    /// <summary>Hop-by-hop. A challenge from the proxy, not from the origin.</summary>
+    public const string ProxyAuthenticate = "Proxy-Authenticate";
+
+    /// <summary>Hop-by-hop. A credential for the proxy, not for the origin.</summary>
+    public const string ProxyAuthorization = "Proxy-Authorization";
+
+    /// <summary>
+    /// When the message was generated.
+    /// </summary>
+    /// <remarks>
+    /// Written per response by the host. A stored copy replayed later dates a response to the
+    /// moment a different one was produced, which is the value every downstream cache computes an
+    /// age from.
+    /// </remarks>
+    public const string Date = "Date";
+
+    /// <summary>What produced the response. The host's to write, and the same on all of them.</summary>
+    public const string Server = "Server";
 
     public static class Cors {
         public const string AccessControlAllowOrigin = "Access-Control-Allow-Origin";

--- a/src/Requests/Hardened.Requests.Caching.Memory.Tests/HardenedMemoryResponseCacheTests.cs
+++ b/src/Requests/Hardened.Requests.Caching.Memory.Tests/HardenedMemoryResponseCacheTests.cs
@@ -105,5 +105,7 @@ public class HardenedMemoryResponseCacheTests {
         public ValueTask Set(
             string key, CachedResponse response, TimeSpan duration, CancellationToken cancellationToken) =>
             default;
+
+        public ValueTask EvictByTag(string tag, CancellationToken cancellationToken) => default;
     }
 }

--- a/src/Requests/Hardened.Requests.Caching.Memory.Tests/MemoryResponseCacheStoreTests.cs
+++ b/src/Requests/Hardened.Requests.Caching.Memory.Tests/MemoryResponseCacheStoreTests.cs
@@ -12,12 +12,14 @@ public class MemoryResponseCacheStoreTests {
 
     private static MemoryResponseCacheStore Store(
         long sizeLimit = MemoryResponseCacheConfiguration.DefaultSizeLimit,
-        long maximumBodySize = MemoryResponseCacheConfiguration.DefaultMaximumBodySize) =>
+        long maximumBodySize = MemoryResponseCacheConfiguration.DefaultMaximumBodySize,
+        TimeProvider? clock = null) =>
         new(Options.Create<IMemoryResponseCacheConfiguration>(
-            new MemoryResponseCacheConfiguration {
-                SizeLimit = sizeLimit,
-                MaximumBodySize = maximumBodySize
-            }));
+                new MemoryResponseCacheConfiguration {
+                    SizeLimit = sizeLimit,
+                    MaximumBodySize = maximumBodySize
+                }),
+            clock ?? TimeProvider.System);
 
     private static CachedResponse Response(
         int bodyLength = 4,
@@ -275,5 +277,83 @@ public class MemoryResponseCacheStoreTests {
         await store.EvictByTag("nothing", TestContext.Current.CancellationToken);
 
         Assert.NotNull(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// The duration is decided on the clock the store was given, so a test can move time instead of
+    /// waiting.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in the response-cache contract took a clock, so a test for a five-minute entry could
+    /// only sleep and a test for the specification's day-long entry could not be written. Every
+    /// trial arm substituted the whole store to get past it.
+    /// </remarks>
+    [Fact]
+    public async Task AnEntryIsGoneOnceTheClockPassesItsDuration() {
+        var clock = new TestClock();
+        using var store = Store(clock: clock);
+
+        await store.Set(
+            "k", Response(), TimeSpan.FromDays(1), TestContext.Current.CancellationToken);
+
+        clock.Advance(TimeSpan.FromDays(1));
+
+        Assert.Null(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AnEntryInsideItsDurationIsStillServed() {
+        var clock = new TestClock();
+        using var store = Store(clock: clock);
+
+        await store.Set(
+            "k", Response(), TimeSpan.FromDays(1), TestContext.Current.CancellationToken);
+
+        clock.Advance(TimeSpan.FromHours(23));
+
+        Assert.NotNull(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// An expired entry is dropped rather than withheld, so the tag index stops naming a response
+    /// nothing will be served.
+    /// </summary>
+    [Fact]
+    public async Task AnExpiredEntryIsNotEvictedAgainByItsTag() {
+        var clock = new TestClock();
+        using var store = Store(clock: clock);
+
+        await store.Set(
+            "k",
+            Response(tags: "rates"),
+            TimeSpan.FromMinutes(5),
+            TestContext.Current.CancellationToken);
+
+        clock.Advance(TimeSpan.FromMinutes(6));
+
+        Assert.Null(await store.Get("k", TestContext.Current.CancellationToken));
+
+        await store.Set(
+            "k",
+            Response(tags: "alerts"),
+            TimeSpan.FromMinutes(5),
+            TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A clock a test moves by hand. Written here rather than taken from
+    /// Microsoft.Extensions.TimeProvider.Testing, which would be a package reference for four
+    /// lines.
+    /// </summary>
+    private sealed class TestClock : TimeProvider {
+        private DateTimeOffset _now = new(2026, 9, 3, 9, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan by) => _now += by;
     }
 }

--- a/src/Requests/Hardened.Requests.Caching.Memory.Tests/MemoryResponseCacheStoreTests.cs
+++ b/src/Requests/Hardened.Requests.Caching.Memory.Tests/MemoryResponseCacheStoreTests.cs
@@ -19,10 +19,13 @@ public class MemoryResponseCacheStoreTests {
                 MaximumBodySize = maximumBodySize
             }));
 
-    private static CachedResponse Response(int bodyLength = 4, string? contentType = "application/json") =>
+    private static CachedResponse Response(
+        int bodyLength = 4,
+        string? contentType = "application/json",
+        params string[] tags) =>
         new(200, contentType, new byte[bodyLength], [
             new KeyValuePair<string, StringValues>("Cache-Control", new StringValues("public"))
-        ]);
+        ], tags);
 
     [Fact]
     public async Task AKeyNothingWasStoredUnderReadsBackAsNothing() {
@@ -117,5 +120,160 @@ public class MemoryResponseCacheStoreTests {
     [Fact]
     public void AnEntryCostsItsBody() {
         Assert.Equal(4, Response(bodyLength: 4).Size);
+    }
+
+    /// <summary>
+    /// The seam the 0.19.0-rc1000 trial found missing: an application could not reach its own
+    /// entries at all, so a published change appeared when the entry expired and not before.
+    /// </summary>
+    [Fact]
+    public async Task AnEntryIsGoneOnceItsTagIsEvicted() {
+        using var store = Store();
+
+        await store.Set(
+            "k",
+            Response(tags: "rates"),
+            TimeSpan.FromHours(1),
+            TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.Null(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Every entry under the tag, which is the whole point: one publish invalidates the read of
+    /// each symbol rather than the one the publisher happened to name.
+    /// </summary>
+    [Fact]
+    public async Task EveryEntryUnderTheTagGoes() {
+        using var store = Store();
+
+        foreach (var key in new[] { "EUR", "GBP", "JPY" }) {
+            await store.Set(
+                key,
+                Response(tags: "rates"),
+                TimeSpan.FromHours(1),
+                TestContext.Current.CancellationToken);
+        }
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.Null(await store.Get("EUR", TestContext.Current.CancellationToken));
+        Assert.Null(await store.Get("GBP", TestContext.Current.CancellationToken));
+        Assert.Null(await store.Get("JPY", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AnEntryUnderAnotherTagStays() {
+        using var store = Store();
+
+        await store.Set(
+            "rate", Response(tags: "rates"), TimeSpan.FromHours(1), TestContext.Current.CancellationToken);
+
+        await store.Set(
+            "alert", Response(tags: "alerts"), TimeSpan.FromHours(1), TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(await store.Get("alert", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// An entry carrying two tags is reachable by either, and evicting one takes it out of the
+    /// other's index rather than leaving a key nothing can serve.
+    /// </summary>
+    [Fact]
+    public async Task AnEntryUnderTwoTagsGoesWithTheFirstOfThem() {
+        using var store = Store();
+
+        await store.Set(
+            "k",
+            Response(tags: ["rates", "symbols"]),
+            TimeSpan.FromHours(1),
+            TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.Null(await store.Get("k", TestContext.Current.CancellationToken));
+
+        // The second tag no longer names it, so re-storing under that tag and evicting the first
+        // does not take the new entry with it.
+        await store.Set(
+            "k",
+            Response(tags: "symbols"),
+            TimeSpan.FromHours(1),
+            TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A key written again under a different tag is reachable by the new one and not by the old.
+    /// </summary>
+    /// <remarks>
+    /// The index is keyed by tag, so a replacement has to be unindexed as it is replaced. Left in,
+    /// the old tag would drop an entry that is no longer tagged that way.
+    /// </remarks>
+    [Fact]
+    public async Task AReplacedEntryIsIndexedByItsNewTag() {
+        using var store = Store();
+
+        await store.Set(
+            "k", Response(tags: "rates"), TimeSpan.FromHours(1), TestContext.Current.CancellationToken);
+
+        await store.Set(
+            "k", Response(tags: "alerts"), TimeSpan.FromHours(1), TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(await store.Get("k", TestContext.Current.CancellationToken));
+
+        await store.EvictByTag("alerts", TestContext.Current.CancellationToken);
+
+        Assert.Null(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A key stored again after its tag was evicted is still reachable by that tag.
+    /// </summary>
+    /// <remarks>
+    /// MemoryCache raises eviction callbacks on the thread pool, so the callback cleaning the index
+    /// for the removed entry can arrive after the replacement has been indexed. Acting on it then
+    /// leaves an entry nothing can invalidate, which is a publish nobody sees until the duration
+    /// runs out - the defect the tag was added for, back again as a race.
+    /// </remarks>
+    [Fact]
+    public async Task AKeyStoredAgainAfterAnEvictionIsStillReachableByItsTag() {
+        using var store = Store();
+
+        await store.Set(
+            "k", Response(tags: "rates"), TimeSpan.FromHours(1), TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        await store.Set(
+            "k", Response(tags: "rates"), TimeSpan.FromHours(1), TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("rates", TestContext.Current.CancellationToken);
+
+        Assert.Null(await store.Get("k", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A tag nothing was stored under is not an error. An application invalidating what it just
+    /// wrote does not know whether anything had read it yet.
+    /// </summary>
+    [Fact]
+    public async Task EvictingATagNothingUsedDoesNothing() {
+        using var store = Store();
+
+        await store.Set("k", Response(), TimeSpan.FromHours(1), TestContext.Current.CancellationToken);
+
+        await store.EvictByTag("nothing", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(await store.Get("k", TestContext.Current.CancellationToken));
     }
 }

--- a/src/Requests/Hardened.Requests.Caching.Memory/HardenedMemoryResponseCache.cs
+++ b/src/Requests/Hardened.Requests.Caching.Memory/HardenedMemoryResponseCache.cs
@@ -59,6 +59,11 @@ public partial class HardenedMemoryResponseCache : IServiceCollectionConfigurati
                 serviceProvider.GetRequiredService<IConfigurationManager>()
                     .GetConfiguration<IMemoryResponseCacheConfiguration>()));
 
+        // Try, so an application or a test that has substituted a clock keeps it. The store reads
+        // this to decide whether an entry is still valid, which is what makes a duration something
+        // a test can move rather than something it has to wait out.
+        services.TryAddSingleton(TimeProvider.System);
+
         // Try, so a deployment that has a shared store - Amz replaces this one registration -
         // wins over the in-process one whichever order the modules were listed in.
         services.TryAddSingleton<IResponseCacheStore, MemoryResponseCacheStore>();

--- a/src/Requests/Hardened.Requests.Caching.Memory/MemoryResponseCacheStore.cs
+++ b/src/Requests/Hardened.Requests.Caching.Memory/MemoryResponseCacheStore.cs
@@ -24,11 +24,21 @@ namespace Hardened.Requests.Caching.Memory;
 /// expiry on read, so an entry that went stale during a freeze of any length is never returned.
 /// Only reclamation happens late.
 /// </para>
+/// <para>
+/// <b>Whether an entry is still valid is decided on the <see cref="TimeProvider"/> this was
+/// given, not on the one <see cref="MemoryCache"/> reclaims with.</b> Nothing in the response-cache
+/// contract took a clock, so a test for a five-minute entry could only sleep for five minutes and
+/// a test for the specification's day-long entry could not be written at all. Substituting the
+/// whole store was the workaround every trial arm reached for. The absolute expiration is still
+/// set, because that is what frees the memory without a read; the check on the way out is what
+/// makes the duration mean something a test can move.
+/// </para>
 /// </remarks>
 public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable {
 
     private readonly MemoryCache _cache;
     private readonly long _maximumBodySize;
+    private readonly TimeProvider _timeProvider;
 
     /// <summary>
     /// Which keys each tag names.
@@ -47,15 +57,42 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
     /// </remarks>
     private readonly Dictionary<string, HashSet<string>> _keysByTag = new(StringComparer.Ordinal);
 
-    public MemoryResponseCacheStore(IOptions<IMemoryResponseCacheConfiguration> configuration) {
+    public MemoryResponseCacheStore(
+        IOptions<IMemoryResponseCacheConfiguration> configuration, TimeProvider timeProvider) {
         var settings = configuration.Value;
 
         _maximumBodySize = settings.MaximumBodySize;
+        _timeProvider = timeProvider;
         _cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = settings.SizeLimit });
     }
 
-    public ValueTask<CachedResponse?> Get(string key, CancellationToken cancellationToken) =>
-        new(_cache.TryGetValue(key, out CachedResponse? cached) ? cached : null);
+    /// <summary>
+    /// The entry stored under <paramref name="key"/>, or null when there is none or it has expired.
+    /// </summary>
+    /// <remarks>
+    /// An entry past its duration is removed rather than merely withheld, so the tag index does not
+    /// keep naming a response nothing will be served.
+    /// </remarks>
+    public ValueTask<CachedResponse?> Get(string key, CancellationToken cancellationToken) {
+        if (!_cache.TryGetValue(key, out Entry? entry) || entry == null) {
+            return new ValueTask<CachedResponse?>((CachedResponse?)null);
+        }
+
+        if (entry.ExpiresAt > _timeProvider.GetUtcNow()) {
+            return new ValueTask<CachedResponse?>(entry.Response);
+        }
+
+        // Unindexed here rather than left to the eviction callback, which arrives on the thread
+        // pool: a tag still naming this key would take the next entry stored under the key with it
+        // the next time that tag was evicted.
+        lock (_keysByTag) {
+            Forget(key, entry);
+
+            _cache.Remove(key);
+        }
+
+        return new ValueTask<CachedResponse?>((CachedResponse?)null);
+    }
 
     /// <summary>
     /// Stores <paramref name="response"/>, unless it is larger than one entry may be.
@@ -80,11 +117,11 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
             // A key written again may have been indexed under different tags. Unindexing what is
             // being replaced is what keeps EvictByTag from dropping an entry that is no longer
             // tagged that way, and it is why the callback ignores a replacement.
-            if (_cache.TryGetValue(key, out CachedResponse? replaced)) {
+            if (_cache.TryGetValue(key, out Entry? replaced)) {
                 Forget(key, replaced);
             }
 
-            _cache.Set(key, response, new MemoryCacheEntryOptions {
+            _cache.Set(key, new Entry(response, _timeProvider.GetUtcNow() + duration), new MemoryCacheEntryOptions {
                 AbsoluteExpirationRelativeToNow = duration,
 
                 // Sized, because MemoryCacheOptions.SizeLimit is only enforced when every entry says
@@ -126,6 +163,16 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
 
     public void Dispose() => _cache.Dispose();
 
+    /// <summary>
+    /// A stored response and when this store stops answering with it.
+    /// </summary>
+    /// <remarks>
+    /// The expiry is held rather than derived, so the entry carries the answer for the clock the
+    /// store was given. <see cref="MemoryCache"/> holds its own, on the machine clock, and that one
+    /// only decides when the memory is freed.
+    /// </remarks>
+    private sealed record Entry(CachedResponse Response, DateTimeOffset ExpiresAt);
+
     /// <remarks>Called holding the lock.</remarks>
     private void Index(string key, IReadOnlyList<string> tags) {
         foreach (var tag in tags) {
@@ -156,8 +203,7 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
             // evicted: these arrive on the thread pool, so a key can be stored again before its
             // predecessor's callback runs. Unindexing then would leave a response nothing can
             // invalidate.
-            if (_cache.TryGetValue(key, out CachedResponse? current) &&
-                !ReferenceEquals(current, value)) {
+            if (_cache.TryGetValue(key, out Entry? current) && !ReferenceEquals(current, value)) {
                 return;
             }
 
@@ -167,13 +213,13 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
 
     /// <remarks>Called holding the lock.</remarks>
     private void Forget(object key, object? value) {
-        if (value is not CachedResponse response) {
+        if (value is not Entry entry) {
             return;
         }
 
         var name = (string)key;
 
-        foreach (var tag in response.Tags) {
+        foreach (var tag in entry.Response.Tags) {
             if (!_keysByTag.TryGetValue(tag, out var tagged)) {
                 continue;
             }

--- a/src/Requests/Hardened.Requests.Caching.Memory/MemoryResponseCacheStore.cs
+++ b/src/Requests/Hardened.Requests.Caching.Memory/MemoryResponseCacheStore.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Hardened.Requests.Abstract.Caching;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -117,19 +118,23 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
             // A key written again may have been indexed under different tags. Unindexing what is
             // being replaced is what keeps EvictByTag from dropping an entry that is no longer
             // tagged that way, and it is why the callback ignores a replacement.
+            // Not null when the lookup succeeded: this store is the only thing that writes to its
+            // own cache, and it never writes one.
             if (_cache.TryGetValue(key, out Entry? replaced)) {
-                Forget(key, replaced);
+                Forget(key, replaced!);
             }
 
-            _cache.Set(key, new Entry(response, _timeProvider.GetUtcNow() + duration), new MemoryCacheEntryOptions {
+            var entry = new Entry(response, _timeProvider.GetUtcNow() + duration) {
+                TagSets = Index(key, response.Tags)
+            };
+
+            _cache.Set(key, entry, new MemoryCacheEntryOptions {
                 AbsoluteExpirationRelativeToNow = duration,
 
                 // Sized, because MemoryCacheOptions.SizeLimit is only enforced when every entry says
                 // how big it is - and an entry with no size on a cache with a limit throws.
                 Size = response.Size
             }.RegisterPostEvictionCallback(OnEvicted));
-
-            Index(key, response.Tags);
         }
 
         return default;
@@ -171,30 +176,74 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
     /// store was given. <see cref="MemoryCache"/> holds its own, on the machine clock, and that one
     /// only decides when the memory is freed.
     /// </remarks>
-    private sealed record Entry(CachedResponse Response, DateTimeOffset ExpiresAt);
+    private sealed record Entry(CachedResponse Response, DateTimeOffset ExpiresAt) {
 
-    /// <remarks>Called holding the lock.</remarks>
-    private void Index(string key, IReadOnlyList<string> tags) {
-        foreach (var tag in tags) {
+        /// <summary>
+        /// The index sets this entry was added to, so leaving them needs no lookup. Empty for an
+        /// entry whose declaration named no tags, which is most of them.
+        /// </summary>
+        public IReadOnlyList<(string Tag, HashSet<string> Keys)> TagSets { get; init; } = [];
+    }
+
+    /// <summary>
+    /// Adds <paramref name="key"/> to each tag's keys, and hands back the sets it joined.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The sets rather than the tag names, because the entry keeps them: leaving an index is then a
+    /// removal from a set the entry already holds, with no dictionary lookup that could miss. The
+    /// case that would have missed is real - a tag evicted while an entry carrying it is still in
+    /// the cache - and it arrives on the thread pool, where no test can meet it.
+    /// </para>
+    /// <para>Called holding the lock.</para>
+    /// </remarks>
+    private IReadOnlyList<(string Tag, HashSet<string> Keys)> Index(
+        string key, IReadOnlyList<string> tags) {
+        if (tags.Count == 0) {
+            return [];
+        }
+
+        var joined = new (string, HashSet<string>)[tags.Count];
+
+        for (var i = 0; i < tags.Count; i++) {
+            var tag = tags[i];
+
             if (!_keysByTag.TryGetValue(tag, out var tagged)) {
                 _keysByTag[tag] = tagged = new HashSet<string>(StringComparer.Ordinal);
             }
 
             tagged.Add(key);
+            joined[i] = (tag, tagged);
         }
+
+        return joined;
     }
 
     /// <summary>
-    /// Takes an entry that is no longer in the cache out of the index.
+    /// Takes an entry <see cref="MemoryCache"/> reclaimed out of the index.
     /// </summary>
     /// <remarks>
-    /// Without it the index grows for the life of the process: every expired entry would leave its
-    /// key behind under every tag it carried, and an eviction by tag would walk keys that are long
-    /// gone.
+    /// <para>
+    /// <b>The only cleanup this store does not schedule itself.</b> <c>Set</c>, <c>Get</c> and
+    /// <see cref="EvictByTag"/> each unindex before they remove, so by the time this runs for one
+    /// of them there is nothing left to do. What is left is what <see cref="MemoryCache"/>
+    /// reclaims on its own - an expiry its own scan found, a compaction under the size limit - and
+    /// without this the index would name those keys for the life of the process.
+    /// </para>
+    /// <para>
+    /// Excluded from coverage rather than asserted. <see cref="MemoryCache"/> raises these on the
+    /// thread pool, so whether it has run at any moment is a race, and no sequence of <c>Get</c>,
+    /// <c>Set</c> and <see cref="EvictByTag"/> can both schedule one and observe its effect: the
+    /// index is not readable from outside, and every consequence of it is one the synchronous
+    /// paths have already produced. A test here would assert a timing window.
+    /// </para>
     /// </remarks>
+    [ExcludeFromCodeCoverage(
+        Justification = "Raised by MemoryCache on the thread pool, for reclamation this store did " +
+                        "not schedule. No test driving the public surface can execute it.")]
     private void OnEvicted(object key, object? value, EvictionReason reason, object? state) {
         // A replacement has already been unindexed by Set, which knew the new entry's tags.
-        if (reason == EvictionReason.Replaced) {
+        if (reason == EvictionReason.Replaced || value is not Entry evicted) {
             return;
         }
 
@@ -203,32 +252,33 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
             // evicted: these arrive on the thread pool, so a key can be stored again before its
             // predecessor's callback runs. Unindexing then would leave a response nothing can
             // invalidate.
-            if (_cache.TryGetValue(key, out Entry? current) && !ReferenceEquals(current, value)) {
+            if (_cache.TryGetValue(key, out Entry? current) && !ReferenceEquals(current, evicted)) {
                 return;
             }
 
-            Forget(key, value);
+            Forget((string)key, evicted);
         }
     }
 
-    /// <remarks>Called holding the lock.</remarks>
-    private void Forget(object key, object? value) {
-        if (value is not Entry entry) {
-            return;
-        }
-
-        var name = (string)key;
-
-        foreach (var tag in entry.Response.Tags) {
-            if (!_keysByTag.TryGetValue(tag, out var tagged)) {
-                continue;
-            }
-
-            tagged.Remove(name);
-
-            if (tagged.Count == 0) {
-                _keysByTag.Remove(tag);
-            }
+    /// <summary>
+    /// Takes an entry that is no longer in the cache out of the sets it joined.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Without it the index grows for the life of the process: every entry would leave its key
+    /// behind under every tag it carried, and an eviction by tag would walk keys that are long
+    /// gone.
+    /// </para>
+    /// <para>
+    /// A set emptied this way is left in place. Removing it would have to prove the dictionary
+    /// still holds this set rather than one built for the same tag since - and an empty set costs
+    /// one entry per tag an application uses, which is a number the application writes by hand.
+    /// </para>
+    /// <para>Called holding the lock.</para>
+    /// </remarks>
+    private static void Forget(string key, Entry entry) {
+        foreach (var (_, tagged) in entry.TagSets) {
+            tagged.Remove(key);
         }
     }
 }

--- a/src/Requests/Hardened.Requests.Caching.Memory/MemoryResponseCacheStore.cs
+++ b/src/Requests/Hardened.Requests.Caching.Memory/MemoryResponseCacheStore.cs
@@ -30,6 +30,23 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
     private readonly MemoryCache _cache;
     private readonly long _maximumBodySize;
 
+    /// <summary>
+    /// Which keys each tag names.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Held here rather than asked of <see cref="MemoryCache"/>, which cannot enumerate its own
+    /// keys and could not answer "every entry tagged rates" if it could - the tag is on the entry.
+    /// </para>
+    /// <para>
+    /// Under a lock rather than concurrent collections. Every operation on it is a whole tag or a
+    /// whole entry, so the unit that has to be atomic is bigger than one dictionary write, and
+    /// <see cref="EvictByTag"/> taking the tag out before touching the cache is what stops a
+    /// concurrent store from re-indexing a key mid-eviction.
+    /// </para>
+    /// </remarks>
+    private readonly Dictionary<string, HashSet<string>> _keysByTag = new(StringComparer.Ordinal);
+
     public MemoryResponseCacheStore(IOptions<IMemoryResponseCacheConfiguration> configuration) {
         var settings = configuration.Value;
 
@@ -54,16 +71,118 @@ public sealed class MemoryResponseCacheStore : IResponseCacheStore, IDisposable 
             return default;
         }
 
-        _cache.Set(key, response, new MemoryCacheEntryOptions {
-            AbsoluteExpirationRelativeToNow = duration,
+        // Written and indexed as one step, under the lock the eviction callback also takes. Apart,
+        // a callback for the entry being replaced can arrive after the new entry has been indexed -
+        // MemoryCache raises them on the thread pool - and unindex the entry that just arrived,
+        // which leaves a response nothing can invalidate and a publish nobody sees until it
+        // expires.
+        lock (_keysByTag) {
+            // A key written again may have been indexed under different tags. Unindexing what is
+            // being replaced is what keeps EvictByTag from dropping an entry that is no longer
+            // tagged that way, and it is why the callback ignores a replacement.
+            if (_cache.TryGetValue(key, out CachedResponse? replaced)) {
+                Forget(key, replaced);
+            }
 
-            // Sized, because MemoryCacheOptions.SizeLimit is only enforced when every entry says
-            // how big it is - and an entry with no size on a cache with a limit throws.
-            Size = response.Size
-        });
+            _cache.Set(key, response, new MemoryCacheEntryOptions {
+                AbsoluteExpirationRelativeToNow = duration,
+
+                // Sized, because MemoryCacheOptions.SizeLimit is only enforced when every entry says
+                // how big it is - and an entry with no size on a cache with a limit throws.
+                Size = response.Size
+            }.RegisterPostEvictionCallback(OnEvicted));
+
+            Index(key, response.Tags);
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Drops every entry stored under <paramref name="tag"/>.
+    /// </summary>
+    /// <remarks>
+    /// The tag is taken out of the index before anything is removed from the cache, so a concurrent
+    /// store cannot add a key to a tag that is halfway through being evicted. Keys carrying other
+    /// tags as well are unindexed from those by the eviction callback.
+    /// </remarks>
+    public ValueTask EvictByTag(string tag, CancellationToken cancellationToken) {
+        string[] keys;
+
+        lock (_keysByTag) {
+            if (!_keysByTag.Remove(tag, out var tagged)) {
+                return default;
+            }
+
+            keys = [..tagged];
+        }
+
+        foreach (var key in keys) {
+            _cache.Remove(key);
+        }
 
         return default;
     }
 
     public void Dispose() => _cache.Dispose();
+
+    /// <remarks>Called holding the lock.</remarks>
+    private void Index(string key, IReadOnlyList<string> tags) {
+        foreach (var tag in tags) {
+            if (!_keysByTag.TryGetValue(tag, out var tagged)) {
+                _keysByTag[tag] = tagged = new HashSet<string>(StringComparer.Ordinal);
+            }
+
+            tagged.Add(key);
+        }
+    }
+
+    /// <summary>
+    /// Takes an entry that is no longer in the cache out of the index.
+    /// </summary>
+    /// <remarks>
+    /// Without it the index grows for the life of the process: every expired entry would leave its
+    /// key behind under every tag it carried, and an eviction by tag would walk keys that are long
+    /// gone.
+    /// </remarks>
+    private void OnEvicted(object key, object? value, EvictionReason reason, object? state) {
+        // A replacement has already been unindexed by Set, which knew the new entry's tags.
+        if (reason == EvictionReason.Replaced) {
+            return;
+        }
+
+        lock (_keysByTag) {
+            // The index entry belongs to whatever is in the cache now, which may not be what was
+            // evicted: these arrive on the thread pool, so a key can be stored again before its
+            // predecessor's callback runs. Unindexing then would leave a response nothing can
+            // invalidate.
+            if (_cache.TryGetValue(key, out CachedResponse? current) &&
+                !ReferenceEquals(current, value)) {
+                return;
+            }
+
+            Forget(key, value);
+        }
+    }
+
+    /// <remarks>Called holding the lock.</remarks>
+    private void Forget(object key, object? value) {
+        if (value is not CachedResponse response) {
+            return;
+        }
+
+        var name = (string)key;
+
+        foreach (var tag in response.Tags) {
+            if (!_keysByTag.TryGetValue(tag, out var tagged)) {
+                continue;
+            }
+
+            tagged.Remove(name);
+
+            if (tagged.Count == 0) {
+                _keysByTag.Remove(tag);
+            }
+        }
+    }
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheResponseAttributeTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheResponseAttributeTests.cs
@@ -90,16 +90,83 @@ public class CacheResponseAttributeTests {
 
     /// <summary>
     /// A requirement over grants alone settles before serialization, which is ahead of the cache, so
-    /// it is safe to cache behind one.
+    /// it is safe to cache behind one - once the declaration has said who the answer is for.
     /// </summary>
     [Fact]
     public void AGrantOnlyHandlerIsStillCached() {
-        var attribute = new CacheResponseAttribute<CacheTestSupport.FixedKey>();
+        var attribute = new CacheResponseAttribute<CacheTestSupport.FixedKey> {
+            Scope = CacheScope.AllCallers
+        };
 
         var handler = CacheTestSupport.Handler(
             [attribute], requirement: Requirement.Grant("catalog:read"));
 
         Assert.Single(attribute.GetFilters(handler));
+    }
+
+    /// <summary>
+    /// The defect three trial arms found, from the other end: a handler whose answer might depend
+    /// on who asked, cached without anybody having decided that it does not.
+    /// </summary>
+    /// <remarks>
+    /// The framework used to decide this from <c>Requirement.RequiresContext</c>, which is true
+    /// only for a predicate requirement - so an ownership check written as handler code, which is
+    /// what a description forces, was cached and served to the next caller. Nothing on the handler
+    /// distinguishes that from a shared read, so the declaration has to.
+    /// </remarks>
+    [Theory]
+    [InlineData("grant")]
+    [InlineData("authenticated")]
+    public void AGuardedHandlerThatStatesNoScopeNamesTheHandler(string kind) {
+        var attribute = new CacheResponseAttribute<CacheTestSupport.FixedKey>();
+
+        var handler = CacheTestSupport.Handler(
+            [attribute],
+            requirement: kind == "grant"
+                ? Requirement.Grant("catalog:read")
+                : Requirement.Authenticated());
+
+        var exception = Assert.Throws<CacheScopeUndeclaredException>(
+            () => attribute.GetFilters(handler).ToList());
+
+        Assert.Equal("GET /catalog", exception.Handler);
+        Assert.Contains("CacheScope.PerCaller", exception.Message);
+        Assert.Contains("CacheScope.AllCallers", exception.Message);
+    }
+
+    /// <summary>
+    /// A handler that requires nothing of its caller has one audience whatever it answers, so there
+    /// is nothing to decide and the ordinary public read stays free of ceremony.
+    /// </summary>
+    [Fact]
+    public void AnUnguardedHandlerNeedsNoScope() {
+        var attribute = new CacheResponseAttribute<CacheTestSupport.FixedKey>();
+
+        Assert.Single(attribute.GetFilters(CacheTestSupport.Handler([attribute])));
+    }
+
+    /// <summary>
+    /// Composed attributes share one entry, so it has one audience. Two that disagree is a mistake
+    /// rather than a precedence question.
+    /// </summary>
+    [Fact]
+    public void TwoScopesThatDisagreeNameTheHandler() {
+        var first = new CacheResponseAttribute<CacheTestSupport.FixedKey> {
+            Scope = CacheScope.AllCallers
+        };
+
+        var second = new CacheResponseAttribute<CacheTestSupport.SecondKey> {
+            Scope = CacheScope.PerCaller
+        };
+
+        var handler = CacheTestSupport.Handler([first, second]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => first.GetFilters(handler).ToList());
+
+        Assert.Contains("GET /catalog", exception.Message);
+        Assert.Contains(nameof(CacheScope.AllCallers), exception.Message);
+        Assert.Contains(nameof(CacheScope.PerCaller), exception.Message);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheResponseAttributeTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheResponseAttributeTests.cs
@@ -224,6 +224,38 @@ public class CacheResponseAttributeTests {
     }
 
     /// <summary>
+    /// The tags every declaration named reach the entry, in the order they were declared, and a
+    /// tag two of them named is one tag.
+    /// </summary>
+    [Fact]
+    public async Task ComposedTagsBecomeOneSet() {
+        var first = new CacheResponseAttribute<CacheTestSupport.FixedKey> {
+            Tags = ["rates", "symbols"]
+        };
+
+        var second = new CacheResponseAttribute<CacheTestSupport.SecondKey> {
+            Tags = ["symbols", "alerts"]
+        };
+
+        var handler = CacheTestSupport.Handler([first, second]);
+        var filter = ResponseCacheFilter.Compose(handler, [first, second]);
+
+        Assert.Equal(["rates", "symbols", "alerts"], (await Stored(filter)).Tags);
+    }
+
+    /// <summary>
+    /// A declaration naming none is an entry nothing can invalidate by name, which is what every
+    /// declaration written before tags existed is.
+    /// </summary>
+    [Fact]
+    public async Task ADeclarationWithNoTagsStoresNone() {
+        var attribute = new CacheResponseAttribute<CacheTestSupport.FixedKey>();
+        var handler = CacheTestSupport.Handler([attribute]);
+
+        Assert.Empty((await Stored(ResponseCacheFilter.Compose(handler, [attribute]))).Tags);
+    }
+
+    /// <summary>
     /// The attribute's own values reach the strategy that was named.
     /// </summary>
     [Fact]
@@ -250,6 +282,23 @@ public class CacheResponseAttributeTests {
         await Pipeline.Chain(context, filter).Next();
 
         return Assert.Single(store.Writes).Duration;
+    }
+
+    /// <summary>
+    /// The entry this filter hands the store, observed by serving one request through it.
+    /// </summary>
+    private static async Task<CachedResponse> Stored(ResponseCacheFilter filter) {
+        var store = new CacheTestSupport.RecordingStore();
+
+        var context = Pipeline.Context(
+            configureServices: services => services.AddSingleton<IResponseCacheStore>(store));
+
+        await Pipeline.Chain(context, filter).Next();
+
+        var key = Assert.Single(store.Writes).Key;
+
+        return Assert.IsType<CachedResponse>(
+            await store.Get(key, TestContext.Current.CancellationToken));
     }
 
     private sealed class RecordingProvider : ICacheKeyProvider {

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheTestSupport.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/CacheTestSupport.cs
@@ -36,6 +36,8 @@ internal static class CacheTestSupport {
 
         public List<(string Key, TimeSpan Duration)> Writes { get; } = [];
 
+        public List<string> Evictions { get; } = [];
+
         public ValueTask<CachedResponse?> Get(string key, CancellationToken cancellationToken) {
             Reads.Add(key);
 
@@ -47,6 +49,20 @@ internal static class CacheTestSupport {
             string key, CachedResponse response, TimeSpan duration, CancellationToken cancellationToken) {
             Writes.Add((key, duration));
             _entries[key] = response;
+
+            return default;
+        }
+
+        /// <summary>
+        /// Drops what it was given under that tag, so a test can assert on the entry rather than on
+        /// the call.
+        /// </summary>
+        public ValueTask EvictByTag(string tag, CancellationToken cancellationToken) {
+            Evictions.Add(tag);
+
+            foreach (var entry in _entries.Where(e => e.Value.Tags.Contains(tag)).ToList()) {
+                _entries.Remove(entry.Key);
+            }
 
             return default;
         }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
@@ -310,6 +310,90 @@ public class ResponseCacheFilterTests {
         Assert.Contains("Hardened.Requests.Caching.Memory", exception.Message);
     }
 
+    /// <summary>
+    /// The authorization bypass this filter shipped with, found in the 0.19.0-rc1000 trial.
+    /// </summary>
+    /// <remarks>
+    /// <c>AuthorizationFilter</c> and <c>RateLimitFilter</c> sit ahead of this stage and refuse by
+    /// recording the failure and calling <c>Next</c>, so the serialization filter behind can write
+    /// it. Replaying a stored 200 over that record answered the refused caller with an entry a
+    /// permitted caller had filled.
+    /// </remarks>
+    [Fact]
+    public async Task ARefusedRequestIsNotAnsweredFromTheStore() {
+        var store = new CacheTestSupport.RecordingStore();
+
+        await Pipeline.Chain(Context(store), Filter(), Writing("secret")).Next();
+
+        var refused = Context(store);
+
+        refused.Response.ExceptionValue = new UnauthorizedAccessException("no grant");
+
+        // The warming request read the store on its way to missing. What matters is what the
+        // refused one does, so only its reads are in scope.
+        store.Reads.Clear();
+
+        // Nothing stands in for the handler here, because nothing runs one: the serialization
+        // filter reads the same record and writes the refusal instead of binding and invoking.
+        await Pipeline.Chain(refused, Filter()).Next();
+
+        Assert.Equal("", BodyOf(refused));
+        Assert.Empty(store.Reads);
+    }
+
+    /// <summary>
+    /// The refusal survives the stage, so the filter behind still has one to write.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedRequestKeepsItsRefusal() {
+        var store = new CacheTestSupport.RecordingStore();
+        var refusal = new UnauthorizedAccessException("no grant");
+        var context = Context(store);
+
+        context.Response.ExceptionValue = refusal;
+
+        await Pipeline.Chain(context, Filter()).Next();
+
+        Assert.Same(refusal, context.Response.ExceptionValue);
+    }
+
+    /// <summary>
+    /// A refused request continues down the chain, which is what lets the serialization filter
+    /// write the refusal. Returning here instead would answer nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedRequestStillReachesTheFilterThatWritesIt() {
+        var store = new CacheTestSupport.RecordingStore();
+        var context = Context(store);
+        var reached = false;
+
+        context.Response.ExceptionValue = new UnauthorizedAccessException("no grant");
+
+        await Pipeline.Chain(context, Filter(), new Pipeline.Inline(_ => {
+            reached = true;
+
+            return Task.CompletedTask;
+        })).Next();
+
+        Assert.True(reached);
+    }
+
+    /// <summary>
+    /// Nor does a refused request fill the store. A key computed from a request nobody was allowed
+    /// to make is one the next caller would hit.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedRequestIsNotStored() {
+        var store = new CacheTestSupport.RecordingStore();
+        var context = Context(store);
+
+        context.Response.ExceptionValue = new UnauthorizedAccessException("no grant");
+
+        await Pipeline.Chain(context, Filter(), Writing("secret")).Next();
+
+        Assert.Empty(store.Writes);
+    }
+
     private static Pipeline.Inline Writing(string body, Action? onRun = null) =>
         new(async chain => {
             onRun?.Invoke();

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
@@ -300,15 +300,39 @@ public class ResponseCacheFilterTests {
     /// The store is the whole opt-in, so a handler that declares caching in an application with no
     /// store says so rather than quietly serving uncached.
     /// </summary>
+    /// <remarks>
+    /// Recorded on the response rather than thrown. This stage is ahead of the filter that turns a
+    /// failure into bytes, and throwing unwound past it - so this message reached the log and the
+    /// caller got a 500 with Content-Length: 0.
+    /// </remarks>
     [Fact]
     public async Task NoRegisteredStoreNamesTheHandler() {
-        var chain = Pipeline.Chain(Pipeline.Context(), Filter(), Writing("catalog"));
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, Filter(), Writing("catalog")).Next();
 
         var exception =
-            await Assert.ThrowsAsync<ResponseCacheStoreMissingException>(() => chain.Next());
+            Assert.IsType<ResponseCacheStoreMissingException>(context.Response.ExceptionValue);
 
         Assert.Equal("GET /catalog", exception.Handler);
         Assert.Contains("Hardened.Requests.Caching.Memory", exception.Message);
+    }
+
+    /// <summary>
+    /// And the chain continues, which is what lets the serialization filter write the failure as
+    /// the framework's error envelope instead of a bodyless 500.
+    /// </summary>
+    [Fact]
+    public async Task NoRegisteredStoreStillReachesTheFilterThatWritesIt() {
+        var reached = false;
+
+        await Pipeline.Chain(Pipeline.Context(), Filter(), new Pipeline.Inline(_ => {
+            reached = true;
+
+            return Task.CompletedTask;
+        })).Next();
+
+        Assert.True(reached);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Caching;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
@@ -484,6 +485,94 @@ public class ResponseCacheFilterTests {
         await Pipeline.Chain(context, Filter(), Writing("secret")).Next();
 
         Assert.Empty(store.Writes);
+    }
+
+    /// <summary>
+    /// One caller's answer is never handed to another, whatever the handler put in it.
+    /// </summary>
+    /// <remarks>
+    /// The key carries the caller, so the ownership check that did not run on the hit does not need
+    /// to: the entry belongs to the caller it was filled for.
+    /// </remarks>
+    [Fact]
+    public async Task PerCallerAnswersEachCallerFromTheirOwnEntry() {
+        var store = new CacheTestSupport.RecordingStore();
+
+        await Pipeline.Chain(
+            AsCaller(store, "subscriber-one"), PerCaller(), Writing("one")).Next();
+
+        var other = AsCaller(store, "subscriber-two");
+
+        await Pipeline.Chain(other, PerCaller(), Writing("two")).Next();
+
+        Assert.Equal("two", BodyOf(other));
+    }
+
+    /// <summary>
+    /// And the same caller twice is still a hit, so the feature survives being made safe.
+    /// </summary>
+    [Fact]
+    public async Task PerCallerStillAnswersTheSameCallerFromTheStore() {
+        var store = new CacheTestSupport.RecordingStore();
+        var ran = 0;
+
+        await Pipeline.Chain(
+            AsCaller(store, "subscriber-one"),
+            PerCaller(),
+            Writing("one", () => ran++)).Next();
+
+        await Pipeline.Chain(
+            AsCaller(store, "subscriber-one"),
+            PerCaller(),
+            Writing("one", () => ran++)).Next();
+
+        Assert.Equal(1, ran);
+    }
+
+    /// <summary>
+    /// Two issuers naming the same subject are two callers. An application that accepts more than
+    /// one is the application where that matters.
+    /// </summary>
+    [Fact]
+    public async Task PerCallerSeparatesTheSameSubjectFromTwoIssuers() {
+        var store = new CacheTestSupport.RecordingStore();
+
+        await Pipeline.Chain(
+            AsCaller(store, "subject", issuer: "https://first"), PerCaller(), Writing("one")).Next();
+
+        var other = AsCaller(store, "subject", issuer: "https://second");
+
+        await Pipeline.Chain(other, PerCaller(), Writing("two")).Next();
+
+        Assert.Equal("two", BodyOf(other));
+    }
+
+    /// <summary>
+    /// A caller with no subject has nothing to key on, and the entry that would result is the
+    /// shared one this scope exists to refuse. So the request is neither looked up nor stored.
+    /// </summary>
+    [Fact]
+    public async Task PerCallerLeavesACallerWithNoSubjectUncached() {
+        var store = new CacheTestSupport.RecordingStore();
+        var context = Context(store);
+
+        await Pipeline.Chain(context, PerCaller(), Writing("one")).Next();
+
+        Assert.Equal("one", BodyOf(context));
+        Assert.Empty(store.Reads);
+        Assert.Empty(store.Writes);
+    }
+
+    private static ResponseCacheFilter PerCaller() =>
+        new([new CacheTestSupport.FixedKey()], "GET /catalog", 60, CacheScope.PerCaller);
+
+    private static IExecutionContext AsCaller(
+        CacheTestSupport.RecordingStore store, string subject, string? issuer = null) {
+        var context = Context(store);
+
+        context.CallerPrincipal = new CallerPrincipal("test", subject: subject, issuer: issuer);
+
+        return context;
     }
 
     private static Pipeline.Inline Writing(string body, Action? onRun = null) =>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Caching/ResponseCacheFilterTests.cs
@@ -311,6 +311,98 @@ public class ResponseCacheFilterTests {
     }
 
     /// <summary>
+    /// The header that made every cache hit malformed on a real socket, found in the
+    /// 0.19.0-rc1000 trial.
+    /// </summary>
+    /// <remarks>
+    /// A host frames a response with no <c>Content-Length</c> as <c>Transfer-Encoding: chunked</c>
+    /// and puts that header on the response it is writing. The capture kept it, and the hit
+    /// re-declared chunked framing and then wrote the stored bytes unframed - zero body on Kestrel,
+    /// a protocol error on ASP.NET Core. <c>ITestWebApp</c> has no transport, so nothing in this
+    /// repository could see it.
+    /// </remarks>
+    [Theory]
+    [InlineData(KnownHeaders.TransferEncoding, "chunked")]
+    [InlineData(KnownHeaders.ContentLength, "149")]
+    [InlineData(KnownHeaders.Connection, "keep-alive")]
+    [InlineData(KnownHeaders.KeepAlive, "timeout=5")]
+    [InlineData(KnownHeaders.Trailer, "Expires")]
+    [InlineData(KnownHeaders.Upgrade, "websocket")]
+    [InlineData(KnownHeaders.Date, "Wed, 03 Sep 2026 09:00:00 GMT")]
+    [InlineData(KnownHeaders.Server, "Kestrel")]
+    public async Task ATransportHeaderIsNeverStored(string name, string value) {
+        var store = new CacheTestSupport.RecordingStore();
+
+        // Set inside the chain, which is where the transport sets it: the body is copied to the
+        // real stream in CaptureAndStore's finally, and framing is decided by that write.
+        await Pipeline.Chain(Context(store), Filter(), new Pipeline.Inline(chain => {
+            chain.Context.Response.Headers[name] = new StringValues(value);
+
+            return Task.CompletedTask;
+        })).Next();
+
+        var second = Context(store);
+
+        await Pipeline.Chain(second, Filter()).Next();
+
+        Assert.False(second.Response.Headers.ContainsKey(name));
+    }
+
+    /// <summary>
+    /// A header the response already carried belongs to the request that carried it, not to the
+    /// representation.
+    /// </summary>
+    /// <remarks>
+    /// The filters that write these sit ahead of this stage, so they run on a hit as well as on a
+    /// miss and write the current request's value. Storing one froze the first caller's
+    /// <c>X-Correlation-Id</c> onto every later caller for the whole duration, and did the same to
+    /// <c>RateLimit-Remaining</c>.
+    /// </remarks>
+    [Fact]
+    public async Task AHeaderTheChainDidNotWriteIsNotStored() {
+        var store = new CacheTestSupport.RecordingStore();
+        var first = Context(store);
+
+        first.Response.Headers["X-Correlation-Id"] = new StringValues("first");
+
+        await Pipeline.Chain(first, Filter(), Writing("catalog")).Next();
+
+        var second = Context(store);
+
+        second.Response.Headers["X-Correlation-Id"] = new StringValues("second");
+
+        await Pipeline.Chain(second, Filter()).Next();
+
+        Assert.Equal("second", second.Response.Headers["X-Correlation-Id"]);
+    }
+
+    /// <summary>
+    /// A header the chain changed is stored, because a miss would have changed it the same way.
+    /// </summary>
+    [Fact]
+    public async Task AHeaderTheChainChangedIsStored() {
+        var store = new CacheTestSupport.RecordingStore();
+        var first = Context(store);
+
+        first.Response.Headers[KnownHeaders.CacheControl] = new StringValues("no-store");
+
+        await Pipeline.Chain(first, Filter(), new Pipeline.Inline(chain => {
+            chain.Context.Response.Headers[KnownHeaders.CacheControl] =
+                new StringValues("public, max-age=60");
+
+            return Task.CompletedTask;
+        })).Next();
+
+        var second = Context(store);
+
+        second.Response.Headers[KnownHeaders.CacheControl] = new StringValues("no-store");
+
+        await Pipeline.Chain(second, Filter()).Next();
+
+        Assert.Equal("public, max-age=60", second.Response.Headers[KnownHeaders.CacheControl]);
+    }
+
+    /// <summary>
     /// The authorization bypass this filter shipped with, found in the 0.19.0-rc1000 trial.
     /// </summary>
     /// <remarks>

--- a/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
@@ -1,3 +1,4 @@
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Caching;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
@@ -31,13 +32,22 @@ namespace Hardened.Requests.Runtime.Caching;
 /// </para>
 ///
 /// <para>
-/// <b>A resource-scoped handler is never cached.</b> The filter runs at
-/// <see cref="FilterOrder.ResponseCache"/>, which is after authorization over grants alone
-/// and before authorization that reads bound parameters - so a stored response for "may this caller
-/// edit <em>this</em> pet" would be served to a caller the resource check would refuse. ASP.NET
-/// Core ships that hazard as a documentation note telling you to call <c>UseOutputCache</c> after
-/// <c>UseAuthorization</c>. Here the filter is not installed at all, decided once per handler from
-/// <see cref="IExecutionRequestHandlerInfo.Requirement"/>.
+/// <b>A handler that requires anything of its caller has to say who its answer may be served
+/// to.</b> Set <see cref="Scope"/> to <see cref="CacheScope.PerCaller"/> when the answer depends on
+/// who asked, or to <see cref="CacheScope.AllCallers"/> when every caller the guard admits gets the
+/// same bytes. Leaving it unstated on a guarded handler is a failure naming the handler as its
+/// filter chain is built, because both readings of silence are behaviour somebody would call a
+/// defect - see <see cref="CacheScope"/>. A handler requiring nothing needs none of this.
+/// </para>
+///
+/// <para>
+/// <b>A requirement that reads the request is still never cached.</b> The filter runs at
+/// <see cref="FilterOrder.ResponseCache"/>, which is after authorization over grants alone and
+/// before authorization that reads bound parameters - so such a requirement does not run on a hit
+/// at all, and keying per caller would not make it run. The filter is not installed, decided once
+/// per handler from <see cref="Requirement.RequiresContext"/>. ASP.NET Core ships the same hazard
+/// as a documentation note telling you to call <c>UseOutputCache</c> after
+/// <c>UseAuthorization</c>.
 /// </para>
 /// </summary>
 /// <typeparam name="TProvider">
@@ -56,9 +66,9 @@ namespace Hardened.Requests.Runtime.Caching;
 /// </para>
 /// <para>
 /// The cost is that the compiler no longer catches two of the same strategy, and that
-/// <see cref="Duration"/> can appear more than once. The first attribute that sets one wins and two
-/// that disagree fail as the chain is built, which keeps the ordinary single-attribute case free of
-/// ceremony.
+/// <see cref="Duration"/> and <see cref="Scope"/> can each appear more than once. The first
+/// attribute that sets one wins and two that disagree fail as the chain is built, which keeps the
+/// ordinary single-attribute case free of ceremony.
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
@@ -86,6 +96,16 @@ public sealed class CacheResponseAttribute<TProvider> :
     /// </remarks>
     public int Duration { get; set; }
 
+    /// <summary>
+    /// Who a stored response may be served to.
+    /// </summary>
+    /// <remarks>
+    /// Required on a handler that requires anything of its caller, and meaningless on one that does
+    /// not. Like <see cref="Duration"/> it is left at its default rather than assigned in the
+    /// constructor, so that "the author did not say" survives composition.
+    /// </remarks>
+    public CacheScope Scope { get; set; }
+
     public ICacheKeyProvider CreateKeyProvider() => TProvider.Create(Values);
 
     public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
@@ -93,6 +113,7 @@ public sealed class CacheResponseAttribute<TProvider> :
             yield break;
         }
 
+        // A requirement that reads the request does not run on a hit, and no scope makes it run.
         // Decided here rather than warned about. See the class remarks.
         if (handlerInfo.Requirement?.RequiresContext == true) {
             yield break;

--- a/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
@@ -106,6 +106,30 @@ public sealed class CacheResponseAttribute<TProvider> :
     /// </remarks>
     public CacheScope Scope { get; set; }
 
+    /// <summary>
+    /// The names an entry from this handler can be invalidated by.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [Get("/rates/{symbol}")]
+    /// [CacheResponse&lt;VaryByRoute&gt;(Duration = 3600, Tags = ["rates"])]
+    /// public Rate Read(string symbol) =&gt; _rates.Latest(symbol);
+    ///
+    /// // and where a new set is published
+    /// await _store.EvictByTag("rates", cancellationToken);
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// A name the declaration chooses, rather than the key the filter composed. The key carries the
+    /// handler's method and path, a unit separator, the caller when the scope is per-caller and
+    /// then each strategy's part - which is a shape nothing publishes and an application should not
+    /// have to rebuild to invalidate its own entries. Composed attributes contribute to one set, in
+    /// the order they were declared.
+    /// </remarks>
+    public string[] Tags { get; set; } = [];
+
+    IReadOnlyList<string> ICacheResponseDeclaration.Tags => Tags;
+
     public ICacheKeyProvider CreateKeyProvider() => TProvider.Create(Values);
 
     public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {

--- a/src/Requests/Hardened.Requests.Runtime/Caching/CacheScopeUndeclaredException.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/CacheScopeUndeclaredException.cs
@@ -1,0 +1,37 @@
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Caching;
+
+namespace Hardened.Requests.Runtime.Caching;
+
+/// <summary>
+/// A handler requires something of its caller, declares <c>[CacheResponse]</c>, and did not say who
+/// a stored response may be served to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Raised rather than read either way, because both readings are behaviour somebody would call a
+/// defect. Sharing one entry among callers is a data leak the moment the handler's answer depends
+/// on who asked; keying per caller is safe and silently turns a cache that was shedding load into
+/// one entry per caller. See <see cref="CacheScope"/>.
+/// </para>
+/// <para>
+/// Raised as the handler's filter chain is built, alongside the other two failures a declaration
+/// can express, so it names the handler and is asked once rather than per request.
+/// </para>
+/// </remarks>
+public class CacheScopeUndeclaredException : InvalidOperationException {
+
+    public CacheScopeUndeclaredException(string handler, Requirement requirement)
+        : base($"{handler} requires {requirement} of its caller and declares [CacheResponse] " +
+               "without saying who a stored response may be served to. Set " +
+               "Scope = CacheScope.PerCaller if the answer depends on who asked - an owner-scoped " +
+               "read, anything filtered by the caller's tenant - or Scope = CacheScope.AllCallers " +
+               "if every caller the guard admits gets the same bytes.") {
+        Handler = handler;
+    }
+
+    /// <summary>
+    /// The handler that declared it, as "METHOD /path".
+    /// </summary>
+    public string Handler { get; }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Text;
 using Hardened.Requests.Abstract.Caching;
 using Hardened.Requests.Abstract.Execution;
@@ -56,6 +57,45 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     /// no two different requests can compose the same key by moving the boundary between two parts.
     /// </remarks>
     private const char Separator = '\u001f';
+
+    /// <summary>
+    /// The response headers a stored entry never keeps, whatever wrote them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Hop-by-hop first, and that is the whole of a defect.</b> A response framed by the host as
+    /// <c>Transfer-Encoding: chunked</c> had that header captured with it, and a hit re-declared
+    /// chunked framing and then wrote the stored bytes with no chunk header and no terminator: zero
+    /// body on Kestrel, a protocol error on ASP.NET Core, on every cached operation and every key
+    /// strategy. RFC 9110 is explicit that these describe a connection rather than a representation
+    /// and must never be stored or forwarded, and the reason nothing here caught it is that
+    /// <c>ITestWebApp</c> has no transport to set one.
+    /// </para>
+    /// <para>
+    /// <c>Content-Length</c> for the same reason from the other end: the transport frames what is
+    /// actually written on the hit, and a stored length can only duplicate or contradict it.
+    /// <c>Date</c> and <c>Server</c> belong to the host and to the moment - a replayed <c>Date</c>
+    /// is what every downstream cache computes an age from.
+    /// </para>
+    /// <para>
+    /// <c>Set-Cookie</c> is here because it belongs to the caller rather than to the
+    /// representation. Replaying one hands a second caller the first one's session.
+    /// </para>
+    /// </remarks>
+    private static readonly FrozenSet<string> NotStored = new[] {
+        KnownHeaders.SetCookie,
+        KnownHeaders.TransferEncoding,
+        KnownHeaders.ContentLength,
+        KnownHeaders.Connection,
+        KnownHeaders.KeepAlive,
+        KnownHeaders.TE,
+        KnownHeaders.Trailer,
+        KnownHeaders.Upgrade,
+        KnownHeaders.ProxyAuthenticate,
+        KnownHeaders.ProxyAuthorization,
+        KnownHeaders.Date,
+        KnownHeaders.Server
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     private readonly ICacheKeyProvider[] _keyProviders;
     private readonly string _handlerKey;
@@ -255,6 +295,11 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
         var transportBody = response.Body;
         var buffer = new MemoryStream();
 
+        // Taken before the chain is entered, and taken after the key was composed so that a
+        // strategy writing its own header - VaryByHeader writes Vary - is on this side of the line
+        // rather than captured. See Replayable.
+        var carried = Carried(response.Headers);
+
         response.Body = buffer;
 
         try {
@@ -276,7 +321,7 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
             response.Status ?? 200,
             response.ContentType,
             buffer.ToArray(),
-            Replayable(response.Headers));
+            Replayable(response.Headers, carried));
 
         await store.Set(key, entry, _duration, context.CancellationToken);
     }
@@ -294,20 +339,54 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
         response.ExceptionValue == null && (response.Status ?? 200) == 200;
 
     /// <summary>
+    /// Headers this response already carried before the chain inside the cache was entered.
+    /// </summary>
+    /// <remarks>
+    /// Allocated on the miss path only, next to a buffer holding the whole body.
+    /// </remarks>
+    private static Dictionary<string, StringValues> Carried(
+        IDictionary<string, StringValues> headers) {
+        var carried = new Dictionary<string, StringValues>(
+            headers.Count, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var header in headers) {
+            carried[header.Key] = header.Value;
+        }
+
+        return carried;
+    }
+
+    /// <summary>
     /// The response headers a second caller may be given.
     /// </summary>
     /// <remarks>
-    /// Everything except <c>Set-Cookie</c>, which is about the caller rather than the representation
-    /// - replaying one hands a second caller the first one's session. Stripped as the response is
-    /// captured rather than as one is replayed, so a store written by an older build cannot leak one
-    /// either.
+    /// <para>
+    /// Stripped as the response is captured rather than as one is replayed, so a store written by
+    /// an older build cannot leak one either.
+    /// </para>
+    /// <para>
+    /// <b>Only what the chain inside the cache produced.</b> A header this response already carried
+    /// on the way in was written by a filter ordered ahead of this stage, which runs on a hit as
+    /// well as on a miss - so storing its value freezes one request's <c>X-Correlation-Id</c>, or
+    /// one request's <c>RateLimit-Remaining</c>, onto every later caller, while leaving out
+    /// nothing: the filter that wrote it writes it again. A header the chain <em>changed</em> is
+    /// kept, because a miss would have changed it the same way.
+    /// </para>
+    /// <para>
+    /// <see cref="NotStored"/> covers what is never the representation's whatever wrote it.
+    /// </para>
     /// </remarks>
     private static IReadOnlyList<KeyValuePair<string, StringValues>> Replayable(
-        IDictionary<string, StringValues> headers) {
+        IDictionary<string, StringValues> headers,
+        Dictionary<string, StringValues> carried) {
         var replayable = new List<KeyValuePair<string, StringValues>>(headers.Count);
 
         foreach (var header in headers) {
-            if (string.Equals(header.Key, KnownHeaders.SetCookie, StringComparison.OrdinalIgnoreCase)) {
+            if (NotStored.Contains(header.Key)) {
+                continue;
+            }
+
+            if (carried.TryGetValue(header.Key, out var before) && before.Equals(header.Value)) {
                 continue;
             }
 

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -46,7 +46,9 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     /// </summary>
     /// <remarks>
     /// ASP.NET Core's output cache defaults to the same minute. The alternative default is
-    /// "forever", which is the wrong one for a store nothing can invalidate by tag yet.
+    /// "forever", which is the wrong one to reach by saying nothing: a declaration that meant it
+    /// can name a duration, and one that did not think about it should not get an entry only a
+    /// tag can ever remove.
     /// </remarks>
     public const int DefaultDuration = 60;
 

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -23,6 +23,12 @@ namespace Hardened.Requests.Runtime.Caching;
 /// so a request served from the store is still measured and still logged.
 /// </para>
 /// <para>
+/// <b>A request a filter ahead of this one refused is neither answered from the store nor stored.</b>
+/// Those filters record the refusal and continue rather than short-circuiting, because the filter
+/// that writes it is behind them - so "still travelling" does not mean "still permitted", and this
+/// stage has to read what they recorded rather than infer it from having been reached.
+/// </para>
+/// <para>
 /// <b>Not for a handler that streams.</b> Capturing a response means buffering it, so a handler
 /// returning <c>IAsyncEnumerable&lt;T&gt;</c> would hold its whole sequence in memory and answer no
 /// sooner than it finished. This does not refuse one: whether a handler streams is decided by the
@@ -119,6 +125,22 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
 
     public async Task Execute(IExecutionChain chain) {
         var context = chain.Context;
+
+        // A request already refused is not one the store may answer.
+        //
+        // Everything ahead of FilterOrder.Serialization refuses by recording the failure on the
+        // response and calling Next, so that the serialization filter can write it - which means an
+        // authorization or rate-limit refusal reaches this filter as a request that is still
+        // travelling. Replaying a stored 200 over it discards the refusal and answers the caller who
+        // was turned away, from an entry a permitted caller filled. Both refusers sit ahead of this
+        // stage precisely so they settle first; reading what they recorded is what makes that
+        // ordering mean anything.
+        if (context.Response.ExceptionValue != null) {
+            await chain.Next();
+
+            return;
+        }
+
         var key = await Key(context);
 
         if (key == null) {

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -241,8 +241,8 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
         if (store == null) {
             // Recorded and continued rather than thrown, which is the rule for everything ahead of
             // FilterOrder.Serialization and one this filter used to break: throwing here unwound
-            // past the filter that writes a response, so the excellent message reached the log and
-            // the caller got a 500 with Content-Length: 0.
+            // past the filter that writes a response, so the message naming the handler reached the
+            // log and the caller got a 500 with Content-Length: 0.
             context.Response.ExceptionValue = new ResponseCacheStoreMissingException(_handlerKey);
 
             await chain.Next();
@@ -270,12 +270,14 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     }
 
     /// <summary>
-    /// The composite key, or null when any strategy declined this request.
+    /// The composite key, or null when a strategy declined this request or the caller cannot be
+    /// told apart from another.
     /// </summary>
     /// <remarks>
     /// <para>
     /// Prefixed with the handler's method and path, so two handlers keyed the same way - two routes
-    /// both varying on <c>culture</c> - do not answer each other's requests.
+    /// both varying on <c>culture</c> - do not answer each other's requests, and then by the caller
+    /// when the scope is <see cref="CacheScope.PerCaller"/>.
     /// </para>
     /// <para>
     /// A null from any one strategy leaves the whole request neither looked up nor stored. There is

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -219,6 +219,20 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
             return;
         }
 
+        var store = Store(context);
+
+        if (store == null) {
+            // Recorded and continued rather than thrown, which is the rule for everything ahead of
+            // FilterOrder.Serialization and one this filter used to break: throwing here unwound
+            // past the filter that writes a response, so the excellent message reached the log and
+            // the caller got a 500 with Content-Length: 0.
+            context.Response.ExceptionValue = new ResponseCacheStoreMissingException(_handlerKey);
+
+            await chain.Next();
+
+            return;
+        }
+
         var key = await Key(context);
 
         if (key == null) {
@@ -227,7 +241,6 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
             return;
         }
 
-        var store = Store(context);
         var cached = await store.Get(key, context.CancellationToken);
 
         if (cached != null) {
@@ -312,12 +325,18 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
         return string.IsNullOrEmpty(subject) ? null : principal.Issuer + Separator + subject;
     }
 
-    private IResponseCacheStore Store(IExecutionContext context) {
+    /// <summary>
+    /// The registered store, or null when the application registered none.
+    /// </summary>
+    /// <remarks>
+    /// Asked before the key is composed, so a declaration with nowhere to put its answers fails the
+    /// same way on every request rather than only on the requests a strategy was willing to key -
+    /// and so a <c>ByPayload</c> handler does not hash a body on the way to failing.
+    /// </remarks>
+    private IResponseCacheStore? Store(IExecutionContext context) {
         // Racy by construction and harmless: two requests may both resolve, and both are handed the
         // same singleton.
-        return _store ??=
-            context.RootServiceProvider.GetService<IResponseCacheStore>() ??
-            throw new ResponseCacheStoreMissingException(_handlerKey);
+        return _store ??= context.RootServiceProvider.GetService<IResponseCacheStore>();
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Text;
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Abstract.Caching;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
@@ -100,6 +101,7 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     private readonly ICacheKeyProvider[] _keyProviders;
     private readonly string _handlerKey;
     private readonly TimeSpan _duration;
+    private readonly CacheScope _scope;
 
     /// <summary>
     /// Resolved once, on the first request this filter serves. There is no service provider where
@@ -108,10 +110,21 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     /// </summary>
     private IResponseCacheStore? _store;
 
-    public ResponseCacheFilter(ICacheKeyProvider[] keyProviders, string handlerKey, int duration) {
+    /// <param name="scope">
+    /// Who a stored response may be served to. <see cref="CacheScope.Unstated"/> is taken as
+    /// <see cref="CacheScope.AllCallers"/> here: whether leaving it unstated is allowed at all is
+    /// decided in <see cref="Compose"/>, which is the half that can see what the handler requires
+    /// of its caller.
+    /// </param>
+    public ResponseCacheFilter(
+        ICacheKeyProvider[] keyProviders,
+        string handlerKey,
+        int duration,
+        CacheScope scope = CacheScope.AllCallers) {
         _keyProviders = keyProviders;
         _handlerKey = handlerKey;
         _duration = TimeSpan.FromSeconds(duration <= 0 ? DefaultDuration : duration);
+        _scope = scope;
     }
 
     /// <summary>
@@ -119,14 +132,16 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     /// </summary>
     /// <remarks>
     /// Called once per handler, as its filter chain is built. Every failure a declaration can
-    /// express - a strategy handed values it cannot use, two durations that disagree - is raised
-    /// here, naming the handler, rather than on a request.
+    /// express - a strategy handed values it cannot use, two durations that disagree, a guarded
+    /// handler that has not said who its stored response may be served to - is raised here, naming
+    /// the handler, rather than on a request.
     /// </remarks>
     public static ResponseCacheFilter Compose(
         IExecutionRequestHandlerInfo handlerInfo,
         IReadOnlyList<ICacheResponseDeclaration> declarations) {
         var providers = new ICacheKeyProvider[declarations.Count];
         var duration = 0;
+        var scope = CacheScope.Unstated;
 
         for (var i = 0; i < declarations.Count; i++) {
             var declaration = declarations[i];
@@ -139,6 +154,17 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
                     $"[CacheResponse] on {handlerInfo.Method} {handlerInfo.Path} could not build its " +
                     $"cache key strategy: {exception.Message}",
                     exception);
+            }
+
+            if (declaration.Scope != CacheScope.Unstated) {
+                if (scope != CacheScope.Unstated && scope != declaration.Scope) {
+                    throw new InvalidOperationException(
+                        $"{handlerInfo.Method} {handlerInfo.Path} declares [CacheResponse] twice " +
+                        $"with different scopes, {scope} and {declaration.Scope}. Composed " +
+                        "attributes share one entry, so it has one audience.");
+                }
+
+                scope = declaration.Scope;
             }
 
             if (declaration.Duration == 0) {
@@ -159,8 +185,20 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
             }
         }
 
-        return new ResponseCacheFilter(
-            providers, handlerInfo.Method + " " + handlerInfo.Path, duration);
+        var handlerKey = handlerInfo.Method + " " + handlerInfo.Path;
+        var requirement = handlerInfo.Requirement;
+
+        if (scope == CacheScope.Unstated) {
+            // A handler that requires nothing of its caller has one audience whatever it answers,
+            // so there is nothing for an author to decide and nothing to interrupt them over.
+            if (requirement != null) {
+                throw new CacheScopeUndeclaredException(handlerKey, requirement);
+            }
+
+            scope = CacheScope.AllCallers;
+        }
+
+        return new ResponseCacheFilter(providers, handlerKey, duration, scope);
     }
 
     public async Task Execute(IExecutionChain chain) {
@@ -216,14 +254,29 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     /// </para>
     /// </remarks>
     private async ValueTask<string?> Key(IExecutionContext context) {
-        // One strategy is the ordinary case, and needs neither a builder nor a separator.
-        if (_keyProviders.Length == 1) {
+        string? caller = null;
+
+        if (_scope == CacheScope.PerCaller) {
+            caller = Caller(context.CallerPrincipal);
+
+            if (caller == null) {
+                return null;
+            }
+        }
+
+        // One strategy and one audience is the ordinary case, and needs neither a builder nor a
+        // separator.
+        if (_keyProviders.Length == 1 && caller == null) {
             var only = await _keyProviders[0].Key(context);
 
             return only == null ? null : _handlerKey + Separator + only;
         }
 
         var key = new StringBuilder(_handlerKey);
+
+        if (caller != null) {
+            key.Append(Separator).Append(caller);
+        }
 
         foreach (var provider in _keyProviders) {
             var part = await provider.Key(context);
@@ -236,6 +289,27 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
         }
 
         return key.ToString();
+    }
+
+    /// <summary>
+    /// What separates one caller's entries from another's, or null when nothing does.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The issuer as well as the subject. A subject is unique to whoever issued it, so two trusted
+    /// issuers naming the same subject are two callers - and an application that accepts more than
+    /// one is exactly the application where that matters.
+    /// </para>
+    /// <para>
+    /// A caller with no subject returns null, which leaves the request neither looked up nor
+    /// stored. The alternative is one entry shared by every caller who has no subject, which is the
+    /// entry <see cref="CacheScope.PerCaller"/> exists to refuse.
+    /// </para>
+    /// </remarks>
+    private static string? Caller(ICallerPrincipal principal) {
+        var subject = principal.Subject;
+
+        return string.IsNullOrEmpty(subject) ? null : principal.Issuer + Separator + subject;
     }
 
     private IResponseCacheStore Store(IExecutionContext context) {

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheFilter.cs
@@ -102,6 +102,7 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     private readonly string _handlerKey;
     private readonly TimeSpan _duration;
     private readonly CacheScope _scope;
+    private readonly string[] _tags;
 
     /// <summary>
     /// Resolved once, on the first request this filter serves. There is no service provider where
@@ -116,15 +117,20 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
     /// decided in <see cref="Compose"/>, which is the half that can see what the handler requires
     /// of its caller.
     /// </param>
+    /// <param name="tags">
+    /// The names an entry from this handler can be invalidated by, or none.
+    /// </param>
     public ResponseCacheFilter(
         ICacheKeyProvider[] keyProviders,
         string handlerKey,
         int duration,
-        CacheScope scope = CacheScope.AllCallers) {
+        CacheScope scope = CacheScope.AllCallers,
+        string[]? tags = null) {
         _keyProviders = keyProviders;
         _handlerKey = handlerKey;
         _duration = TimeSpan.FromSeconds(duration <= 0 ? DefaultDuration : duration);
         _scope = scope;
+        _tags = tags ?? [];
     }
 
     /// <summary>
@@ -142,6 +148,7 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
         var providers = new ICacheKeyProvider[declarations.Count];
         var duration = 0;
         var scope = CacheScope.Unstated;
+        List<string>? tags = null;
 
         for (var i = 0; i < declarations.Count; i++) {
             var declaration = declarations[i];
@@ -154,6 +161,14 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
                     $"[CacheResponse] on {handlerInfo.Method} {handlerInfo.Path} could not build its " +
                     $"cache key strategy: {exception.Message}",
                     exception);
+            }
+
+            foreach (var tag in declaration.Tags) {
+                // Deduped, because two composed declarations naming the same tag is one tag, and an
+                // index that held the key twice would have to be right about removing it twice.
+                if (!(tags ??= []).Contains(tag, StringComparer.Ordinal)) {
+                    tags.Add(tag);
+                }
             }
 
             if (declaration.Scope != CacheScope.Unstated) {
@@ -198,7 +213,7 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
             scope = CacheScope.AllCallers;
         }
 
-        return new ResponseCacheFilter(providers, handlerKey, duration, scope);
+        return new ResponseCacheFilter(providers, handlerKey, duration, scope, tags?.ToArray());
     }
 
     public async Task Execute(IExecutionChain chain) {
@@ -414,7 +429,8 @@ public sealed class ResponseCacheFilter : IExecutionFilter {
             response.Status ?? 200,
             response.ContentType,
             buffer.ToArray(),
-            Replayable(response.Headers, carried));
+            Replayable(response.Headers, carried),
+            _tags);
 
         await store.Set(key, entry, _duration, context.CancellationToken);
     }

--- a/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheStoreMissingException.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/ResponseCacheStoreMissingException.cs
@@ -5,15 +5,20 @@ namespace Hardened.Requests.Runtime.Caching;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Thrown rather than ignored. The alternative is an attribute that compiles, travels into the
+/// Raised rather than ignored. The alternative is an attribute that compiles, travels into the
 /// handler's metadata and does nothing - which is the failure <c>[CacheControl]</c> spent three
 /// years in, and the one a separate package exists to avoid.
 /// </para>
 /// <para>
-/// <b>It is raised on the first request to the handler, not at startup.</b> Handlers are
-/// constructed lazily, on the first request their route matches, so there is no point at which the
-/// application knows which of them declare this. Failing here is as early as the question can be
-/// asked.
+/// <b>It is raised on a request to the handler, not at startup.</b> Handlers are constructed
+/// lazily, on the first request their route matches, so there is no point at which the application
+/// knows which of them declare this. Failing here is as early as the question can be asked.
+/// </para>
+/// <para>
+/// <b>Recorded on the response rather than thrown.</b> The cache stage is ahead of the one that
+/// turns a failure into bytes, and a filter on that side of the line refuses by recording and
+/// continuing. Thrown, it unwound past the filter that would have written a body, so this message
+/// reached the log and the caller got a 500 with nothing in it.
 /// </para>
 /// </remarks>
 public class ResponseCacheStoreMissingException : InvalidOperationException {

--- a/src/Requests/Hardened.Requests.Testing/TestGrantsPrincipalSource.cs
+++ b/src/Requests/Hardened.Requests.Testing/TestGrantsPrincipalSource.cs
@@ -19,6 +19,10 @@ namespace Hardened.Requests.Testing;
 /// request.Headers[TestGrantsPrincipalSource.GrantsHeader] = "pets:read pets:write";
 /// </code>
 /// <para>
+/// <see cref="SubjectHeader"/> names which caller, for a test where one caller's data reaching
+/// another is the thing being asserted.
+/// </para>
+/// <para>
 /// A request without the header stays anonymous, which is what an authorization test wants both
 /// halves of: the refusal for the caller who presented nothing, and the answer for the caller
 /// holding exactly the named grants. <see cref="AnonymousGrantsValue"/> is the third state - a
@@ -27,6 +31,20 @@ namespace Hardened.Requests.Testing;
 /// </remarks>
 public sealed class TestGrantsPrincipalSource : IPrincipalSource {
     public const string GrantsHeader = "X-Test-Grants";
+
+    /// <summary>
+    /// Which caller, for a test where two of them is the point.
+    /// </summary>
+    /// <remarks>
+    /// Optional, and <see cref="DefaultSubject"/> without it, so a test that only cares about
+    /// grants states only grants. It exists because the grants header cannot distinguish one caller
+    /// from another and an ownership test is exactly a test that has to: every caller had the same
+    /// subject, so "does one subscriber get another's row" was not a question this could ask.
+    /// </remarks>
+    public const string SubjectHeader = "X-Test-Subject";
+
+    /// <summary>The subject a request that names none is authenticated as.</summary>
+    public const string DefaultSubject = "integration-test";
 
     /// <summary>Authenticates with no grants at all, for the caller who is merely known.</summary>
     public const string AnonymousGrantsValue = "-";
@@ -41,11 +59,15 @@ public sealed class TestGrantsPrincipalSource : IPrincipalSource {
 
         var value = header.ToString();
 
+        var subject = context.Request.Headers.TryGetValue(SubjectHeader, out var named)
+            ? named.ToString()
+            : DefaultSubject;
+
         return new ValueTask<ICallerPrincipal?>(new CallerPrincipal(
             SchemeName,
             value == AnonymousGrantsValue
                 ? []
                 : value.Split(' ', StringSplitOptions.RemoveEmptyEntries),
-            subject: "integration-test"));
+            subject: subject));
     }
 }

--- a/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
@@ -26,6 +26,9 @@
   <ItemGroup Label="Hardened">
     <PackageVersion Include="Hardened.Shared.Runtime" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Requests.Runtime" Version="$(HardenedVersion)" />
+    <!-- The store [CacheResponse] needs. ByPayload is the strategy for a function handler, which
+         is the one place a URL key cannot be the whole input. -->
+    <PackageVersion Include="Hardened.Requests.Caching.Memory" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Shared.Testing" Version="$(HardenedVersion)" />
   </ItemGroup>
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
@@ -24,6 +24,9 @@
     <PackageVersion Include="Hardened.Web.Runtime" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Web.Kestrel.Runtime" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Web.AspNetCore.Runtime" Version="$(HardenedVersion)" />
+    <!-- The store [CacheResponse] needs. Listed rather than referenced, so adding the reference is
+         one line in a csproj and not two files. -->
+    <PackageVersion Include="Hardened.Requests.Caching.Memory" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Shared.Testing" Version="$(HardenedVersion)" />
 <!--#if (unionMode) -->
     <!--

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/ResponseCacheOverASocketTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/ResponseCacheOverASocketTests.cs
@@ -109,6 +109,30 @@ public class ResponseCacheOverASocketTests {
     }
 
     /// <summary>
+    /// A handler that declares caching in an application with no store answers the framework's
+    /// error envelope rather than a 500 with nothing in it.
+    /// </summary>
+    /// <remarks>
+    /// It answered <c>500</c> and <c>Content-Length: 0</c>. The filter threw at
+    /// <c>FilterOrder.ResponseCache</c>, one stage ahead of the filter that turns a failure into
+    /// bytes, so the failure unwound past the only thing that would have written a body. Recording
+    /// it and continuing is the rule for that side of the line, and the envelope is what a caller
+    /// gets from every other server fault. The message that names the handler and the package to
+    /// reference stays in the log, where an unexpected 500's detail belongs.
+    /// </remarks>
+    [Fact]
+    public async Task NoRegisteredStoreAnswersAnEnvelopeRatherThanAnEmptyFiveHundred() {
+        await using var harness = await Harness.Start(
+            TestContext.Current.CancellationToken, withStore: false);
+
+        var response = await harness.Raw(TestContext.Current.CancellationToken);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(500, (int)response.StatusCode);
+        Assert.Contains("ServerError", body);
+    }
+
+    /// <summary>
     /// A Hardened application on Kestrel, listening on a port the OS picked, answering one route
     /// from behind a response cache.
     /// </summary>
@@ -127,7 +151,12 @@ public class ResponseCacheOverASocketTests {
         /// <summary>Every entry the store was handed, for asserting on what was captured.</summary>
         public List<CachedResponse> Stored { get; } = [];
 
-        public static async Task<Harness> Start(CancellationToken cancellationToken) {
+        /// <param name="withStore">
+        /// False composes the application the way an author who declared [CacheResponse] and
+        /// referenced no store package composed theirs.
+        /// </param>
+        public static async Task<Harness> Start(
+            CancellationToken cancellationToken, bool withStore = true) {
             // A short timeout because the failure this exists for is a hang, not a bad answer: a
             // response that declares chunked framing and writes none leaves the client waiting for
             // a terminator that never comes. The default hundred seconds is a hundred seconds of
@@ -135,7 +164,7 @@ public class ResponseCacheOverASocketTests {
             var harness = new Harness(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
             var store = new RecordingStore(harness.Stored);
 
-            harness._app = Build(store);
+            harness._app = Build(withStore ? store : null);
 
             harness.Compose(store);
 
@@ -153,12 +182,15 @@ public class ResponseCacheOverASocketTests {
         }
 
         public async Task<HttpResponseMessage> Response(CancellationToken cancellationToken) {
-            var response = await _client.GetAsync("/rates", cancellationToken);
+            var response = await Raw(cancellationToken);
 
             response.EnsureSuccessStatusCode();
 
             return response;
         }
+
+        public Task<HttpResponseMessage> Raw(CancellationToken cancellationToken) =>
+            _client.GetAsync("/rates", cancellationToken);
 
         public async ValueTask DisposeAsync() {
             _client.Dispose();
@@ -166,7 +198,7 @@ public class ResponseCacheOverASocketTests {
             await _app.DisposeAsync();
         }
 
-        private static HardenedKestrelApplication Build(IResponseCacheStore store) {
+        private static HardenedKestrelApplication Build(IResponseCacheStore? store) {
             var services = new ServiceCollection();
 
             services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
@@ -176,7 +208,9 @@ public class ResponseCacheOverASocketTests {
 
             // The filter resolves this from the root provider on its first request, so it has to be
             // in the collection before the application is built.
-            services.AddSingleton(store);
+            if (store != null) {
+                services.AddSingleton(store);
+            }
 
             // Port 0, so the OS picks one and concurrent test classes cannot collide.
             return HardenedKestrelApplication.Create(
@@ -219,6 +253,13 @@ public class ResponseCacheOverASocketTests {
 
             public async Task Execute(IExecutionChain chain) {
                 var response = chain.Context.Response;
+
+                // What IoFilter does at FilterOrder.Serialization: a request already decided is
+                // not bound and its handler is not invoked, so that whatever recorded the failure
+                // is what the caller is answered with.
+                if (response.ExceptionValue != null) {
+                    return;
+                }
 
                 _harness.Answered++;
 

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/ResponseCacheOverASocketTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/ResponseCacheOverASocketTests.cs
@@ -1,0 +1,261 @@
+using System.Net;
+using System.Text;
+using Hardened.Requests.Abstract.Caching;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Requests.Runtime.Caching;
+using Hardened.Requests.Runtime.Middleware;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests;
+
+/// <summary>
+/// A response-cache hit over a real socket, which is the only place two of its defects were
+/// visible.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written after the 0.19.0-rc1000 trial, where three arms and 311 green tests - at least 24 of
+/// them asserting cache hits - missed both. <c>ITestWebApp</c> has no transport, so it never sets
+/// a transfer encoding and never frames a body; the framework's own response-cache SUT is driven
+/// through that harness, so nothing in this repository put a cached response on a wire.
+/// </para>
+/// <para>
+/// Deliberately no routing and no generated handler. The chain is two middleware filters - the
+/// cache, then something terminal to answer - which is enough to exercise the transport and keeps
+/// this test in the project that owns the Kestrel host. Everything the defects needed comes from
+/// the host: Kestrel frames a body with no <c>Content-Length</c> as chunked, and
+/// <see cref="MiddlewareService"/> seeds <see cref="CorrelationHeaderFilter"/> ahead of anything
+/// an application registers.
+/// </para>
+/// </remarks>
+public class ResponseCacheOverASocketTests {
+
+    /// <summary>Long enough that a body silently truncated to nothing is unmistakable.</summary>
+    private const string Answer = """{"base":"USD","rates":{"EUR":0.92,"GBP":0.79}}""";
+
+    /// <summary>
+    /// The malformed hit. Kestrel answered <c>200 OK</c> with correct headers and zero body bytes;
+    /// ASP.NET Core answered a chunk-length parse error. The entry had captured the host's own
+    /// <c>Transfer-Encoding: chunked</c>, so the hit re-declared chunked framing and then wrote the
+    /// stored bytes with no chunk header and no terminator.
+    /// </summary>
+    [Fact]
+    public async Task AHitCarriesTheWholeBodyTheMissCarried() {
+        await using var harness = await Harness.Start(TestContext.Current.CancellationToken);
+
+        var miss = await harness.Get(TestContext.Current.CancellationToken);
+        var hit = await harness.Get(TestContext.Current.CancellationToken);
+
+        Assert.Equal(Answer, miss);
+        Assert.Equal(Answer, hit);
+    }
+
+    /// <summary>
+    /// And the handler ran once, so the second answer really was the store's.
+    /// </summary>
+    [Fact]
+    public async Task AHitDoesNotRunTheHandler() {
+        await using var harness = await Harness.Start(TestContext.Current.CancellationToken);
+
+        await harness.Get(TestContext.Current.CancellationToken);
+        await harness.Get(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, harness.Answered);
+    }
+
+    /// <summary>
+    /// A cache hit carries the id of the request it answered, not the id of the request that
+    /// filled the entry.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CorrelationHeaderFilter"/> is seeded into every host's middleware chain and sets
+    /// the header on the way in, ahead of the cache - so it runs on a hit as well as on a miss and
+    /// the current request's id is already on the response. Capturing it froze the first caller's
+    /// id onto everyone else's response for the whole duration, which is a caller quoting somebody
+    /// else's request in a support ticket.
+    /// </remarks>
+    [Fact]
+    public async Task AHitCarriesTheCallersOwnCorrelationId() {
+        await using var harness = await Harness.Start(TestContext.Current.CancellationToken);
+
+        var miss = await harness.Response(TestContext.Current.CancellationToken);
+        var hit = await harness.Response(TestContext.Current.CancellationToken);
+
+        var first = miss.Headers.GetValues(CorrelationHeaderFilter.HeaderName).Single();
+        var second = hit.Headers.GetValues(CorrelationHeaderFilter.HeaderName).Single();
+
+        Assert.NotEqual(first, second);
+    }
+
+    /// <summary>
+    /// A hop-by-hop header is the host's to decide on the hit, as it was on the miss.
+    /// </summary>
+    [Fact]
+    public async Task AHitIsFramedByTheHostRatherThanByTheStore() {
+        await using var harness = await Harness.Start(TestContext.Current.CancellationToken);
+
+        await harness.Get(TestContext.Current.CancellationToken);
+
+        var entry = Assert.Single(harness.Stored);
+
+        Assert.DoesNotContain(
+            entry.Headers,
+            header => string.Equals(
+                header.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// A Hardened application on Kestrel, listening on a port the OS picked, answering one route
+    /// from behind a response cache.
+    /// </summary>
+    private sealed class Harness : IAsyncDisposable {
+        private readonly HttpClient _client;
+
+        private HardenedKestrelApplication _app = null!;
+
+        private Harness(HttpClient client) {
+            _client = client;
+        }
+
+        /// <summary>How many times the terminal filter answered, so a hit is provable.</summary>
+        public int Answered { get; private set; }
+
+        /// <summary>Every entry the store was handed, for asserting on what was captured.</summary>
+        public List<CachedResponse> Stored { get; } = [];
+
+        public static async Task<Harness> Start(CancellationToken cancellationToken) {
+            // A short timeout because the failure this exists for is a hang, not a bad answer: a
+            // response that declares chunked framing and writes none leaves the client waiting for
+            // a terminator that never comes. The default hundred seconds is a hundred seconds of
+            // CI per test.
+            var harness = new Harness(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
+            var store = new RecordingStore(harness.Stored);
+
+            harness._app = Build(store);
+
+            harness.Compose(store);
+
+            await harness._app.StartAsync(cancellationToken);
+
+            harness._client.BaseAddress = new Uri(harness._app.Addresses.First());
+
+            return harness;
+        }
+
+        public async Task<string> Get(CancellationToken cancellationToken) {
+            var response = await Response(cancellationToken);
+
+            return await response.Content.ReadAsStringAsync(cancellationToken);
+        }
+
+        public async Task<HttpResponseMessage> Response(CancellationToken cancellationToken) {
+            var response = await _client.GetAsync("/rates", cancellationToken);
+
+            response.EnsureSuccessStatusCode();
+
+            return response;
+        }
+
+        public async ValueTask DisposeAsync() {
+            _client.Dispose();
+
+            await _app.DisposeAsync();
+        }
+
+        private static HardenedKestrelApplication Build(IResponseCacheStore store) {
+            var services = new ServiceCollection();
+
+            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
+            services.AddTransient<IHardenedEnvironment>(_ => new EnvironmentImpl("test"));
+
+            new KestrelRuntime().PopulateServiceCollection(services);
+
+            // The filter resolves this from the root provider on its first request, so it has to be
+            // in the collection before the application is built.
+            services.AddSingleton(store);
+
+            // Port 0, so the OS picks one and concurrent test classes cannot collide.
+            return HardenedKestrelApplication.Create(
+                services, kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+        }
+
+        /// <summary>
+        /// The cache, then the filter that answers. Registered before the server starts, so both
+        /// land ahead of the routing filter the runner attaches.
+        /// </summary>
+        private void Compose(IResponseCacheStore store) {
+            var cache = new ResponseCacheFilter(
+                [new EveryRequest()], "GET /rates", ResponseCacheFilter.DefaultDuration);
+
+            var middleware = _app.Services.GetRequiredService<IMiddlewareService>();
+
+            middleware.Use(_ => cache);
+            middleware.Use(_ => new Answering(this, store));
+        }
+
+        /// <summary>One entry for every request, which is what a collection endpoint has.</summary>
+        private sealed class EveryRequest : ICacheKeyProvider {
+            public static ICacheKeyProvider Create(string[] values) => new EveryRequest();
+
+            public ValueTask<string?> Key(IExecutionContext context) => new("only");
+        }
+
+        /// <summary>
+        /// Writes the answer and stops. Nothing sets <c>ResponseValue</c>, so the response is these
+        /// bytes and whatever the host frames them with - which is the point.
+        /// </summary>
+        private sealed class Answering : IExecutionFilter {
+            private readonly Harness _harness;
+            private readonly IResponseCacheStore _store;
+
+            public Answering(Harness harness, IResponseCacheStore store) {
+                _harness = harness;
+                _store = store;
+            }
+
+            public async Task Execute(IExecutionChain chain) {
+                var response = chain.Context.Response;
+
+                _harness.Answered++;
+
+                response.Status = 200;
+                response.ContentType = "application/json";
+                response.ShouldSerialize = false;
+
+                await response.Body.WriteAsync(
+                    Encoding.UTF8.GetBytes(Answer), chain.Context.CancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// An in-process store that keeps what it was handed, so a test can assert on the entry as
+        /// well as on the response.
+        /// </summary>
+        private sealed class RecordingStore : IResponseCacheStore {
+            private readonly Dictionary<string, CachedResponse> _entries = new(StringComparer.Ordinal);
+            private readonly List<CachedResponse> _stored;
+
+            public RecordingStore(List<CachedResponse> stored) {
+                _stored = stored;
+            }
+
+            public ValueTask<CachedResponse?> Get(string key, CancellationToken cancellationToken) =>
+                new(_entries.GetValueOrDefault(key));
+
+            public ValueTask Set(
+                string key,
+                CachedResponse response,
+                TimeSpan duration,
+                CancellationToken cancellationToken) {
+                _entries[key] = response;
+                _stored.Add(response);
+
+                return default;
+            }
+        }
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/ResponseCacheOverASocketTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/ResponseCacheOverASocketTests.cs
@@ -297,6 +297,14 @@ public class ResponseCacheOverASocketTests {
 
                 return default;
             }
+
+            public ValueTask EvictByTag(string tag, CancellationToken cancellationToken) {
+                foreach (var entry in _entries.Where(e => e.Value.Tags.Contains(tag)).ToList()) {
+                    _entries.Remove(entry.Key);
+                }
+
+                return default;
+            }
         }
     }
 }


### PR DESCRIPTION
# Close the response-cache defects the 0.19.0-rc1000 trial found

Eight defects from the trial's combined report, all of them in `[CacheResponse<T>]` or the store
behind it. Three are blockers, and three of the eight were invisible to all 311 tests the three
arms wrote.

| # | Severity | What it was | Commit |
|---|---|---|---|
| H-01 | blocker | A hit replayed a stored 200 over a refusal authorization had already recorded | `Refuse a cached answer to a caller a filter already refused` |
| H-02 | blocker | The resource-scope guard read `RequiresContext`, which misses every ownership check an adopter writes | `Have a guarded handler say who its cached answer is for` |
| H-03 | blocker | Every hit was malformed HTTP: the host's `Transfer-Encoding: chunked` was stored and replayed | `Store only the headers a cached response owns` |
| H-07 | major | A hit carried the first caller's `X-Correlation-Id` and `RateLimit-Remaining` | same |
| H-09 | major | `IResponseCacheStore` had no invalidation seam, so a publish waited for expiry | `Invalidate cached responses by tag` |
| H-13 | major | The missing-store failure threw ahead of serialization and answered 500 with no body | `Answer the missing store with a response rather than a bare 500` |
| H-31 | minor | The store expired on wall-clock time with no clock seam, so a duration could only be slept | `Expire stored responses on a clock a test can move` |
| H-51 | papercut | The templates' central package list omitted the store package | `List the response-cache store in the templates' package versions` |

## The two changes worth reviewing as design

**`CacheScope` (H-02).** The old rule claimed a resource-scoped handler was never cached, decided
from `Requirement.RequiresContext` - true only for a `Requirement.Predicate`, false for grants and
for `Authenticated()`. Nothing on a handler separates "every caller holding `rates:read` gets these
same bytes" from "each caller gets their own", so the declaration now says: `CacheScope.PerCaller`
keys on the caller's issuer and subject, `CacheScope.AllCallers` shares one entry, and a handler
that requires something of its caller and states neither fails naming itself as its filter chain is
built.

Defaulting silently to `PerCaller` was the alternative. It is safe, and it turns one shared entry
into one per caller - so a cache added to shed load quietly stops shedding it. A requirement that
reads the request is still not cached at all, because it does not run on a hit and no scope makes
it run.

**`EvictByTag` on `IResponseCacheStore` (H-09).** Required rather than defaulted: a store that
answers a publish by doing nothing is the failure the feature exists to end. That breaks any custom
store an adopter wrote to work around the gap, loudly, at compile time. Three test doubles in this
repository needed the member. A tag rather than a `Remove(key)`, because the key is the handler's
`METHOD path`, a unit separator, the caller when the scope is per-caller and then each strategy's
part - a shape nothing publishes and one trial arm reverse-engineered out of the filter.

## Why nothing here caught three of them

`ITestWebApp` has no transport, so it sets no transfer encoding and frames no body, and the
framework's own response-cache SUT is driven through it. `Put a cached response on a real socket`
adds the missing coverage: a Hardened app on Kestrel, a port the OS picks, and two middleware
filters rather than a routed handler - the cache, then something terminal to answer. Everything the
defects needed comes from the host, since Kestrel frames a body with no `Content-Length` as chunked
and `MiddlewareService` seeds `CorrelationHeaderFilter` ahead of whatever an application registers.
Reverting the capture fix under those tests hangs the client rather than answering short, which is
why its `HttpClient` has a ten-second timeout instead of the default hundred.

H-01's own test was equally absent: the SUT carried the exact attribute pair with the comment "safe
to cache behind" and only ever warmed and read as a granted caller.

## Verification

- `dotnet test src/Hardened.Framework.sln` - 32 assemblies, 0 failed, 0 skipped.
- `dotnet build --configuration Release -p:ContinuousIntegrationBuild=true` - clean apart from
  HSMT011, the pinned Smithy CLI mismatch on this machine (1.56.0 installed against a 1.73.0 pin).
  That is the report's own H-62 and is unrelated to this branch.
- Each blocker's test was run against the unfixed code first and fails there.
- `src/PublicApi` re-approved; the diff is `CacheScope`, `Scope`/`Tags` on the declaration and the
  attribute, `CachedResponse.Tags`, `IResponseCacheStore.EvictByTag`,
  `CacheScopeUndeclaredException`, `MemoryResponseCacheStore`'s `TimeProvider`, the hop-by-hop
  `KnownHeaders` constants and `TestGrantsPrincipalSource.SubjectHeader`.

Not run: `scripts/verify-templates.sh`. It installs and uninstalls the `Hardened.Templates` package
in the machine's `dotnet new` state, and the template change is one inert `PackageVersion` line, so
the release gate is the right place for it rather than a local run.

`coverage-baseline.json` is untouched - a baseline written locally is not reproducible, per
`AGENTS.md`. The new default interface members on `ICacheResponseDeclaration` are the one piece of
added code nothing else reaches, and `Pin what a declaration that answers neither new question
means` covers them.

## Out of scope, deliberately

**H-10, response caching absent from the published documentation.** That is the Hardened.Docs
repository and cannot be in this PR. `docs/response-caching.md` here is updated in full - who a
stored answer is for, invalidating by tag, testing a duration, a table of what a capture drops and
why - so the site page has something accurate to be written from.

**A build-time diagnostic for an undeclared scope.** The generator can see `[CacheResponse<T>]` and
`[AuthorizeGrants]` on one method and could refuse at compile time, which is earlier than a first
request. The runtime check has to exist anyway, because a requirement can come from a convention
the generator cannot see, so this is additive rather than a replacement.

**The rate-limit store's clock (H-31's other half).** `InProcessRateLimitStore` has the same
property. Registering `TimeProvider.System` is scoped to the response-cache module here rather than
made a framework-wide decision in a cache PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
