### PR TITLE
Harden server-sent events: retry guard, refusal, Last-Event-ID, 204 and heartbeat

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -220,6 +220,24 @@ meant: a class-level `[Compress]` for the default rule over every operation, or 
 
 An error, with no `NoWarn`. Removing one declaration is the whole fix.
 
+## Streaming
+
+### HRDW004 — `[ServerSentEvents]` on a handler that does not stream
+
+A handler carries `[ServerSentEvents]` and returns something other than `IAsyncEnumerable<T>`.
+
+```
+'FeedController.Latest' carries [ServerSentEvents] but does not return IAsyncEnumerable<T>, so
+there is no stream to frame and the response is buffered and serialized as JSON. Return
+IAsyncEnumerable<T> to stream it as text/event-stream, or remove the attribute.
+```
+
+The attribute names a framing for a stream. On a handler with no stream the generator emits an
+ordinary buffered handler and ignores the framing, so the response would be JSON and the document
+would describe it as JSON, while the author believed they had written an event stream.
+
+An error, with no `NoWarn`. Either return `IAsyncEnumerable<T>` or remove the attribute.
+
 ## Other diagnostics
 
 | Id | Meaning |

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/StreamingTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/StreamingTests.cs
@@ -1,4 +1,5 @@
 using Hardened.IntegrationTests.WebApp.SUT.Controllers;
+using Hardened.IntegrationTests.WebApp.SUT.Tests.Support;
 using Hardened.Requests.Abstract.Headers;
 
 namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
@@ -228,6 +229,255 @@ public class StreamingTests {
         var response = await testWebApp.Get("/streaming/events");
 
         Assert.DoesNotContain(":\n\n", await BodyOf(response));
+    }
+
+    #endregion
+
+    #region reconnecting
+
+    private static Action<TestWebRequest> WithHeader(string name, string value) =>
+        request => request.Headers[name] = value;
+
+    /// <summary>
+    /// The client comes back with the last id it saw, and the handler resumes after it.
+    /// </summary>
+    [HardenedTest]
+    public async Task AReconnectWithLastEventIdResumesAfterThatEvent(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/streaming/events-resume", WithHeader(KnownHeaders.LastEventId, "2"));
+
+        response.Assert.Ok();
+
+        Assert.Equal(
+            """
+            id: 3
+            data: {"sensor":"east","reading":-3,"settled":false}
+
+            id: 4
+            data: {"sensor":"west","reading":7,"settled":true}
+
+
+            """.ReplaceLineEndings("\n"),
+            await BodyOf(response));
+    }
+
+    [HardenedTest]
+    public async Task AReconnectWithNoLastEventIdStartsFromTheBeginning(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/events-resume");
+
+        response.Assert.Ok();
+
+        var body = await BodyOf(response);
+
+        Assert.StartsWith("id: 1\n", body);
+        Assert.Contains("id: 4\n", body);
+    }
+
+    /// <summary>
+    /// A 204 is the one answer that makes an <c>EventSource</c> stop reconnecting, and it has to
+    /// be a real 204: no content type, no completion comment. Kestrel aborts a 204 that carries a
+    /// body, and the client reads an abort as a network error and reconnects from it.
+    /// </summary>
+    [HardenedTest]
+    public async Task AReconnectPastTheLastEventIsA204WithNoBody(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/streaming/events-resume", WithHeader(KnownHeaders.LastEventId, "4"));
+
+        Assert.Equal(204, response.StatusCode);
+        Assert.False(response.Headers.ContainsKey(KnownHeaders.ContentType));
+        Assert.Equal("", await BodyOf(response));
+    }
+
+    /// <summary>
+    /// API Gateway payload 2.0 and a function URL deliver header names in lower case.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheLastEventIdHeaderIsReadCaseInsensitively(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/streaming/events-resume", WithHeader("last-event-id", "3"));
+
+        response.Assert.Ok();
+
+        Assert.Equal(
+            """
+            id: 4
+            data: {"sensor":"west","reading":7,"settled":true}
+
+
+            """.ReplaceLineEndings("\n"),
+            await BodyOf(response));
+    }
+
+    #endregion
+
+    #region refusals and failures
+
+    private static Action<TestWebRequest> AsAnEventSource() =>
+        request => request.Headers[KnownHeaders.Accept] = KnownContentType.EventStream;
+
+    /// <summary>
+    /// A refusal on an event-stream route leaves as the refusal's status with a JSON body, which
+    /// is what makes an <c>EventSource</c> stop: any status other than 200, or any content type
+    /// other than <c>text/event-stream</c>, fails the connection for good. <c>text/event-stream</c>
+    /// around a JSON error would be parsed as garbage and reconnected to forever.
+    /// </summary>
+    /// <remarks>
+    /// The request carries <c>Accept: text/event-stream</c> exactly as a browser sends it, because
+    /// that is the header the negotiation has to look past. Reading the code said the default
+    /// serializer catches this; this is the run.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ARefusalOnAnSseRouteIsJsonNotAHalfOpenEventStream(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/events-guarded", AsAnEventSource());
+
+        response.Assert.Unauthorized();
+
+        Assert.StartsWith(KnownContentType.Json, response.Headers[KnownHeaders.ContentType].ToString());
+
+        var body = await response.ReadTextAsync();
+
+        Assert.StartsWith("{", body);
+        Assert.DoesNotContain("data:", body);
+        Assert.DoesNotContain(":\n\n", body);
+    }
+
+    /// <summary>The newline-delimited twin: no framing, no trailing newline, just the error.</summary>
+    [HardenedTest]
+    public async Task ARefusalOnAStreamedRouteDoesNotEmitTheFramingPrologue(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/models-guarded");
+
+        response.Assert.Unauthorized();
+
+        Assert.StartsWith(KnownContentType.Json, response.Headers[KnownHeaders.ContentType].ToString());
+
+        var body = await response.ReadTextAsync();
+
+        Assert.StartsWith("{", body);
+        Assert.EndsWith("}", body);
+    }
+
+    /// <summary>
+    /// A throw before the first event has nothing on the wire yet, so there is still a whole
+    /// response to answer with, and it is the same error document a buffered handler's throw gets.
+    /// </summary>
+    [HardenedTest]
+    public async Task AFailureBeforeTheFirstEventIsAnErrorDocument(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/events-fail-before-first", AsAnEventSource());
+
+        Assert.Equal(500, response.StatusCode);
+        Assert.StartsWith(KnownContentType.Json, response.Headers[KnownHeaders.ContentType].ToString());
+
+        var body = await response.ReadTextAsync();
+
+        Assert.StartsWith("{", body);
+        Assert.DoesNotContain("data:", body);
+    }
+
+    /// <summary>
+    /// A throw after the first event ends the stream. The bytes are with the client, so the only
+    /// honest answer is to stop; on the in-memory harness the failure reaches the caller the way an
+    /// aborted connection reaches a host, and a client sees the connection end and comes back with
+    /// <c>Last-Event-ID</c>.
+    /// </summary>
+    [HardenedTest]
+    public async Task AFailureAfterTheFirstEventEndsTheStream(ITestWebApp testWebApp) {
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            testWebApp.Get("/streaming/events-fail-after-first", AsAnEventSource()));
+
+        Assert.Equal("nothing to stream", failure.Message);
+    }
+
+    #endregion
+
+    #region retry
+
+    /// <summary>
+    /// <c>[Retry]</c> wraps the call that produces the sequence; the enumeration runs outside it,
+    /// in the filter that writes the items. So a failure after the first event is not retried, the
+    /// event is not written twice, and the failure ends the stream as it would without the
+    /// attribute. Row 14 of the test-gap findings suspected a duplicate here; this pins that the
+    /// construction rules it out.
+    /// </summary>
+    [HardenedTest]
+    public async Task ARetryAfterTheFirstItemIsWrittenDoesNotDuplicateIt(ITestWebApp testWebApp) {
+        var before = StreamingController.RetryAfterFirstEnumerations;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            testWebApp.Get("/streaming/events-retry-after-first"));
+
+        Assert.Equal(1, StreamingController.RetryAfterFirstEnumerations - before);
+    }
+
+    /// <summary>
+    /// What a retry does cover on a streaming handler: the call. A handler that fails to produce
+    /// the sequence is called again, and the events arrive.
+    /// </summary>
+    [HardenedTest]
+    public async Task ARetryOnAStreamingHandlerRetriesTheCall(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/events-retry-call");
+
+        response.Assert.Ok();
+
+        Assert.Equal(
+            """
+            data: {"sensor":"north","reading":12,"settled":false}
+
+            data: {"sensor":"south","reading":41,"settled":true}
+
+
+            """.ReplaceLineEndings("\n"),
+            await BodyOf(response));
+    }
+
+    #endregion
+
+    #region heartbeat and headers
+
+    /// <summary>
+    /// A stream quiet for longer than the interval carries a comment line between its events, so
+    /// an intermediary that cuts idle responses sees bytes. At least one rather than a count: the
+    /// handler waits 100 ms at a 10 ms interval, and how many timers fire in that window is the
+    /// scheduler's business.
+    /// </summary>
+    [HardenedTest]
+    [HeartbeatEvery(10)]
+    public async Task AHeartbeatArrivesBetweenSlowEvents(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/events-slow");
+
+        response.Assert.Ok();
+
+        var body = await BodyOf(response);
+
+        Assert.StartsWith("data: {\"sensor\":\"north\"", body);
+        Assert.Contains(": keep-alive\n\n", body);
+        Assert.EndsWith("data: {\"sensor\":\"south\",\"reading\":41,\"settled\":true}\n\n", body);
+        Assert.DoesNotContain(":\n\n", body);
+    }
+
+    /// <summary>
+    /// <c>Cache-Control: no-cache</c> keeps a shared cache out of the path, and
+    /// <c>X-Accel-Buffering: no</c> turns off nginx's per-response buffering. Both are inert
+    /// where they do not apply.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnEventStreamCarriesNoCacheAndNoAccelBuffering(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/events");
+
+        response.Assert.Ok();
+
+        Assert.Equal("no-cache", response.Headers[KnownHeaders.CacheControl].ToString());
+        Assert.Equal("no", response.Headers[KnownHeaders.XAccelBuffering].ToString());
+    }
+
+    /// <summary>A newline-delimited response is an ordinary representation, and says nothing.</summary>
+    [HardenedTest]
+    public async Task ANewlineDelimitedStreamCarriesNeitherHeader(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/streaming/models");
+
+        response.Assert.Ok();
+
+        Assert.False(response.Headers.ContainsKey(KnownHeaders.CacheControl));
+        Assert.False(response.Headers.ContainsKey(KnownHeaders.XAccelBuffering));
     }
 
     #endregion

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Support/HeartbeatEveryAttribute.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Support/HeartbeatEveryAttribute.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Hardened.Requests.Runtime.Streaming;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Support;
+
+/// <summary>
+/// Sets the heartbeat interval for one test's application.
+/// </summary>
+/// <remarks>
+/// Per test rather than on the application, because the interval is global and the event-stream
+/// tests assert exact bodies: a short interval on every test would put a heartbeat into whichever
+/// of them happened to yield slowly on a loaded runner. Registered after the module, so it amends
+/// what the request module registered.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class HeartbeatEveryAttribute : Attribute, IHardenedTestDependencyRegistrationAttribute {
+    private readonly int _milliseconds;
+
+    public HeartbeatEveryAttribute(int milliseconds) {
+        _milliseconds = milliseconds;
+    }
+
+    public void RegisterDependencies(
+        AttributeCollection attributeCollection,
+        MethodInfo methodInfo,
+        IHardenedEnvironment environment,
+        IServiceCollection serviceCollection) {
+        serviceCollection.ConfigureStreaming(
+            streaming => streaming.HeartbeatInterval = TimeSpan.FromMilliseconds(_milliseconds));
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/StreamingController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/StreamingController.cs
@@ -1,5 +1,9 @@
 using System.Runtime.CompilerServices;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Authorization;
+using Hardened.Requests.Runtime.Filters;
 using Hardened.Web.Runtime.Attributes;
 
 namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
@@ -129,4 +133,161 @@ public class StreamingController {
 
         yield break;
     }
+
+    #region reconnect, refusal, failure, retry and heartbeat
+
+    private static readonly Measurement[] Readings = [
+        new("north", 12, false),
+        new("south", 41, true),
+        new("east", -3, false),
+        new("west", 7, true)
+    ];
+
+    /// <summary>
+    /// The reconnect contract in one handler: resume after the event the client last saw, and end
+    /// the subscription with a 204 once there is nothing more to say.
+    /// </summary>
+    /// <remarks>
+    /// An <c>EventSource</c> sends <c>Last-Event-ID</c> on its own. This reads it, replays from the
+    /// event after it, and answers the reconnect that arrives holding the last id with a 204 - the
+    /// one status that makes the client stop. The 204 is decided inside the iterator, which is the
+    /// natural place to write it and the case the filter has to get right: the status is set after
+    /// the handler call returned, at the first <c>MoveNextAsync</c>.
+    /// </remarks>
+    [Get("/events-resume")]
+    [ServerSentEvents]
+    public async IAsyncEnumerable<SseItem<Measurement>> EventsResume(
+        [FromHeader(KnownHeaders.LastEventId)] string? lastEventId,
+        IExecutionContext context) {
+        var after = int.TryParse(lastEventId, out var id) ? id : 0;
+
+        if (after >= Readings.Length) {
+            context.Response.Status = 204;
+
+            yield break;
+        }
+
+        for (var i = after; i < Readings.Length; i++) {
+            yield return new SseItem<Measurement>(Readings[i], Id: (i + 1).ToString());
+
+            await Task.Yield();
+        }
+    }
+
+    /// <summary>A guarded event stream, for what a refusal on one looks like on the wire.</summary>
+    [Get("/events-guarded")]
+    [ServerSentEvents]
+    [AuthorizeGrants("events:read")]
+    public async IAsyncEnumerable<Measurement> EventsGuarded() {
+        yield return Readings[0];
+
+        await Task.Yield();
+    }
+
+    /// <summary>The newline-delimited twin of <see cref="EventsGuarded"/>.</summary>
+    [Get("/models-guarded")]
+    [AuthorizeGrants("events:read")]
+    public async IAsyncEnumerable<Measurement> ModelsGuarded() {
+        yield return Readings[0];
+
+        await Task.Yield();
+    }
+
+    /// <summary>
+    /// Fails before its first event. The iterator has begun and nothing has reached the wire, so
+    /// the failure is an error document rather than an empty stream.
+    /// </summary>
+    [Get("/events-fail-before-first")]
+    [ServerSentEvents]
+    public async IAsyncEnumerable<Measurement> EventsFailBeforeFirst() {
+        await Task.Yield();
+
+        if (ThrowNothingToStream()) {
+            yield return Readings[0];
+        }
+    }
+
+    /// <summary>Fails after its first event, which is already with the client.</summary>
+    [Get("/events-fail-after-first")]
+    [ServerSentEvents]
+    public async IAsyncEnumerable<Measurement> EventsFailAfterFirst() {
+        yield return Readings[0];
+
+        await Task.Yield();
+
+        if (ThrowNothingToStream()) {
+            yield return Readings[1];
+        }
+    }
+
+    /// <summary>
+    /// How many times <see cref="EventsRetryAfterFirst"/> has been enumerated, across the process.
+    /// </summary>
+    /// <remarks>
+    /// Static because the test cannot read the body: the failure escapes the harness the way an
+    /// aborted connection escapes a host. What it can read is whether the enumeration ran once or
+    /// was run again, which is the whole question.
+    /// </remarks>
+    public static int RetryAfterFirstEnumerations;
+
+    /// <summary>
+    /// Under <c>[Retry]</c>, yields one event and fails. The retry filter wraps the call that
+    /// produced the sequence, not the enumeration, so the failure is not retried and the event is
+    /// not duplicated.
+    /// </summary>
+    [Get("/events-retry-after-first")]
+    [ServerSentEvents]
+    [Retry(Attempts = 3, SleepTime = 0)]
+    public async IAsyncEnumerable<Measurement> EventsRetryAfterFirst() {
+        Interlocked.Increment(ref RetryAfterFirstEnumerations);
+
+        yield return Readings[0];
+
+        await Task.Yield();
+
+        if (ThrowNothingToStream()) {
+            yield return Readings[1];
+        }
+    }
+
+    private int _retryCalls;
+
+    /// <summary>
+    /// Under <c>[Retry]</c>, throws on the first call and returns the sequence on the second. The
+    /// call is what a retry covers, so the events arrive.
+    /// </summary>
+    /// <remarks>
+    /// Not an iterator, on purpose: an iterator's body runs at enumeration, outside the retry
+    /// fork. The controller is transient, so the count is per request, and both attempts share
+    /// the instance - which is the documented cost of where <c>FilterOrder.Retry</c> sits.
+    /// </remarks>
+    [Get("/events-retry-call")]
+    [ServerSentEvents]
+    [Retry(Attempts = 3, SleepTime = 0)]
+    public IAsyncEnumerable<Measurement> EventsRetryCall() {
+        if (++_retryCalls == 1) {
+            throw new InvalidOperationException("first call fails");
+        }
+
+        return Events();
+    }
+
+    /// <summary>
+    /// Two events with a silence between them longer than the heartbeat interval a test sets.
+    /// </summary>
+    [Get("/events-slow")]
+    [ServerSentEvents]
+    public async IAsyncEnumerable<Measurement> EventsSlow(
+        [EnumeratorCancellation] CancellationToken cancellationToken) {
+        yield return Readings[0];
+
+        await Task.Delay(100, cancellationToken);
+
+        yield return Readings[1];
+    }
+
+    private static bool ThrowNothingToStream() =>
+        throw new InvalidOperationException("nothing to stream");
+
+    #endregion
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -2377,6 +2377,165 @@
         }
       }
     },
+    "/streaming/events-fail-after-first": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "eventsFailAfterFirst",
+        "summary": "Fails after its first event, which is already with the client.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/streaming/events-fail-before-first": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "eventsFailBeforeFirst",
+        "summary": "Fails before its first event. The iterator has begun and nothing has reached the wire, so the failure is an error document rather than an empty stream.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/streaming/events-guarded": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "eventsGuarded",
+        "summary": "A guarded event stream, for what a refusal on one looks like on the wire.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/streaming/events-resume": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "eventsResume",
+        "summary": "The reconnect contract in one handler: resume after the event the client last saw, and end the subscription with a 204 once there is nothing more to say.",
+        "description": "An EventSource sends Last-Event-ID on its own. This reads it, replays from the event after it, and answers the reconnect that arrives holding the last id with a 204 - the one status that makes the client stop. The 204 is decided inside the iterator, which is the natural place to write it and the case the filter has to get right: the status is set after the handler call returned, at the first MoveNextAsync.",
+        "parameters": [
+          {
+            "name": "Last-Event-ID",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/streaming/events-retry-after-first": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "eventsRetryAfterFirst",
+        "summary": "Under [Retry], yields one event and fails. The retry filter wraps the call that produced the sequence, not the enumeration, so the failure is not retried and the event is not duplicated.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/streaming/events-retry-call": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "eventsRetryCall",
+        "summary": "Under [Retry], throws on the first call and returns the sequence on the second. The call is what a retry covers, so the events arrive.",
+        "description": "Not an iterator, on purpose: an iterator's body runs at enumeration, outside the retry fork. The controller is transient, so the count is per request, and both attempts share the instance - which is the documented cost of where FilterOrder.Retry sits.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/streaming/events-slow": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "eventsSlow",
+        "summary": "Two events with a silence between them longer than the heartbeat interval a test sets.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/streaming/events-with-ids": {
       "get": {
         "tags": [
@@ -2406,6 +2565,27 @@
         ],
         "operationId": "models",
         "summary": "A model per line, which is the case that used to throw.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/x-ndjson": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Measurement"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/streaming/models-guarded": {
+      "get": {
+        "tags": [
+          "Streaming"
+        ],
+        "operationId": "modelsGuarded",
+        "summary": "The newline-delimited twin of .",
         "responses": {
           "200": {
             "description": "OK",

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -580,6 +580,7 @@ namespace Hardened.Requests.Abstract.Headers
         public const string IfNoneMatch = "If-None-Match";
         public const string IfRange = "If-Range";
         public const string KeepAlive = "Keep-Alive";
+        public const string LastEventId = "Last-Event-ID";
         public const string LastModified = "Last-Modified";
         public const string Location = "Location";
         public const string Origin = "Origin";
@@ -594,6 +595,7 @@ namespace Hardened.Requests.Abstract.Headers
         public const string TransferEncoding = "Transfer-Encoding";
         public const string Upgrade = "Upgrade";
         public const string Vary = "Vary";
+        public const string XAccelBuffering = "X-Accel-Buffering";
         public static class Cors
         {
             public const string AccessControlAllowCredentials = "Access-Control-Allow-Credentials";
@@ -1634,6 +1636,7 @@ namespace Hardened.Requests.Abstract.Serializer
     {
         string ContentType { get; }
         System.Threading.Tasks.ValueTask WriteCompletion(Hardened.Requests.Abstract.Execution.IExecutionContext context);
+        System.Threading.Tasks.ValueTask<bool> WriteHeartbeat(Hardened.Requests.Abstract.Execution.IExecutionContext context);
         System.Threading.Tasks.ValueTask WriteItem(Hardened.Requests.Abstract.Execution.IExecutionContext context, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task> serialize);
     }
     public interface IStringConverter

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -385,7 +385,7 @@ namespace Hardened.Requests.Runtime.Execution
     [DependencyModules.Runtime.Attributes.SingletonService(Using=DependencyModules.Runtime.Attributes.RegistrationType.Try)]
     public class IOFilterProvider : Hardened.Requests.Abstract.RequestFilter.IIOFilterProvider
     {
-        public IOFilterProvider(Hardened.Requests.Abstract.Serializer.IContextSerializationService contextSerializationService, Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IResponseHeaderConfiguration> responseHeaderConfiguration) { }
+        public IOFilterProvider(Hardened.Requests.Abstract.Serializer.IContextSerializationService contextSerializationService, Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IResponseHeaderConfiguration> responseHeaderConfiguration, Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Streaming.IStreamingConfiguration> streamingConfiguration) { }
         public Hardened.Requests.Abstract.Execution.IExecutionFilter ProvideAsyncEnumerableFilter<TItem>(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequest) { }
         public Hardened.Requests.Abstract.Execution.IExecutionFilter ProvideAsyncEnumerableFilter<TItem>(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequest, Hardened.Requests.Abstract.Serializer.IStreamFraming? framing) { }
         public Hardened.Requests.Abstract.Execution.IExecutionFilter ProvideFilter(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequest) { }
@@ -413,7 +413,7 @@ namespace Hardened.Requests.Runtime.Filters
 {
     public class AsyncEnumerableIoFilter<TItem> : Hardened.Requests.Abstract.Execution.IExecutionFilter
     {
-        public AsyncEnumerableIoFilter(System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequest, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task> serializeResponse, System.Action<Hardened.Requests.Abstract.Execution.IExecutionContext>? headerActions, Hardened.Requests.Abstract.Serializer.IStreamFraming? framing = null) { }
+        public AsyncEnumerableIoFilter(System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task<Hardened.Requests.Abstract.Execution.IExecutionRequestParameters>> deserializeRequest, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task> serializeResponse, System.Action<Hardened.Requests.Abstract.Execution.IExecutionContext>? headerActions, Hardened.Requests.Abstract.Serializer.IStreamFraming? framing = null, System.TimeSpan heartbeatInterval = default) { }
         public System.Threading.Tasks.Task Execute(Hardened.Requests.Abstract.Execution.IExecutionChain chain) { }
     }
     public class ConditionalFilterProvider : Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider
@@ -455,6 +455,7 @@ namespace Hardened.Requests.Runtime.Filters
         public NdjsonFraming() { }
         public string ContentType { get; }
         public System.Threading.Tasks.ValueTask WriteCompletion(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.ValueTask<bool> WriteHeartbeat(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.ValueTask WriteItem(Hardened.Requests.Abstract.Execution.IExecutionContext context, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task> serialize) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false)]
@@ -485,6 +486,7 @@ namespace Hardened.Requests.Runtime.Filters
         public SseFraming() { }
         public string ContentType { get; }
         public System.Threading.Tasks.ValueTask WriteCompletion(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.ValueTask<bool> WriteHeartbeat(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.ValueTask WriteItem(Hardened.Requests.Abstract.Execution.IExecutionContext context, System.Func<Hardened.Requests.Abstract.Execution.IExecutionContext, System.Threading.Tasks.Task> serialize) { }
     }
 }
@@ -846,6 +848,23 @@ namespace Hardened.Requests.Runtime.Serializer
         public bool IsDefaultSerializer { get; }
         public bool CanProduce(string mediaType, Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.Task SerializeResponse(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+    }
+}
+namespace Hardened.Requests.Runtime.Streaming
+{
+    public interface IStreamingConfiguration
+    {
+        System.TimeSpan HeartbeatInterval { get; }
+    }
+    public class StreamingConfiguration : Hardened.Requests.Runtime.Streaming.IStreamingConfiguration
+    {
+        public static readonly System.TimeSpan DefaultHeartbeatInterval;
+        public StreamingConfiguration() { }
+        public System.TimeSpan HeartbeatInterval { get; set; }
+    }
+    public static class StreamingServiceCollectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection ConfigureStreaming(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Hardened.Requests.Runtime.Streaming.StreamingConfiguration> configure) { }
     }
 }
 namespace Hardened.Requests.Runtime.Validation

--- a/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Headers/KnownHeaders.cs
@@ -13,6 +13,28 @@ public static class KnownHeaders {
 
     public const string CacheControl = "Cache-Control";
 
+    /// <summary>
+    /// The id of the last event a reconnecting <c>EventSource</c> received.
+    /// </summary>
+    /// <remarks>
+    /// Sent by the client on its own, on every reconnect, carrying the last <c>id:</c> field it
+    /// saw. A streaming handler that binds it can resume after that event rather than replaying
+    /// from the start. Hosts deliver header names in whatever case they like - API Gateway and a
+    /// function URL lower-case them - and the header collection matches without regard to case.
+    /// </remarks>
+    public const string LastEventId = "Last-Event-ID";
+
+    /// <summary>
+    /// Whether an nginx in front of this response may buffer it. Everything else ignores it.
+    /// </summary>
+    /// <remarks>
+    /// <c>no</c> turns proxy buffering off for one response, which is what lets a streamed body
+    /// reach the client as it is written rather than when the proxy's buffer fills. Written on
+    /// every event stream, because a stream that works locally and stalls behind a default nginx
+    /// is otherwise a support ticket.
+    /// </remarks>
+    public const string XAccelBuffering = "X-Accel-Buffering";
+
     public const string ContentEncoding = "Content-Encoding";
 
     public const string ContentType = "Content-Type";

--- a/src/Requests/Hardened.Requests.Abstract/Serializer/IStreamFraming.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Serializer/IStreamFraming.cs
@@ -53,4 +53,25 @@ public interface IStreamFraming {
     /// put at least one byte on the wire.
     /// </remarks>
     ValueTask WriteCompletion(IExecutionContext context);
+
+    /// <summary>
+    /// Writes something a client discards, to keep a quiet connection open, and says whether it
+    /// did.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Called by the filter when the handler has produced nothing for the configured interval. An
+    /// intermediary that cuts an idle response - CloudFront after 30 seconds between packets, a
+    /// default nginx after 60, Azure's load balancer after 230 - sees bytes instead, and the client
+    /// is spared a reconnect, a replay from <c>Last-Event-ID</c> and, on Lambda, a second
+    /// invocation.
+    /// </para>
+    /// <para>
+    /// <c>false</c> means the format has no way to say nothing: newline-delimited JSON has no
+    /// comment syntax. The filter stops asking after the first <c>false</c>. The default answers
+    /// that, so a framing written before this member existed keeps compiling and keeps its
+    /// behaviour.
+    /// </para>
+    /// </remarks>
+    ValueTask<bool> WriteHeartbeat(IExecutionContext context) => new(false);
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterOrderingTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/FilterOrderingTests.cs
@@ -318,17 +318,19 @@ public class FilterOrderingTests {
     }
 
     /// <summary>
-    /// <c>[Retry]</c> orders itself at <c>FilterOrder.HandlerCreation - 10</c> so that it wraps
-    /// controller creation as well as the handler call. A retry that reused one controller
-    /// instance across attempts would replay whatever state the failed attempt left behind.
+    /// <c>[Retry]</c> orders itself at <c>FilterOrder.Retry</c>: behind serialization, so the
+    /// failure the invoke filter records is still on the response when the retry filter looks and
+    /// the response is serialized once rather than once per attempt; and ahead of the handler, so
+    /// an attempt is the handler call. Controller creation is outside it, which is the documented
+    /// cost of the position - every attempt shares the instance.
     /// </summary>
     [Fact]
-    public async Task RetryIsOrderedAheadOfControllerCreation() {
+    public async Task RetryIsOrderedBehindSerializationAndAheadOfTheHandler() {
         var log = new List<string>();
 
         var result = await Run(log, _ => { }, new RecordingRetryProvider(log));
 
-        Assert.Equal(new[] { "retry", Instance, Io, Invoke }, result);
+        Assert.Equal(new[] { Instance, Io, "retry", Invoke }, result);
     }
 
     /// <summary>
@@ -344,7 +346,7 @@ public class FilterOrderingTests {
 
         public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
             yield return new RequestFilterInfo(
-                _ => new Pipeline.Recording(_log, "retry"), FilterOrder.HandlerCreation - 10);
+                _ => new Pipeline.Recording(_log, "retry"), FilterOrder.Retry);
         }
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/IOFilterProviderTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/IOFilterProviderTests.cs
@@ -3,6 +3,7 @@ using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Configuration;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Streaming;
 using Hardened.Requests.Runtime.Tests.Support;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -29,7 +30,9 @@ namespace Hardened.Requests.Runtime.Tests.Execution;
 /// </remarks>
 public class IOFilterProviderTests {
 
-    private static IOFilterProvider Provider(Action<ResponseHeaderConfiguration>? configure = null) {
+    private static IOFilterProvider Provider(
+        Action<ResponseHeaderConfiguration>? configure = null,
+        TimeSpan? heartbeatInterval = null) {
         var configuration = new ResponseHeaderConfiguration();
 
         configure?.Invoke(configuration);
@@ -38,8 +41,45 @@ public class IOFilterProviderTests {
 
         serialization.SerializeResponse(Arg.Any<IExecutionContext>()).Returns(Task.CompletedTask);
 
+        var streaming = new StreamingConfiguration();
+
+        if (heartbeatInterval != null) {
+            streaming.HeartbeatInterval = heartbeatInterval.Value;
+        }
+
         return new IOFilterProvider(
-            serialization, Options.Create<IResponseHeaderConfiguration>(configuration));
+            serialization,
+            Options.Create<IResponseHeaderConfiguration>(configuration),
+            Options.Create<IStreamingConfiguration>(streaming));
+    }
+
+    /// <summary>
+    /// The configured interval reaches the streamed filter. Asserted through a stream that is quiet
+    /// for longer than it, because the interval is otherwise invisible from outside.
+    /// </summary>
+    [Fact]
+    public async Task TheConfiguredHeartbeatIntervalReachesTheStreamedFilter() {
+        var filter = Provider(heartbeatInterval: TimeSpan.FromMilliseconds(10))
+            .ProvideAsyncEnumerableFilter<string>(HandlerInfo(), NoParameters, SseFraming.Instance);
+
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, filter,
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = QuietThenOne();
+
+                return Task.CompletedTask;
+            })).Next();
+
+        var body = System.Text.Encoding.UTF8.GetString(((MemoryStream)context.Response.Body).ToArray());
+
+        Assert.Contains(": keep-alive\n\n", body);
+    }
+
+    private static async IAsyncEnumerable<string> QuietThenOne() {
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        yield return "one";
     }
 
     private static IExecutionRequestHandlerInfo HandlerInfo() =>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/AsyncEnumerableIoFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/AsyncEnumerableIoFilterTests.cs
@@ -1,7 +1,9 @@
 using System.Text;
 using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Logging;
 using Hardened.Requests.Abstract.Metrics;
+using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.Filters;
 using Hardened.Requests.Runtime.Tests.Support;
@@ -39,8 +41,13 @@ public class AsyncEnumerableIoFilterTests {
 
     private static AsyncEnumerableIoFilter<T> Filter<T>(
         Func<IExecutionContext, Task>? serialize = null,
-        Action<IExecutionContext>? headerActions = null) =>
-        new(Empty, serialize ?? WriteValue, headerActions);
+        Action<IExecutionContext>? headerActions = null,
+        IStreamFraming? framing = null,
+        TimeSpan heartbeat = default) =>
+        new(Empty, serialize ?? WriteValue, headerActions, framing, heartbeat);
+
+    private static IStreamFraming Framing(string name) =>
+        name == "sse" ? SseFraming.Instance : NdjsonFraming.Instance;
 
     private static async IAsyncEnumerable<string> Items(params string[] values) {
         foreach (var value in values) {
@@ -292,4 +299,314 @@ public class AsyncEnumerableIoFilterTests {
         Assert.Equal("yes", context.Response.Headers["X-Stream"].ToString());
         Assert.Equal("item\n\n", Body(context));
     }
+
+    #region a 204 ends a subscription
+
+    /// <summary>
+    /// A handler that has nothing more to say sets 204 from inside its iterator and yields nothing,
+    /// and nothing is written: no content type, no completion bytes. Kestrel aborts the connection
+    /// on a 204 with a body, and a client reads that as a network error and reconnects - the
+    /// opposite of what a 204 is for. Decided in the filter rather than the framing because it
+    /// holds for both.
+    /// </summary>
+    [Theory]
+    [InlineData("sse")]
+    [InlineData("ndjson")]
+    public async Task A204FromTheHandlerWritesNoFramingAndNoCompletion(string framing) {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, Filter<string>(framing: Framing(framing)),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = EndsSubscription(c.Context);
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal(204, context.Response.Status);
+        Assert.Null(context.Response.ContentType);
+        Assert.Equal("", Body(context));
+        Assert.False(context.Response.ShouldSerialize);
+    }
+
+    private static async IAsyncEnumerable<string> EndsSubscription(IExecutionContext context) {
+        await Task.Yield();
+
+        context.Response.Status = 204;
+
+        yield break;
+    }
+
+    #endregion
+
+    #region failures
+
+    /// <summary>
+    /// A failure before the first item is an error document under its own status, the same as a
+    /// failure in the handler call: the iterator has begun, but nothing has reached the wire, so
+    /// there is still a whole response to answer with.
+    /// </summary>
+    [Fact]
+    public async Task AFailureBeforeTheFirstItemIsAnErrorDocumentNotAStream() {
+        var serialized = new List<string>();
+        var context = Pipeline.Context();
+
+        var filter = new AsyncEnumerableIoFilter<string>(
+            Empty,
+            c => {
+                serialized.Add(c.Response.ExceptionValue?.Message ?? "no failure");
+
+                return Task.CompletedTask;
+            },
+            null,
+            SseFraming.Instance);
+
+        await Pipeline.Chain(context, filter,
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = FailsBeforeFirst();
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal("before the first item", Assert.Single(serialized));
+        Assert.Null(context.Response.ContentType);
+        Assert.Equal("", Body(context));
+        Assert.False(context.Response.ShouldSerialize);
+    }
+
+    /// <summary>
+    /// A failure after the first item ends the stream and reaches the host, because the bytes are
+    /// with the client and nothing can take them back. On Kestrel that is a connection abort; to a
+    /// client it is the connection ending, which it reconnects from with <c>Last-Event-ID</c>.
+    /// </summary>
+    [Fact]
+    public async Task AFailureAfterTheFirstItemEndsTheStream() {
+        var context = Pipeline.Context();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Pipeline.Chain(context, Filter<string>(framing: SseFraming.Instance),
+                new Pipeline.Inline(c => {
+                    c.Context.Response.ResponseValue = FailsAfterFirst();
+
+                    return Task.CompletedTask;
+                })).Next());
+
+        Assert.Equal("data: alpha\n\n", Body(context));
+        Assert.Equal(KnownContentType.EventStream, context.Response.ContentType);
+    }
+
+    private static async IAsyncEnumerable<string> FailsBeforeFirst() {
+        await Task.Yield();
+
+        if (Throw("before the first item")) {
+            yield return "never";
+        }
+    }
+
+    private static async IAsyncEnumerable<string> FailsAfterFirst() {
+        yield return "alpha";
+
+        await Task.Yield();
+
+        if (Throw("after the first item")) {
+            yield return "never";
+        }
+    }
+
+    private static bool Throw(string message) => throw new InvalidOperationException(message);
+
+    #endregion
+
+    #region heartbeats
+
+    /// <summary>
+    /// A body that says when the heartbeat has been written, so the test can hold the handler
+    /// quiet until then and release it afterwards, with no clock and no guessed sleep.
+    /// </summary>
+    private sealed class WatchedBody : MemoryStream {
+        private readonly TaskCompletionSource _heartbeatSeen;
+
+        public WatchedBody(TaskCompletionSource heartbeatSeen) {
+            _heartbeatSeen = heartbeatSeen;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) {
+            base.Write(buffer, offset, count);
+
+            if (Encoding.UTF8.GetString(ToArray()).Contains(": keep-alive\n\n")) {
+                _heartbeatSeen.TrySetResult();
+            }
+        }
+    }
+
+    private static async IAsyncEnumerable<string> Gated(Task release, string value) {
+        await release;
+
+        yield return value;
+    }
+
+    private static async IAsyncEnumerable<string> QuietThen(TimeSpan quiet, params string[] values) {
+        await Task.Delay(quiet, TestContext.Current.CancellationToken);
+
+        foreach (var value in values) {
+            yield return value;
+        }
+    }
+
+    /// <summary>
+    /// A handler that is quiet for longer than the interval gets a heartbeat, and the item that
+    /// eventually arrives follows it. The handler is released only once the heartbeat has been
+    /// observed on the body, so the order is asserted rather than hoped for.
+    /// </summary>
+    [Fact]
+    public async Task AQuietStreamGetsAHeartbeat() {
+        var heartbeatSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = Pipeline.Context();
+
+        context.Response.Body = new WatchedBody(heartbeatSeen);
+
+        var run = Pipeline.Chain(context,
+            Filter<string>(framing: SseFraming.Instance, heartbeat: TimeSpan.FromMilliseconds(10)),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = Gated(release.Task, "alpha");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        await heartbeatSeen.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        release.SetResult();
+
+        await run;
+
+        var body = Body(context);
+
+        Assert.StartsWith(": keep-alive\n\n", body);
+        Assert.EndsWith("data: alpha\n\n", body);
+        Assert.DoesNotContain(":\n\n", body);
+    }
+
+    [Fact]
+    public async Task AStreamThatYieldsPromptlyGetsNoHeartbeat() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context,
+            Filter<string>(framing: SseFraming.Instance, heartbeat: TimeSpan.FromSeconds(1)),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = Items("alpha", "beta");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal("data: alpha\n\ndata: beta\n\n", Body(context));
+    }
+
+    [Fact]
+    public async Task AZeroIntervalMeansNoHeartbeat() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, Filter<string>(framing: SseFraming.Instance),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = QuietThen(TimeSpan.FromMilliseconds(100), "alpha");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal("data: alpha\n\n", Body(context));
+    }
+
+    /// <summary>
+    /// The format has no comment syntax, so the framing declines and the filter stops asking.
+    /// </summary>
+    [Fact]
+    public async Task NdjsonGetsNoHeartbeatWhateverTheInterval() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, Filter<string>(heartbeat: TimeSpan.FromMilliseconds(10)),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = QuietThen(TimeSpan.FromMilliseconds(100), "alpha");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal("alpha\n\n", Body(context));
+    }
+
+    /// <summary>
+    /// A heartbeat is bytes, and the empty-stream comment exists only to put a byte on a body that
+    /// has none. A stream that heartbeated and then ended without events writes no second comment.
+    /// </summary>
+    [Fact]
+    public async Task AnEmptyStreamThatHeartbeatedWritesNoCompletionComment() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context,
+            Filter<string>(framing: SseFraming.Instance, heartbeat: TimeSpan.FromMilliseconds(10)),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = QuietThen(TimeSpan.FromMilliseconds(100));
+
+                return Task.CompletedTask;
+            })).Next();
+
+        var body = Body(context);
+
+        Assert.Contains(": keep-alive\n\n", body);
+        Assert.DoesNotContain(":\n\n", body);
+    }
+
+    #endregion
+
+    #region event-stream headers
+
+    [Fact]
+    public async Task AnEventStreamCarriesNoCacheAndNoAccelBuffering() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, Filter<string>(framing: SseFraming.Instance),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = Items("alpha");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal("no-cache", context.Response.Headers[KnownHeaders.CacheControl].ToString());
+        Assert.Equal("no", context.Response.Headers[KnownHeaders.XAccelBuffering].ToString());
+    }
+
+    /// <summary>A handler or filter that already said something about caching is not overruled.</summary>
+    [Fact]
+    public async Task AHandlersOwnCacheControlIsKeptOnAnEventStream() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, Filter<string>(framing: SseFraming.Instance),
+            new Pipeline.Inline(c => {
+                c.Context.Response.Headers[KnownHeaders.CacheControl] = "no-store";
+                c.Context.Response.ResponseValue = Items("alpha");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal("no-store", context.Response.Headers[KnownHeaders.CacheControl].ToString());
+    }
+
+    /// <summary>
+    /// A newline-delimited response is an ordinary representation a cache may keep, so it is left
+    /// to say for itself.
+    /// </summary>
+    [Fact]
+    public async Task ANewlineDelimitedStreamCarriesNeitherHeader() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, Filter<string>(),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = Items("alpha");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.False(context.Response.Headers.ContainsKey(KnownHeaders.CacheControl));
+        Assert.False(context.Response.Headers.ContainsKey(KnownHeaders.XAccelBuffering));
+    }
+
+    #endregion
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RetryFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RetryFilterTests.cs
@@ -324,6 +324,35 @@ public class RetryFilterTests {
     }
 
     /// <summary>
+    /// A response with bytes on the wire is not run again. A fork onto a body that already holds
+    /// part of an answer would write a second answer after it, and nothing can take the first
+    /// back - so a started response is treated like an exhausted budget, whatever the failure was.
+    /// The guard is for a handler or a filter that writes to the body itself; a streaming handler
+    /// never trips it, because its enumeration runs outside the fork.
+    /// </summary>
+    [Fact]
+    public async Task Execute_DoesNotAttemptAgainOnceTheResponseHasStarted() {
+        var attempts = 0;
+        var context = Pipeline.Context();
+
+        var downstream = new Pipeline.Inline(chain => {
+            attempts++;
+
+            chain.Context.Response.Body.WriteByte((byte)'x');
+            chain.Context.Response.ExceptionValue =
+                new InvalidOperationException("after the first byte");
+
+            return Task.CompletedTask;
+        });
+
+        await Pipeline.Chain(context, Filter(attempts: 3), downstream).Next();
+
+        Assert.Equal(1, attempts);
+        Assert.Equal(1, context.Response.Body.Length);
+        Assert.Equal("after the first byte", context.Response.ExceptionValue?.Message);
+    }
+
+    /// <summary>
     /// The budget stops the attempts even when the count has not been reached.
     /// </summary>
     [Fact]

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -13,6 +13,7 @@ using Hardened.Shared.Runtime.Configuration;
 using Hardened.Shared.Runtime.DependencyInjection;
 using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Serializer;
+using Hardened.Requests.Runtime.Streaming;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -31,7 +32,8 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
                 new NewConfigurationValueProvider<IJsonSerializerConfiguration, JsonSerializerConfiguration>(null),
                 new NewConfigurationValueProvider<ILinkConfiguration, LinkConfiguration>(null),
                 new NewConfigurationValueProvider<IAuthorizationConfiguration, AuthorizationConfiguration>(null),
-                new NewConfigurationValueProvider<ICompressionConfiguration, CompressionConfiguration>(null)
+                new NewConfigurationValueProvider<ICompressionConfiguration, CompressionConfiguration>(null),
+                new NewConfigurationValueProvider<IStreamingConfiguration, StreamingConfiguration>(null)
             }));
         services.AddSingleton(
             s => Options.Create(s.GetRequiredService<IConfigurationManager>()
@@ -52,6 +54,10 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         services.AddSingleton(
             s => Options.Create(s.GetRequiredService<IConfigurationManager>()
                 .GetConfiguration<ICompressionConfiguration>()));
+
+        services.AddSingleton(
+            s => Options.Create(s.GetRequiredService<IConfigurationManager>()
+                .GetConfiguration<IStreamingConfiguration>()));
 
         // The caller, as a service a handler can take. Scoped rather than resolved from the
         // context, because the container has no per-request instance of the context to build one

--- a/src/Requests/Hardened.Requests.Runtime/Execution/IOFilterProvider.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/IOFilterProvider.cs
@@ -1,9 +1,10 @@
-﻿using DependencyModules.Runtime.Attributes;
+using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
 using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Configuration;
 using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Streaming;
 using Microsoft.Extensions.Options;
 
 namespace Hardened.Requests.Runtime.Execution;
@@ -12,12 +13,15 @@ namespace Hardened.Requests.Runtime.Execution;
 public class IOFilterProvider : IIOFilterProvider {
     private readonly IContextSerializationService _contextSerializationService;
     private readonly Action<IExecutionContext>? _headerActions;
+    private readonly TimeSpan _heartbeatInterval;
 
     public IOFilterProvider(
         IContextSerializationService contextSerializationService,
-        IOptions<IResponseHeaderConfiguration> responseHeaderConfiguration) {
+        IOptions<IResponseHeaderConfiguration> responseHeaderConfiguration,
+        IOptions<IStreamingConfiguration> streamingConfiguration) {
         _contextSerializationService = contextSerializationService;
         _headerActions = SetupHeaderActions(responseHeaderConfiguration.Value);
+        _heartbeatInterval = streamingConfiguration.Value.HeartbeatInterval;
     }
 
     private Action<IExecutionContext>? SetupHeaderActions(IResponseHeaderConfiguration responseHeaderConfiguration) {
@@ -70,7 +74,7 @@ public class IOFilterProvider : IIOFilterProvider {
     }
 
     /// <summary>
-    /// The streamed filter, framed the way the handler asked for.
+    /// The streamed filter, framed the way the handler asked for, with the configured heartbeat.
     /// </summary>
     /// <remarks>
     /// An overload rather than a changed signature: <c>IIOFilterProvider</c> is public, and a
@@ -85,7 +89,8 @@ public class IOFilterProvider : IIOFilterProvider {
             deserializeRequest,
             _contextSerializationService.SerializeResponse,
             _headerActions,
-            framing
+            framing,
+            _heartbeatInterval
         );
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/AsyncEnumerableIoFilter.cs
@@ -13,20 +13,28 @@ public class AsyncEnumerableIoFilter<TItem> : IExecutionFilter {
     private readonly Func<IExecutionContext, Task> _serializeResponse;
     private readonly Action<IExecutionContext>? _headerActions;
     private readonly IStreamFraming _framing;
+    private readonly TimeSpan _heartbeatInterval;
 
     /// <param name="framing">
     /// What goes around each item. Defaults to newline-delimited JSON, which is what every
     /// streamed handler answered as before there was a choice.
     /// </param>
+    /// <param name="heartbeatInterval">
+    /// How long the handler may be quiet before the framing is asked to write a heartbeat, or zero
+    /// for never - which is what a filter built without one does, and what
+    /// <c>IOFilterProvider</c> replaces with the configured interval.
+    /// </param>
     public AsyncEnumerableIoFilter(
         Func<IExecutionContext, Task<IExecutionRequestParameters>> deserializeRequest,
         Func<IExecutionContext, Task> serializeResponse,
         Action<IExecutionContext>? headerActions,
-        IStreamFraming? framing = null) {
+        IStreamFraming? framing = null,
+        TimeSpan heartbeatInterval = default) {
         _deserializeRequest = deserializeRequest;
         _serializeResponse = serializeResponse;
         _headerActions = headerActions;
         _framing = framing ?? NdjsonFraming.Instance;
+        _heartbeatInterval = heartbeatInterval;
     }
 
     public async Task Execute(IExecutionChain chain) {
@@ -84,24 +92,14 @@ public class AsyncEnumerableIoFilter<TItem> : IExecutionFilter {
                 chain.Context.Response.ShouldSerialize = false;
             }
             else if (chain.Context.Response.ResponseValue is IAsyncEnumerable<TItem> asyncEnumerable) {
-                context.Response.ContentType = _framing.ContentType;
                 context.Response.ShouldSerialize = false;
 
-                await foreach (var item in asyncEnumerable.WithCancellation(context.CancellationToken)) {
-                    context.Response.ResponseValue = item;
-
-                    await _framing.WriteItem(context, _serializeResponse);
-
-                    // Per item, which is the whole point of streaming: a caller reads the first
-                    // result while the handler is still producing the rest. Through a compressing
-                    // body this is a sync flush on the encoder, so a compressed stream is one
-                    // member delivered item by item rather than one member per item.
-                    await context.Response.Body.FlushAsync(context.CancellationToken);
+                // A stream that failed before it began is answered the way a refusal is: as an
+                // error document under its own status. The failure is on the response by the time
+                // this returns false, and nothing has reached the wire.
+                if (!await WriteStream(context, asyncEnumerable)) {
+                    await _serializeResponse(chain.Context);
                 }
-
-                await _framing.WriteCompletion(context);
-
-                await context.Response.Body.FlushAsync(context.CancellationToken);
             }
             else if (chain.Context.Response.ShouldSerialize) {
                 await _serializeResponse(chain.Context);
@@ -111,6 +109,186 @@ public class AsyncEnumerableIoFilter<TItem> : IExecutionFilter {
         }
         finally {
             context.RequestMetrics.Record(RequestMetrics.ResponseDuration, responseTimestamp.GetElapsedMilliseconds());
+        }
+    }
+
+    /// <summary>
+    /// Every item, each flushed as it is written, with a heartbeat wherever the handler is quiet
+    /// for longer than the interval.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The stream commits to its content type at the first byte, not before.</b> A handler that
+    /// has nothing more to say answers a reconnect with a 204, and it says so from inside its
+    /// iterator - which runs at the first <c>MoveNextAsync</c>, after the handler call returned.
+    /// Committing before enumerating would put <c>text/event-stream</c> and a completion comment on
+    /// that 204, and Kestrel refuses a body on a 204 by aborting the connection, which the client
+    /// reads as a network error and reconnects from: the opposite of what the status is for. So the
+    /// content type, the event-stream headers and the completion bytes all wait for the first item,
+    /// the first heartbeat, or the end of a stream that is not a 204.
+    /// </para>
+    /// <para>
+    /// An explicit enumerator rather than <c>await foreach</c>, so the token still reaches a
+    /// handler's <c>[EnumeratorCancellation]</c> parameter and so the wait for the next item is a
+    /// task that can be raced against the heartbeat timer. The race is only run when the handler
+    /// has not already answered: a stream at a thousand items a second never starts a timer, and
+    /// one that does start is cancelled the moment the item arrives rather than left to expire.
+    /// </para>
+    /// <para>
+    /// The handler's enumerator does not touch the response body - a handler that writes to the
+    /// body itself is not a streaming handler - so a heartbeat can never land inside an item.
+    /// </para>
+    /// </remarks>
+    /// <returns>
+    /// False when the handler failed before anything was committed, with the failure recorded on
+    /// the response and nothing written; true otherwise. A failure after the first byte propagates
+    /// - the bytes are with the client, so the only honest answer is to end the stream, and the
+    /// client comes back with <c>Last-Event-ID</c>.
+    /// </returns>
+    private async Task<bool> WriteStream(IExecutionContext context, IAsyncEnumerable<TItem> stream) {
+        var cancellationToken = context.CancellationToken;
+        var response = context.Response;
+
+        // Off once the framing says it has nothing to write, and off from the start at zero.
+        var progress = new Progress { Heartbeats = _heartbeatInterval > TimeSpan.Zero };
+
+        await using var enumerator = stream.GetAsyncEnumerator(cancellationToken);
+
+        while (true) {
+            bool hasItem;
+
+            try {
+                var moveNext = enumerator.MoveNextAsync();
+
+                hasItem = progress.Heartbeats && !moveNext.IsCompleted
+                    ? await MoveNextWithHeartbeats(context, moveNext.AsTask(), progress)
+                    : await moveNext;
+            }
+            catch (Exception exception) when (!progress.Committed && !cancellationToken.IsCancellationRequested) {
+                response.ExceptionValue = exception;
+
+                return false;
+            }
+
+            if (!hasItem) {
+                break;
+            }
+
+            Commit(response, progress);
+
+            response.ResponseValue = enumerator.Current;
+
+            await _framing.WriteItem(context, _serializeResponse);
+
+            // Per item, which is the whole point of streaming: a caller reads the first result
+            // while the handler is still producing the rest. Through a compressing body this is a
+            // sync flush on the encoder, so a compressed stream is one member delivered item by
+            // item rather than one member per item.
+            await response.Body.FlushAsync(cancellationToken);
+        }
+
+        // Nothing was written and the handler said there is nothing to write. No content type, no
+        // completion bytes: a 204 with a body is not a 204.
+        if (!progress.Committed && response.Status is 204 or 304) {
+            return true;
+        }
+
+        Commit(response, progress);
+
+        await _framing.WriteCompletion(context);
+
+        await response.Body.FlushAsync(cancellationToken);
+
+        return true;
+    }
+
+    /// <summary>
+    /// What one stream has done so far. Shared between the loop and the heartbeat race, and read
+    /// by the exception filter, which is why it is an object rather than a pair of locals: a
+    /// failure after a heartbeat has to be seen as a failure after the first byte.
+    /// </summary>
+    private sealed class Progress {
+        public bool Committed;
+
+        public bool Heartbeats;
+    }
+
+    /// <summary>
+    /// Waits for the next item, writing a heartbeat each time the interval passes first.
+    /// </summary>
+    /// <remarks>
+    /// Turns heartbeats off for the rest of the stream once the framing answers that it has nothing
+    /// to write. The stream is committed before the framing is asked, because a heartbeat is bytes
+    /// and the headers have to be ahead of them - so a framing that declines has committed the
+    /// content type a little earlier than its first item would have, which changes nothing on the
+    /// wire.
+    /// </remarks>
+    private async Task<bool> MoveNextWithHeartbeats(
+        IExecutionContext context, Task<bool> moveNext, Progress progress) {
+        var cancellationToken = context.CancellationToken;
+        var response = context.Response;
+
+        while (!moveNext.IsCompleted && !cancellationToken.IsCancellationRequested) {
+            // Linked so a client that goes away releases the timer with everything else, and
+            // cancelled when the item wins so the timer is released rather than left to expire.
+            using var pause = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            var delay = Task.Delay(_heartbeatInterval, pause.Token);
+
+            if (await Task.WhenAny(moveNext, delay) == moveNext) {
+                pause.Cancel();
+
+                break;
+            }
+
+            if (delay.IsCanceled) {
+                break;
+            }
+
+            Commit(response, progress);
+
+            if (!await _framing.WriteHeartbeat(context)) {
+                progress.Heartbeats = false;
+
+                break;
+            }
+
+            await response.Body.FlushAsync(cancellationToken);
+        }
+
+        return await moveNext;
+    }
+
+    /// <summary>
+    /// The content type and, for an event stream, the two headers it needs from whatever sits
+    /// between it and the client. Once, before the first byte.
+    /// </summary>
+    /// <remarks>
+    /// <c>Cache-Control: no-cache</c> is what the standard's examples carry, and what keeps a
+    /// shared cache from storing a stream and replaying it. <c>X-Accel-Buffering: no</c> is
+    /// nginx's per-response switch for proxy buffering; everything else ignores it. Both defer to
+    /// a handler or a filter that already set them. Only for an event stream: a newline-delimited
+    /// response is an ordinary representation a cache may keep, so it is left to say for itself.
+    /// </remarks>
+    private void Commit(IExecutionResponse response, Progress progress) {
+        if (progress.Committed) {
+            return;
+        }
+
+        progress.Committed = true;
+
+        response.ContentType = _framing.ContentType;
+
+        if (string.Equals(_framing.ContentType, KnownContentType.EventStream, StringComparison.OrdinalIgnoreCase)) {
+            var headers = response.Headers;
+
+            if (!headers.ContainsKey(KnownHeaders.CacheControl)) {
+                headers[KnownHeaders.CacheControl] = "no-cache";
+            }
+
+            if (!headers.ContainsKey(KnownHeaders.XAccelBuffering)) {
+                headers[KnownHeaders.XAccelBuffering] = "no";
+            }
         }
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/NdjsonFraming.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/NdjsonFraming.cs
@@ -39,4 +39,10 @@ public class NdjsonFraming : IStreamFraming {
 
         return default;
     }
+
+    /// <summary>
+    /// Nothing. The format has no comment syntax, and a blank line is not an item every reader
+    /// skips, so a quiet NDJSON stream cannot be kept alive from inside the body.
+    /// </summary>
+    public ValueTask<bool> WriteHeartbeat(IExecutionContext context) => new(false);
 }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/RetryAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/RetryAttribute.cs
@@ -16,6 +16,14 @@ namespace Hardened.Requests.Runtime.Filters;
 /// backoff, which is amplification arriving exactly when the system can least absorb it.
 /// </para>
 /// <para>
+/// <b>On a streaming handler a retry covers the call, never the enumeration.</b> A handler
+/// returning <c>IAsyncEnumerable&lt;T&gt;</c> returns a lazy sequence, and an attempt ends when the
+/// call does; the items are produced afterwards, by the filter that writes them, outside any
+/// attempt. So a failure producing the sequence is retried and a failure while enumerating it is
+/// not - it ends the stream, and the client comes back with <c>Last-Event-ID</c>. Making the
+/// enumeration safe to run again is the author's job, and the event id is the tool for it.
+/// </para>
+/// <para>
 /// See <see cref="FilterOrder.Retry"/> for why the filter sits where it does, and what that costs.
 /// </para>
 /// </remarks>

--- a/src/Requests/Hardened.Requests.Runtime/Filters/RetryFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/RetryFilter.cs
@@ -32,6 +32,15 @@ namespace Hardened.Requests.Runtime.Filters;
 /// budget to be told what the first attempt already knew. Non-idempotent verbs are declined for a
 /// blunter reason - a retried <c>POST</c> is a second write.
 /// </para>
+/// <para>
+/// <b>A started response is not retried.</b> Every host answers
+/// <see cref="IExecutionResponse.ResponseStarted"/>, and once it is true the bytes are with the
+/// client: a fork onto that body would write a second answer after the first, and nothing can take
+/// the first back. A handler returning <c>IAsyncEnumerable&lt;T&gt;</c> never trips this from
+/// inside an attempt - it returns a lazy sequence, and the enumeration happens in the filter at
+/// <c>FilterOrder.Serialization</c>, outside every attempt - so the guard is for a handler or a
+/// filter that writes to the body itself and then fails.
+/// </para>
 /// </remarks>
 public class RetryFilter : IExecutionFilter {
     private readonly int _attempts;
@@ -128,7 +137,10 @@ public class RetryFilter : IExecutionFilter {
                 return;
             }
 
+            // A response with bytes on the wire is treated like an exhausted budget: the failure
+            // is still the failure, and only the remedy is gone.
             if (attempt >= _attempts ||
+                response.ResponseStarted ||
                 !_shouldRetry(failure) ||
                 context.CancellationToken.IsCancellationRequested ||
                 Exhausted(start)) {

--- a/src/Requests/Hardened.Requests.Runtime/Filters/SseFraming.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/SseFraming.cs
@@ -37,9 +37,21 @@ public class SseFraming : IStreamFraming {
     /// <remarks>
     /// What an empty stream ends with. The protocol has no way to say "nothing happened", and a
     /// zero-byte body is the case Lambda Function URLs do not close promptly - so an empty stream
-    /// sends one line every client discards rather than nothing at all.
+    /// sends one line every client discards rather than nothing at all. A heartbeat counts: once
+    /// any byte is on the wire the hang cannot occur, so a stream that heartbeated and then ended
+    /// writes no second comment.
     /// </remarks>
     private static readonly byte[] EmptyStreamComment = ":\n\n"u8.ToArray();
+
+    /// <summary>
+    /// The heartbeat, which is also a comment line and also discarded.
+    /// </summary>
+    /// <remarks>
+    /// Not the bare <c>:</c> that ends an empty stream. A test asserting that a stream carries no
+    /// trailing comment looks for that exact sequence, and a heartbeat landing in a slow run would
+    /// fail it for the wrong reason. The text is for whoever reads the raw stream.
+    /// </remarks>
+    private static readonly byte[] Heartbeat = ": keep-alive\n\n"u8.ToArray();
 
     public string ContentType => KnownContentType.EventStream;
 
@@ -66,13 +78,20 @@ public class SseFraming : IStreamFraming {
     }
 
     public ValueTask WriteCompletion(IExecutionContext context) {
-        // Only when nothing was written. Every event already ends with a blank line, so a stream
-        // that produced anything is complete, and adding to it would dispatch an empty event.
+        // Only when nothing was written, a heartbeat included. Every event already ends with a
+        // blank line, so a stream that produced anything is complete, and adding to it would
+        // dispatch an empty event.
         if (context.Response.Body.Position == 0) {
             context.Response.Body.Write(EmptyStreamComment, 0, EmptyStreamComment.Length);
         }
 
         return default;
+    }
+
+    public ValueTask<bool> WriteHeartbeat(IExecutionContext context) {
+        context.Response.Body.Write(Heartbeat, 0, Heartbeat.Length);
+
+        return new ValueTask<bool>(true);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/ExceptionResponseSerializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/ExceptionResponseSerializer.cs
@@ -57,6 +57,7 @@ public class ExceptionResponseSerializer : IExceptionResponseSerializer {
     /// operation's success.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The operation's own representations get first refusal, so a caller of a JSON operation
     /// still gets JSON errors and an XML one XML. But those representations were declared for the
     /// success body, and an error model often is not writable as any of them - a
@@ -67,6 +68,18 @@ public class ExceptionResponseSerializer : IExceptionResponseSerializer {
     /// keeps the second pass out of the declared-set tier that just refused - and located again.
     /// A <see cref="NotAcceptableException"/> is not caught: the client's stated preference is a
     /// different question, answered where it always was.
+    /// </para>
+    /// <para>
+    /// <b>A refused event stream is a refused request, not an event stream.</b> A browser
+    /// <c>EventSource</c> sends <c>Accept: text/event-stream</c>, and a refusal on that route - an
+    /// authorization failure, a bind failure, a throw before the first item - arrives here with no
+    /// content type committed, because the streaming filter commits one only once it has something
+    /// to write. Nothing produces <c>text/event-stream</c> for an error model, so the locator
+    /// falls through to the default serializer and the answer is JSON under the refusal's status.
+    /// That is the outcome the standard requires: a status other than 200, or a body not typed
+    /// <c>text/event-stream</c>, makes the client fail the connection and stop, where
+    /// <c>text/event-stream</c> around a JSON object would be parsed as garbage and reconnected to
+    /// forever. <c>StreamingTests</c> pins it through a real refusal.
     /// </remarks>
     private IResponseSerializer FindErrorSerializer(IExecutionContext context) {
         try {

--- a/src/Requests/Hardened.Requests.Runtime/Streaming/IStreamingConfiguration.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Streaming/IStreamingConfiguration.cs
@@ -1,0 +1,23 @@
+namespace Hardened.Requests.Runtime.Streaming;
+
+/// <summary>
+/// How a streamed response is kept alive while the handler is quiet.
+/// </summary>
+/// <remarks>
+/// Registered by the request module with its defaults, so every application has a heartbeat
+/// without asking for one. Amend it with <c>services.ConfigureStreaming</c>.
+/// </remarks>
+public interface IStreamingConfiguration {
+    /// <summary>
+    /// How long a stream may be silent before a heartbeat is written, or <see cref="TimeSpan.Zero"/>
+    /// for never.
+    /// </summary>
+    /// <remarks>
+    /// Fifteen seconds by default: what the WHATWG standard suggests, and half of the tightest idle
+    /// cut on the list - CloudFront drops a response that is quiet for 30 seconds between packets,
+    /// and retries the request while the first invocation keeps streaming to nobody. Only a framing
+    /// with something to write honours it; newline-delimited JSON has no comment syntax and stays
+    /// silent whatever this says.
+    /// </remarks>
+    TimeSpan HeartbeatInterval { get; }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Streaming/StreamingConfiguration.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Streaming/StreamingConfiguration.cs
@@ -1,0 +1,11 @@
+namespace Hardened.Requests.Runtime.Streaming;
+
+/// <inheritdoc cref="IStreamingConfiguration"/>
+public class StreamingConfiguration : IStreamingConfiguration {
+    /// <summary>
+    /// The WHATWG standard's "every 15 seconds or so".
+    /// </summary>
+    public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(15);
+
+    public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
+}

--- a/src/Requests/Hardened.Requests.Runtime/Streaming/StreamingServiceCollectionExtensions.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Streaming/StreamingServiceCollectionExtensions.cs
@@ -1,0 +1,40 @@
+using Hardened.Shared.Runtime.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hardened.Requests.Runtime.Streaming;
+
+public static class StreamingServiceCollectionExtensions {
+
+    /// <summary>
+    /// Amends the streaming configuration.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public void ConfigureServices(IServiceCollection services) {
+    ///     services.ConfigureStreaming(streaming => {
+    ///         streaming.HeartbeatInterval = TimeSpan.FromSeconds(5);
+    ///     });
+    /// }
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// An amender rather than a replacement value, so it composes with the defaults the request
+    /// module registers - the same shape as <c>ConfigureCompression</c>.
+    /// </remarks>
+    public static IServiceCollection ConfigureStreaming(
+        this IServiceCollection services, Action<StreamingConfiguration> configure) {
+        services.AddSingleton<IConfigurationPackage>(
+            new SimpleConfigurationPackage(
+                Array.Empty<IConfigurationValueProvider>(),
+                new IConfigurationValueAmender[] {
+                    new SimpleConfigurationValueAmender<StreamingConfiguration>(
+                        (_, configuration) => {
+                            configure(configuration);
+
+                            return configuration;
+                        })
+                }));
+
+        return services;
+    }
+}

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
@@ -105,6 +105,9 @@
         <Compile Include="../Hardened.SourceGenerator/Web/CompressDiagnostics.cs">
             <Link>Web\CompressDiagnostics.cs</Link>
         </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Web/StreamFramingDiagnostics.cs">
+            <Link>Web\StreamFramingDiagnostics.cs</Link>
+        </Compile>
     </ItemGroup>
 
     <!--

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
@@ -191,7 +191,8 @@ public class ModelComparisonTests {
     /// them twice - once each way - as a side effect of removing and re-adding the template
     /// annotation. A model that reports the same text for two different responses is the thing that
     /// makes such a failure unreadable. Streaming framing is the third, and adding it here is what
-    /// this test is for.
+    /// this test is for. The framing finding is the fourth: a handler whose attribute is removed or
+    /// whose return type changes has to change this string, or the diagnostic outlives the code.
     /// </remarks>
     [Fact]
     public void AResponseModelDescribesAllOfItsResponseAnnotations() {
@@ -206,7 +207,8 @@ public class ModelComparisonTests {
             ProducedContentTypes = "text/plain,text/csv",
             UnionCases = "global::App.Todo|201|01;global::App.NotFound|404|01",
             ThrowsDiagnostic = "OutOfStock",
-            ValidationErrorStatus = 422
+            ValidationErrorStatus = 422,
+            StreamFramingDiagnostic = "sse"
         };
 
         // Every field, because this string is what the incremental caches compare to decide
@@ -214,7 +216,7 @@ public class ModelComparisonTests {
         Assert.Equal(
             "True:System.Fortunes:text/csv:sse:System.String:201:" +
             "Models.DefaultErrorBodies.NotFoundProblem:text/plain,text/csv:" +
-            "global::App.Todo|201|01;global::App.NotFound|404|01::OutOfStock:422",
+            "global::App.Todo|201|01;global::App.NotFound|404|01::OutOfStock:422:sse",
             model.ToString());
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
@@ -153,6 +153,17 @@ public record ResponseInformationModel {
     public string? ThrowsDiagnostic { get; set; }
 
     /// <summary>
+    /// The framing named on a handler that has no stream to frame, or null where the two agree.
+    /// </summary>
+    /// <remarks>
+    /// Carried rather than reported where it is found, for the reason <see cref="UnionDiagnostic"/>
+    /// is, and reported from the routing generator as <c>HRDW004</c>. The emitter branches on the
+    /// return type first and ignores the framing on such a handler, so without the report the
+    /// author would get a buffered JSON response and a document that says so.
+    /// </remarks>
+    public string? StreamFramingDiagnostic { get; set; }
+
+    /// <summary>
     /// How a streamed response is framed on the wire, or null for newline-delimited JSON.
     /// </summary>
     /// <remarks>
@@ -180,6 +191,7 @@ public record ResponseInformationModel {
     public override string ToString() {
         return $"{IsAsync}:{OutputType}:{RawResponseContentType}:{StreamFraming}:{ReturnType}" +
                $":{DefaultStatusCode}:{NullResponseBodyExpression}:{ProducedContentTypes}" +
-               $":{UnionCases}:{UnionDiagnostic}:{ThrowsDiagnostic}:{ValidationErrorStatus}";
+               $":{UnionCases}:{UnionDiagnostic}:{ThrowsDiagnostic}:{ValidationErrorStatus}" +
+               $":{StreamFramingDiagnostic}";
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -595,9 +595,10 @@ public abstract class BaseRequestModelGenerator {
                 "text/plain";
         }
 
-        // Framing is named here and validated where a diagnostic can be reported - a syntax
-        // transform cannot report one, so an attribute on a handler that streams nothing has to be
-        // carried forward rather than rejected in place.
+        // Framing is named here and reported where a diagnostic can be - a syntax transform
+        // cannot report one, so an attribute on a handler that streams nothing is carried forward
+        // as a finding rather than rejected in place. The mismatch is decided here because this is
+        // where the return type is known.
         var framing = context.Node.GetAttribute("ServerSentEvents") != null
             ? StreamFramingNames.ServerSentEvents
             : null;
@@ -606,6 +607,7 @@ public abstract class BaseRequestModelGenerator {
 
         return new ResponseInformationModel {
             StreamFraming = framing,
+            StreamFramingDiagnostic = framing != null && !isAsyncEnumerable ? framing : null,
             IsAsync = isAsync,
             IsAsyncEnumerable = isAsyncEnumerable,
             AsyncEnumerableItemType = asyncEnumerableItemType,

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -86,10 +86,16 @@ public static class RoutingTableGenerator {
         // shipped contract rather than in the generated code, which is exactly why nothing else
         // would ever surface it.
         foreach (var handler in routable) {
+            var name = handler.ControllerType.Name + "." + handler.HandlerMethod;
+
             ResponseModelDiagnostics.ReportCaseSetFindings(
-                context,
-                handler.ControllerType.Name + "." + handler.HandlerMethod,
-                handler.ResponseInformation.UnionDiagnostic);
+                context, name, handler.ResponseInformation.UnionDiagnostic);
+
+            // A framing on a handler with nothing to frame compiles and runs too, as a buffered
+            // JSON response, which is why the attribute's promise of a build error is kept here
+            // rather than left to be found in an environment.
+            StreamFramingDiagnostics.Report(
+                context, name, handler.ResponseInformation.StreamFramingDiagnostic);
         }
 
         // A scheme-shape attribute somewhere nothing reads it is a silent no-op - the build was

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/StreamFramingDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/StreamFramingDiagnostics.cs
@@ -1,0 +1,54 @@
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Web;
+
+/// <summary>
+/// <c>[ServerSentEvents]</c> on a handler that does not return <c>IAsyncEnumerable&lt;T&gt;</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The attribute names a framing for a stream, and a handler that returns anything else has no
+/// stream to frame. The emitter branches on the return type first and ignores the framing on such
+/// a handler, so without this the author gets a buffered JSON response, a document that says so,
+/// and nothing that says why. The attribute's own doc has promised a build error since it existed;
+/// this is that error.
+/// </para>
+/// <para>
+/// An error rather than a warning, like <see cref="CompressDiagnostics"/>: there is no
+/// configuration under which the attribute means anything on that handler. Found in the syntax
+/// transform, where the return type is known, and reported from the routing generator, which has a
+/// <c>SourceProductionContext</c> - the route <c>ResponseModelDiagnostics</c> takes. At
+/// <see cref="Location.None"/> for the reason its neighbours are: the handler model carries no
+/// location, by design, because a span on it would rebuild every handler below an edit.
+/// </para>
+/// </remarks>
+public static class StreamFramingDiagnostics {
+    public const string DiagnosticId = "HRDW004";
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the reason
+    /// <c>AmbiguousRouteDiagnostics.Descriptor</c> is: RS2008 looks for the field, and these
+    /// projects set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "[ServerSentEvents] on a handler that does not return IAsyncEnumerable<T>",
+        messageFormat:
+        "'{0}' carries [ServerSentEvents] but does not return IAsyncEnumerable<T>, so there is no " +
+        "stream to frame and the response is buffered and serialized as JSON. Return " +
+        "IAsyncEnumerable<T> to stream it as text/event-stream, or remove the attribute.",
+        category: "Hardened.Web",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports the finding the transform carried, if there is one.
+    /// </summary>
+    public static void Report(SourceProductionContext context, string handler, string? finding) {
+        if (string.IsNullOrEmpty(finding)) {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Descriptor(), Location.None, handler));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Streaming/ServerSentEventsDiagnosticTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Streaming/ServerSentEventsDiagnosticTests.cs
@@ -1,0 +1,94 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.Web;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Streaming;
+
+/// <summary>
+/// <c>[ServerSentEvents]</c> on a handler with no stream to frame.
+///
+/// <para>
+/// The attribute's own doc promised a build error from the day it shipped, and nothing raised one:
+/// the emitter branches on the return type first and ignored the framing, so the author got a
+/// buffered JSON response and a document that said so. <c>HRDW004</c> is that error.
+/// </para>
+/// </summary>
+public class ServerSentEventsDiagnosticTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),      // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)  // Hardened.Requests.Abstract
+    ];
+
+    private static GeneratorResult Generate(string handler) =>
+        GeneratorTestHarness.Run(
+            $$"""
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class FeedController {
+            {{handler}}
+            }
+            """,
+            new WebLibrarySourceGenerator(),
+            Anchors);
+
+    private static IEnumerable<Diagnostic> Reported(GeneratorResult result) =>
+        result.GeneratorDiagnostics.Where(d => d.Id == StreamFramingDiagnostics.DiagnosticId);
+
+    /// <summary>
+    /// Every buffered shape: a value, a task, a list, and a synchronous sequence - which is not a
+    /// stream either, however much it looks like one.
+    /// </summary>
+    [Theory]
+    [InlineData("public string Latest() => \"one\";")]
+    [InlineData("public Task<string> Latest() => Task.FromResult(\"one\");")]
+    [InlineData("public List<string> Latest() => new();")]
+    [InlineData("public IEnumerable<string> Latest() => new[] { \"one\" };")]
+    public void ServerSentEventsOnABufferedHandlerIsHRDW004(string handler) {
+        var diagnostic = Assert.Single(Reported(Generate($"""
+            [Get("/latest")]
+            [ServerSentEvents]
+            {handler}
+            """)));
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("FeedController.Latest", diagnostic.GetMessage());
+        Assert.Contains("IAsyncEnumerable<T>", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void ServerSentEventsOnAnAsyncEnumerableHandlerReportsNothing() {
+        var result = Generate("""
+            [Get("/feed")]
+            [ServerSentEvents]
+            public async IAsyncEnumerable<string> Feed() {
+                yield return "one";
+                await Task.CompletedTask;
+            }
+            """).AssertNoErrors();
+
+        Assert.Empty(Reported(result));
+        Assert.Contains("SseFraming.Instance", result.SourceContaining("FeedController_Feed"));
+    }
+
+    [Fact]
+    public void ABufferedHandlerWithoutTheAttributeReportsNothing() {
+        var result = Generate("""
+            [Get("/latest")]
+            public string Latest() => "one";
+            """).AssertNoErrors();
+
+        Assert.Empty(Reported(result));
+    }
+}

--- a/src/Web/Hardened.Web.Runtime/Attributes/ServerSentEventsAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Attributes/ServerSentEventsAttribute.cs
@@ -25,15 +25,48 @@ namespace Hardened.Web.Runtime.Attributes;
 /// a stream that sets ids can resume where it left off.
 /// </para>
 /// <para>
+/// <b>The reconnect contract.</b> The client reconnects on its own after the stream ends or the
+/// connection drops, sending <c>Last-Event-ID</c>, and stops on a 204 or on any status other than
+/// 200. A handler that sets ids binds the header with
+/// <c>[FromHeader(KnownHeaders.LastEventId)] string? lastEventId</c>, replays from the event after
+/// it, and - when the subscription is over for good - takes <c>IExecutionContext</c>, sets
+/// <c>context.Response.Status = 204</c> and yields nothing. The pipeline writes no framing and no
+/// body for that 204. Decide it before the first item: a 204 after an event or a heartbeat has
+/// gone out is a 204 with a body, which the host refuses.
+/// </para>
+/// <example>
+/// <code>
+/// [Get("/orders/live")]
+/// [ServerSentEvents]
+/// public async IAsyncEnumerable&lt;SseItem&lt;OrderEvent&gt;&gt; Live(
+///     [FromHeader(KnownHeaders.LastEventId)] string? lastEventId,
+///     IExecutionContext context) { … }
+/// </code>
+/// </example>
+/// <para>
+/// <b>Refusals, failures and retries.</b> A refusal on the route - authorization, binding, a throw
+/// before the first event - leaves as its own status with a JSON body, and the client stops. A
+/// failure after the first event ends the stream, and the client comes back with
+/// <c>Last-Event-ID</c>. <c>[Retry]</c> retries the call that produces the sequence and never the
+/// enumeration, so an event is never duplicated by a retry.
+/// </para>
+/// <para>
+/// <b>Quiet streams are kept open.</b> A stream that is silent for longer than the heartbeat
+/// interval, fifteen seconds by default, carries a comment line the client discards, so an
+/// intermediary that cuts idle responses sees bytes. Every event stream also carries
+/// <c>Cache-Control: no-cache</c> and <c>X-Accel-Buffering: no</c> unless the handler set them.
+/// <c>services.ConfigureStreaming</c> changes the interval; zero turns the heartbeat off.
+/// </para>
+/// <para>
 /// <b>It needs a host that can flush.</b> Kestrel, ASP.NET Core and the Lambda streaming runtime
 /// all can. The buffered API Gateway runtime cannot - it accumulates the whole body before
 /// returning, so events would arrive together at the end or not at all - and the generator reports
 /// that at build time rather than leaving it to be found in an environment.
 /// </para>
 /// <para>
-/// On a handler that does not return <c>IAsyncEnumerable&lt;T&gt;</c> this is a build error: there
-/// is no stream to frame, and silently ignoring it would leave an author believing a buffered
-/// response was an event stream.
+/// On a handler that does not return <c>IAsyncEnumerable&lt;T&gt;</c> this is a build error,
+/// <c>HRDW004</c>: there is no stream to frame, and silently ignoring it would leave an author
+/// believing a buffered response was an event stream.
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]

--- a/src/Web/Hardened.Web.StaticContent.Tests/StaticContentMountProviderTests.cs
+++ b/src/Web/Hardened.Web.StaticContent.Tests/StaticContentMountProviderTests.cs
@@ -10,6 +10,7 @@ using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Configuration;
 using Hardened.Requests.Runtime.Execution;
 using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Streaming;
 using Hardened.Shared.Runtime.Collections;
 using Hardened.Shared.Runtime.Utilities;
 using Hardened.Web.Runtime.DependencyInjection;
@@ -92,10 +93,12 @@ public class StaticContentMountProviderTests : IDisposable {
             _ => new ItemPool<SHA256>(SHA256.Create, _ => { }, hash => hash.Dispose()));
 
         // Never reached - every response here sets ShouldSerialize false - but IOFilterProvider
-        // takes it to construct.
+        // takes them to construct.
         services.TryAddSingleton(Substitute.For<IContextSerializationService>());
         services.TryAddSingleton(
             Options.Create<IResponseHeaderConfiguration>(new ResponseHeaderConfiguration()));
+        services.TryAddSingleton(
+            Options.Create<IStreamingConfiguration>(new StreamingConfiguration()));
 
         var configuration = Substitute.For<IStaticContentConfiguration>();
 


### PR DESCRIPTION
Framework half of the SSE hardening plan (`~/Hardened/docs/SSE-PLAN.md`, items 1, 2, 3, 5 and 6). The Amz items are out: the host work is changing and the buffered-host diagnostic will not be needed. The Docs item follows once this is on a preview feed.

## What changes on the wire

Behaviour change, for the release body on the tag. Every `text/event-stream` response now carries `Cache-Control: no-cache` and `X-Accel-Buffering: no` unless the handler set them, and a stream that is quiet for 15 seconds carries a `: keep-alive` comment line. `services.ConfigureStreaming(s => s.HeartbeatInterval = ...)` changes the interval; zero turns it off. A consumer test asserting an exact SSE body over a slow handler can now see a heartbeat.

## Item by item

**A started stream is not retried.** `RetryFilter` treats `ResponseStarted` like an exhausted budget. A streaming handler never trips it from inside the fork, because the enumeration runs in the filter at `Serialization`, outside every attempt. `RetryAttribute` now says so: a retry covers the call, never the enumeration. The retry stand-in in `FilterOrderingTests` sat at `HandlerCreation - 10`, which is not where `[Retry]` orders; it sits at `FilterOrder.Retry` now and the test asserts that order.

**A refusal on an SSE route is a refusal.** Pinned through a real refusal with `Accept: text/event-stream`: the status is the refusal's and the body is JSON, so the client stops. The mechanism is the default-serializer fallback, not the `ContentTypeNotProducibleException` catch the plan expected; the remarks on `ExceptionResponseSerializer` say which.

**`[ServerSentEvents]` on a handler that does not stream is HRDW004.** Carried on `ResponseInformationModel` and in its cache key, reported from the routing table generator beside the case-set findings. At `Location.None` like its neighbours: the handler model deliberately carries no location.

**`Last-Event-ID` is bound, and 204 ends a subscription.** `KnownHeaders.LastEventId`. The filter now commits the content type at the first byte rather than before enumerating, so a handler can set 204 from inside its iterator and yield nothing, and the response is a real 204: no content type, no completion comment. The same lazy commit makes a throw before the first item an error document under its own status; a throw after the first item still ends the stream.

**Heartbeat.** `IStreamFraming.WriteHeartbeat` with a default returning false, so existing framings keep compiling. `SseFraming` writes `: keep-alive`; NDJSON declines and the filter stops asking. The loop is an explicit enumerator racing `MoveNextAsync` against a linked `Task.Delay`, started only when the handler has not already answered and cancelled when the item wins. `StreamingConfiguration` is registered by the request module with the compression configuration's shape.

## Tests

Unit: the retry guard, the 204 on both framings, failure before and after the first item, heartbeats on a gated stream with no clock, zero interval, NDJSON declining, the empty-then-heartbeat case, the two headers and a handler's own `Cache-Control`. Generator: HRDW004 over four buffered shapes and its absence on a stream. Integration in `StreamingTests`: resume after an id, from the start, past the last id (204 with nothing), lower-case header, refusal on SSE and NDJSON, failure before and after the first event, retry after the first item (enumerated once) and retry of the call, a heartbeat between slow events under a per-test `[HeartbeatEvery(10)]`, and the headers on SSE but not NDJSON.

The public API approval covers the interface member, the two constants, the two constructors and the streaming configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
