### PR TITLE
Write each handler's composed filter chain at Debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ handler's return *value*, so a filter that changes the payload changes the value
 bytes. The ordering, the context and the shipped positions are in
 [the execution pipeline](https://ipjohnson.github.io/Hardened.Docs/guide/execution-pipeline).
 
+To see what a handler's chain was composed into, enable `Debug` for the `Hardened.Requests.Pipeline`
+log category. It writes one line per handler as the chain is built, naming each filter and its
+order in the order they run, and costs nothing per request whether it is on or off.
+
 ## What else the build writes
 
 The same generate-don't-reflect treatment runs through the rest of the framework:

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -754,7 +754,9 @@ namespace Hardened.Requests.Abstract.RequestFilter
     public class RequestFilterInfo
     {
         public RequestFilterInfo(System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter> filterFunc, int? order = default) { }
+        public RequestFilterInfo(System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter> filterFunc, int? order, string name) { }
         public System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, Hardened.Requests.Abstract.Execution.IExecutionFilter> FilterFunc { get; }
+        public string? Name { get; }
         public int? Order { get; }
     }
 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -320,6 +320,7 @@ namespace Hardened.Requests.Runtime.Execution
     }
     public static class ExecutionHelper
     {
+        public const string FilterChainLogCategory = "Hardened.Requests.Pipeline";
         public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup AsyncEnumerableFilterEmptyParameters<TController, TItem>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeNoParameters<TController> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders, Hardened.Requests.Abstract.Serializer.IStreamFraming? framing = null) { }
         public static Hardened.Requests.Runtime.Execution.ExecutionHandlerSetup AsyncEnumerableFilterWithParameters<TController, TParameter, TItem>(System.IServiceProvider serviceProvider, Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequestFunc, Hardened.Requests.Runtime.Execution.ExecutionHelper.InvokeWithParameters<TController, TParameter> invokeMethod, System.Collections.Generic.IEnumerable<Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider> filterProviders, Hardened.Requests.Abstract.Serializer.IStreamFraming? framing = null)
             where TController :  class { }

--- a/src/Requests/Hardened.Requests.Abstract.Tests/RequestFilter/RequestFilterInfoTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/RequestFilter/RequestFilterInfoTests.cs
@@ -1,0 +1,36 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+
+namespace Hardened.Requests.Abstract.Tests.RequestFilter;
+
+/// <summary>
+/// The name a registration may give its filter, for the composed-chain log.
+/// </summary>
+public class RequestFilterInfoTests {
+
+    private sealed class Noop : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    /// <summary>
+    /// The registration every existing provider makes. Nothing about it changes, and the name is
+    /// left for the log to derive.
+    /// </summary>
+    [Fact]
+    public void ARegistrationThatGivesNoNameHasNone() {
+        var info = new RequestFilterInfo(_ => new Noop(), 5);
+
+        Assert.Null(info.Name);
+        Assert.Equal(5, info.Order);
+        Assert.IsType<Noop>(info.FilterFunc(null!));
+    }
+
+    [Fact]
+    public void ANamedRegistrationKeepsItsNameAndItsOrder() {
+        var info = new RequestFilterInfo(_ => new Noop(), 5, "Noop");
+
+        Assert.Equal("Noop", info.Name);
+        Assert.Equal(5, info.Order);
+        Assert.IsType<Noop>(info.FilterFunc(null!));
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/RequestFilter/FilterOrder.cs
+++ b/src/Requests/Hardened.Requests.Abstract/RequestFilter/FilterOrder.cs
@@ -29,6 +29,12 @@ namespace Hardened.Requests.Abstract.RequestFilter;
 /// line refuses by recording the failure and continuing, so the serialization filter can write the
 /// response; behind it, an ordinary short circuit is what stops the handler.
 /// </para>
+/// <para>
+/// <b>What a handler's chain was composed into is written once, as it is built</b>, when the
+/// <c>Hardened.Requests.Pipeline</c> log category is enabled at Debug: each filter and its order,
+/// in the order they run. A position that reads right and lands wrong shows there rather than in
+/// a stack trace, and an application that has not enabled it pays nothing per request.
+/// </para>
 /// </remarks>
 public static class FilterOrder {
 

--- a/src/Requests/Hardened.Requests.Abstract/RequestFilter/RequestFilterInfo.cs
+++ b/src/Requests/Hardened.Requests.Abstract/RequestFilter/RequestFilterInfo.cs
@@ -1,14 +1,41 @@
-﻿using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Execution;
 
 namespace Hardened.Requests.Abstract.RequestFilter;
 
+/// <summary>
+/// One filter's place in a handler's chain: how to get the filter, where it runs, and what to call
+/// it when the composed chain is written out.
+/// </summary>
 public class RequestFilterInfo {
     public RequestFilterInfo(Func<IExecutionContext, IExecutionFilter> filterFunc, int? order = null) {
         FilterFunc = filterFunc;
         Order = order;
     }
 
+    /// <param name="filterFunc">What builds the filter for a request.</param>
+    /// <param name="order">Where it runs, or null for <see cref="FilterOrder.DefaultValue"/>.</param>
+    /// <param name="name">
+    /// What the composed-chain log calls it. A registration that gives none is named for whatever
+    /// registered it, which reads well for an attribute and less well for a factory method three
+    /// calls removed from the filter it builds.
+    /// </param>
+    public RequestFilterInfo(
+        Func<IExecutionContext, IExecutionFilter> filterFunc, int? order, string name)
+        : this(filterFunc, order) {
+        Name = name;
+    }
+
     public Func<IExecutionContext, IExecutionFilter> FilterFunc { get; }
 
     public int? Order { get; }
+
+    /// <summary>
+    /// What the composed-chain log calls this filter, or null to be named for what registered it.
+    /// </summary>
+    /// <remarks>
+    /// The chain keeps factories rather than filters, so a filter's own type is not known until a
+    /// request builds one. The name is what lets the chain be written out as it is composed, once
+    /// per handler, rather than on a request. See <c>ExecutionHelper.FilterChainLogCategory</c>.
+    /// </remarks>
+    public string? Name { get; }
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterChainLogTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterChainLogTests.cs
@@ -1,0 +1,251 @@
+using System.Reflection.Emit;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Execution;
+
+/// <summary>
+/// The one line that shows what a handler's chain was composed into.
+///
+/// <para>
+/// Until it existed the only way to see the assembled chain was to throw inside a filter and read
+/// the stack, which is how the 0.19.0-rc1000 trial found a filter at a position that read right
+/// and landed wrong. The line is written once, as the chain is built, at Debug on its own category,
+/// and the assertions here are as much about what it costs when nobody is listening as about what
+/// it says when somebody is.
+/// </para>
+/// </summary>
+public class FilterChainLogTests {
+
+    private class Controller { }
+
+    private sealed class InstanceStandIn : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    private sealed class IoStandIn : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    private sealed class TenantFilter : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    private sealed class AuditFilter : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    private sealed class Generic<T> : IExecutionFilter {
+        public Task Execute(IExecutionChain chain) => chain.Next();
+    }
+
+    /// <summary>
+    /// Registers the way an attribute that gives no name does: a closure over the filter, and a
+    /// static lambda, both of which the compiler nests inside this type.
+    /// </summary>
+    private sealed class TenantProvider : IRequestFilterProvider {
+        public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
+            var filter = new TenantFilter();
+
+            yield return new RequestFilterInfo(_ => filter, FilterOrder.Authentication);
+            yield return new RequestFilterInfo(static _ => new AuditFilter(), FilterOrder.Retry);
+        }
+    }
+
+    /// <summary>
+    /// A logger that records what it was asked and what it was told, so a test can see the check
+    /// happen without the line following it.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger {
+        private readonly bool _debug;
+
+        public RecordingLogger(bool debug) {
+            _debug = debug;
+        }
+
+        public int EnabledChecks { get; private set; }
+
+        public List<(LogLevel Level, EventId EventId, string Message)> Lines { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) {
+            EnabledChecks++;
+
+            return _debug && logLevel >= LogLevel.Debug;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Lines.Add((logLevel, eventId, formatter(state, exception)));
+    }
+
+    private static (ILoggerFactory Factory, RecordingLogger Logger) Logging(bool debug) {
+        var logger = new RecordingLogger(debug);
+        var factory = Substitute.For<ILoggerFactory>();
+
+        factory.CreateLogger(Arg.Any<string>()).Returns(logger);
+
+        return (factory, logger);
+    }
+
+    /// <summary>
+    /// Composes the real filter array through <c>ExecutionHelper</c>, with stand-ins for the
+    /// three filters the pipeline pins itself, and returns it without running it.
+    /// </summary>
+    private static ExecutionHandlerSetup Compose(
+        ILoggerFactory? loggerFactory,
+        Action<IGlobalFilterRegistry>? register = null,
+        params IRequestFilterProvider[] filterProviders) {
+        var registry = new GlobalFilterRegistry(Array.Empty<IRequestFilterProvider>());
+
+        register?.Invoke(registry);
+
+        var ioProvider = Substitute.For<IIOFilterProvider>();
+        ioProvider.ProvideFilter(
+                Arg.Any<IExecutionRequestHandlerInfo>(),
+                Arg.Any<Func<IExecutionContext, Task<IExecutionRequestParameters>>>())
+            .Returns(new IoStandIn());
+
+        var instanceProvider = Substitute.For<IInstanceFilterProvider>();
+        instanceProvider.ProvideFilter<Controller>(Arg.Any<IServiceProvider>())
+            .Returns(new InstanceStandIn());
+
+        var context = Pipeline.Context(configureServices: services => {
+            services.AddSingleton<IGlobalFilterRegistry>(registry);
+            services.AddSingleton(ioProvider);
+            services.AddSingleton(instanceProvider);
+
+            if (loggerFactory != null) {
+                services.AddSingleton(loggerFactory);
+            }
+        });
+
+        var handlerInfo = new ExecutionRequestHandlerInfo(
+            "/orders", "GET", typeof(Controller), "Read");
+
+        return ExecutionHelper.StandardFilterEmptyParameters<Controller>(
+            context.RequestServices, handlerInfo, (_, _) => { }, filterProviders);
+    }
+
+    private static IRequestFilterProvider Providing(RequestFilterInfo info) {
+        var provider = Substitute.For<IRequestFilterProvider>();
+
+        provider.GetFilters(Arg.Any<IExecutionRequestHandlerInfo>()).Returns(new[] { info });
+
+        return provider;
+    }
+
+    /// <summary>
+    /// Every filter, in the order it runs, with its order beside it. The pinned three and a filter
+    /// registered by instance are named for their types, with a generic's arity dropped; a
+    /// registration that gave no name is named for the type that made it, whether the lambda
+    /// captured anything or not.
+    /// </summary>
+    [Fact]
+    public void TheComposedChainIsWrittenOnceAtDebugOnItsOwnCategory() {
+        var (factory, logger) = Logging(debug: true);
+
+        Compose(
+            factory,
+            registry => registry.RegisterFilter(new Generic<int>(), FilterOrder.Validation),
+            new TenantProvider());
+
+        factory.Received(1).CreateLogger(ExecutionHelper.FilterChainLogCategory);
+
+        var line = Assert.Single(logger.Lines);
+
+        Assert.Equal(LogLevel.Debug, line.Level);
+        Assert.Equal(78010, line.EventId.Id);
+        Assert.Equal(
+            "GET /orders filter chain: " +
+            "InstanceStandIn@-10000, TenantProvider@2000, IoStandIn@7000, Generic@8000, " +
+            "TenantProvider@10000, InvokeNoParametersFilter@200000",
+            line.Message);
+    }
+
+    [Fact]
+    public void ANamedRegistrationIsWrittenByItsName() {
+        var (factory, logger) = Logging(debug: true);
+
+        Compose(
+            factory,
+            filterProviders: Providing(
+                new RequestFilterInfo(_ => new TenantFilter(), FilterOrder.Authentication, "Tenant")));
+
+        Assert.Contains("Tenant@2000", Assert.Single(logger.Lines).Message);
+    }
+
+    /// <summary>
+    /// A filter with no order sorts at the default, and the line says so rather than leaving the
+    /// position blank.
+    /// </summary>
+    [Fact]
+    public void AFilterWithNoOrderIsWrittenAtTheDefaultValue() {
+        var (factory, logger) = Logging(debug: true);
+
+        Compose(
+            factory,
+            filterProviders: Providing(new RequestFilterInfo(_ => new TenantFilter(), null, "Tenant")));
+
+        Assert.Contains("Tenant@" + FilterOrder.DefaultValue, Assert.Single(logger.Lines).Message);
+    }
+
+    /// <summary>
+    /// A factory with no declaring type at all - an emitted method - is named for the method,
+    /// because there is nothing else to name it for.
+    /// </summary>
+    [Fact]
+    public void AFactoryWithNoDeclaringTypeIsNamedForItsMethod() {
+        var method = new DynamicMethod("Factory", typeof(IExecutionFilter), [typeof(IExecutionContext)]);
+        var il = method.GetILGenerator();
+
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+
+        var factory = (Func<IExecutionContext, IExecutionFilter>)method.CreateDelegate(
+            typeof(Func<IExecutionContext, IExecutionFilter>));
+
+        var (loggerFactory, logger) = Logging(debug: true);
+
+        Compose(
+            loggerFactory,
+            filterProviders: Providing(new RequestFilterInfo(factory, FilterOrder.Authentication)));
+
+        Assert.Contains("Factory@2000", Assert.Single(logger.Lines).Message);
+    }
+
+    /// <summary>
+    /// What the line costs when nobody is listening: the level is asked once, per handler, and
+    /// nothing is described or written. The generated logging method would ask again before
+    /// writing, so a single check is proof the description was never built.
+    /// </summary>
+    [Fact]
+    public void BelowDebugTheLevelIsCheckedOnceAndNothingIsWritten() {
+        var (factory, logger) = Logging(debug: false);
+
+        Compose(factory, filterProviders: new TenantProvider());
+
+        Assert.Equal(1, logger.EnabledChecks);
+        Assert.Empty(logger.Lines);
+    }
+
+    /// <summary>
+    /// A pipeline assembled with no logging at all - the bare chains some tests build - composes
+    /// as it always did.
+    /// </summary>
+    [Fact]
+    public void AnApplicationWithoutLoggingComposesAsBefore() {
+        var setup = Compose(loggerFactory: null, filterProviders: new TenantProvider());
+
+        Assert.Equal(5, setup.Filters.Length);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizationFilterProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Authorization/AuthorizationFilterProvider.cs
@@ -65,7 +65,7 @@ public class AuthorizationFilterProvider {
         var filter = new AuthorizationFilter(
             requirement, beforeSerialization: order < FilterOrder.Serialization);
 
-        return new RequestFilterInfo(_ => filter, order);
+        return new RequestFilterInfo(_ => filter, order, nameof(AuthorizationFilter));
     }
 
     private static bool IsAnonymous(IReadOnlyList<object> metadata) {

--- a/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Caching/CacheResponseAttribute.cs
@@ -145,7 +145,7 @@ public sealed class CacheResponseAttribute<TProvider> :
 
         var filter = ResponseCacheFilter.Compose(handlerInfo, declarations);
 
-        yield return new RequestFilterInfo(_ => filter, FilterOrder.ResponseCache);
+        yield return new RequestFilterInfo(_ => filter, FilterOrder.ResponseCache, nameof(ResponseCacheFilter));
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Compression/RequestDecompressionProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Compression/RequestDecompressionProvider.cs
@@ -16,6 +16,7 @@ internal sealed class RequestDecompressionProvider : IRequestFilterProvider {
     private readonly RequestDecompressionFilter _filter = new();
 
     public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
-        yield return new RequestFilterInfo(_ => _filter, FilterOrder.Before + FilterOrder.ResponseCache);
+        yield return new RequestFilterInfo(
+            _ => _filter, FilterOrder.Before + FilterOrder.ResponseCache, nameof(RequestDecompressionFilter));
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
@@ -4,10 +4,30 @@ using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
 using Hardened.Requests.Abstract.Serializer;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Hardened.Requests.Runtime.Execution;
 
-public static class ExecutionHelper {
+public static partial class ExecutionHelper {
+
+    /// <summary>
+    /// The log category that writes each handler's composed filter chain, at Debug.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One line per handler, as its chain is built: each filter and its order, in the order they
+    /// run. What it answers is "did my filter land where I meant?" - a position that reads right
+    /// and lands wrong, an attribute that was never carried into the metadata, a global filter
+    /// that stood down - which until this existed could only be reconstructed from a stack trace.
+    /// </para>
+    /// <para>
+    /// Its own category so it can be turned on alone, and off by default: a chain is composed
+    /// once per handler, so an application that has not enabled it pays one <c>IsEnabled</c>
+    /// check per handler and nothing per request.
+    /// </para>
+    /// </remarks>
+    public const string FilterChainLogCategory = "Hardened.Requests.Pipeline";
+
     private static readonly Task<IExecutionRequestParameters> _emptyRequestParameters =
         Task.FromResult(EmptyParameters.Instance);
 
@@ -215,12 +235,15 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
         var filterList =
             serviceProvider.GetRequiredService<IGlobalFilterRegistry>().GetFilters(handlerInfo);
 
-        filterList.Add(new RequestFilterInfo(_ => ioFilter, FilterOrder.Serialization));
+        filterList.Add(new RequestFilterInfo(
+            _ => ioFilter, FilterOrder.Serialization, FilterNames.Of(ioFilter)));
 
-        filterList.Add(new RequestFilterInfo(_ => invokeFilter, FilterOrder.EndPointInvoke));
+        filterList.Add(new RequestFilterInfo(
+            _ => invokeFilter, FilterOrder.EndPointInvoke, FilterNames.Of(invokeFilter)));
 
-        filterList.Add(new RequestFilterInfo(_ => instanceFilter, FilterOrder.HandlerCreation));
-        
+        filterList.Add(new RequestFilterInfo(
+            _ => instanceFilter, FilterOrder.HandlerCreation, FilterNames.Of(instanceFilter)));
+
         foreach (var requestFilterProvider in filterProviders) {
             filterList.AddRange(requestFilterProvider.GetFilters(handlerInfo));
         }
@@ -233,13 +256,56 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
         // What was wrong was the tie breaking differently between runs, which for anything
         // straddling serialization decides whether a body is written. Registration order is now
         // what settles it, and registration order is deterministic.
+        var chain = filterList
+            .OrderBy(filter => filter.Order ?? FilterOrder.DefaultValue)
+            .ToArray();
+
+        LogFilterChain(serviceProvider, handlerInfo, chain);
+
         return new ExecutionHandlerSetup(
             handlerInfo,
-            filterList
-                .OrderBy(filter => filter.Order ?? FilterOrder.DefaultValue)
-                .Select(filter => filter.FilterFunc)
-                .ToArray());
+            Array.ConvertAll(chain, filter => filter.FilterFunc));
     }
+
+    /// <summary>
+    /// Writes what <paramref name="chain"/> was composed into, when anything is listening.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The factory is optional and the level is checked before anything is described, so an
+    /// application that has not enabled <see cref="FilterChainLogCategory"/> at Debug pays a
+    /// service lookup and one boolean per handler, once, and a pipeline assembled without logging
+    /// at all - the bare chains some tests build - pays the lookup alone.
+    /// </para>
+    /// <para>
+    /// Written here, where the chain is composed, rather than on the first request that runs it:
+    /// the orders are still to hand, and the line arrives whether or not a request ever does.
+    /// </para>
+    /// </remarks>
+    private static void LogFilterChain(
+        IServiceProvider serviceProvider,
+        IExecutionRequestHandlerInfo handlerInfo,
+        RequestFilterInfo[] chain) {
+        var logger = serviceProvider.GetService<ILoggerFactory>()?.CreateLogger(FilterChainLogCategory);
+
+        if (logger == null || !logger.IsEnabled(LogLevel.Debug)) {
+            return;
+        }
+
+        var described = new string[chain.Length];
+
+        for (var i = 0; i < chain.Length; i++) {
+            described[i] = FilterNames.Of(chain[i]) + "@" + (chain[i].Order ?? FilterOrder.DefaultValue);
+        }
+
+        LogFilterChain(logger, handlerInfo.Method, handlerInfo.Path, string.Join(", ", described));
+    }
+
+    [LoggerMessage(
+        EventId = 78010,
+        Level = LogLevel.Debug,
+        Message = "{httpMethod} {path} filter chain: {chain}")]
+    private static partial void LogFilterChain(ILogger logger, string httpMethod, string path, string chain);
 
     /// <summary>
     /// Conjoins whatever the conventions require onto what the handler declared.

--- a/src/Requests/Hardened.Requests.Runtime/Execution/FilterNames.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/FilterNames.cs
@@ -1,0 +1,48 @@
+using System.Runtime.CompilerServices;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+
+namespace Hardened.Requests.Runtime.Execution;
+
+/// <summary>
+/// What the composed-chain log calls a filter.
+/// </summary>
+internal static class FilterNames {
+
+    /// <summary>
+    /// The type's name without the arity a generic carries: <c>ValidationFilter</c> rather than
+    /// <c>ValidationFilter`1</c>.
+    /// </summary>
+    public static string Of(Type type) {
+        var name = type.Name;
+        var arity = name.IndexOf('`');
+
+        return arity < 0 ? name : name.Substring(0, arity);
+    }
+
+    public static string Of(IExecutionFilter filter) => Of(filter.GetType());
+
+    /// <summary>
+    /// The name the registration gave, or failing that the type that made it: a lambda's
+    /// enclosing type, found by walking out of what the compiler generated for it, and the factory
+    /// method's own name when there is no type at all.
+    /// </summary>
+    /// <remarks>
+    /// Reflection, and deliberately only here. This runs once per handler, and only when the log
+    /// is enabled, so nothing on a request pays for it.
+    /// </remarks>
+    public static string Of(RequestFilterInfo filter) {
+        if (filter.Name != null) {
+            return filter.Name;
+        }
+
+        var method = filter.FilterFunc.Method;
+        var type = method.DeclaringType;
+
+        while (type != null && type.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false)) {
+            type = type.DeclaringType;
+        }
+
+        return type == null ? method.Name : Of(type);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Filters/GlobalFilterRegistry.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/GlobalFilterRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Execution;
 
 namespace Hardened.Requests.Runtime.Filters;
 
@@ -13,7 +14,9 @@ public class GlobalFilterRegistry : IGlobalFilterRegistry {
     }
 
     public void RegisterFilter(IExecutionFilter filter, int order = FilterOrder.DefaultValue) {
-        var filterInfo = new RequestFilterInfo(_ => filter, order);
+        // Named for the instance, since it is to hand. The closure below would otherwise name the
+        // registry, which registered nothing on its own account.
+        var filterInfo = new RequestFilterInfo(_ => filter, order, FilterNames.Of(filter));
 
         RegisterFilter(_ => filterInfo);
     }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/RetryAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/RetryAttribute.cs
@@ -67,6 +67,7 @@ public class RetryAttribute : Attribute, IRequestFilterProvider {
     public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
         yield return new RequestFilterInfo(
             _ => new RetryFilter(Attempts, SleepTime, TotalBudget, AllowNonIdempotent),
-            FilterOrder.Retry);
+            FilterOrder.Retry,
+            nameof(RetryFilter));
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/RateLimiting/RateLimitAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/RateLimiting/RateLimitAttribute.cs
@@ -68,6 +68,6 @@ public class RateLimitAttribute : Attribute, IRequestFilterProvider {
         var beforeSerialization = order < FilterOrder.Serialization;
 
         yield return new RequestFilterInfo(
-            _ => new RateLimitFilter(policy, beforeSerialization), order);
+            _ => new RateLimitFilter(policy, beforeSerialization), order, nameof(RateLimitFilter));
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Validation/ValidateAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Validation/ValidateAttribute.cs
@@ -33,7 +33,8 @@ public sealed class ValidateAttribute<TValidated> : Attribute, IRequestFilterPro
 
         yield return new RequestFilterInfo(
             context => filter ??= new ValidationFilter<TValidated>(Resolve(context)),
-            FilterOrder.Validation);
+            FilterOrder.Validation,
+            nameof(ValidationFilter<TValidated>));
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Validation/ValidationFilterProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Validation/ValidationFilterProvider.cs
@@ -46,7 +46,8 @@ public sealed class ValidationFilterProvider<TValidated> : IRequestFilterProvide
 
         yield return new RequestFilterInfo(
             context => filter ??= new ValidationFilter<TValidated>(Resolve(context)),
-            FilterOrder.Validation);
+            FilterOrder.Validation,
+            nameof(ValidationFilter<TValidated>));
     }
 
     /// <summary>

--- a/src/Web/Hardened.Web.Runtime/Attributes/CacheControlAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Attributes/CacheControlAttribute.cs
@@ -36,6 +36,6 @@ public class CacheControlAttribute : Attribute, IRequestFilterProvider {
 
         var filter = new CacheControlFilter(headerValue);
 
-        yield return new RequestFilterInfo(_ => filter, FilterOrder.BeforeSerialization);
+        yield return new RequestFilterInfo(_ => filter, FilterOrder.BeforeSerialization, nameof(CacheControlFilter));
     }
 }

--- a/src/Web/Hardened.Web.Runtime/Compression/CompressAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Compression/CompressAttribute.cs
@@ -60,7 +60,7 @@ public class CompressAttribute : Attribute, IRequestFilterProvider {
     /// take. The configuration is read from the application's services on the first request.
     /// </summary>
     protected static RequestFilterInfo Filter(ResponseCompressionFilter filter) =>
-        new(_ => filter, FilterOrder.Before + FilterOrder.ResponseCache);
+        new(_ => filter, FilterOrder.Before + FilterOrder.ResponseCache, nameof(ResponseCompressionFilter));
 }
 
 /// <summary>

--- a/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGetAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGetAttribute.cs
@@ -45,7 +45,7 @@ public sealed class ConditionalGetAttribute : Attribute, IRequestFilterProvider 
             yield break;
         }
 
-        yield return new RequestFilterInfo(_ => _filter, FilterOrder.Conditional);
+        yield return new RequestFilterInfo(_ => _filter, FilterOrder.Conditional, nameof(ConditionalGetFilter));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes the "A debug dump of the composed filter chain" row of the 0.19 remaining-work ledger. The trial's balanced report put it as: "ASP.NET Core's pipeline is inspectable and Hardened's is not. Arm A had to reconstruct the assembled chain from exception stack traces, and a one-line dump of the composed chain per handler at Debug level would pay for itself."

## What it does

Enable `Debug` for the `Hardened.Requests.Pipeline` log category and every handler writes one line as its chain is built, naming each filter and its order in the order they run:

```
GET /rates/{symbol} filter chain: InstanceFilter@-10000, AuthorizationFilter@4000, ConditionalGetFilter@5000, RequestDecompressionFilter@5500, ResponseCompressionFilter@5500, ResponseCacheFilter@6000, IoFilter@7000, ValidationFilter@8000, InvokeWithParametersFilter@200000
```

What it answers is "did my filter land where I meant?" - a position that reads right and lands wrong, an attribute never carried into the metadata, a global default standing down - which until now showed only in a stack trace.

- **Opt in by log level, and free when it is off.** The line is written in `ExecutionHelper.CreateFilterArray`, the one place a chain is composed, which runs once per handler. The logger factory is resolved as optional and `IsEnabled(Debug)` is checked before anything is described, so an application that has not enabled the category pays one boolean per handler at first request and nothing per request, and a pipeline assembled without logging at all pays the lookup alone. Its own category so it can be switched on alone.
- **`RequestFilterInfo` gains an optional name.** The chain keeps factories rather than filters, so a filter's type is not known until a request builds one; the name is what lets the line be written as the chain is composed rather than on a request. The existing constructor is unchanged and every framework provider now passes a name, which is `nameof` the filter it builds. A registration that gives none is named for whatever registered it, by walking out of what the compiler generated for its lambda, and for its method when there is no type at all. That reflection runs only under the `IsEnabled` guard. A generic filter's arity is dropped, so `ValidationFilter` rather than `ValidationFilter`1`.
- **Docs.** The README's filter section and the `FilterOrder` remarks say where to turn it on.

## Public surface

`RequestFilterInfo.Name` and the three-argument constructor in `Hardened.Requests.Abstract`; `ExecutionHelper.FilterChainLogCategory` in `Hardened.Requests.Runtime`. Approved files updated.

## Verification

- `dotnet build src/Hardened.Framework.sln --configuration Release -p:ContinuousIntegrationBuild=true` with the pinned Smithy CLI 1.73.0 on the path: no warnings.
- `dotnet test src/Hardened.Framework.sln --no-build --configuration Release`: 33 assemblies, all passing, nothing skipped, no duplicate IDs.
- `FilterChainLogTests` composes the real filter array through `ExecutionHelper` and asserts the exact line, the category, the event id, the derived names for an unnamed closure, a static lambda and an emitted method with no declaring type, the default order, that below Debug the level is asked once and nothing is described or written, and that a pipeline with no logging composes as before. `RequestFilterInfoTests` covers the new constructor. Local coverage over the affected test projects: every changed class in `Hardened.Requests.Abstract` and `Hardened.Requests.Runtime` is at 100% line and branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
