### PR TITLE
Fill a Smithy error's message, and report a document no reader accepts

### DIFF
--- a/docs/client-by-default-handoff.md
+++ b/docs/client-by-default-handoff.md
@@ -89,18 +89,21 @@ records what happened when they met the code.
 
 ## Discovered and not fixed
 
-- A Smithy service in throws mode answers a declared 404 by returning null, and the runtime
-  writes no body at all: `404` with `Content-Length: 0`, while the served document promises the
-  `TodoNotFound` shape, a `@error` structure with a required `message`. A Kiota client registered
-  that shape for the 404 and throws a bare `ApiException` saying the error failed to deserialize.
-  The declared models answer with the body, so the scaffolded test runs there and is skipped with
-  the defect named under `--contract smithy --response-model throws`. Runtime dispatch for a null
-  return with a named error shape is the place to fix it; it was not touched here.
+- ~~A Smithy service in throws mode answers a declared 404 by returning null, and the runtime
+  writes no body at all.~~ **Fixed.** `SchemaModel.IsErrorShape` carries the `@error` trait through
+  to `DefaultErrorBody`, which fills a required `message` with the status's reason phrase - the
+  same act as filling 7807's `title`, and licensed by the same thing: Smithy gives that member one
+  meaning. Keyed on the trait rather than the member's name, because `{ message: string }` is an
+  ordinary shape. The scaffolded test is no longer skipped under
+  `--contract smithy --response-model throws`, and `PetStoreRoutingTests` covers the same shape
+  in-repo.
 - An OpenAPI service in throws mode answers the same null return with the document's `Problem` and
   no `detail`, which deserializes. The generated client throws the typed
   `Problem` either way; only its detail differs between the modes, and the scaffolded test asserts
-  the detail under the declared models alone. Whether a null return should carry a default detail
-  is a runtime question, left open.
+  the detail under the declared models alone. **Settled as intended**: `status` and `title` are
+  facts about the status code and are filled; `detail` is a fact about this occurrence, which the
+  framework does not have. Inventing one would put words in the handler's mouth, and a handler with
+  something to say throws instead. ASP.NET Core answers a bare 404 with no body at all.
 
 - The Smithy integration application's served document repeats the `post` key under `/`, because
   its bank service speaks the AWS JSON protocol and every operation is `POST /` told apart by a
@@ -108,6 +111,11 @@ records what happened when they met the code.
   carries it faithfully in both formats, but Microsoft.OpenApi's reader refuses the document, so
   the Smithy application is excluded from the JSON-versus-YAML parse comparison with the reason in
   the test. A Kiota client cannot be generated from that document either.
+
+  Not fixable as OpenAPI: a Path Item is a map keyed by method and holds one `post`. Synthesising
+  a path per operation would describe routes the service does not serve. **The export says so now**
+  under `031`, a warning naming the path, rather than leaving an unusable file to be discovered by
+  whatever was pointed at it.
 - `RequestPathDecoder` documents `a%zz`, `a%` and `a%2` as left alone, and the socket probe
   confirms Kestrel does the same. `System.Uri` will not carry those three, so they are asserted
   over a raw socket only; the handler is held to the rows an `HttpClient` can send.

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -357,7 +357,7 @@ the other.
 | `020`–`024` | The shared model-diagnostics pass. See below. |
 | `026` | Warning. `$(HardenedResponseModel)` is `Standard`, the throws mode's name before 0.19.0. The mode selected is unchanged; write `Throws`. Reported once per project. |
 | `027` | The description references something it does not declare. Part of the model-diagnostics pass; see below. |
-| `018`, `019`, `028`–`030` | The document export, which the three generator packages share. See below. |
+| `018`, `019`, `028`–`031` | The document export, which the three generator packages share. See below. |
 
 ### The Smithy CLI task (HSMT010–HSMT014)
 
@@ -369,7 +369,7 @@ the other.
 | `HSMT013` | Warning. What the CLI said without failing, with the same per-finding attribution. |
 | `HSMT014` | The CLI exited cleanly but wrote no AST. Unlike `HSMT012`, the fix is not in a `.smithy` file. |
 
-### The document export (018, 019, 028–030)
+### The document export (018, 019, 028–031)
 
 `<HardenedOpenApiOutput>` writes the OpenAPI document an assembly serves to a file after the
 compile, read out of the compiled assembly by the `Hardened.OpenApiDocument.BuildTask` task that all
@@ -385,6 +385,7 @@ onward follows the model-diagnostics pass, since `025` is retired and stays so.
 | `028` | The output path's extension names no format. Use `.json` for indented JSON, or `.yaml` or `.yml` for YAML. |
 | `029` | `<HardenedOpenApiOutputVersion>` is not `3.0.0` or `3.1.0`. Remove it to write the version the application serves. |
 | `030` | Warning. The file was lowered to a version with no `itemSchema`, and the named operation streams its response; the file describes it with its media type and no schema. Remove `<HardenedOpenApiOutputVersion>` to export the 3.2 document the application serves. Once per operation. |
+| `031` | Warning. The served document puts more than one operation at the named path under the same method, so the file repeats a key OpenAPI cannot tell apart: readers refuse it and no client can be generated from it. Once per path. |
 
 ```
 <HardenedOpenApiOutput> is set to 'openapi/Todos.json', but Todos.dll carries no served OpenAPI
@@ -392,6 +393,32 @@ document. The document is written only for a module that enables publishing, and
 that one copy. Add [Enable<OpenApiDocumentPublishing>] to the module that declares the routes, or
 remove the property.
 ```
+
+#### 031 - two operations at one method and path
+
+```
+The served document puts more than one operation at '/' under the same method, so the exported
+file repeats a key that OpenAPI has no way to tell apart. Readers refuse it and no client can be
+generated from it.
+```
+
+What an RPC protocol looks like in OpenAPI. `awsJson1_0` and `awsJson1_1` put every operation at
+`POST /` and dispatch on `X-Amz-Target`, so a service speaking one has as many `post` keys under
+`/` as it has operations. OpenAPI's Path Item is a map keyed by method, so it can hold one.
+
+**The service is unaffected.** Those protocols are supported and cost less to serve than
+`restJson1` - dispatch is an exact-match switch rather than a route tree. What cannot be done is
+describe them in OpenAPI, and the export carries the model faithfully rather than inventing paths
+the service does not serve. A document with synthetic `POST /Bank.GetBalance` keys would generate
+a client that calls URLs answering 404.
+
+A model that wants a generated client gives each operation its own method and path with `@http`,
+which is what `restJson1` uses. Where the protocol is the point, `<NoWarn>` the code and treat the
+file as a record of what is served rather than as generator input.
+
+A warning rather than an error, because the input is not wrong the way `028` and `029` are and the
+file is worth having for a diff or an archive. Under `ContinuousIntegrationBuild` it fails the
+build like every other warning here.
 
 The export writes what the server serves - the normalised document, never the source contract -
 and what it writes does not change the served document: a `.yaml` file at 3.0.0 leaves

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/PetStoreRoutingTests.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/PetStoreRoutingTests.cs
@@ -176,4 +176,35 @@ public class PetStoreRoutingTests {
 
         response.Assert.NotFound();
     }
+
+    /// <summary>
+    /// A miss answers the shape the model declared for the status, not an empty body.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// GetPet returns null for a pet it does not hold, which is a 404. PetNotFound is an
+    /// <c>@error</c> with a <c>@required message</c>, and nothing in the request says what that
+    /// message should be - so the response used to carry the status and no body at all, while the
+    /// served document promised the shape. A generated client registers that shape for the status,
+    /// finds nothing to deserialize and throws a bare transport exception rather than the typed
+    /// error, which is how the defect was found.
+    /// </para>
+    /// <para>
+    /// The message is the status's reason phrase, because that is the whole of what is known here:
+    /// Smithy gives <c>message</c> one meaning, so filling it is conformance, and nothing invents
+    /// a reason the handler did not give. A handler with something to say throws
+    /// <c>new PetNotFound("...").AsException()</c> instead, as the Throttled route does.
+    /// </para>
+    /// </remarks>
+    [HardenedTest]
+    public async Task GetPet_AnswersAMissWithTheDeclaredErrorShape(ITestWebApp app) {
+        var response = await app.Get("/pets/no-such-pet");
+
+        response.Assert.NotFound();
+
+        var error = response.Deserialize<PetNotFound>();
+
+        Assert.NotNull(error);
+        Assert.Equal("Not Found", error.Message);
+    }
 }

--- a/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
@@ -34,6 +34,12 @@ namespace Hardened.Generation;
 /// so filling them is conformance rather than a guess. Matched on shape, not on the schema's name,
 /// so an unrelated schema whose <c>status</c> means something else is not mistaken for one.
 /// </item>
+/// <item>
+/// Smithy's <c>message</c>, on a shape the model declared with <c>@error</c>. The specification
+/// gives that member one meaning, so the reason phrase goes in it for the same reason it goes in
+/// 7807's <c>title</c>. Keyed on the trait rather than the member's name: an ordinary payload
+/// with a <c>message</c> is not an error.
+/// </item>
 /// <item>Nothing. An optional member with neither is left at its C# default.</item>
 /// </list>
 /// <para>
@@ -99,7 +105,7 @@ internal static class DefaultErrorBody {
 
         foreach (var property in SchemaShape.Constructor(schema)) {
             var csType = TypeMapper.MapPropertyToCSharpType(property);
-            var value = Value(property, csType, statusCode, isProblem);
+            var value = Value(property, csType, statusCode, isProblem, schema.IsErrorShape);
 
             if (value != null) {
                 arguments.Add(value);
@@ -129,12 +135,22 @@ internal static class DefaultErrorBody {
     }
 
     private static string? Value(
-        PropertyModel property, string csType, int statusCode, bool isProblem) {
+        PropertyModel property, string csType, int statusCode, bool isProblem, bool isErrorShape) {
         // The document's own default first. It is the one source here that is not an inference.
         var declared = DefaultLiteral.Format(property.Default, csType);
 
         if (declared != null) {
             return declared;
+        }
+
+        // Smithy's message member, which the specification defines as the error message of an
+        // @error structure. Filling it is the same act as filling 7807's title: the description
+        // said what the member means, so writing the reason phrase into it is conformance rather
+        // than a guess. Keyed on the shape carrying @error rather than on the member's name,
+        // because { message: string } is an ordinary shape and an ordinary payload's message is
+        // not this.
+        if (isErrorShape && property.Name == "message" && csType == "string") {
+            return "\"" + ReasonPhrase(statusCode) + "\"";
         }
 
         if (!isProblem) {

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/SchemaModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/SchemaModel.cs
@@ -7,6 +7,19 @@ internal class SchemaModel : IEquatable<SchemaModel> {
     /// <summary>The spec's <c>deprecated</c>, which becomes <c>[Obsolete]</c>.</summary>
     public bool IsDeprecated { get; set; }
 
+    /// <summary>
+    /// Whether the description declared this schema as an error rather than as a payload.
+    /// </summary>
+    /// <remarks>
+    /// Set by the Smithy front end for a shape carrying <c>@error</c>, and false for everything
+    /// OpenAPI produces, which has no way to say it: a <c>$ref</c> under a 4xx response is a
+    /// schema like any other. Provenance rather than shape, because the thing it licenses -
+    /// filling a required <c>message</c> in <c>DefaultErrorBody</c> - is only safe where the
+    /// description says the member is an error message, and <c>{ message: string }</c> is far too
+    /// ordinary a shape to read that off.
+    /// </remarks>
+    public bool IsErrorShape { get; set; }
+
     /// <summary>The schema's <c>description</c>, as the generated type's doc comment.</summary>
     public string? Description { get; set; }
     public List<PropertyModel> Properties { get; set; } = new();
@@ -109,6 +122,7 @@ internal class SchemaModel : IEquatable<SchemaModel> {
         if (ReferenceEquals(this, other)) return true;
         return Name == other.Name && Kind == other.Kind &&
                Description == other.Description && IsDeprecated == other.IsDeprecated &&
+               IsErrorShape == other.IsErrorShape &&
                Type == other.Type && Format == other.Format &&
                ArrayItemsRef == other.ArrayItemsRef &&
                ArrayItemsType == other.ArrayItemsType &&

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -336,6 +336,7 @@ internal static class SpecModelSerializer {
         record.Add("Kind", schema.Kind.ToString());
         record.Add("Description", schema.Description);
         record.Add("IsDeprecated", schema.IsDeprecated);
+        record.Add("IsErrorShape", schema.IsErrorShape);
         record.Add("EnumMemberNamesAreDeclared", schema.EnumMemberNamesAreDeclared);
         record.Add("DiscriminatorPropertyName", schema.DiscriminatorPropertyName);
         record.Add("BaseRef", schema.BaseRef);
@@ -426,6 +427,7 @@ internal static class SpecModelSerializer {
         Kind = ReadSchemaKind(record.String("Kind")),
         Description = record.String("Description"),
         IsDeprecated = record.Bool("IsDeprecated"),
+        IsErrorShape = record.Bool("IsErrorShape"),
         EnumMemberNamesAreDeclared = record.Bool("EnumMemberNamesAreDeclared"),
         DiscriminatorPropertyName = record.String("DiscriminatorPropertyName"),
         BaseRef = record.String("BaseRef"),

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DefaultErrorBodyTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DefaultErrorBodyTests.cs
@@ -1,0 +1,137 @@
+using Hardened.Generation;
+using Hardened.Generation.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// What a handler's null return writes for a status the description declared a body for.
+/// </summary>
+/// <remarks>
+/// The rule is that a required member with nothing to fill it from means no instance at all, so
+/// the response carries no body rather than one with an invented value in it. The exceptions are
+/// the members a specification gives a meaning to: 7807's and Smithy's <c>message</c>.
+/// </remarks>
+public class DefaultErrorBodyTests {
+
+    private static SchemaModel Schema(
+        string name, bool isErrorShape, params PropertyModel[] properties) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object, IsErrorShape = isErrorShape };
+
+        foreach (var property in properties) {
+            schema.Properties.Add(property);
+
+            if (property.IsRequired) {
+                schema.Required.Add(property.Name);
+            }
+        }
+
+        return schema;
+    }
+
+    private static PropertyModel String(string name, bool required) =>
+        new() { Name = name, Type = "string", IsRequired = required };
+
+    /// <summary>
+    /// The defect a generated client made visible. A Smithy @error carries a required message, so
+    /// nothing could fill it, so a null return wrote no body at all - while the served document
+    /// promised the shape. A Kiota client registered that shape for the status and threw a bare
+    /// ApiException saying the error failed to deserialize.
+    /// </summary>
+    [Fact]
+    public void ASmithyErrorShapeFillsItsRequiredMessage() {
+        var schemas = new[] { Schema("TodoNotFound", isErrorShape: true, String("message", required: true)) };
+
+        var arguments = DefaultErrorBody.Arguments(schemas, "TodoNotFound", 404);
+
+        Assert.NotNull(arguments);
+        Assert.Equal(["\"Not Found\""], arguments);
+    }
+
+    /// <summary>
+    /// Keyed on the trait rather than the member's name. An ordinary payload that happens to carry
+    /// a required message is not an error, and writing a reason phrase into it would be inventing
+    /// a domain value - which is the thing this whole rule exists to refuse.
+    /// </summary>
+    [Fact]
+    public void AnOrdinaryPayloadWithARequiredMessageStillGetsNoInstance() {
+        var schemas = new[] { Schema("ChatPost", isErrorShape: false, String("message", required: true)) };
+
+        Assert.Null(DefaultErrorBody.Arguments(schemas, "ChatPost", 404));
+    }
+
+    /// <summary>
+    /// An error shape's other required members are not messages, so the refusal stands for them
+    /// and the whole instance is withheld. Filling one member and inventing another would be
+    /// worse than writing nothing.
+    /// </summary>
+    [Fact]
+    public void AnErrorShapeWithAnotherRequiredMemberStillGetsNoInstance() {
+        var schemas = new[] {
+            Schema("Throttled", isErrorShape: true,
+                String("message", required: true),
+                String("retryToken", required: true))
+        };
+
+        Assert.Null(DefaultErrorBody.Arguments(schemas, "Throttled", 404));
+    }
+
+    /// <summary>
+    /// An optional member is left at its C# default whether the shape is an error or not, so an
+    /// error shape whose message is optional is filled rather than withheld.
+    /// </summary>
+    [Fact]
+    public void AnErrorShapeFillsAMessageAndDefaultsTheRest() {
+        var schemas = new[] {
+            Schema("PetMissing", isErrorShape: true,
+                String("message", required: true),
+                String("hint", required: false))
+        };
+
+        Assert.Equal(["\"Not Found\"", "default"], DefaultErrorBody.Arguments(schemas, "PetMissing", 404));
+    }
+
+    /// <summary>
+    /// The status decides the phrase, so the same shape bound to a 409 says so.
+    /// </summary>
+    [Fact]
+    public void ThePhraseIsTheStatusItIsFilledFor() {
+        var schemas = new[] { Schema("TitleTaken", isErrorShape: true, String("message", required: true)) };
+
+        Assert.Equal(["\"Conflict\""], DefaultErrorBody.Arguments(schemas, "TitleTaken", 409));
+    }
+
+    /// <summary>
+    /// The document's own default still wins, because it is the one source here that is not an
+    /// inference.
+    /// </summary>
+    [Fact]
+    public void ADeclaredDefaultBeatsTheReasonPhrase() {
+        var property = String("message", required: true);
+        property.Default = "no such todo";
+
+        var schemas = new[] { Schema("TodoNotFound", isErrorShape: true, property) };
+
+        Assert.Equal(["\"no such todo\""], DefaultErrorBody.Arguments(schemas, "TodoNotFound", 404));
+    }
+
+    /// <summary>
+    /// Nothing changes for the shape OpenAPI produces: 7807's members are filled from their
+    /// specified meanings and an optional detail is left empty, which is the milder half of the
+    /// same defect and is deliberate. A handler that wants to say why throws instead.
+    /// </summary>
+    [Fact]
+    public void AProblemFillsItsSpecifiedMembersAndLeavesDetailEmpty() {
+        var schemas = new[] {
+            Schema("Problem", isErrorShape: false,
+                String("type", required: false),
+                String("title", required: false),
+                new PropertyModel { Name = "status", Type = "integer", IsRequired = false },
+                String("detail", required: false))
+        };
+
+        Assert.Equal(
+            ["\"about:blank\"", "\"Not Found\"", "404", "default"],
+            DefaultErrorBody.Arguments(schemas, "Problem", 404));
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/WriteOpenApiDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/WriteOpenApiDocumentTests.cs
@@ -47,8 +47,8 @@ public class WriteOpenApiDocumentTests : IDisposable {
 
         // The Smithy application's bank service repeats an operation key, which the export reports
         // under 031 and which is not what this test is about. Everything else says nothing.
-        Assert.Empty(result.Warnings.Where(warning => !warning.Code!.EndsWith(
-            WriteOpenApiDocument.RepeatedOperationKeyCode, StringComparison.Ordinal)));
+        Assert.DoesNotContain(result.Warnings, warning => !warning.Code!.EndsWith(
+            WriteOpenApiDocument.RepeatedOperationKeyCode, StringComparison.Ordinal));
 
         var expected = JsonTreeWriter.WriteIndented(JsonTree.Parse(ServedDocumentOf(assembly)));
 
@@ -125,8 +125,9 @@ public class WriteOpenApiDocumentTests : IDisposable {
         Assert.True(result.Succeeded, result.ErrorText);
 
         var warning = Assert.Single(
-            result.Warnings.Where(candidate => candidate.Code.EndsWith(
-                WriteOpenApiDocument.RepeatedOperationKeyCode, StringComparison.Ordinal)));
+            result.Warnings,
+            candidate => candidate.Code.EndsWith(
+                WriteOpenApiDocument.RepeatedOperationKeyCode, StringComparison.Ordinal));
 
         Assert.Contains("'/'", warning.Message);
         Assert.Contains("@http", warning.Message);

--- a/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/WriteOpenApiDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/WriteOpenApiDocumentTests.cs
@@ -43,8 +43,12 @@ public class WriteOpenApiDocumentTests : IDisposable {
 
         Assert.True(result.Succeeded, result.ErrorText);
         Assert.Empty(result.Errors);
-        Assert.Empty(result.Warnings);
         Assert.True(result.Changed);
+
+        // The Smithy application's bank service repeats an operation key, which the export reports
+        // under 031 and which is not what this test is about. Everything else says nothing.
+        Assert.Empty(result.Warnings.Where(warning => !warning.Code!.EndsWith(
+            WriteOpenApiDocument.RepeatedOperationKeyCode, StringComparison.Ordinal)));
 
         var expected = JsonTreeWriter.WriteIndented(JsonTree.Parse(ServedDocumentOf(assembly)));
 
@@ -79,6 +83,10 @@ public class WriteOpenApiDocumentTests : IDisposable {
     /// exports still succeed, and the day the served document stops repeating the key this test
     /// fails and the application joins the theory.
     /// </summary>
+    /// <remarks>
+    /// The export says so now, under <c>031</c>, rather than leaving a file to be discovered
+    /// unreadable by whatever was pointed at it. A warning, so the file is still written.
+    /// </remarks>
     [Fact]
     public void TheSmithyApplicationRepeatsAnOperationKeyAndStillExportsBothFormats() {
         Assert.True(_harness.Run(TaskHarness.Fixture(TaskHarness.SmithyApp), "out.json").Succeeded);
@@ -99,6 +107,47 @@ public class WriteOpenApiDocumentTests : IDisposable {
         var yaml = File.ReadAllText(_harness.Under("out.yaml"));
 
         Assert.Equal(posts, yaml.Split('\n').Count(line => line == "    post:"));
+    }
+
+    /// <summary>
+    /// And the export says which path, once, rather than leaving the file to be found unreadable
+    /// by whatever was pointed at it.
+    /// </summary>
+    /// <remarks>
+    /// One report per path however many operations collide there: the reader's answer is the same
+    /// after the second, and the fix - give each operation its own method and path - is one edit to
+    /// the model rather than one per operation.
+    /// </remarks>
+    [Fact]
+    public void ARepeatedOperationKeyIsReported() {
+        var result = _harness.Run(TaskHarness.Fixture(TaskHarness.SmithyApp), "reported.json");
+
+        Assert.True(result.Succeeded, result.ErrorText);
+
+        var warning = Assert.Single(
+            result.Warnings.Where(candidate => candidate.Code.EndsWith(
+                WriteOpenApiDocument.RepeatedOperationKeyCode, StringComparison.Ordinal)));
+
+        Assert.Contains("'/'", warning.Message);
+        Assert.Contains("@http", warning.Message);
+        Assert.Contains("no client can be generated", warning.Message);
+
+        // The file is still there. The warning is about what a reader will make of it, not about
+        // whether writing it was the right thing to do.
+        Assert.True(File.Exists(_harness.Under("reported.json")));
+    }
+
+    /// <summary>
+    /// The applications whose documents key their operations the way OpenAPI does say nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(TaskHarness.WebApp)]
+    [InlineData(TaskHarness.OpenApiApp)]
+    public void ADocumentWithNoRepeatedKeyIsSilent(string assembly) {
+        var result = _harness.Run(TaskHarness.Fixture(assembly), "quiet.json");
+
+        Assert.True(result.Succeeded, result.ErrorText);
+        Assert.DoesNotContain(WriteOpenApiDocument.RepeatedOperationKeyCode, result.WarningText);
     }
 
     [Fact]
@@ -176,12 +225,16 @@ public class WriteOpenApiDocumentTests : IDisposable {
         Assert.DoesNotContain("itemSchema", written);
     }
 
+    /// <remarks>
+    /// Nothing about <em>lowering</em>, which is what this measures. The Smithy application also
+    /// repeats an operation key, and 031 says so on every export of it whatever the version.
+    /// </remarks>
     [Fact]
     public void LoweringAnApplicationWithNoStreamingWarnsNothing() {
         var result = _harness.Run(TaskHarness.Fixture(TaskHarness.SmithyApp), "lowered.json", version: "3.0.0");
 
         Assert.True(result.Succeeded, result.ErrorText);
-        Assert.Empty(result.Warnings);
+        Assert.DoesNotContain(WriteOpenApiDocument.StreamLostItemSchemaCode, result.WarningText);
         Assert.Contains("\"openapi\": \"3.0.0\"", File.ReadAllText(_harness.Under("lowered.json")));
     }
 

--- a/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask/WriteOpenApiDocument.cs
+++ b/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask/WriteOpenApiDocument.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Text;
 using Hardened.Generation.Document;
 using Microsoft.Build.Framework;
@@ -74,6 +76,8 @@ public sealed class WriteOpenApiDocument : Microsoft.Build.Utilities.Task {
     public const string UnknownVersionCode = "029";
 
     public const string StreamLostItemSchemaCode = "030";
+
+    public const string RepeatedOperationKeyCode = "031";
 
     private const string PublishingAttribute = "[Enable<OpenApiDocumentPublishing>]";
 
@@ -159,6 +163,18 @@ public sealed class WriteOpenApiDocument : Microsoft.Build.Utilities.Task {
             return false;
         }
 
+        foreach (var path in RepeatedOperationKeys(document)) {
+            Log.LogWarning(null, prefix + RepeatedOperationKeyCode, null, ProjectFile(), 0, 0, 0, 0,
+                $"The served document puts more than one operation at '{path}' under the same method, " +
+                "so the exported file repeats a key that OpenAPI has no way to tell apart. Readers " +
+                "refuse it and no client can be generated from it. This is what an RPC protocol " +
+                "looks like in OpenAPI - awsJson1_0 and awsJson1_1 put every operation at POST / and " +
+                "dispatch on X-Amz-Target - and the service itself is unaffected. Give each operation " +
+                "its own method and path with Smithy's @http trait for a document a generator can " +
+                $"read, or set <NoWarn>$(NoWarn);{prefix}{RepeatedOperationKeyCode}</NoWarn> to keep " +
+                "exporting the file as it is.");
+        }
+
         if (version != null) {
             foreach (var operation in OpenApiDocumentLowering.Lower(document, version)) {
                 Log.LogWarning(null, prefix + StreamLostItemSchemaCode, null, ProjectFile(), 0, 0, 0, 0,
@@ -204,6 +220,46 @@ public sealed class WriteOpenApiDocument : Microsoft.Build.Utilities.Task {
 
     private static bool HasExtension(string path, string extension) =>
         string.Equals(Path.GetExtension(path), extension, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Every path the document puts two operations under one method at, in document order.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// OpenAPI's Path Item is a map keyed by method, so this is a key repeated in an object - a
+    /// shape the tree carries faithfully and a reader refuses. It is read off the written tree
+    /// rather than from the model, because the export is what has to answer for the file: the task
+    /// never sees the description, and the same file is what a generator will be pointed at.
+    /// </para>
+    /// <para>
+    /// A warning rather than an error. The input is not wrong, unlike <c>028</c> and <c>029</c>,
+    /// and the file is a faithful record of what the service serves - worth having for a diff or
+    /// an archive even where no generator can read it. Under <c>ContinuousIntegrationBuild</c> it
+    /// fails the build like every other warning here, which is where it matters.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<string> RepeatedOperationKeys(JsonObject document) {
+        if (document.Get("paths") is not JsonObject paths) {
+            yield break;
+        }
+
+        foreach (var path in paths.Members) {
+            if (path.Value is not JsonObject item) {
+                continue;
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var reported = false;
+
+            foreach (var operation in item.Members) {
+                if (!seen.Add(operation.Key) && !reported) {
+                    reported = true;
+
+                    yield return path.Key;
+                }
+            }
+        }
+    }
 
     private static bool StartsWith(byte[] bytes, string prefix) {
         if (bytes.Length < prefix.Length) {

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -1247,7 +1247,12 @@ internal static class SmithySpecParser {
         var schema = new SchemaModel {
             Name = name,
             Description = Text(shape, SmithyTraits.Documentation),
-            IsDeprecated = SmithyAst.HasTrait(shape, SmithyTraits.Deprecated)
+            IsDeprecated = SmithyAst.HasTrait(shape, SmithyTraits.Deprecated),
+
+            // Carried onto the schema because DefaultErrorBody needs it, and it is the only place
+            // that knows: by the time a schema reaches the shared generation model, an error shape
+            // and a payload look alike. See SchemaModel.IsErrorShape.
+            IsErrorShape = SmithyAst.HasTrait(shape, SmithyTraits.Error)
         };
 
         switch (SmithyAst.Kind(shape)) {

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1ClientTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1ClientTests.cs
@@ -105,16 +105,14 @@ public class TemplateModuleNameClientTests {
     /// </summary>
 #if (throwsMode)
     /// <remarks>
-    /// Skipped rather than bent. In throws mode this service answers the 404 by returning null,
-    /// and the runtime writes no body for a named error shape it has no message for - while the
-    /// document promises a TodoNotFound body. The client sees a bare ApiException whose registered
-    /// error failed to deserialize. That is a runtime gap the generated client makes visible, not
-    /// a client defect; the declared models answer with the body, and this test runs there.
+    /// In throws mode this service answers the 404 by returning null, and the message is the
+    /// status's reason phrase: Smithy gives an @error's message one meaning, so the runtime fills
+    /// it rather than sending the bodiless 404 that used to make the client throw a bare
+    /// ApiException. A handler with something to say throws
+    /// new TodoNotFound("...").AsException() instead.
     /// </remarks>
-    [HardenedTest(Skip = "Smithy throws mode answers a null return with a bodiless 404; the document declares a TodoNotFound body. See the framework's client-by-default handoff notes.")]
-#else
-    [HardenedTest]
 #endif
+    [HardenedTest]
     public async Task UnknownTodo_IsATypedError(TemplateModuleNameClient client) {
         var failure = await Assert.ThrowsAsync<ClientModels.TodoNotFound>(() => client.Todos[9999].GetAsync());
 


### PR DESCRIPTION
Two of the three gaps `docs/client-by-default-handoff.md` left open under *Discovered and not fixed*. The third is settled as intended rather than fixed.

## A Smithy error's required `message`

A Smithy service in throws mode answered a declared 404 by returning `null` and wrote no body, while the served document promised the `@error` shape. A generated client registers that shape for the status, finds nothing to deserialize and throws a bare `ApiException` rather than the typed error. That is how the defect was found, and why the scaffolded test shipped skipped under `--contract smithy --response-model throws`.

`DefaultErrorBody` already refuses to fill a required member it has nothing to fill from, and that rule is right — writing a reason phrase into a required `accountId` would be inventing a domain value. But Smithy's `message` is not a domain member. The specification gives an `@error` structure's `message` one meaning, which is the same standing 7807's `title` and `status` have, and those are already filled on the stated grounds that *the description said what the member means, so filling it is conformance rather than a guess*.

`SchemaModel.IsErrorShape` carries the trait through, set by the Smithy parser and false for everything OpenAPI produces, which has no way to say it. Keyed on the trait rather than on the member's name: `{ message: string }` is far too ordinary a shape to read an error off.

| | Result |
|---|---|
| `@error` shape, required `message` | filled with the status's reason phrase |
| ordinary payload, required `message` | no instance, as before |
| `@error` shape, a second required member | no instance — filling one and inventing another is worse than writing nothing |
| a declared `default` on the member | still wins; it is the one source that is not an inference |

## `031` — a document no reader accepts

A Smithy model on an AWS JSON protocol puts every operation at `POST /` and dispatches on `X-Amz-Target`, so the served document repeats a key OpenAPI cannot tell apart. Readers refuse it and no client can be generated from it.

Not fixable as OpenAPI: a Path Item is a map keyed by method and holds one `post`. Synthesising `POST /Bank.GetBalance` per operation would describe routes the service does not serve, and a client built from it would call URLs answering 404. So the export names the path instead of leaving an unusable file to be discovered by whatever was pointed at it.

A **warning**, not an error. The input is not wrong the way `028` and `029` are, and the file is a faithful record worth having for a diff or an archive. Under `ContinuousIntegrationBuild` it fails the build like every other warning here, and the message names the `NoWarn` for a service where the protocol is the point.

## The one not fixed

An OpenAPI service in throws mode answers the same null return with a `Problem` carrying no `detail`. `status` and `title` are facts about the status code and are filled; `detail` is a fact about *this occurrence*, which the framework does not have. Inventing one puts words in the handler's mouth, and a handler with something to say throws instead. ASP.NET Core answers a bare 404 with no body at all. Recorded as intended in the handoff notes rather than left open.

## Verification

- `PetStoreRoutingTests.GetPet_AnswersAMissWithTheDeclaredErrorShape` covers the shape in-repo. Copied onto the parent commit it fails with `The input does not contain any JSON tokens`, which is the empty body.
- `verify-templates.sh kestrel:smithy:throws` runs **16 passed, 0 skipped**, where that row previously carried the skip. The un-skipped test drives a real Kiota client through the pipeline.
- `DefaultErrorBodyTests` pins each row of the table above, including that an ordinary payload is unaffected.
- Full solution: 33 test assemblies, all green, with the pinned Smithy CLI 1.73.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
