### PR TITLE
Stop the pack-list check searching template content and build output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,12 +195,26 @@ jobs:
           # packages, so a consumer referencing both fails with CS0111/CS8646.
           EXEMPT="Hardened.DependencyModules.SourceGenerator"
 
+          # Two kinds of path are not this repository's packages and must not be searched for
+          # here.
+          #
+          # A project under templates/ is scaffolded into somebody else's repository, where they
+          # may well pack it - Hardened1.Client is packable because a consumer's client project
+          # should be. It is content, not a package this repository ships, and treating it as one
+          # failed the 0.20.0-rc1000 release at this step.
+          #
+          # obj/ is build output. The template staging step copies templates/ into
+          # obj/staged-templates/, so every template project appears twice on a machine that has
+          # built, and the second copy exists or not depending on what ran before this.
           MISSING=""
           while IFS= read -r project; do
             name=$(basename "$project" .csproj)
             case " $EXEMPT " in *" $name "*) continue ;; esac
             grep -qF "$project" .github/workflows/release.yaml || MISSING="$MISSING $name"
-          done < <(grep -rl "<IsPackable>[Tt]rue</IsPackable>" --include='*.csproj' src | sort)
+          done < <(grep -rl "<IsPackable>[Tt]rue</IsPackable>" --include='*.csproj' src \
+                     | grep -v '/obj/' \
+                     | grep -v '/Hardened.Templates/templates/' \
+                     | sort)
 
           if [ -n "$MISSING" ]; then
             echo "::error::These projects are packable but absent from the pack list:$MISSING"


### PR DESCRIPTION
The `v0.20.0-rc1000` release failed at **Verify the pack list covers every packable project**,
naming `Hardened1.Client`.

That project is the client the `hardened-web` template scaffolds. It carries
`<IsPackable>true</IsPackable>` because a consumer's client project should be packable — it is
template *content*, not a package this repository ships, so no entry in the pack list could ever
satisfy the check. It did not exist at `v0.19.0-rc1000`, which is why this has been correct until
now.

`obj/` is excluded for a second reason found while fixing the first: the template staging step
copies `templates/` into `obj/staged-templates/`, so every template project appears twice on a
machine that has built, and whether the second copy is there depends on what ran before.

The pack list itself is right — 23 projects, and packing them at `0.20.0-rc1000` locally produces
23 packages all correctly stamped. Only the guard was wrong.

**Nothing was published.** This step runs ahead of `Pack` and both push steps, so no partial
release reached nuget.org or GitHub Packages and the version is free to re-use rather than burned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
