### PR TITLE
Compile constraints on a code-first handler's parameters and publish them

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -169,6 +169,31 @@ second one rather than anywhere in the code.
 
 ## Validation
 
+### HRDV001 — retired
+
+It warned that a constraint attribute written on a handler's parameter was not compiled into a
+validator. A constraint on a query, header, path, cookie, form or body parameter of a hand-written
+handler is compiled into the handler's parameters validator now, read and resolved by the same
+ValidationModules front end that reads one off a property, so a constraint that does not fit the
+parameter's type is reported under that front end's own `VM` id, exactly as it would be on a
+property. The id is not reused.
+
+### HRDV005 — a condition on a parameter constraint names a model member
+
+`When` and `Unless` on a constraint name a bool property or method of the model the constraint
+sits on, which the generated validator calls before checking. A handler parameter sits on no
+model, so there is nothing for the name to resolve against.
+
+```
+'When' on [StringLength] for parameter 'id' names a member of the model the constraint sits
+on, and a handler parameter sits on no model. Remove the condition, or move the constraint onto
+a property of a model type where the member it names is declared.
+```
+
+An error, because a condition that is ignored is a constraint that runs when its author said it
+should not. The other constraints on the same parameter are not compiled either while it stands;
+the message is the whole fix.
+
 ### HRDV004 — nested constraints are never reached
 
 A generated validator descends into a member only where `[ValidateNested]` says to, so omitting it

--- a/docs/openapi-document.md
+++ b/docs/openapi-document.md
@@ -132,9 +132,14 @@ Strict parsing is part of the assertion: `System.Text.Json` refuses raw control 
 multi-line description that stopped being escaped fails these suites rather than the reference
 page.
 
-Known gaps, stated rather than implied: code-first cannot express a
-constraint on a query, header or path parameter (`HRDV001` names the ways out), and
-`@timestampFormat` is read for nullability and otherwise inert. Nullable scalar parameters used
+A constraint on a code-first query, header, path or cookie parameter is published as the facet it
+declares, as a model property's is: `[Range(Min = 2, Max = 8)]` on the parameter is `minimum` and
+`maximum` on its schema, and `[Required]` on a parameter that could be absent is `required: true`.
+Only the `ValidationModules.Constraints` vocabulary reaches the document, which is the rule for
+properties too.
+
+Known gaps, stated rather than implied: `@timestampFormat` is read for nullability and otherwise
+inert. Nullable scalar parameters used
 to be listed here too, blamed on a type argument lost in the syntax transform. The diagnosis was
 wrong: the argument survived, the definition arrived named with the C# keyword, and the schema
 switch matched only CLR names. `ScalarSchema` accepts both spellings now.

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ParameterConstraintTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ParameterConstraintTests.cs
@@ -1,0 +1,153 @@
+using System.Text.Json;
+using Hardened.Requests.Runtime.Validation;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// Constraints on a hand-written handler's own parameters, end to end: the 400 a query, header or
+/// path value earns, the name it is reported under, and the facets the document publishes for it.
+/// </summary>
+/// <remarks>
+/// The 0.19.0-rc1000 trial called this the single largest thing code-first gave up: a
+/// <c>precision</c> bounded 2..8 was a hand-written check, and the document published an integer
+/// with no bounds. Every handler behind these tests declares the constraint and nothing else.
+/// </remarks>
+public class ParameterConstraintTests {
+
+    private static Action<TestWebRequest> Header(string name, string value) =>
+        request => request.Headers[name] = new StringValues(value);
+
+    private static RequestValidationError Refusal(TestWebResponse response) {
+        response.Assert.BadRequest();
+
+        var error = response.Deserialize<RequestValidationError>();
+
+        Assert.NotNull(error);
+        Assert.Equal("ValidationError", error.Type);
+
+        return error;
+    }
+
+    // ---------------------------------------------------------------- query
+
+    [HardenedTest]
+    public async Task ABoundOnAQueryValueIsEnforced(ITestWebApp testWebApp) {
+        var refused = Refusal(await testWebApp.Get("/constraints/precision?precision=9"));
+
+        Assert.Contains(refused.Errors, e => e.Field == "precision" && e.Code == "range");
+
+        var accepted = await testWebApp.Get("/constraints/precision?precision=4");
+
+        accepted.Assert.Ok();
+
+        Assert.Equal(4, accepted.Deserialize<int>());
+    }
+
+    // ---------------------------------------------------------------- header
+
+    /// <summary>Pathed under the header's own name, which is what the caller sent.</summary>
+    [HardenedTest]
+    public async Task ALengthOnAHeaderIsPathedUnderTheHeaderName(ITestWebApp testWebApp) {
+        var refused = Refusal(await testWebApp.Get("/constraints/region", Header("X-Region", "EUR")));
+
+        Assert.Contains(refused.Errors, e => e.Field == "X-Region" && e.Code == "string_length");
+
+        var accepted = await testWebApp.Get("/constraints/region", Header("X-Region", "EU"));
+
+        accepted.Assert.Ok();
+
+        Assert.Equal("EU", accepted.Deserialize<string>());
+    }
+
+    // ---------------------------------------------------------------- path
+
+    /// <summary>
+    /// The route constraint and the value constraint answer different questions. A token that is
+    /// not an integer reaches no route, which is a 404; an integer outside the bound reaches the
+    /// route and is refused, which is a 400.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABoundOnAPathTokenSitsBehindItsRouteConstraint(ITestWebApp testWebApp) {
+        var noRoute = await testWebApp.Get("/constraints/page/abc");
+
+        noRoute.Assert.NotFound();
+
+        var refused = Refusal(await testWebApp.Get("/constraints/page/0"));
+
+        Assert.Contains(refused.Errors, e => e.Field == "count" && e.Code == "range");
+
+        var accepted = await testWebApp.Get("/constraints/page/7");
+
+        accepted.Assert.Ok();
+
+        Assert.Equal(7, accepted.Deserialize<int>());
+    }
+
+    // ---------------------------------------------------------------- required and pattern
+
+    [HardenedTest]
+    public async Task AQueryValueTheCallerMustSendIsReportedWhenAbsent(ITestWebApp testWebApp) {
+        var absent = Refusal(await testWebApp.Get("/constraints/tagged"));
+
+        Assert.Contains(absent.Errors, e => e.Field == "tag" && e.Code == "required");
+
+        var wrongShape = Refusal(await testWebApp.Get("/constraints/tagged?tag=ABC"));
+
+        Assert.Contains(wrongShape.Errors, e => e.Field == "tag" && e.Code == "pattern");
+
+        var accepted = await testWebApp.Get("/constraints/tagged?tag=abc");
+
+        accepted.Assert.Ok();
+
+        Assert.Equal("abc", accepted.Deserialize<string>());
+    }
+
+    // ---------------------------------------------------------------- the document
+
+    /// <summary>
+    /// The other half of the same declaration: the document repeats the constraint as the facet it
+    /// came from, so a generated client and a reader are told what the server enforces.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheDocumentPublishesTheConstraintsAsFacets(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/openapi.json");
+
+        response.Assert.Ok();
+
+        using var document = JsonDocument.Parse(await response.ReadTextAsync());
+
+        var precision = Parameter(document.RootElement, "/constraints/precision", "precision");
+
+        Assert.Equal(2, precision.GetProperty("schema").GetProperty("minimum").GetInt32());
+        Assert.Equal(8, precision.GetProperty("schema").GetProperty("maximum").GetInt32());
+        Assert.Equal("integer", precision.GetProperty("schema").GetProperty("type").GetString());
+
+        var region = Parameter(document.RootElement, "/constraints/region", "X-Region");
+
+        Assert.Equal(2, region.GetProperty("schema").GetProperty("minLength").GetInt32());
+        Assert.Equal(2, region.GetProperty("schema").GetProperty("maxLength").GetInt32());
+
+        var count = Parameter(document.RootElement, "/constraints/page/{count}", "count");
+
+        Assert.Equal(1, count.GetProperty("schema").GetProperty("minimum").GetInt32());
+        Assert.Equal(100, count.GetProperty("schema").GetProperty("maximum").GetInt32());
+
+        var tag = Parameter(document.RootElement, "/constraints/tagged", "tag");
+
+        Assert.True(tag.GetProperty("required").GetBoolean());
+        Assert.Equal("^[a-z]+$", tag.GetProperty("schema").GetProperty("pattern").GetString());
+    }
+
+    private static JsonElement Parameter(JsonElement document, string path, string name) {
+        foreach (var parameter in document
+                     .GetProperty("paths").GetProperty(path).GetProperty("get")
+                     .GetProperty("parameters").EnumerateArray()) {
+            if (parameter.GetProperty("name").GetString() == name) {
+                return parameter;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException($"No parameter named '{name}' at '{path}'.");
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ConstraintsController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ConstraintsController.cs
@@ -1,0 +1,40 @@
+using Hardened.Web.Runtime.Attributes;
+using ValidationModules.Constraints;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// Constraints written on a hand-written handler's own parameters: a query value, a header, a
+/// path token and a value the caller must send.
+/// </summary>
+/// <remarks>
+/// Nothing here mentions validation. The constraint is the whole declaration, as it is on a body
+/// model, and the same declaration is what the published document repeats as the parameter's
+/// facets. Until the web generator read a parameter's constraints, each of these was HRDV001 and a
+/// hand-written check throwing <c>ValidationException</c>, and the document said only "an integer".
+/// </remarks>
+[BasePath("/constraints")]
+public class ConstraintsController {
+
+    /// <summary>A bound on a query value, pathed under the query key.</summary>
+    [Get("/precision")]
+    public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) => precision;
+
+    /// <summary>A length on a header, pathed under the header's own name.</summary>
+    [Get("/region")]
+    public string Region([FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
+
+    /// <summary>
+    /// A bound behind a route constraint. The route decides whether the URL exists, so
+    /// <c>/page/abc</c> is a 404; the constraint decides whether the value is acceptable, so
+    /// <c>/page/0</c> is a 400.
+    /// </summary>
+    [Get("/page/{count:int}")]
+    public int Page([Range(Min = 1, Max = 100)] int count) => count;
+
+    /// <summary>
+    /// A value the caller must send, on a type that can be absent, with a shape it must take.
+    /// </summary>
+    [Get("/tagged")]
+    public string Tagged([FromQueryString] [Required] [Pattern("^[a-z]+$")] string? tag) => tag!;
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -27,6 +27,9 @@
       "name": "Conditional"
     },
     {
+      "name": "Constraints"
+    },
+    {
       "name": "EnumVocabulary"
     },
     {
@@ -1196,6 +1199,184 @@
         }
       }
     },
+    "/constraints/page/{count}": {
+      "get": {
+        "tags": [
+          "Constraints"
+        ],
+        "operationId": "page",
+        "summary": "A bound behind a route constraint. The route decides whether the URL exists, so /page/abc is a 404; the constraint decides whether the value is acceptable, so /page/0 is a 400.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The path did not name a resource: a token failed its route constraint."
+          }
+        }
+      }
+    },
+    "/constraints/precision": {
+      "get": {
+        "tags": [
+          "Constraints"
+        ],
+        "operationId": "precision",
+        "summary": "A bound on a query value, pathed under the query key.",
+        "parameters": [
+          {
+            "name": "precision",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 2,
+              "maximum": 8
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/constraints/region": {
+      "get": {
+        "tags": [
+          "Constraints"
+        ],
+        "operationId": "region",
+        "summary": "A length on a header, pathed under the header's own name.",
+        "parameters": [
+          {
+            "name": "X-Region",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/constraints/tagged": {
+      "get": {
+        "tags": [
+          "Constraints"
+        ],
+        "operationId": "constraintsTagged",
+        "summary": "A value the caller must send, on a type that can be absent, with a shape it must take.",
+        "parameters": [
+          {
+            "name": "tag",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z]+$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/cookies/set": {
       "get": {
         "tags": [
@@ -2232,7 +2413,7 @@
         "tags": [
           "ResponseCache"
         ],
-        "operationId": "tagged",
+        "operationId": "responseCacheTagged",
         "summary": "A read whose entry outlives anything worth waiting for, invalidated by name when the thing it read changes.",
         "description": "The pair is the whole feature. Without an application's only way to reach its own entries was to expire them, so a published change appeared within the cache lifetime and never sooner.",
         "responses": {

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ParameterModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ParameterModel.cs
@@ -87,6 +87,28 @@ internal class ParameterModel : IEquatable<ParameterModel>, IConstraintFacets {
     public int? MaxItems { get; set; }
     public List<string>? EnumValues { get; set; }
 
+    /// <summary>
+    /// The facets a compilation read off a hand-written handler's parameter, as the inside of a
+    /// schema object, or null. A described parameter states its facets in the typed members above
+    /// and never sets this.
+    /// </summary>
+    /// <remarks>
+    /// A transport field, like <see cref="MemberNameOverride"/>: the code-first web generator
+    /// describes its handlers through this model on their way to the shared builder, and the
+    /// document writer derives such a parameter's schema from its C# type rather than from
+    /// <see cref="Type"/>, which is empty here - so the facets arrive already spelled, from the
+    /// same reader that spells them for a body model's properties, and are spliced in beside the
+    /// derived schema.
+    /// </remarks>
+    public string? SchemaFacets { get; set; }
+
+    /// <summary>
+    /// Whether <c>[Required]</c> is written on a hand-written handler's parameter. Kept apart from
+    /// <see cref="IsRequired"/>, which the binder reads: the constraint is the validator's to
+    /// enforce and the document's to state, not a reason for the binder to refuse the request.
+    /// </summary>
+    public bool RequiredByConstraint { get; set; }
+
     public bool HasValidationConstraints =>
         IsRequired || MinLength.HasValue || MaxLength.HasValue ||
         Minimum.HasValue || Maximum.HasValue ||
@@ -117,6 +139,7 @@ internal class ParameterModel : IEquatable<ParameterModel>, IConstraintFacets {
                ExclusiveMinimum == other.ExclusiveMinimum && ExclusiveMaximum == other.ExclusiveMaximum &&
                Pattern == other.Pattern && RouteConstraint == other.RouteConstraint &&
                MinItems == other.MinItems && MaxItems == other.MaxItems &&
+               SchemaFacets == other.SchemaFacets && RequiredByConstraint == other.RequiredByConstraint &&
                SameEnumValues(other);
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestParameterInformation.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestParameterInformation.cs
@@ -66,6 +66,26 @@ public class RequestParameterInformation {
     internal ParameterModel? SpecParameter { get; set; }
 
     /// <summary>
+    /// The JSON Schema facets the constraints written on this parameter imply, as the inside of
+    /// an object, or null when it declares none the document can say.
+    /// </summary>
+    /// <remarks>
+    /// Read where the parameter's symbol is, in the syntax transform, and spliced into the schema
+    /// where the schema is written, at the output stage - the same journey
+    /// <see cref="Description"/> makes. Set for a hand-written handler only, and carried through
+    /// the description the web generator writes for it, since the shared builder rebuilds every
+    /// parameter from that description. A parameter that came from a contract states its facets
+    /// in <see cref="SpecParameter"/>'s typed members instead, which the writer prefers.
+    /// </remarks>
+    public string? SchemaFacets { get; set; }
+
+    /// <summary>
+    /// Whether <c>[Required]</c> is written on the parameter, so a nullable parameter the caller
+    /// must still send is published as required.
+    /// </summary>
+    public bool RequiredByConstraint { get; set; }
+
+    /// <summary>
     /// Whether every public constructor of <see cref="ParameterType"/> takes an interface.
     /// </summary>
     /// <remarks>
@@ -103,7 +123,9 @@ public class RequestParameterInformation {
             CustomAttribute,
             ConstructorRequiresServices) {
             Description = Description,
-            SpecParameter = SpecParameter
+            SpecParameter = SpecParameter,
+            SchemaFacets = SchemaFacets,
+            RequiredByConstraint = RequiredByConstraint
         };
 
     public override bool Equals(object obj) {
@@ -148,6 +170,11 @@ public class RequestParameterInformation {
         }
 
         if (!Equals(SpecParameter, requestParameterInformation.SpecParameter)) {
+            return false;
+        }
+
+        if (SchemaFacets != requestParameterInformation.SchemaFacets ||
+            RequiredByConstraint != requestParameterInformation.RequiredByConstraint) {
             return false;
         }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -404,8 +404,10 @@ public static class OpenApiDocumentGenerator {
             // A parameter carrying a default is one the caller may omit - the binder answers
             // with the default rather than a 400 - so publishing it required documents a demand
             // the service does not make. Path parameters stay required whatever they carry,
-            // because OpenAPI requires it of them and a path segment cannot be absent.
-            var required = parameter.Required &&
+            // because OpenAPI requires it of them and a path segment cannot be absent. A
+            // [Required] on a parameter that could be absent is the same demand the validator
+            // makes, and is published as one.
+            var required = (parameter.Required || parameter.RequiredByConstraint) &&
                            (parameter.DefaultValue == null ||
                             parameter.BindingType == ParameterBindType.Path);
 
@@ -1088,7 +1090,12 @@ public static class OpenApiDocumentGenerator {
         if (spec == null || (string.IsNullOrEmpty(spec.Type) &&
                              spec.EnumValues is not { Count: > 0 } &&
                              !spec.IsArray)) {
-            return EnumSchema(parameter.ParameterType, enums) ?? ScalarSchema(parameter.ParameterType);
+            // A hand-written handler's constraints, read off the parameter where its symbol was
+            // in hand and spliced in here, so a bound the validator enforces is a bound the
+            // document states - the same statement written twice, as it is for a property.
+            return SchemaConstraintWriter.Merge(
+                EnumSchema(parameter.ParameterType, enums) ?? ScalarSchema(parameter.ParameterType),
+                parameter.SchemaFacets);
         }
 
         var builder = new StringBuilder();

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/SchemaConstraintWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/SchemaConstraintWriter.cs
@@ -42,34 +42,50 @@ internal static class SchemaConstraintWriter {
     private const string ConstraintsNamespace = "ValidationModules.Constraints";
 
     /// <summary>
-    /// <paramref name="schema"/> with the facets <paramref name="property"/>'s constraints imply.
+    /// <paramref name="schema"/> with the facets <paramref name="member"/>'s constraints imply.
     /// </summary>
     /// <remarks>
-    /// A property whose schema <em>is</em> a <c>$ref</c> is returned untouched. OpenAPI 3.0
-    /// ignores every sibling of a <c>$ref</c>, so facets written beside one would be silently
-    /// dropped by any reader - which is worse than not writing them, because the document would
-    /// claim a constraint it does not communicate. Only the top level: this used to search the
-    /// whole string, so an array of referenced objects - whose <c>items</c> nests a
-    /// <c>$ref</c> - lost every facet it had, <c>[ItemCount]</c>'s bounds included, and the
-    /// bounds belong on the array where no reference sits.
+    /// <see cref="FacetsOf"/> and <see cref="Merge"/> in one step, for a property whose symbol and
+    /// schema are in hand together. A code-first parameter's are not: its symbol lives in the
+    /// syntax transform and its schema is built at the output stage, so the model carries the
+    /// facets between the two.
     /// </remarks>
-    public static string Apply(string schema, IPropertySymbol property) {
-        if (schema.Length < 2 ||
-            schema.StartsWith("{\"$ref\"", System.StringComparison.Ordinal)) {
-            return schema;
-        }
+    public static string Apply(string schema, ISymbol member) => Merge(schema, FacetsOf(member));
 
-        var facets = new List<string>();
+    /// <summary>
+    /// The facets <paramref name="member"/>'s constraints imply, as the inside of a JSON object,
+    /// or null when it declares none the document can say.
+    /// </summary>
+    public static string? FacetsOf(ISymbol member) {
+        List<string>? facets = null;
 
-        foreach (var attribute in property.GetAttributes()) {
+        foreach (var attribute in member.GetAttributes()) {
             if (attribute.AttributeClass?.ContainingNamespace?.ToDisplayString() != ConstraintsNamespace) {
                 continue;
             }
 
-            Facets(attribute, facets);
+            Facets(attribute, facets ??= new List<string>());
         }
 
-        if (facets.Count == 0) {
+        return facets is { Count: > 0 } ? string.Join(",", facets) : null;
+    }
+
+    /// <summary>
+    /// <paramref name="schema"/> with <paramref name="facets"/> spliced in.
+    /// </summary>
+    /// <remarks>
+    /// A schema that <em>is</em> a <c>$ref</c> is returned untouched. OpenAPI 3.0 ignores every
+    /// sibling of a <c>$ref</c>, so facets written beside one would be silently dropped by any
+    /// reader - which is worse than not writing them, because the document would claim a
+    /// constraint it does not communicate. Only the top level: this used to search the whole
+    /// string, so an array of referenced objects - whose <c>items</c> nests a <c>$ref</c> - lost
+    /// every facet it had, <c>[ItemCount]</c>'s bounds included, and the bounds belong on the array
+    /// where no reference sits.
+    /// </remarks>
+    public static string Merge(string schema, string? facets) {
+        if (facets == null ||
+            schema.Length < 2 ||
+            schema.StartsWith("{\"$ref\"", System.StringComparison.Ordinal)) {
             return schema;
         }
 
@@ -77,16 +93,16 @@ internal static class SchemaConstraintWriter {
         var body = schema.Substring(1, schema.Length - 2);
         var separator = body.Length > 0 ? "," : "";
 
-        return "{" + body + separator + string.Join(",", facets) + "}";
+        return "{" + body + separator + facets + "}";
     }
 
-    /// <summary>Whether the property is required because a constraint says so.</summary>
+    /// <summary>Whether the member is required because a constraint says so.</summary>
     /// <remarks>
-    /// Separate from <see cref="Apply"/> because <c>required</c> is a list on the enclosing object
-    /// rather than a facet on the property, which is where a schema says it.
+    /// Separate from <see cref="Apply"/> because <c>required</c> is a list on the enclosing object,
+    /// or a field on a parameter, rather than a facet on the schema, which is where a schema says it.
     /// </remarks>
-    public static bool IsRequired(IPropertySymbol property) =>
-        property.GetAttributes().Any(attribute =>
+    public static bool IsRequired(ISymbol member) =>
+        member.GetAttributes().Any(attribute =>
             attribute.AttributeClass?.Name == "RequiredAttribute" &&
             attribute.AttributeClass.ContainingNamespace?.ToDisplayString() == ConstraintsNamespace);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -338,11 +338,22 @@ public abstract class BaseRequestModelGenerator {
 
             if (parameterInformation == null) {
                 parameterInformation = GetParameterInfo(
-                    generatorSyntaxContext, 
+                    generatorSyntaxContext,
                     methodDeclaration,
-                    requestHandlerNameModel, 
+                    requestHandlerNameModel,
                     parameter,
                     i);
+            }
+
+            // What the parameter's own constraints say for the document, read here because this
+            // is where its symbol is. The validator that enforces them is HandlerValidationFrontEnd's,
+            // which reads the same attributes through ValidationModules; this reads only the ones
+            // the document can say, so the two are the same statement written twice, as they are
+            // for a property.
+            if (PublishesFacets(parameterInformation.BindingType) &&
+                generatorSyntaxContext.SemanticModel.GetDeclaredSymbol(parameter) is { } symbol) {
+                parameterInformation.SchemaFacets = SchemaConstraintWriter.FacetsOf(symbol);
+                parameterInformation.RequiredByConstraint = SchemaConstraintWriter.IsRequired(symbol);
             }
 
             parameters.Add(parameterInformation);
@@ -350,6 +361,17 @@ public abstract class BaseRequestModelGenerator {
 
         return parameters;
     }
+
+    /// <summary>
+    /// Whether the document describes this parameter with a schema of its own, which is where a
+    /// facet can be written. A body has a schema the document builds from its type, and a service
+    /// or the context is not the caller's to constrain.
+    /// </summary>
+    private static bool PublishesFacets(ParameterBindType bindingType) =>
+        bindingType is ParameterBindType.Path
+            or ParameterBindType.QueryString
+            or ParameterBindType.Header
+            or ParameterBindType.Cookie;
 
     protected virtual RequestParameterInformation? DefaultGetParameterFromAttribute(
         AttributeSyntax attribute, 

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -292,6 +292,11 @@ internal static class SpecHandlerModelBuilder {
                 // bounds and the enum vocabulary are facts only the document wants, and carrying
                 // the model beats re-deriving them from the C# type, which can only guess.
                 SpecParameter = param,
+                // And what a hand-written handler's parameter constrains, which its description
+                // carried through here from the compilation because it has no typed slot on the
+                // way in: the writer splices it beside the schema it derives from the C# type.
+                SchemaFacets = param.SchemaFacets,
+                RequiredByConstraint = param.RequiredByConstraint
             });
         }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Validation/HandlerValidationDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Validation/HandlerValidationDiagnostics.cs
@@ -5,33 +5,29 @@ namespace Hardened.SourceGenerator.Validation;
 public static class HandlerValidationDiagnostics {
 
     /// <summary>
-    /// A constraint attribute written directly on a handler's parameter.
+    /// A <c>When</c> or <c>Unless</c> on a constraint written on a handler's parameter.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>Why this is a warning and not a feature.</b> Reading a constraint off a parameter needs
-    /// the same work reading one off a property needs, and ValidationModules already does all of
-    /// it: the two attribute vocabularies, the pattern reference form, the AOT pattern policy, and
-    /// the diagnostics for a constraint that does not fit its member's type. All of that is reached
-    /// through a front-end typed on <c>IPropertySymbol</c>, and its pattern handling is private. A
-    /// parameter is not a property, so compiling these here would mean a second implementation of a
-    /// policy that ValidationModules owns - which is exactly the arrangement the OpenAPI path was
-    /// rebuilt to avoid.
+    /// The two name a member of the model the constraint sits on - a bool property or method the
+    /// generated validator calls before checking - and a handler parameter sits on no model. The
+    /// front end that reads the constraint would look the member up on a type it was never given,
+    /// so the one decision about a parameter's constraint this generator makes itself is to refuse
+    /// this shape before the reader sees it.
     /// </para>
     /// <para>
-    /// Warning rather than silence because the alternative is the failure this whole design
-    /// refuses: a constraint that was declared, was never compiled, and never says so. Put the
-    /// constraint on the model the parameter binds to and it is compiled today.
+    /// An error, because a condition that is ignored is a constraint that runs when its author said
+    /// it should not. <c>HRDV001</c>, which warned that a constraint on a parameter was not compiled
+    /// at all, is retired: it is compiled now.
     /// </para>
     /// </remarks>
-    public static readonly DiagnosticDescriptor ConstraintOnParameter = new(
-        "HRDV001",
-        "Constraint on a handler parameter is not compiled",
-        "'{0}' on parameter '{1}' is not compiled into a validator. Constraints are read from the " +
-        "types parameters bind to, not from the parameters themselves - move it onto a property of " +
-        "a model type, or declare the operation in an OpenAPI specification, where the build task " +
-        "compiles parameter constraints.",
+    public static readonly DiagnosticDescriptor ConditionOnParameterConstraint = new(
+        "HRDV005",
+        "A condition on a parameter constraint names a model member",
+        "'{0}' on [{1}] for parameter '{2}' names a member of the model the constraint sits on, and " +
+        "a handler parameter sits on no model. Remove the condition, or move the constraint onto a " +
+        "property of a model type where the member it names is declared.",
         "Hardened.Validation",
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Validation/HandlerValidationFrontEnd.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Validation/HandlerValidationFrontEnd.cs
@@ -32,32 +32,43 @@ namespace Hardened.SourceGenerator.Validation;
 /// MSBuild task runs before compilation and writes its interfaces as ordinary source.
 /// </para>
 /// <para>
-/// So the validator for <c>Parameters</c> is emitted here, where the type is known - and it does
-/// nothing itself except descend into the parameters that carry structure, calling the validators
-/// the validation generator emitted for their types. Those are named by convention rather than
-/// observed, which is safe only because naming one that does not exist fails to compile.
+/// So the validator for <c>Parameters</c> is emitted here, where the type is known, and it does two
+/// things. It descends into the parameters that carry structure, calling the validators the
+/// validation generator emitted for their types - named by convention rather than observed, which
+/// is safe only because naming one that does not exist fails to compile. And it checks the
+/// constraints written on the parameters themselves: <c>[Range]</c> on a query value,
+/// <c>[StringLength]</c> on a header, <c>[Required]</c> on a path token. Those are read and
+/// resolved by ValidationModules' own front end, through the two entry points it exposes for any
+/// member symbol, so a parameter is held to exactly the policy a property is - both vocabularies,
+/// the pattern forms, the type-fit diagnostics - and nothing about a constraint is decided here.
 /// </para>
 /// </remarks>
 public static class HandlerValidationFrontEnd {
 
     /// <summary>
-    /// The model for this handler's parameters validator, or null when nothing about the handler
-    /// asks for one.
+    /// What <see cref="Build"/> produces: the model, or null when nothing about the handler asks
+    /// for one, and whatever was reported reading the parameters' own constraints.
+    /// </summary>
+    public sealed record Built(ValidatedTypeModel? Model, ImmutableArray<Diagnostic> Diagnostics);
+
+    /// <summary>
+    /// The model for this handler's parameters validator, with the diagnostics its constraints
+    /// raised.
     /// </summary>
     /// <param name="handler">The handler, whose parameter list this walks.</param>
-    /// <param name="parameterTypes">
-    /// The declared type of each parameter, positionally aligned with the handler's parameter list.
-    /// Passed in rather than resolved here because the decision below depends on build properties,
-    /// which are not reachable from inside a syntax transform - so the symbols have to survive one
+    /// <param name="parameters">
+    /// The symbol of each parameter, positionally aligned with the handler's parameter list. Passed
+    /// in rather than resolved here because the decision below depends on build properties, which
+    /// are not reachable from inside a syntax transform - so the symbols have to survive one
     /// pipeline stage to meet them.
     /// </param>
     /// <param name="compilation">
     /// The compilation the parameter symbols came from - the front end walks inherited members and
     /// answers accessibility questions against it, so it must be the same snapshot.
     /// </param>
-    public static ValidatedTypeModel? Build(
+    public static Built Build(
         RequestHandlerModel handler,
-        ImmutableArray<ITypeSymbol?> parameterTypes,
+        ImmutableArray<IParameterSymbol?> parameters,
         Compilation compilation,
         ValidationGeneratorOptions options,
         CancellationToken cancellationToken) {
@@ -66,9 +77,15 @@ public static class HandlerValidationFrontEnd {
         // Emitting a second validator here would validate the same values twice and report every
         // failure twice with it.
         if (handler.ParametersInterface != null) {
-            return null;
+            return new Built(null, ImmutableArray<Diagnostic>.Empty);
         }
 
+        // One front end for the handler, and kept: what it reports about a constraint written on a
+        // parameter is reported nowhere else. HasValidator's is thrown away for the opposite reason.
+        var frontEnd = new AttributeFrontEnd(
+            compilation, options.CompileDataAnnotations, options.FieldNamer, options.ResolvedPatternPolicy);
+
+        var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
         var properties = ImmutableArray.CreateBuilder<ValidatedPropertyModel>();
 
         for (var i = 0; i < handler.RequestParameterInformationList.Count; i++) {
@@ -76,29 +93,33 @@ public static class HandlerValidationFrontEnd {
 
             var parameter = handler.RequestParameterInformationList[i];
 
-            if (!CarriesRequestData(parameter.BindingType) || i >= parameterTypes.Length) {
+            if (!CarriesRequestData(parameter.BindingType) || i >= parameters.Length) {
                 continue;
             }
 
-            if (parameterTypes[i] is not { } type) {
+            if (parameters[i] is not { } symbol) {
                 continue;
             }
 
-            if (BuildProperty(type, parameter, compilation, options) is { } property) {
+            if (BuildProperty(symbol, parameter, compilation, options, frontEnd, diagnostics) is { } property) {
                 properties.Add(property);
             }
         }
 
+        diagnostics.AddRange(frontEnd.Diagnostics);
+
         if (properties.Count == 0) {
-            return null;
+            return new Built(null, diagnostics.ToImmutable());
         }
 
-        return new ValidatedTypeModel(
-            handler.InvokeHandlerType.Namespace,
-            "Parameters",
-            $"global::{handler.InvokeHandlerType.Namespace}.{handler.InvokeHandlerType.Name}.Parameters",
-            ValidatorNameFor(handler),
-            new EquatableArray<ValidatedPropertyModel>(properties.ToImmutable()));
+        return new Built(
+            new ValidatedTypeModel(
+                handler.InvokeHandlerType.Namespace,
+                "Parameters",
+                $"global::{handler.InvokeHandlerType.Namespace}.{handler.InvokeHandlerType.Name}.Parameters",
+                ValidatorNameFor(handler),
+                new EquatableArray<ValidatedPropertyModel>(properties.ToImmutable())),
+            diagnostics.ToImmutable());
     }
 
     /// <summary>
@@ -119,36 +140,40 @@ public static class HandlerValidationFrontEnd {
         bindingType is ParameterBindType.Body
             or ParameterBindType.Path
             or ParameterBindType.QueryString
-            or ParameterBindType.Header;
+            or ParameterBindType.Header
+            or ParameterBindType.Cookie
+            or ParameterBindType.Form
+            or ParameterBindType.CustomAttribute;
 
     /// <summary>
-    /// The declared type of every parameter, aligned with the handler's parameter list.
+    /// The symbol of every parameter, aligned with the handler's parameter list.
     /// </summary>
-    public static ImmutableArray<ITypeSymbol?> ParameterTypesOf(
+    public static ImmutableArray<IParameterSymbol?> ParameterSymbolsOf(
         GeneratorSyntaxContext context, MethodDeclarationSyntax methodDeclaration) {
 
-        var types = ImmutableArray.CreateBuilder<ITypeSymbol?>(
+        var symbols = ImmutableArray.CreateBuilder<IParameterSymbol?>(
             methodDeclaration.ParameterList.Parameters.Count);
 
         foreach (var parameter in methodDeclaration.ParameterList.Parameters) {
-            types.Add(context.SemanticModel.GetDeclaredSymbol(parameter)?.Type);
+            symbols.Add(context.SemanticModel.GetDeclaredSymbol(parameter));
         }
 
-        return types.ToImmutable();
+        return symbols.ToImmutable();
     }
 
     /// <summary>
-    /// One parameter, described as a property of the <c>Parameters</c> class it becomes.
+    /// One parameter, described as a property of the <c>Parameters</c> class it becomes: whether
+    /// its type has a validator of its own to descend into, and what it constrains itself.
     /// </summary>
-    /// <remarks>
-    /// Only structure is read here - whether the parameter's type has a validator of its own.
-    /// Constraints written directly on the parameter are reported by
-    /// <see cref="HandlerValidationDiagnostics"/> rather than compiled; see the note there.
-    /// </remarks>
     private static ValidatedPropertyModel? BuildProperty(
-        ITypeSymbol type, RequestParameterInformation parameter, Compilation compilation,
-        ValidationGeneratorOptions options) {
+        IParameterSymbol symbol,
+        RequestParameterInformation parameter,
+        Compilation compilation,
+        ValidationGeneratorOptions options,
+        AttributeFrontEnd frontEnd,
+        ImmutableArray<Diagnostic>.Builder diagnostics) {
 
+        var type = symbol.Type;
         var shape = PropertyShape.Scalar;
         string? elementTypeName = null;
         string? elementValidatorName = null;
@@ -167,7 +192,12 @@ public static class HandlerValidationFrontEnd {
         } else if (dictionary is null && elementType is null && HasValidator(type, compilation, options)) {
             shape = PropertyShape.Object;
             elementValidatorName = QualifiedValidator((INamedTypeSymbol)type);
-        } else {
+        }
+
+        var descends = shape != PropertyShape.Scalar;
+        var constraints = Constraints(symbol, type, elementType, frontEnd, diagnostics);
+
+        if (!descends && constraints.Count == 0) {
             return null;
         }
 
@@ -183,8 +213,63 @@ public static class HandlerValidationFrontEnd {
             TypeFacts.IsNullableValueType(type),
             elementType is not null && TypeFacts.IsIndexable(type),
             TypeFacts.CountAccessor(type),
-            true,
-            EquatableArray<ConstraintModel>.Empty);
+            descends,
+            new EquatableArray<ConstraintModel>(constraints.ToImmutableArray()),
+            DisplayName: constraints.Count > 0 ? symbol.Name : null);
+    }
+
+    /// <summary>
+    /// The constraints written on the parameter itself, read and resolved by ValidationModules.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>ReadConstraintsFor</c> and <c>ValidateAndResolve</c> are the same two calls the front
+    /// end's own <c>Build</c> makes for a property, typed on the member symbol rather than on a
+    /// property, so the reading is not reimplemented here and cannot drift from it.
+    /// </para>
+    /// <para>
+    /// A <c>When</c> or <c>Unless</c> names a member of the model the constraint sits on, and a
+    /// handler parameter sits on no model - the front end would look for the member on a type it
+    /// was never given. Refused here, before the reader, as the one thing about a parameter's
+    /// constraint this generator decides itself.
+    /// </para>
+    /// </remarks>
+    private static List<ConstraintModel> Constraints(
+        IParameterSymbol symbol,
+        ITypeSymbol type,
+        ITypeSymbol? elementType,
+        AttributeFrontEnd frontEnd,
+        ImmutableArray<Diagnostic>.Builder diagnostics) {
+
+        foreach (var attribute in symbol.GetAttributes()) {
+            if (!ConstraintAttributeFacts.IsConstraint(attribute)) {
+                continue;
+            }
+
+            foreach (var argument in attribute.NamedArguments) {
+                if (argument.Key is not ("When" or "Unless")) {
+                    continue;
+                }
+
+                diagnostics.Add(Diagnostic.Create(
+                    HandlerValidationDiagnostics.ConditionOnParameterConstraint,
+                    symbol.Locations.FirstOrDefault(),
+                    argument.Key,
+                    attribute.AttributeClass!.Name,
+                    symbol.Name));
+
+                return new List<ConstraintModel>();
+            }
+        }
+
+        var constraints = frontEnd.ReadConstraintsFor(symbol, type);
+
+        if (constraints.Count > 0) {
+            frontEnd.ValidateAndResolve(
+                symbol, type, constraints, type.SpecialType == SpecialType.System_String, elementType);
+        }
+
+        return constraints;
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Validation/HandlerValidationGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Validation/HandlerValidationGenerator.cs
@@ -16,8 +16,8 @@ namespace Hardened.SourceGenerator.Validation;
 
 /// <summary>
 /// Attaches validation to hand-written handlers: the validator for the generated
-/// <c>Parameters</c> class, the filter that runs it, and warnings for constraints written where
-/// this generator does not read them.
+/// <c>Parameters</c> class, the filter that runs it, and whatever ValidationModules reports about
+/// the constraints written on the parameters themselves.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -79,9 +79,9 @@ public static class HandlerValidationGenerator {
     /// what to do with it are known.
     /// </summary>
     /// <remarks>
-    /// The parameter types cross into the next stage as symbols, which is what lets the decision
-    /// there depend on build properties. Nothing else does: the diagnostics are settled here,
-    /// because whether a constraint sits on a parameter is not a question any property changes.
+    /// The parameter symbols cross into the next stage as symbols, which is what lets the decision
+    /// there depend on build properties - and what lets the constraints written on them be read
+    /// there, by a front end configured from those properties.
     /// </remarks>
     private static Candidate Analyze(
         BaseRequestModelGenerator modelGenerator,
@@ -93,12 +93,11 @@ public static class HandlerValidationGenerator {
 
         // The compilation rides with the symbols it produced rather than arriving through a
         // Combine, so the front end asks its accessibility questions of the same snapshot the
-        // parameter types came from.
+        // parameter symbols came from.
         return new Candidate(
             handler,
-            HandlerValidationFrontEnd.ParameterTypesOf(context, methodDeclaration),
-            context.SemanticModel.Compilation,
-            UncompiledConstraints(context, methodDeclaration));
+            HandlerValidationFrontEnd.ParameterSymbolsOf(context, methodDeclaration),
+            context.SemanticModel.Compilation);
     }
 
     private static Resolved Resolve(
@@ -108,20 +107,20 @@ public static class HandlerValidationGenerator {
         CancellationToken cancellationToken) {
 
         // Nothing emits validators for this compilation, so there is nothing to attach to and
-        // nothing to warn about - a project that never opted into validation behaves as it did.
+        // nothing to report - a project that never opted into validation behaves as it did.
         if (!validationAvailable) {
             return new Resolved(candidate.Handler, null, ImmutableArray<Diagnostic>.Empty);
         }
 
-        var validator = HandlerValidationFrontEnd.Build(
-            candidate.Handler, candidate.ParameterTypes, candidate.Compilation, options,
+        var built = HandlerValidationFrontEnd.Build(
+            candidate.Handler, candidate.Parameters, candidate.Compilation, options,
             cancellationToken);
 
-        if (validator is null) {
-            return new Resolved(candidate.Handler, null, candidate.Diagnostics);
+        if (built.Model is null) {
+            return new Resolved(candidate.Handler, null, built.Diagnostics);
         }
 
-        return new Resolved(WithFilter(candidate.Handler, validator), validator, candidate.Diagnostics);
+        return new Resolved(WithFilter(candidate.Handler, built.Model), built.Model, built.Diagnostics);
     }
 
     /// <summary>
@@ -163,40 +162,10 @@ public static class HandlerValidationGenerator {
         return withFilter;
     }
 
-    /// <summary>
-    /// Warnings for constraints written where this generator does not read them.
-    /// </summary>
-    private static ImmutableArray<Diagnostic> UncompiledConstraints(
-        GeneratorSyntaxContext context, MethodDeclarationSyntax methodDeclaration) {
-
-        var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        foreach (var parameter in methodDeclaration.ParameterList.Parameters) {
-            if (context.SemanticModel.GetDeclaredSymbol(parameter) is not { } symbol) {
-                continue;
-            }
-
-            foreach (var attribute in symbol.GetAttributes()) {
-                if (!ConstraintAttributeFacts.IsConstraint(attribute)) {
-                    continue;
-                }
-
-                diagnostics.Add(Diagnostic.Create(
-                    HandlerValidationDiagnostics.ConstraintOnParameter,
-                    parameter.GetLocation(),
-                    attribute.AttributeClass!.Name,
-                    symbol.Name));
-            }
-        }
-
-        return diagnostics.ToImmutable();
-    }
-
     private sealed record Candidate(
         RequestHandlerModel Handler,
-        ImmutableArray<ITypeSymbol?> ParameterTypes,
-        Compilation Compilation,
-        ImmutableArray<Diagnostic> Diagnostics);
+        ImmutableArray<IParameterSymbol?> Parameters,
+        Compilation Compilation);
 
     public sealed record Resolved(
         RequestHandlerModel Handler,

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
@@ -376,7 +376,12 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
                         Name = Wire(p),
                         MemberNameOverride = p.Name,
                         In = Location(p.BindingType),
-                        IsRequired = p.Required
+                        IsRequired = p.Required,
+                        // What the parameter's own constraints say for the document, read off
+                        // its symbol before this description was written and carried through
+                        // it, since the builder below rebuilds every parameter from here.
+                        SchemaFacets = p.SchemaFacets,
+                        RequiredByConstraint = p.RequiredByConstraint
                     }).ToList()
                 }
             }

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ParameterConstraintDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ParameterConstraintDocumentTests.cs
@@ -1,0 +1,137 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Runtime.Validation;
+using Hardened.Shared.Runtime.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Validation.SourceGenerator;
+using Hardened.Web.Runtime.Attributes;
+using Hardened.Web.Runtime.OpenApi;
+using Microsoft.CodeAnalysis;
+using ValidationModules;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests;
+
+/// <summary>
+/// The document half of a constraint on a hand-written handler's parameter: the same attribute
+/// the parameters validator enforces is published as the facet it declares.
+/// </summary>
+/// <remarks>
+/// In this project rather than beside the other document tests because the constraint vocabulary
+/// has to resolve, and this is the test project that references it.
+/// </remarks>
+public class ParameterConstraintDocumentTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),                    // Hardened.Web.Runtime
+        typeof(FromBodyAttribute),               // Hardened.Requests.Abstract
+        typeof(ValidationFilterProvider<object>),// Hardened.Requests.Runtime
+        typeof(IValidatorFor<object>),           // ValidationModules.Runtime
+        typeof(EnableAttribute<>),               // Hardened.Shared.Runtime
+        typeof(OpenApiDocumentPublishing)        // the marker
+    ];
+
+    private const string Source = """
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+        using Hardened.Web.Runtime.OpenApi;
+        using ValidationModules.Constraints;
+
+        namespace TestApp;
+
+        [HardenedModule]
+        [Enable<OpenApiDocumentPublishing>]
+        public partial class Application { }
+
+        public class RateController {
+            [Get("/rates/{count:int}")]
+            public string Read(
+                [Range(Min = 1, Max = 100)] int count,
+                [FromQueryString] [Range(Min = 2, Max = 8)] int precision,
+                [FromHeader("X-Region")] [StringLength(2, 2)] string region,
+                [FromQueryString] [Required] [Pattern("^[a-z]+$")] string? tag) => region;
+        }
+        """;
+
+    private static JsonElement Document() {
+        var result = GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Test.cs"] = Source },
+            new IIncrementalGenerator[] {
+                new WebLibrarySourceGenerator(), new HardenedValidationGenerator()
+            },
+            Anchors).AssertNoErrors();
+
+        var match = Regex.Match(
+            result.SourceContaining("OpenApiDocument"),
+            @"new byte\[\]\s*\{(.*?)\}\s*;", RegexOptions.Singleline);
+
+        Assert.True(match.Success, "No document byte array in the generated source.");
+
+        var bytes = match.Groups[1].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(byte.Parse)
+            .ToArray();
+
+        using var source = new MemoryStream(bytes, writable: false);
+        using var gzip = new GZipStream(source, CompressionMode.Decompress);
+        using var inflated = new MemoryStream();
+
+        gzip.CopyTo(inflated);
+
+        return JsonDocument.Parse(inflated.ToArray()).RootElement.Clone();
+    }
+
+    private static JsonElement Parameter(JsonElement document, string name) {
+        var operation = document.GetProperty("paths").GetProperty("/rates/{count}").GetProperty("get");
+
+        foreach (var parameter in operation.GetProperty("parameters").EnumerateArray()) {
+            if (parameter.GetProperty("name").GetString() == name) {
+                return parameter;
+            }
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            $"No parameter named '{name}'. The operation was: {operation.GetRawText()}");
+    }
+
+    [Fact]
+    public void ABoundOnAPathTokenIsPublishedAsMinimumAndMaximum() {
+        var schema = Parameter(Document(), "count").GetProperty("schema");
+
+        Assert.Equal("integer", schema.GetProperty("type").GetString());
+        Assert.Equal(1, schema.GetProperty("minimum").GetInt32());
+        Assert.Equal(100, schema.GetProperty("maximum").GetInt32());
+    }
+
+    [Fact]
+    public void ABoundOnAQueryValueIsPublishedAsMinimumAndMaximum() {
+        var schema = Parameter(Document(), "precision").GetProperty("schema");
+
+        Assert.Equal(2, schema.GetProperty("minimum").GetInt32());
+        Assert.Equal(8, schema.GetProperty("maximum").GetInt32());
+    }
+
+    [Fact]
+    public void ALengthOnAHeaderIsPublishedAsMinLengthAndMaxLength() {
+        var schema = Parameter(Document(), "X-Region").GetProperty("schema");
+
+        Assert.Equal("string", schema.GetProperty("type").GetString());
+        Assert.Equal(2, schema.GetProperty("minLength").GetInt32());
+        Assert.Equal(2, schema.GetProperty("maxLength").GetInt32());
+    }
+
+    /// <summary>
+    /// A nullable parameter is optional by its type, and <c>[Required]</c> is what says the caller
+    /// must send it anyway - so the document says so too, beside the pattern.
+    /// </summary>
+    [Fact]
+    public void ARequiredNullableQueryValueIsPublishedAsRequiredWithItsPattern() {
+        var parameter = Parameter(Document(), "tag");
+
+        Assert.True(parameter.GetProperty("required").GetBoolean());
+        Assert.Equal("^[a-z]+$", parameter.GetProperty("schema").GetProperty("pattern").GetString());
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ValidationAttachmentTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ValidationAttachmentTests.cs
@@ -160,12 +160,13 @@ public class ValidationAttachmentTests {
     }
 
     /// <summary>
-    /// A constraint on the parameter itself is not compiled, and says so. The alternative is the
-    /// failure this design refuses everywhere else - a constraint that was declared, never
-    /// evaluated, and never mentioned.
+    /// A constraint on the parameter itself is compiled into the parameters validator and the
+    /// handler carries the filter that runs it. This was HRDV001, a warning that the constraint was
+    /// not compiled at all; the front end that reads a property's constraints reads a parameter's
+    /// through the same two entry points, so there is nothing left to warn about.
     /// </summary>
     [Fact]
-    public void AConstraintOnAParameterIsReported() {
+    public void AConstraintOnAPathParameterIsCompiledIntoTheParametersValidator() {
         var result = Generate("""
             using ValidationModules.Constraints;
             using Hardened.Web.Runtime.Attributes;
@@ -176,9 +177,108 @@ public class ValidationAttachmentTests {
                 [Get("/items/{id}")]
                 public string ItemById([StringLength(3, 3)] string id) => id;
             }
+            """).AssertNoErrors();
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, diagnostic => diagnostic.Id == "HRDV001");
+        Assert.Contains("ValidationFilterProvider<global::", Handler(result, "ItemController_ItemById"));
+
+        var validator = result.SourceContaining("ParametersValidator");
+
+        Assert.Contains("\"id\"", validator);
+    }
+
+    /// <summary>
+    /// A query or header parameter is pathed under the name the caller sent, not the C# name, the
+    /// way a binding failure already is.
+    /// </summary>
+    [Fact]
+    public void AConstraintOnAQueryOrHeaderParameterIsPathedByItsBindingName() {
+        var result = Generate("""
+            using ValidationModules.Constraints;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            public class RateController {
+                [Get("/rates")]
+                public string Read(
+                    [FromQueryString("p")] [Range(Min = 2, Max = 8)] int precision,
+                    [FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
+            }
+            """).AssertNoErrors();
+
+        var validator = result.SourceContaining("ParametersValidator");
+
+        Assert.Contains("\"p\"", validator);
+        Assert.Contains("\"X-Region\"", validator);
+        Assert.DoesNotContain("\"precision\"", validator);
+    }
+
+    /// <summary>
+    /// A constraint on the parameter and a constrained body on the same handler compile into one
+    /// validator: the parameter is checked where it is, and the body is descended into.
+    /// </summary>
+    [Fact]
+    public void AParameterConstraintAndAConstrainedBodyCompileTogether() {
+        var result = Generate(ConstrainedModel + """
+            public class OrderController {
+                [Post("/orders/{id}")]
+                public string Replace([StringLength(3, 3)] string id, Order order) => id;
+            }
+            """).AssertNoErrors();
+
+        var validator = result.SourceContaining("ParametersValidator");
+
+        Assert.Contains("\"id\"", validator);
+        Assert.Contains("new global::TestApp.OrderValidator()", validator);
+    }
+
+    /// <summary>
+    /// A constraint that does not fit the parameter's type is ValidationModules' diagnostic, under
+    /// its own id, exactly as it would be on a property - because it is the same front end saying
+    /// so.
+    /// </summary>
+    [Fact]
+    public void AConstraintThatDoesNotFitTheParameterTypeIsReportedByValidationModules() {
+        var result = Generate("""
+            using ValidationModules.Constraints;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            public class ItemController {
+                [Get("/items/{id}")]
+                public string ItemById([Range(Min = 1, Max = 5)] string id) => id;
+            }
             """);
 
-        Assert.Contains(result.GeneratorDiagnostics, diagnostic => diagnostic.Id == "HRDV001");
+        Assert.Contains(result.GeneratorDiagnostics, diagnostic =>
+            diagnostic.Id.StartsWith("VM") && diagnostic.GetMessage().Contains("id"));
+    }
+
+    /// <summary>
+    /// The one shape refused here rather than read: a condition names a member of the model the
+    /// constraint sits on, and a parameter sits on no model.
+    /// </summary>
+    [Fact]
+    public void AConditionOnAParameterConstraintIsAnError() {
+        var result = Generate("""
+            using ValidationModules.Constraints;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            public class ItemController {
+                [Get("/items/{id}")]
+                public string ItemById([StringLength(3, 3, When = "IsStrict")] string id) => id;
+            }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "HRDV005");
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("'When'", diagnostic.GetMessage());
+        Assert.Contains("'id'", diagnostic.GetMessage());
     }
 
     /// <summary>


### PR DESCRIPTION
Closes the "Code-first constraints on query, header and path parameters" row of the 0.19 remaining-work ledger (H-46). A constraint attribute on a hand-written handler's parameter compiled clean and did two things wrong at once: the build reported HRDV001 and never compiled it, so the bound was a hand-written check throwing `ValidationException`, and the published document described the parameter as an integer with no bounds. A spec-first handler got both from one declaration, which is the framework's central promise, and the trial called this "the single largest thing code-first gives up".

## What it does

```csharp
[Get("/rates/{count:int}")]
public int Page([Range(Min = 1, Max = 100)] int count) => count;

[Get("/precision")]
public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) => precision;
```

- **The constraint is compiled into the handler's parameters validator.** Code-first already emitted a validator for the generated `Parameters` class and attached a `ValidationFilterProvider` for it, but it only descended into parameters whose types had validators of their own. It now also reads the constraints written on the parameters themselves, through the two entry points ValidationModules' front end exposes for any member symbol, `ReadConstraintsFor` and `ValidateAndResolve`. Both are typed on `ISymbol`, and the second's own remark says "the property or parameter the constraints were written on". So a parameter is held to exactly the policy a property is: both vocabularies, the pattern forms, the AOT pattern policy, and the type-fit diagnostics, which arrive under ValidationModules' own `VM` ids. Nothing about a constraint is decided in Hardened. Both entry points are in the published 1.0.0 package CI builds against, so this needs no ValidationModules release.
- **A failure is pathed under the name the caller sent.** `precision` for the query key, `X-Region` for the header, `count` for the path token, with the same envelope and the same declared status a body failure has. `?precision=9` is a 400 with `"field": "precision", "code": "range"`.
- **The document publishes the same declaration as facets.** `[Range(Min = 2, Max = 8)]` is `minimum` and `maximum` on the parameter's schema, `[StringLength(2, 2)]` is `minLength` and `maxLength`, `[Pattern]` is `pattern`, and `[Required]` on a parameter that could be absent is `required: true`. The facets are read by the same `SchemaConstraintWriter` that reads a body property's, where the parameter's symbol is in hand, and carried through the description the code-first web generator writes for its handlers, since the shared builder rebuilds every parameter from that description and the writer derives a code-first parameter's schema from its C# type.
- **HRDV001 is retired and HRDV005 takes the one case that cannot be read.** `When` and `Unless` on a constraint name a member of the model the constraint sits on, and a handler parameter sits on no model, so the front end would look the member up on a type it was never given. Hardened refuses that shape with an error before calling the reader. Everything else goes to ValidationModules unchanged.
- **Route constraints stay routing.** `{count:int}` decides whether the URL exists, a 404; `[Range]` on the same parameter decides whether the value is acceptable, a 400. The SUT declares both on one handler.

## Not changed

`System.ComponentModel.DataAnnotations` follows the existing `CompileDataAnnotations` option for the validator and stays out of the document, which is the rule models already live under. `[AllowedValues]` on a parameter is enforced and not yet published as `enum`.

## Public surface

None. `HandlerValidationDiagnostics.ConstraintOnParameter` (HRDV001) is gone from the generator assembly and `ConditionOnParameterConstraint` (HRDV005) replaces it; `RequestParameterInformation` and `ParameterModel` gain two transport members each, internal to the generators.

## Verification

- `dotnet build src/Hardened.Framework.sln --configuration Release -p:ContinuousIntegrationBuild=true` with the pinned Smithy CLI 1.73.0 on the path: no warnings.
- `dotnet test src/Hardened.Framework.sln --no-build --configuration Release`: 33 assemblies, all passing, nothing skipped, no duplicate IDs.
- `ValidationAttachmentTests` compiles the emitted validator for a constrained path, query and header parameter together with the validation generator's output, asserts the binding-name pathing, a parameter constraint beside a constrained body, ValidationModules' type-fit diagnostic on `[Range]` over a string, and HRDV005. `ParameterConstraintDocumentTests` inflates the emitted document and asserts every facet. `ParameterConstraintTests` drives the new `ConstraintsController` through the Web integration application: the 400 and its field and code for each location, the 404 the route constraint answers beside the 400 the value constraint answers, and the served document's facets.
- The Web integration application's exported document gains four routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
