### PR TITLE
Let a response type state its status and be read back from a response

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -113,6 +113,7 @@ namespace Hardened.Requests.Abstract.Authorization
         public static Hardened.Requests.Abstract.Authorization.AuthorizationChallenge InsufficientAuthentication(string? realm = null, string? description = null) { }
         public static Hardened.Requests.Abstract.Authorization.AuthorizationChallenge InsufficientScope(System.Collections.Generic.IEnumerable<string> requiredGrants, string? realm = null) { }
         public static Hardened.Requests.Abstract.Authorization.AuthorizationChallenge InvalidToken(string? realm = null, string? description = null) { }
+        public static Hardened.Requests.Abstract.Authorization.AuthorizationChallenge Parse(string headerValue, int statusCode = 401) { }
     }
     public enum AuthorizationDecision
     {
@@ -779,13 +780,15 @@ namespace Hardened.Requests.Abstract.RequestFilter
 namespace Hardened.Requests.Abstract.Responses
 {
     [Hardened.Requests.Abstract.Responses.HttpStatus(202)]
-    public sealed class Accepted : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Accepted>
+    public sealed class Accepted : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Accepted>, System.IEquatable<Hardened.Requests.Abstract.Responses.Accepted>
     {
         public Accepted(string? Location = null) { }
         public bool HasBody { get; }
         public string? Location { get; init; }
         public int Status { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.Accepted FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
     public sealed class AnswersStatusAttribute : System.Attribute
@@ -797,139 +800,162 @@ namespace Hardened.Requests.Abstract.Responses
         public string? StatusFrom { get; set; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(502)]
-    public sealed class BadGateway : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadGateway>
+    public sealed class BadGateway : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadGateway>
     {
         public BadGateway(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(502)]
-    public sealed class BadGateway<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadGateway<T>>
+    public sealed class BadGateway<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.BadGateway<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.BadGateway<T>>
     {
         public BadGateway(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.BadGateway<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(400)]
-    public sealed class BadRequest : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadRequest>
+    public sealed class BadRequest : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadRequest>
     {
         public BadRequest(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(400)]
-    public sealed class BadRequest<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadRequest<T>>
+    public sealed class BadRequest<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.BadRequest<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.BadRequest<T>>
     {
         public BadRequest(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.BadRequest<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(409)]
-    public sealed class Conflict : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Conflict>
+    public sealed class Conflict : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Conflict>
     {
         public Conflict(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(409)]
-    public sealed class Conflict<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Conflict<T>>
+    public sealed class Conflict<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Conflict<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Conflict<T>>
     {
         public Conflict(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.Conflict<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(413)]
-    public sealed class ContentTooLarge : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.ContentTooLarge>
+    public sealed class ContentTooLarge : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.ContentTooLarge>
     {
         public ContentTooLarge(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(413)]
-    public sealed class ContentTooLarge<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.ContentTooLarge<T>>
+    public sealed class ContentTooLarge<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.ContentTooLarge<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.ContentTooLarge<T>>
     {
         public ContentTooLarge(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.ContentTooLarge<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(201)]
-    public sealed class Created<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Created<T>>
+    public sealed class Created<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Created<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Created<T>>
     {
         public Created(T Value, string Location) { }
         public string Location { get; init; }
         public int Status { get; }
         public T Value { get; init; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.Created<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(403)]
-    public sealed class Forbidden : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Forbidden>
+    public sealed class Forbidden : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Forbidden>
     {
         public Forbidden(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(403)]
-    public sealed class Forbidden<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Forbidden<T>>
+    public sealed class Forbidden<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Forbidden<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Forbidden<T>>
     {
         public Forbidden(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.Forbidden<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(504)]
-    public sealed class GatewayTimeout : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.GatewayTimeout>
+    public sealed class GatewayTimeout : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.GatewayTimeout>
     {
         public GatewayTimeout(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(504)]
-    public sealed class GatewayTimeout<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.GatewayTimeout<T>>
+    public sealed class GatewayTimeout<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.GatewayTimeout<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.GatewayTimeout<T>>
     {
         public GatewayTimeout(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.GatewayTimeout<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(410)]
-    public sealed class Gone : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Gone>
+    public sealed class Gone : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Gone>
     {
         public Gone(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(410)]
-    public sealed class Gone<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Gone<T>>
+    public sealed class Gone<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Gone<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Gone<T>>
     {
         public Gone(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.Gone<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     public static class Http
     {
@@ -1104,6 +1130,10 @@ namespace Hardened.Requests.Abstract.Responses
     {
         object? Body { get; }
     }
+    public interface IDeclaresStatus
+    {
+        int StatusCode { get; }
+    }
     public interface IHttpStatusResponse
     {
         bool HasBody { get; }
@@ -1113,62 +1143,78 @@ namespace Hardened.Requests.Abstract.Responses
     {
         void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers);
     }
+    public interface IResponseExpectation<TSelf> : Hardened.Requests.Abstract.Responses.IDeclaresStatus
+        where TSelf : Hardened.Requests.Abstract.Responses.IResponseExpectation<TSelf>
+    {
+        TSelf FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers);
+    }
     public interface IStatusCode
     {
         int Status { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(500)]
-    public sealed class InternalServerError : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.InternalServerError>
+    public sealed class InternalServerError : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.InternalServerError>
     {
         public InternalServerError(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(500)]
-    public sealed class InternalServerError<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.InternalServerError<T>>
+    public sealed class InternalServerError<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.InternalServerError<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.InternalServerError<T>>
     {
         public InternalServerError(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.InternalServerError<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(405)]
-    public sealed class MethodNotAllowed : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.MethodNotAllowed>
+    public sealed class MethodNotAllowed : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.MethodNotAllowed>, System.IEquatable<Hardened.Requests.Abstract.Responses.MethodNotAllowed>
     {
         public MethodNotAllowed(string Allow) { }
         public string Allow { get; init; }
         public bool HasBody { get; }
         public int Status { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.MethodNotAllowed FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(405)]
-    public sealed class MethodNotAllowed<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.MethodNotAllowed<T>>
+    public sealed class MethodNotAllowed<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.MethodNotAllowed<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.MethodNotAllowed<T>>
     {
         public MethodNotAllowed(T Body, string Allow) { }
         public string Allow { get; init; }
         public T Body { get; init; }
         public int Status { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.MethodNotAllowed<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(204)]
-    public sealed class NoContent : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NoContent>
+    public sealed class NoContent : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.NoContent>, System.IEquatable<Hardened.Requests.Abstract.Responses.NoContent>
     {
         public NoContent() { }
         public bool HasBody { get; }
         public int Status { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.NoContent FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(406)]
-    public sealed class NotAcceptable : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotAcceptable>
+    public sealed class NotAcceptable : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.NotAcceptable>, System.IEquatable<Hardened.Requests.Abstract.Responses.NotAcceptable>
     {
         public NotAcceptable() { }
         public bool HasBody { get; }
         public int Status { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.NotAcceptable FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(404)]
-    public sealed class NotFound : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotFound>
+    public sealed class NotFound : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotFound>
     {
         public NotFound(string Resource, string? Detail = null) { }
         public string? Detail { get; init; }
@@ -1176,106 +1222,125 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(404)]
-    public sealed class NotFound<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotFound<T>>
+    public sealed class NotFound<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.NotFound<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.NotFound<T>>
     {
         public NotFound(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.NotFound<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(501)]
-    public sealed class NotImplemented : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotImplemented>
+    public sealed class NotImplemented : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotImplemented>
     {
         public NotImplemented(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(501)]
-    public sealed class NotImplemented<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotImplemented<T>>
+    public sealed class NotImplemented<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.NotImplemented<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.NotImplemented<T>>
     {
         public NotImplemented(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.NotImplemented<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(304)]
-    public sealed class NotModified : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.NotModified>
+    public sealed class NotModified : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.NotModified>, System.IEquatable<Hardened.Requests.Abstract.Responses.NotModified>
     {
         public NotModified(string? ETag = null) { }
         public string? ETag { get; init; }
         public bool HasBody { get; }
         public int Status { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.NotModified FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(200)]
-    public sealed class Ok<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Ok<T>>
+    public sealed class Ok<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Ok<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Ok<T>>
     {
         public Ok(T Value, System.Collections.Generic.IReadOnlyDictionary<string, string>? Headers = null) { }
         public Ok(T value, string headerName, string headerValue) { }
         public System.Collections.Generic.IReadOnlyDictionary<string, string>? Headers { get; init; }
         public int Status { get; }
         public T Value { get; init; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.Ok<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(402)]
-    public sealed class PaymentRequired : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PaymentRequired>
+    public sealed class PaymentRequired : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PaymentRequired>
     {
         public PaymentRequired(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(402)]
-    public sealed class PaymentRequired<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PaymentRequired<T>>
+    public sealed class PaymentRequired<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.PaymentRequired<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.PaymentRequired<T>>
     {
         public PaymentRequired(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.PaymentRequired<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(412)]
-    public sealed class PreconditionFailed : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed>
+    public sealed class PreconditionFailed : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed>
     {
         public PreconditionFailed(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(412)]
-    public sealed class PreconditionFailed<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed<T>>
+    public sealed class PreconditionFailed<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.PreconditionFailed<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed<T>>
     {
         public PreconditionFailed(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.PreconditionFailed<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(428)]
-    public sealed class PreconditionRequired : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionRequired>
+    public sealed class PreconditionRequired : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionRequired>
     {
         public PreconditionRequired(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(428)]
-    public sealed class PreconditionRequired<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionRequired<T>>
+    public sealed class PreconditionRequired<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.PreconditionRequired<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionRequired<T>>
     {
         public PreconditionRequired(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.PreconditionRequired<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     public static class ProblemTypes
     {
@@ -1301,7 +1366,7 @@ namespace Hardened.Requests.Abstract.Responses
         public const string UnsupportedMediaType = "urn:hardened:problem:unsupported-media-type";
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(429)]
-    public sealed class RateLimited : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.RateLimited>
+    public sealed class RateLimited : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.RateLimited>
     {
         public RateLimited(System.TimeSpan RetryAfter, string? Detail = null) { }
         public string? Detail { get; init; }
@@ -1309,10 +1374,11 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(429)]
-    public sealed class RateLimited<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.RateLimited<T>>
+    public sealed class RateLimited<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.RateLimited<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.RateLimited<T>>
     {
         public RateLimited(System.TimeSpan RetryAfter, T Body) { }
         public T Body { get; init; }
@@ -1320,25 +1386,30 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.RateLimited<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(408)]
-    public sealed class RequestTimeout : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.RequestTimeout>
+    public sealed class RequestTimeout : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.RequestTimeout>
     {
         public RequestTimeout(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(408)]
-    public sealed class RequestTimeout<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.RequestTimeout<T>>
+    public sealed class RequestTimeout<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.RequestTimeout<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.RequestTimeout<T>>
     {
         public RequestTimeout(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.RequestTimeout<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     public class ResponseException : Hardened.Requests.Abstract.Errors.StatusCodeException
     {
@@ -1356,6 +1427,14 @@ namespace Hardened.Requests.Abstract.Responses
     {
         public ResponseException(T response, string? message = null) { }
         public new T Response { get; }
+    }
+    public static class ResponseExpectation
+    {
+        public static T Body<T>(object? body) { }
+        public static string? OptionalHeader(System.Collections.Generic.IReadOnlyDictionary<string, string> headers, string name) { }
+        public static System.TimeSpan? OptionalRetryAfter(System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
+        public static string RequiredHeader(System.Collections.Generic.IReadOnlyDictionary<string, string> headers, string name) { }
+        public static System.TimeSpan RequiredRetryAfter(System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     public enum ResponseModel
     {
@@ -1483,7 +1562,7 @@ namespace Hardened.Requests.Abstract.Responses
         public static int Seconds(System.TimeSpan delay) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(503)]
-    public sealed class ServiceUnavailable : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.ServiceUnavailable>
+    public sealed class ServiceUnavailable : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.ServiceUnavailable>
     {
         public ServiceUnavailable(System.TimeSpan? After = default, string? Detail = null) { }
         public System.TimeSpan? After { get; init; }
@@ -1491,10 +1570,11 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(503)]
-    public sealed class ServiceUnavailable<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.ServiceUnavailable<T>>
+    public sealed class ServiceUnavailable<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.ServiceUnavailable<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.ServiceUnavailable<T>>
     {
         public ServiceUnavailable(T Body, System.TimeSpan? After = default) { }
         public System.TimeSpan? After { get; init; }
@@ -1502,19 +1582,25 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.ServiceUnavailable<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
-    public sealed class Status<TCode> : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Status<TCode>>
+    public sealed class Status<TCode> : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Status<TCode>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Status<TCode>>
         where TCode : Hardened.Requests.Abstract.Responses.IStatusCode
     {
         public Status() { }
         public bool HasBody { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.Status<TCode> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
-    public sealed class Status<TCode, TBody> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Status<TCode, TBody>>
+    public sealed class Status<TCode, TBody> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Status<TCode, TBody>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Status<TCode, TBody>>
         where TCode : Hardened.Requests.Abstract.Responses.IStatusCode
     {
         public Status(TBody Body) { }
         public TBody Body { get; init; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.Status<TCode, TBody> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
     public sealed class ThrowsAttribute<TError> : System.Attribute
@@ -1525,7 +1611,7 @@ namespace Hardened.Requests.Abstract.Responses
         public int? StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(401)]
-    public sealed class Unauthorized : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Unauthorized>
+    public sealed class Unauthorized : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Unauthorized>
     {
         public Unauthorized(string? Detail = null, Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge = null) { }
         public Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge { get; init; }
@@ -1533,10 +1619,11 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(401)]
-    public sealed class Unauthorized<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Unauthorized<T>>
+    public sealed class Unauthorized<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.Unauthorized<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.Unauthorized<T>>
     {
         public Unauthorized(T Body, Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge = null) { }
         public T Body { get; init; }
@@ -1544,43 +1631,51 @@ namespace Hardened.Requests.Abstract.Responses
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
+        public static Hardened.Requests.Abstract.Responses.Unauthorized<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(422)]
-    public sealed class UnprocessableContent : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnprocessableContent>
+    public sealed class UnprocessableContent : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnprocessableContent>
     {
         public UnprocessableContent(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(422)]
-    public sealed class UnprocessableContent<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnprocessableContent<T>>
+    public sealed class UnprocessableContent<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.UnprocessableContent<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.UnprocessableContent<T>>
     {
         public UnprocessableContent(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.UnprocessableContent<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(415)]
-    public sealed class UnsupportedMediaType : Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnsupportedMediaType>
+    public sealed class UnsupportedMediaType : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnsupportedMediaType>
     {
         public UnsupportedMediaType(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(415)]
-    public sealed class UnsupportedMediaType<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnsupportedMediaType<T>>
+    public sealed class UnsupportedMediaType<T> : Hardened.Requests.Abstract.Responses.ICarriesResponseBody, Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IResponseExpectation<Hardened.Requests.Abstract.Responses.UnsupportedMediaType<T>>, System.IEquatable<Hardened.Requests.Abstract.Responses.UnsupportedMediaType<T>>
     {
         public UnsupportedMediaType(T Body) { }
         public T Body { get; init; }
         public int Status { get; }
         public string Title { get; }
         public string Type { get; }
+        public static int StatusCode { get; }
+        public static Hardened.Requests.Abstract.Responses.UnsupportedMediaType<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
 }
 namespace Hardened.Requests.Abstract.Serializer

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Authorization/AuthorizationChallengeTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Authorization/AuthorizationChallengeTests.cs
@@ -201,4 +201,103 @@ public class AuthorizationChallengeTests {
     }
 
     #endregion
+
+    #region reading one back
+
+    /// <summary>
+    /// Every challenge this type can produce, read back from the header it produced.
+    /// </summary>
+    /// <remarks>
+    /// A round trip rather than four assertions on four parsed strings, because the format is
+    /// written in one place and read in another and the only thing that matters is that they are
+    /// the same format. A parameter added to <c>Format</c> and not to the parser fails here.
+    /// </remarks>
+    public static TheoryData<AuthorizationChallenge> EveryChallenge => new() {
+        AuthorizationChallenge.AuthenticationRequired(),
+        AuthorizationChallenge.AuthenticationRequired("api"),
+        AuthorizationChallenge.InvalidToken(),
+        AuthorizationChallenge.InvalidToken("api", "the token expired"),
+        AuthorizationChallenge.InsufficientAuthentication("api", "a second factor is required"),
+        AuthorizationChallenge.InsufficientScope(["todos:read", "todos:write"], "api"),
+    };
+
+    [Theory]
+    [MemberData(nameof(EveryChallenge))]
+    public void AChallenge_ReadsBackAsTheHeaderItWrote(AuthorizationChallenge challenge) {
+        var parsed = AuthorizationChallenge.Parse(challenge.HeaderValue, challenge.StatusCode);
+
+        Assert.Equal(challenge.HeaderValue, parsed.HeaderValue);
+        Assert.Equal(challenge.Scheme, parsed.Scheme);
+        Assert.Equal(challenge.Error, parsed.Error);
+        Assert.Equal(challenge.Realm, parsed.Realm);
+        Assert.Equal(challenge.Description, parsed.Description);
+        Assert.Equal(challenge.Scope, parsed.Scope);
+        Assert.Equal(challenge.StatusCode, parsed.StatusCode);
+    }
+
+    /// <summary>
+    /// A quoted value holds both characters that would otherwise end a parameter, and a realm is
+    /// the one an application chooses, so both reach the parser in practice.
+    /// </summary>
+    [Fact]
+    public void AQuotedValue_MayHoldACommaAndAQuote() {
+        var parsed = AuthorizationChallenge.Parse(
+            AuthorizationChallenge.InvalidToken("a \"realm\", quoted").HeaderValue);
+
+        Assert.Equal("a \"realm\", quoted", parsed.Realm);
+        Assert.Equal("invalid_token", parsed.Error);
+    }
+
+    [Fact]
+    public void AChallengeThatIsOnlyAScheme_ReadsBackAsThatScheme() {
+        var parsed = AuthorizationChallenge.Parse("Bearer");
+
+        Assert.Equal("Bearer", parsed.Scheme);
+        Assert.Null(parsed.Error);
+        Assert.Empty(parsed.Scope);
+    }
+
+    /// <summary>
+    /// The parameters another server sends. RFC 6750 is a floor rather than a list, so one this
+    /// type does not model is skipped rather than refused.
+    /// </summary>
+    [Fact]
+    public void AParameterThisTypeDoesNotModel_IsIgnored() {
+        var parsed = AuthorizationChallenge.Parse(
+            "Bearer realm=\"api\", error=invalid_token, max_age=60");
+
+        Assert.Equal("api", parsed.Realm);
+        Assert.Equal("invalid_token", parsed.Error);
+    }
+
+    /// <summary>
+    /// 403 is the one challenge that is not a 401, and the header does not say which it was, so
+    /// the caller does.
+    /// </summary>
+    [Fact]
+    public void TheStatusIsTheCallersToState() {
+        Assert.Equal(
+            403,
+            AuthorizationChallenge.Parse(
+                AuthorizationChallenge.InsufficientScope(["todos:read"]).HeaderValue, 403).StatusCode);
+    }
+
+    /// <summary>
+    /// A parameter with no value ends the header rather than being read as an empty one, because a
+    /// challenge this malformed says nothing about what the client should do next.
+    /// </summary>
+    [Fact]
+    public void AParameterWithNoValue_EndsTheHeader() {
+        var parsed = AuthorizationChallenge.Parse("Bearer realm=\"api\", error");
+
+        Assert.Equal("api", parsed.Realm);
+        Assert.Null(parsed.Error);
+    }
+
+    [Fact]
+    public void AnEmptyHeader_IsRefused() {
+        Assert.Throws<ArgumentException>(() => AuthorizationChallenge.Parse("  "));
+    }
+
+    #endregion
 }

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/BuiltInResponseTypeTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/BuiltInResponseTypeTests.cs
@@ -104,6 +104,77 @@ public class BuiltInResponseTypeTests {
 
     #endregion
 
+    #region declared status
+
+    /// <summary>
+    /// The third place a status is written, and the one a test reads.
+    /// </summary>
+    /// <remarks>
+    /// <c>IDeclaresStatus</c> is opt-in on a user's own response type and mandatory on a built-in
+    /// one, because the testing libraries reach every built-in through it. Its value is not asserted
+    /// against the attribute here: each record reads <c>Status =&gt; StatusCode</c>, so the
+    /// agreement test above already covers it, and asserting it twice would only prove the record
+    /// still says what it says.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(BuiltInResponseTypes))]
+    public void BuiltInResponseType_DeclaresItsStatusOnTheType(Type type) {
+        Assert.True(
+            typeof(IDeclaresStatus).IsAssignableFrom(type),
+            type.Name + " must implement IDeclaresStatus.");
+
+        var property = (type.IsGenericTypeDefinition ? type.MakeGenericType(typeof(string)) : type)
+            .GetProperty(nameof(IDeclaresStatus.StatusCode), BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(property);
+        Assert.Equal(type.GetCustomAttribute<HttpStatusAttribute>()!.StatusCode, property!.GetValue(null));
+    }
+
+    /// <summary>
+    /// A response carrying a caller's own body can be read back, so a test can name it.
+    /// </summary>
+    /// <remarks>
+    /// The generic forms are the ones a test asserts through - <c>Returns&lt;NotFound&lt;Problem&gt;&gt;()</c>
+    /// - and each one has to be reachable that way. A new one that forgot <c>IResponseExpectation</c>
+    /// would compile, ship, and only be found by whoever first tried to assert on it.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(BuiltInResponseTypes))]
+    public void AGenericResponseType_CanBeReadBackFromAResponse(Type type) {
+        if (!type.IsGenericTypeDefinition) {
+            return;
+        }
+
+        var closed = type.MakeGenericType(typeof(string));
+
+        Assert.Contains(
+            closed.GetInterfaces(),
+            contract => contract.IsGenericType &&
+                        contract.GetGenericTypeDefinition() == typeof(IResponseExpectation<>) &&
+                        contract.GenericTypeArguments[0] == closed);
+    }
+
+    /// <summary>
+    /// The deliberate exclusion, pinned so it stays deliberate.
+    /// </summary>
+    /// <remarks>
+    /// Each of these states something the handler knew and no client can recover: the resource that
+    /// was looked for, the detail line, the challenge. Making one an expectation would mean
+    /// inventing those values on the way back, so naming one in a test is a compile error that
+    /// points at the generic form instead.
+    /// </remarks>
+    [Fact]
+    public void AResponseStatingWhatTheWireDoesNotCarry_IsNotAnExpectation() {
+        Assert.All(
+            new[] { typeof(NotFound), typeof(Conflict), typeof(Unauthorized), typeof(RateLimited) },
+            type => Assert.DoesNotContain(
+                type.GetInterfaces(),
+                contract => contract.IsGenericType &&
+                            contract.GetGenericTypeDefinition() == typeof(IResponseExpectation<>)));
+    }
+
+    #endregion
+
     #region status markers
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/ResponseExpectationTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/ResponseExpectationTests.cs
@@ -1,0 +1,316 @@
+using System.Reflection;
+using Hardened.Requests.Abstract.Authorization;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Responses;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.Requests.Abstract.Tests.Responses;
+
+/// <summary>
+/// Reading a response type back from what it wrote.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The whole of <c>FromResponse</c> is header names and a body cast, and both are the kind of thing
+/// that is wrong silently. A record that writes <c>Location</c> and reads <c>location</c> back
+/// compiles, and fails only in whichever test first asserted on a 201 - as a missing header on a
+/// response that carried one.
+/// </para>
+/// <para>
+/// So the sweep below writes each response through its own <c>ApplyHeaders</c> and reads it back
+/// through its own <c>FromResponse</c>. Nothing in it names a header, which is what makes it hold
+/// for a response type added later.
+/// </para>
+/// </remarks>
+public class ResponseExpectationTests {
+
+    private sealed record Problem(string Detail);
+
+    #region every expectation, round-tripped through its own headers
+
+    /// <summary>
+    /// Every response type that can be read back, closed over a body type where it takes one.
+    /// </summary>
+    public static TheoryData<Type> Expectations {
+        get {
+            var data = new TheoryData<Type>();
+
+            foreach (var type in typeof(NotFound).Assembly.GetExportedTypes()) {
+                if (type.GetCustomAttribute<HttpStatusAttribute>() == null) {
+                    continue;
+                }
+
+                var closed = type.IsGenericTypeDefinition
+                    ? type.MakeGenericType(typeof(string))
+                    : type;
+
+                if (IsExpectation(closed)) {
+                    data.Add(closed);
+                }
+            }
+
+            return data;
+        }
+    }
+
+    /// <remarks>
+    /// Asked of the closed type's interfaces rather than by constructing
+    /// <c>IResponseExpectation&lt;closed&gt;</c>, which throws rather than answers no when the
+    /// constraint does not hold - and the types this has to answer no for are exactly those.
+    /// </remarks>
+    private static bool IsExpectation(Type type) =>
+        type.GetInterfaces().Any(contract =>
+            contract.IsGenericType &&
+            contract.GetGenericTypeDefinition() == typeof(IResponseExpectation<>) &&
+            contract.GenericTypeArguments[0] == type);
+
+    /// <summary>
+    /// What a response writes, it can read back.
+    /// </summary>
+    /// <remarks>
+    /// The rebuilt value is not compared to the original, because two of these cannot be: a
+    /// dictionary and an <c>AuthorizationChallenge</c> are both reference-compared by the record
+    /// equality that would do it. The members that matter are asserted one type at a time below.
+    /// What this covers is the part no per-type test would notice going wrong on a type added
+    /// later - that the two halves agree on the header names at all.
+    /// </remarks>
+    [Theory]
+    [MemberData(nameof(Expectations))]
+    public void AnExpectation_ReadsBackWhatItWrote(Type type) {
+        var response = (IHttpStatusResponse)Instantiate(type);
+
+        var written = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        if (response is IProvidesResponseHeaders provider) {
+            provider.ApplyHeaders(written);
+        }
+
+        var headers = written.ToDictionary(
+            header => header.Key, header => header.Value.ToString(), StringComparer.Ordinal);
+
+        var body = response is ICarriesResponseBody carrier ? carrier.Body : null;
+
+        var rebuilt = type
+            .GetMethod(nameof(IResponseExpectation<NoContent>.FromResponse),
+                BindingFlags.Public | BindingFlags.Static)!
+            .Invoke(null, [body, headers]);
+
+        Assert.Equal(response.Status, ((IHttpStatusResponse)rebuilt!).Status);
+    }
+
+    /// <summary>
+    /// The lookup is case-insensitive whatever the caller's dictionary is, because header names on
+    /// the wire are and a client reporting <c>location</c> is not reporting a different header.
+    /// </summary>
+    [Fact]
+    public void AHeaderIsFoundWhateverCaseTheClientReportedIt() {
+        var created = Created<string>.FromResponse(
+            "body", new Dictionary<string, string>(StringComparer.Ordinal) { ["location"] = "/todos/1" });
+
+        Assert.Equal("/todos/1", created.Location);
+    }
+
+    #endregion
+
+    #region the members each type reads
+
+    [Fact]
+    public void Created_ReadsItsLocation() {
+        Assert.Equal(
+            new Created<string>("body", "/todos/1"), RoundTrip(new Created<string>("body", "/todos/1")));
+    }
+
+    [Fact]
+    public void RateLimited_ReadsItsDelay() {
+        Assert.Equal(
+            new RateLimited<string>(TimeSpan.FromSeconds(30), "body"),
+            RoundTrip(new RateLimited<string>(TimeSpan.FromSeconds(30), "body")));
+    }
+
+    /// <summary>
+    /// A fractional delay is written as whole seconds, rounded up, so it does not survive the
+    /// round trip as it was given - and a caller reading it back gets what the client was told to
+    /// wait, which is the number that matters.
+    /// </summary>
+    [Fact]
+    public void RateLimited_ReadsTheDelayThatWasSentRatherThanTheOneGiven() {
+        Assert.Equal(
+            TimeSpan.FromSeconds(2), RoundTrip(new RateLimited<string>(TimeSpan.FromMilliseconds(1500), "b")).RetryAfter);
+    }
+
+    [Fact]
+    public void ServiceUnavailable_ReadsItsDelayAndItsAbsence() {
+        Assert.Equal(
+            TimeSpan.FromSeconds(5),
+            RoundTrip(new ServiceUnavailable<string>("body", TimeSpan.FromSeconds(5))).After);
+
+        Assert.Null(RoundTrip(new ServiceUnavailable<string>("body")).After);
+    }
+
+    [Fact]
+    public void MethodNotAllowed_ReadsItsAllowHeader() {
+        Assert.Equal("GET, HEAD", RoundTrip(new MethodNotAllowed<string>("body", "GET, HEAD")).Allow);
+        Assert.Equal("GET, HEAD", RoundTrip(new MethodNotAllowed("GET, HEAD")).Allow);
+    }
+
+    [Fact]
+    public void Accepted_ReadsItsLocationAndItsAbsence() {
+        Assert.Equal("/jobs/1", RoundTrip(new Accepted("/jobs/1")).Location);
+        Assert.Null(RoundTrip(new Accepted()).Location);
+    }
+
+    [Fact]
+    public void NotModified_ReadsItsETagAndItsAbsence() {
+        Assert.Equal("\"abc\"", RoundTrip(new NotModified("\"abc\"")).ETag);
+        Assert.Null(RoundTrip(new NotModified()).ETag);
+    }
+
+    /// <summary>
+    /// The challenge is written as a header and read back as a challenge, so a test asserts on the
+    /// scope that was required rather than on the string it was formatted into.
+    /// </summary>
+    [Fact]
+    public void Unauthorized_ReadsItsChallenge() {
+        var rebuilt = RoundTrip(
+            new Unauthorized<Problem>(
+                new Problem("no token"), AuthorizationChallenge.InvalidToken("api", "it expired")));
+
+        Assert.Equal("no token", rebuilt.Body.Detail);
+        Assert.Equal("invalid_token", rebuilt.Challenge!.Error);
+        Assert.Equal("api", rebuilt.Challenge.Realm);
+        Assert.Equal("it expired", rebuilt.Challenge.Description);
+    }
+
+    /// <summary>
+    /// A 401 constructed with no challenge still sends one, so it reads back with the default
+    /// rather than with the null it was built from.
+    /// </summary>
+    [Fact]
+    public void Unauthorized_ReadsBackTheChallengeItSentRatherThanNone() {
+        var rebuilt = RoundTrip(new Unauthorized<Problem>(new Problem("no token")));
+
+        Assert.Equal(AuthorizationChallenge.BearerScheme, rebuilt.Challenge!.Scheme);
+        Assert.Null(rebuilt.Challenge.Error);
+    }
+
+    /// <summary>
+    /// Every response header, not only the ones the handler passed. The read side cannot tell them
+    /// apart, and a test asking for one wants it either way.
+    /// </summary>
+    [Fact]
+    public void Ok_ReadsEveryHeaderTheResponseCarried() {
+        var rebuilt = Ok<string>.FromResponse(
+            "body",
+            new Dictionary<string, string>(StringComparer.Ordinal) {
+                ["ETag"] = "\"abc\"", ["X-Total-Count"] = "2",
+            });
+
+        Assert.Equal("body", rebuilt.Value);
+        Assert.Equal("\"abc\"", rebuilt.Headers!["ETag"]);
+        Assert.Equal("2", rebuilt.Headers["X-Total-Count"]);
+    }
+
+    #endregion
+
+    #region what it says when the response is not what was expected
+
+    [Fact]
+    public void ABodyThatDidNotArrive_SaysWhatWasDeclared() {
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => ResponseExpectation.Body<Problem>(null));
+
+        Assert.Contains("Problem", thrown.Message, StringComparison.Ordinal);
+        Assert.Contains("carried none", thrown.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The case a test author cannot debug from the client's own error: the status matched, the
+    /// body arrived, and it deserialised into a different model than the expectation names.
+    /// </summary>
+    [Fact]
+    public void ABodyOfAnotherType_NamesBothTypes() {
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => ResponseExpectation.Body<Problem>("a string"));
+
+        Assert.Contains("Problem", thrown.Message, StringComparison.Ordinal);
+        Assert.Contains("String", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AMissingRequiredHeader_ListsTheOnesThatWereThere() {
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => Created<string>.FromResponse(
+                "body", new Dictionary<string, string>(StringComparer.Ordinal) { ["ETag"] = "\"a\"" }));
+
+        Assert.Contains(KnownHeaders.Location, thrown.Message, StringComparison.Ordinal);
+        Assert.Contains("ETag", thrown.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AMissingRequiredHeaderOnAResponseWithNone_SaysSo() {
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => Created<string>.FromResponse("body", new Dictionary<string, string>()));
+
+        Assert.Contains("nothing", thrown.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Retry-After's other legal form. It is a date, turning it into a TimeSpan needs a clock, and
+    /// two runs of the same assertion would disagree - so it is refused by name rather than read
+    /// as zero.
+    /// </summary>
+    [Fact]
+    public void ARetryAfterThatIsADate_IsRefusedRatherThanRead() {
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => RateLimited<string>.FromResponse(
+                "body",
+                new Dictionary<string, string>(StringComparer.Ordinal) {
+                    [KnownHeaders.RetryAfter] = "Wed, 21 Oct 2026 07:28:00 GMT",
+                }));
+
+        Assert.Contains("delta-seconds", thrown.Message, StringComparison.Ordinal);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Writes a response's headers the way the pipeline does, then reads it back the way a client
+    /// testing library does.
+    /// </summary>
+    private static T RoundTrip<T>(T response)
+        where T : IHttpStatusResponse, IResponseExpectation<T> {
+
+        var written = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        if (response is IProvidesResponseHeaders provider) {
+            provider.ApplyHeaders(written);
+        }
+
+        return T.FromResponse(
+            response is ICarriesResponseBody carrier ? carrier.Body : null,
+            written.ToDictionary(
+                header => header.Key, header => header.Value.ToString(), StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// One of each with whatever its constructor asks for, the same way BuiltInResponseTypeTests
+    /// does it. The values are placeholders; only the round trip is asserted on.
+    /// </summary>
+    private static object Instantiate(Type type) {
+        var constructor = type.GetConstructors()
+            .OrderBy(c => c.GetParameters().Length)
+            .First();
+
+        var arguments = constructor.GetParameters()
+            .Select(p => p.ParameterType == typeof(string)
+                ? "placeholder"
+                : p.ParameterType == typeof(TimeSpan)
+                    ? TimeSpan.FromSeconds(1)
+                    : p.HasDefaultValue
+                        ? p.DefaultValue
+                        : Activator.CreateInstance(p.ParameterType))
+            .ToArray();
+
+        return constructor.Invoke(arguments);
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Authorization/AuthorizationChallenge.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Authorization/AuthorizationChallenge.cs
@@ -115,6 +115,101 @@ public sealed class AuthorizationChallenge {
 
     public override string ToString() => HeaderValue;
 
+    /// <summary>
+    /// The challenge a <c>WWW-Authenticate</c> header describes.
+    /// </summary>
+    /// <remarks>
+    /// The other direction of <see cref="HeaderValue"/>, so a test can assert on a challenge it
+    /// received rather than on the string it was written as. Parameters this type does not model
+    /// are ignored, and an unquoted value is read as far as the next comma.
+    /// </remarks>
+    /// <param name="headerValue">The header, scheme first.</param>
+    /// <param name="statusCode">
+    /// The status the challenge was sent with. Not recoverable from the header, and 401 for every
+    /// challenge but <see cref="InsufficientScope"/>.
+    /// </param>
+    public static AuthorizationChallenge Parse(string headerValue, int statusCode = 401) {
+        ArgumentException.ThrowIfNullOrWhiteSpace(headerValue);
+
+        var text = headerValue.Trim();
+        var space = text.IndexOf(' ');
+        string? error = null, realm = null, description = null;
+        IReadOnlyList<string> scope = [];
+
+        if (space >= 0) {
+            foreach (var (name, value) in Parameters(text[(space + 1)..])) {
+                switch (name.ToLowerInvariant()) {
+                    case "realm":
+                        realm = value;
+                        break;
+                    case "error":
+                        error = value;
+                        break;
+                    case "error_description":
+                        description = value;
+                        break;
+                    case "scope":
+                        scope = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                        break;
+                }
+            }
+        }
+
+        return new(statusCode, space < 0 ? text : text[..space], error, realm, scope, description);
+    }
+
+    // A quoted value can hold the comma that separates parameters and the quote that ends one, so
+    // this walks the header rather than splitting it.
+    private static IEnumerable<(string Name, string Value)> Parameters(string text) {
+        var index = 0;
+
+        while (index < text.Length) {
+            while (index < text.Length && (text[index] == ',' || char.IsWhiteSpace(text[index]))) {
+                index++;
+            }
+
+            var nameStart = index;
+
+            while (index < text.Length && text[index] != '=' && text[index] != ',') {
+                index++;
+            }
+
+            if (index == text.Length || text[index] != '=') {
+                yield break;
+            }
+
+            var name = text[nameStart..index].Trim();
+            string value;
+            index++;
+
+            if (index < text.Length && text[index] == '"') {
+                var builder = new StringBuilder();
+                index++;
+
+                while (index < text.Length && text[index] != '"') {
+                    if (text[index] == '\\' && index + 1 < text.Length) {
+                        index++;
+                    }
+
+                    builder.Append(text[index++]);
+                }
+
+                index++;
+                value = builder.ToString();
+            } else {
+                var valueStart = index;
+
+                while (index < text.Length && text[index] != ',') {
+                    index++;
+                }
+
+                value = text[valueStart..index].Trim();
+            }
+
+            yield return (name, value);
+        }
+    }
+
     private static string Format(
         string scheme, string? error, string? realm, IReadOnlyList<string> scope, string? description) {
         var builder = new StringBuilder(scheme);

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Accepted.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Accepted.cs
@@ -22,9 +22,11 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(202)]
 public sealed record Accepted(string? Location = null)
-    : IHttpStatusResponse, IProvidesResponseHeaders {
+    : IHttpStatusResponse, IProvidesResponseHeaders, IResponseExpectation<Accepted> {
 
-    public int Status => 202;
+    public static int StatusCode => 202;
+
+    public int Status => StatusCode;
 
     public bool HasBody => false;
 
@@ -33,4 +35,8 @@ public sealed record Accepted(string? Location = null)
             headers[KnownHeaders.Location] = Location!;
         }
     }
+
+    public static Accepted FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.OptionalHeader(headers, KnownHeaders.Location));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadGateway.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadGateway.cs
@@ -16,11 +16,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(502)]
-public sealed record BadGateway(string? Detail = null) : IHttpStatusResponse {
+public sealed record BadGateway(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.BadGateway;
 
     public string Title => "Bad Gateway";
 
-    public int Status => 502;
+    public static int StatusCode => 502;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadGatewayOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadGatewayOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(502)]
 public sealed record BadGateway<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<BadGateway<T>> {
 
     public string Type => ProblemTypes.BadGateway;
 
     public string Title => "Bad Gateway";
 
-    public int Status => 502;
+    public static int StatusCode => 502;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static BadGateway<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadRequest.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadRequest.cs
@@ -18,11 +18,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(400)]
-public sealed record BadRequest(string? Detail = null) : IHttpStatusResponse {
+public sealed record BadRequest(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.BadRequest;
 
     public string Title => "Bad Request";
 
-    public int Status => 400;
+    public static int StatusCode => 400;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadRequestOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadRequestOfT.cs
@@ -17,13 +17,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(400)]
 public sealed record BadRequest<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<BadRequest<T>> {
 
     public string Type => ProblemTypes.BadRequest;
 
     public string Title => "Bad Request";
 
-    public int Status => 400;
+    public static int StatusCode => 400;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static BadRequest<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Conflict.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Conflict.cs
@@ -9,11 +9,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// unchanged is reasonable once the caller has re-read the resource, and is not otherwise.
 /// </remarks>
 [HttpStatus(409)]
-public sealed record Conflict(string? Detail = null) : IHttpStatusResponse {
+public sealed record Conflict(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.Conflict;
 
     public string Title => "Conflict";
 
-    public int Status => 409;
+    public static int StatusCode => 409;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ConflictOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ConflictOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(409)]
 public sealed record Conflict<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<Conflict<T>> {
 
     public string Type => ProblemTypes.Conflict;
 
     public string Title => "Conflict";
 
-    public int Status => 409;
+    public static int StatusCode => 409;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static Conflict<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ContentTooLarge.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ContentTooLarge.cs
@@ -16,11 +16,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(413)]
-public sealed record ContentTooLarge(string? Detail = null) : IHttpStatusResponse {
+public sealed record ContentTooLarge(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.ContentTooLarge;
 
     public string Title => "Content Too Large";
 
-    public int Status => 413;
+    public static int StatusCode => 413;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ContentTooLargeOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ContentTooLargeOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(413)]
 public sealed record ContentTooLarge<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<ContentTooLarge<T>> {
 
     public string Type => ProblemTypes.ContentTooLarge;
 
     public string Title => "Content Too Large";
 
-    public int Status => 413;
+    public static int StatusCode => 413;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static ContentTooLarge<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Created.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Created.cs
@@ -27,13 +27,21 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(201)]
 public sealed record Created<T>(T Value, string Location)
-    : IHttpStatusResponse, IProvidesResponseHeaders, ICarriesResponseBody {
+    : IHttpStatusResponse, IProvidesResponseHeaders, ICarriesResponseBody,
+        IResponseExpectation<Created<T>> {
 
-    public int Status => 201;
+    public static int StatusCode => 201;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Value;
 
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         headers[KnownHeaders.Location] = Location;
     }
+
+    public static Created<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body),
+            ResponseExpectation.RequiredHeader(headers, KnownHeaders.Location));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Forbidden.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Forbidden.cs
@@ -11,11 +11,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// made.
 /// </remarks>
 [HttpStatus(403)]
-public sealed record Forbidden(string? Detail = null) : IHttpStatusResponse {
+public sealed record Forbidden(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.Forbidden;
 
     public string Title => "Forbidden";
 
-    public int Status => 403;
+    public static int StatusCode => 403;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ForbiddenOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ForbiddenOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(403)]
 public sealed record Forbidden<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<Forbidden<T>> {
 
     public string Type => ProblemTypes.Forbidden;
 
     public string Title => "Forbidden";
 
-    public int Status => 403;
+    public static int StatusCode => 403;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static Forbidden<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/GatewayTimeout.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/GatewayTimeout.cs
@@ -16,11 +16,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(504)]
-public sealed record GatewayTimeout(string? Detail = null) : IHttpStatusResponse {
+public sealed record GatewayTimeout(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.GatewayTimeout;
 
     public string Title => "Gateway Timeout";
 
-    public int Status => 504;
+    public static int StatusCode => 504;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/GatewayTimeoutOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/GatewayTimeoutOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(504)]
 public sealed record GatewayTimeout<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<GatewayTimeout<T>> {
 
     public string Type => ProblemTypes.GatewayTimeout;
 
     public string Title => "Gateway Timeout";
 
-    public int Status => 504;
+    public static int StatusCode => 504;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static GatewayTimeout<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Gone.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Gone.cs
@@ -9,11 +9,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// the reference. Caches and crawlers act on the difference.
 /// </remarks>
 [HttpStatus(410)]
-public sealed record Gone(string? Detail = null) : IHttpStatusResponse {
+public sealed record Gone(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.Gone;
 
     public string Title => "Gone";
 
-    public int Status => 410;
+    public static int StatusCode => 410;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/GoneOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/GoneOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(410)]
 public sealed record Gone<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<Gone<T>> {
 
     public string Type => ProblemTypes.Gone;
 
     public string Title => "Gone";
 
-    public int Status => 410;
+    public static int StatusCode => 410;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static Gone<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/IDeclaresStatus.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/IDeclaresStatus.cs
@@ -1,0 +1,35 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// The status a response type answers with, available from the type rather than from an instance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three readers ask a response type for its status, and each can only reach one of the three
+/// answers. The generator reads <see cref="HttpStatusAttribute"/> at compile time. The pipeline
+/// reads <see cref="IHttpStatusResponse.Status"/> off an instance. A test has neither: the client
+/// throws its own model or hands back an envelope, so there is no instance of this type to read and
+/// no compilation of the handler to inspect.
+/// </para>
+/// <para>
+/// This is that third answer, and it also makes the other two agree by construction - each record
+/// now reads <c>Status =&gt; StatusCode</c>, so there is one literal per type where there were two.
+/// </para>
+/// <para>
+/// Distinct from <see cref="IStatusCode"/>, which names a status that has no record of its own:
+/// there the type <i>is</i> the status, here the type is a response that has one. They cannot be
+/// the same interface, because a response already carries an instance <c>Status</c> and a type
+/// cannot declare a static and an instance member under one name.
+/// </para>
+/// <para>
+/// A separate interface rather than a member on <see cref="IHttpStatusResponse"/>, because a static
+/// abstract added there would break every implementation already compiled against it, an
+/// application's own response types included. Opting in costs one line and nothing breaks by
+/// standing still.
+/// </para>
+/// </remarks>
+public interface IDeclaresStatus {
+
+    /// <summary>The status, the same one <see cref="HttpStatusAttribute"/> declares.</summary>
+    static abstract int StatusCode { get; }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/IResponseExpectation.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/IResponseExpectation.cs
@@ -1,0 +1,48 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// A response type that can be rebuilt from what came back over the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For a test asserting through a generated client. The client hands back a status, a body and a
+/// set of headers in whatever shape its generator chose - a thrown model for Kiota, a returned
+/// envelope for Refit - and this turns those three into the response type the contract names, so
+/// the assertion reads in the same vocabulary the handler and the document already use.
+/// </para>
+/// <para>
+/// <b>The headers are passed because several of these carry one.</b> A 201 has its
+/// <c>Location</c>, a 429 its <c>Retry-After</c>, a 401 its challenge. Each type reads the headers
+/// that are its own, which is knowledge that would otherwise live in a test helper as
+/// parameter-name matching: stringly typed, written once per client library, and silently wrong the
+/// day a record's parameter is renamed.
+/// </para>
+/// <para>
+/// <b>Not every response type is an expectation.</b> A non-generic error record states something
+/// the handler knew and the wire does not carry back in any recoverable form -
+/// <see cref="NotFound.Resource"/> names what was looked for, <see cref="Conflict.Detail"/> the
+/// message. Those implement <see cref="IDeclaresStatus"/> alone, so naming one as an expectation is
+/// a compile error that points at the generic form, which is the one that says what body to expect.
+/// </para>
+/// <para>
+/// This is a test-time interface. Nothing in the request pipeline calls
+/// <see cref="FromResponse"/>; a handler still constructs these directly.
+/// </para>
+/// </remarks>
+/// <typeparam name="TSelf">The implementing type, so the factory can return it.</typeparam>
+public interface IResponseExpectation<TSelf> : IDeclaresStatus where TSelf : IResponseExpectation<TSelf> {
+
+    /// <summary>
+    /// The response type, from the body the client deserialised and the headers it received.
+    /// </summary>
+    /// <param name="body">
+    /// The deserialised body, or null where the status carries none. A type that declares a body
+    /// throws rather than accept null, because a declared body that did not arrive is the defect
+    /// the assertion exists to find.
+    /// </param>
+    /// <param name="headers">
+    /// The response headers. Looked up without regard to case whatever comparer the caller's
+    /// dictionary uses.
+    /// </param>
+    static abstract TSelf FromResponse(object? body, IReadOnlyDictionary<string, string> headers);
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/InternalServerError.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/InternalServerError.cs
@@ -18,11 +18,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(500)]
-public sealed record InternalServerError(string? Detail = null) : IHttpStatusResponse {
+public sealed record InternalServerError(string? Detail = null)
+    : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.InternalServerError;
 
     public string Title => "Internal Server Error";
 
-    public int Status => 500;
+    public static int StatusCode => 500;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/InternalServerErrorOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/InternalServerErrorOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(500)]
 public sealed record InternalServerError<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<InternalServerError<T>> {
 
     public string Type => ProblemTypes.InternalServerError;
 
     public string Title => "Internal Server Error";
 
-    public int Status => 500;
+    public static int StatusCode => 500;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static InternalServerError<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/MethodNotAllowed.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/MethodNotAllowed.cs
@@ -22,13 +22,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(405)]
 public sealed record MethodNotAllowed(string Allow)
-    : IHttpStatusResponse, IProvidesResponseHeaders {
+    : IHttpStatusResponse, IProvidesResponseHeaders, IResponseExpectation<MethodNotAllowed> {
 
-    public int Status => 405;
+    public static int StatusCode => 405;
+
+    public int Status => StatusCode;
 
     public bool HasBody => false;
 
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         headers[KnownHeaders.Allow] = Allow;
     }
+
+    public static MethodNotAllowed FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.RequiredHeader(headers, KnownHeaders.Allow));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/MethodNotAllowedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/MethodNotAllowedOfT.cs
@@ -25,13 +25,21 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(405)]
 public sealed record MethodNotAllowed<T>(T Body, string Allow)
-    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders {
+    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders,
+        IResponseExpectation<MethodNotAllowed<T>> {
 
-    public int Status => 405;
+    public static int StatusCode => 405;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
 
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         headers[KnownHeaders.Allow] = Allow;
     }
+
+    public static MethodNotAllowed<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body),
+            ResponseExpectation.RequiredHeader(headers, KnownHeaders.Allow));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NoContent.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NoContent.cs
@@ -17,9 +17,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(204)]
-public sealed record NoContent : IHttpStatusResponse {
+public sealed record NoContent : IHttpStatusResponse, IResponseExpectation<NoContent> {
 
-    public int Status => 204;
+    public static int StatusCode => 204;
+
+    public int Status => StatusCode;
 
     public bool HasBody => false;
+
+    public static NoContent FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) => new();
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotAcceptable.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotAcceptable.cs
@@ -18,9 +18,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(406)]
-public sealed record NotAcceptable : IHttpStatusResponse {
+public sealed record NotAcceptable : IHttpStatusResponse, IResponseExpectation<NotAcceptable> {
 
-    public int Status => 406;
+    public static int StatusCode => 406;
+
+    public int Status => StatusCode;
 
     public bool HasBody => false;
+
+    public static NotAcceptable FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) => new();
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotFound.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotFound.cs
@@ -19,11 +19,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(404)]
-public sealed record NotFound(string Resource, string? Detail = null) : IHttpStatusResponse {
+public sealed record NotFound(string Resource, string? Detail = null)
+    : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.NotFound;
 
     public string Title => "Not Found";
 
-    public int Status => 404;
+    public static int StatusCode => 404;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotFoundOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotFoundOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(404)]
 public sealed record NotFound<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<NotFound<T>> {
 
     public string Type => ProblemTypes.NotFound;
 
     public string Title => "Not Found";
 
-    public int Status => 404;
+    public static int StatusCode => 404;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static NotFound<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotImplemented.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotImplemented.cs
@@ -15,11 +15,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(501)]
-public sealed record NotImplemented(string? Detail = null) : IHttpStatusResponse {
+public sealed record NotImplemented(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.NotImplemented;
 
     public string Title => "Not Implemented";
 
-    public int Status => 501;
+    public static int StatusCode => 501;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotImplementedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotImplementedOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(501)]
 public sealed record NotImplemented<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<NotImplemented<T>> {
 
     public string Type => ProblemTypes.NotImplemented;
 
     public string Title => "Not Implemented";
 
-    public int Status => 501;
+    public static int StatusCode => 501;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static NotImplemented<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotModified.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotModified.cs
@@ -23,9 +23,11 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(304)]
 public sealed record NotModified(string? ETag = null)
-    : IHttpStatusResponse, IProvidesResponseHeaders {
+    : IHttpStatusResponse, IProvidesResponseHeaders, IResponseExpectation<NotModified> {
 
-    public int Status => 304;
+    public static int StatusCode => 304;
+
+    public int Status => StatusCode;
 
     public bool HasBody => false;
 
@@ -34,4 +36,8 @@ public sealed record NotModified(string? ETag = null)
             headers[KnownHeaders.ETag] = ETag!;
         }
     }
+
+    public static NotModified FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.OptionalHeader(headers, KnownHeaders.ETag));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/OkOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/OkOfT.cs
@@ -33,7 +33,8 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(200)]
 public sealed record Ok<T>(T Value, IReadOnlyDictionary<string, string>? Headers = null)
-    : IHttpStatusResponse, IProvidesResponseHeaders, ICarriesResponseBody {
+    : IHttpStatusResponse, IProvidesResponseHeaders, ICarriesResponseBody,
+        IResponseExpectation<Ok<T>> {
 
     /// <summary>
     /// A 200 carrying one header, which is the common case - an <c>ETag</c>.
@@ -41,7 +42,9 @@ public sealed record Ok<T>(T Value, IReadOnlyDictionary<string, string>? Headers
     public Ok(T value, string headerName, string headerValue)
         : this(value, new Dictionary<string, string> { [headerName] = headerValue }) { }
 
-    public int Status => 200;
+    public static int StatusCode => 200;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Value;
 
@@ -54,4 +57,11 @@ public sealed record Ok<T>(T Value, IReadOnlyDictionary<string, string>? Headers
             headers[header.Key] = header.Value;
         }
     }
+
+    // Every response header, not only the ones this record was constructed with: the read side
+    // cannot tell a header a handler added from one the pipeline did, and a test asking for one
+    // wants it either way.
+    public static Ok<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body), headers);
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PaymentRequired.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PaymentRequired.cs
@@ -16,11 +16,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(402)]
-public sealed record PaymentRequired(string? Detail = null) : IHttpStatusResponse {
+public sealed record PaymentRequired(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.PaymentRequired;
 
     public string Title => "Payment Required";
 
-    public int Status => 402;
+    public static int StatusCode => 402;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PaymentRequiredOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PaymentRequiredOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(402)]
 public sealed record PaymentRequired<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<PaymentRequired<T>> {
 
     public string Type => ProblemTypes.PaymentRequired;
 
     public string Title => "Payment Required";
 
-    public int Status => 402;
+    public static int StatusCode => 402;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static PaymentRequired<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailed.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailed.cs
@@ -10,11 +10,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// its validator is stale, and that is the one thing 412 means.
 /// </remarks>
 [HttpStatus(412)]
-public sealed record PreconditionFailed(string? Detail = null) : IHttpStatusResponse {
+public sealed record PreconditionFailed(string? Detail = null)
+    : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.PreconditionFailed;
 
     public string Title => "Precondition Failed";
 
-    public int Status => 412;
+    public static int StatusCode => 412;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailedOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(412)]
 public sealed record PreconditionFailed<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<PreconditionFailed<T>> {
 
     public string Type => ProblemTypes.PreconditionFailed;
 
     public string Title => "Precondition Failed";
 
-    public int Status => 412;
+    public static int StatusCode => 412;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static PreconditionFailed<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequired.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequired.cs
@@ -17,11 +17,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(428)]
-public sealed record PreconditionRequired(string? Detail = null) : IHttpStatusResponse {
+public sealed record PreconditionRequired(string? Detail = null)
+    : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.PreconditionRequired;
 
     public string Title => "Precondition Required";
 
-    public int Status => 428;
+    public static int StatusCode => 428;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequiredOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequiredOfT.cs
@@ -11,13 +11,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(428)]
 public sealed record PreconditionRequired<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<PreconditionRequired<T>> {
 
     public string Type => ProblemTypes.PreconditionRequired;
 
     public string Title => "Precondition Required";
 
-    public int Status => 428;
+    public static int StatusCode => 428;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static PreconditionRequired<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/RateLimited.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/RateLimited.cs
@@ -21,13 +21,15 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(429)]
 public sealed record RateLimited(TimeSpan RetryAfter, string? Detail = null)
-    : IHttpStatusResponse, IProvidesResponseHeaders {
+    : IHttpStatusResponse, IProvidesResponseHeaders, IDeclaresStatus {
 
     public string Type => ProblemTypes.RateLimited;
 
     public string Title => "Too Many Requests";
 
-    public int Status => 429;
+    public static int StatusCode => 429;
+
+    public int Status => StatusCode;
 
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         headers[KnownHeaders.RetryAfter] = Responses.RetryAfter.HeaderValue(RetryAfter);

--- a/src/Requests/Hardened.Requests.Abstract/Responses/RateLimitedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/RateLimitedOfT.cs
@@ -26,16 +26,23 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(429)]
 public sealed record RateLimited<T>(TimeSpan RetryAfter, T Body)
-    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders {
+    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders,
+        IResponseExpectation<RateLimited<T>> {
 
     public string Type => ProblemTypes.RateLimited;
 
     public string Title => "Too Many Requests";
 
-    public int Status => 429;
+    public static int StatusCode => 429;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         headers[KnownHeaders.RetryAfter] = Responses.RetryAfter.HeaderValue(RetryAfter);
     }
+
+    public static RateLimited<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.RequiredRetryAfter(headers), ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/RequestTimeout.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/RequestTimeout.cs
@@ -17,11 +17,13 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(408)]
-public sealed record RequestTimeout(string? Detail = null) : IHttpStatusResponse {
+public sealed record RequestTimeout(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.RequestTimeout;
 
     public string Title => "Request Timeout";
 
-    public int Status => 408;
+    public static int StatusCode => 408;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/RequestTimeoutOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/RequestTimeoutOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(408)]
 public sealed record RequestTimeout<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<RequestTimeout<T>> {
 
     public string Type => ProblemTypes.RequestTimeout;
 
     public string Title => "Request Timeout";
 
-    public int Status => 408;
+    public static int StatusCode => 408;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static RequestTimeout<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ResponseExpectation.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ResponseExpectation.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+using Hardened.Requests.Abstract.Headers;
+
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// What an <see cref="IResponseExpectation{TSelf}"/> implementation reads a body and a header with.
+/// </summary>
+/// <remarks>
+/// The messages are the point. Each of these fails for a reason a test author can act on without
+/// opening the client's generated code, and having them in one place keeps that wording the same
+/// across every response type and every client library reading them.
+/// </remarks>
+public static class ResponseExpectation {
+
+    /// <summary>The body, as the type the response declares it to be.</summary>
+    /// <exception cref="InvalidOperationException">
+    /// The response carried no body, or carried one of another type.
+    /// </exception>
+    public static T Body<T>(object? body) => body switch {
+        T typed => typed,
+        null => throw new InvalidOperationException(
+            $"The response declares a body of {typeof(T).Name} and carried none."),
+        _ => throw new InvalidOperationException(
+            $"The response declares a body of {typeof(T).Name} and carried " +
+            $"{body.GetType().Name}. The client deserialised this status into a different model " +
+            "than the one the expectation names."),
+    };
+
+    /// <summary>A header the status is required to carry.</summary>
+    /// <exception cref="InvalidOperationException">The header was not present.</exception>
+    public static string RequiredHeader(IReadOnlyDictionary<string, string> headers, string name) {
+        ArgumentNullException.ThrowIfNull(headers);
+
+        return OptionalHeader(headers, name) ?? throw new InvalidOperationException(
+            $"The response declares a {name} header and carried none. Present: " +
+            (headers.Count == 0 ? "nothing" : string.Join(", ", headers.Keys)) + ".");
+    }
+
+    /// <summary>A header the status may carry, or null.</summary>
+    public static string? OptionalHeader(IReadOnlyDictionary<string, string> headers, string name) {
+        ArgumentNullException.ThrowIfNull(headers);
+
+        if (headers.TryGetValue(name, out var value)) {
+            return value;
+        }
+
+        // The caller's dictionary need not be case-insensitive, and header names on the wire are
+        // not. A client that reports "location" would otherwise read as one that sent no header.
+        foreach (var header in headers) {
+            if (string.Equals(header.Key, name, StringComparison.OrdinalIgnoreCase)) {
+                return header.Value;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>The Retry-After delay, which the status is required to carry.</summary>
+    /// <exception cref="InvalidOperationException">
+    /// The header was not present, or was not a whole number of seconds.
+    /// </exception>
+    public static TimeSpan RequiredRetryAfter(IReadOnlyDictionary<string, string> headers) =>
+        Seconds(RequiredHeader(headers, KnownHeaders.RetryAfter));
+
+    /// <summary>The Retry-After delay if the response carried one, or null.</summary>
+    /// <exception cref="InvalidOperationException">
+    /// The header was present and was not a whole number of seconds.
+    /// </exception>
+    public static TimeSpan? OptionalRetryAfter(IReadOnlyDictionary<string, string> headers) =>
+        OptionalHeader(headers, KnownHeaders.RetryAfter) is { } value ? Seconds(value) : null;
+
+    // Seconds only, which is what RetryAfter writes. The HTTP-date form is legal and is not read
+    // back here, because turning one into a TimeSpan needs a clock and would make two runs of the
+    // same assertion disagree.
+    private static TimeSpan Seconds(string value) =>
+        int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds)
+            ? TimeSpan.FromSeconds(seconds)
+            : throw new InvalidOperationException(
+                $"The {KnownHeaders.RetryAfter} header read \"{value}\", which is not a number of " +
+                "seconds. Only the delta-seconds form is read back.");
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailable.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailable.cs
@@ -22,13 +22,15 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(503)]
 public sealed record ServiceUnavailable(TimeSpan? After = null, string? Detail = null)
-    : IHttpStatusResponse, IProvidesResponseHeaders {
+    : IHttpStatusResponse, IProvidesResponseHeaders, IDeclaresStatus {
 
     public string Type => ProblemTypes.ServiceUnavailable;
 
     public string Title => "Service Unavailable";
 
-    public int Status => 503;
+    public static int StatusCode => 503;
+
+    public int Status => StatusCode;
 
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         if (After is { } after) {

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailableOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailableOfT.cs
@@ -26,13 +26,16 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(503)]
 public sealed record ServiceUnavailable<T>(T Body, TimeSpan? After = null)
-    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders {
+    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders,
+        IResponseExpectation<ServiceUnavailable<T>> {
 
     public string Type => ProblemTypes.ServiceUnavailable;
 
     public string Title => "Service Unavailable";
 
-    public int Status => 503;
+    public static int StatusCode => 503;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
@@ -40,4 +43,8 @@ public sealed record ServiceUnavailable<T>(T Body, TimeSpan? After = null)
             headers[KnownHeaders.RetryAfter] = RetryAfter.HeaderValue(after);
         }
     }
+
+    public static ServiceUnavailable<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body), ResponseExpectation.OptionalRetryAfter(headers));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/StatusOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/StatusOfT.cs
@@ -32,12 +32,18 @@ namespace Hardened.Requests.Abstract.Responses;
 /// <typeparam name="TCode">The status, as a marker type. See <see cref="Http"/>.</typeparam>
 /// <typeparam name="TBody">What the response carries.</typeparam>
 public sealed record Status<TCode, TBody>(TBody Body)
-    : IHttpStatusResponse, ICarriesResponseBody
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<Status<TCode, TBody>>
     where TCode : IStatusCode {
 
-    int IHttpStatusResponse.Status => TCode.Status;
+    public static int StatusCode => TCode.Status;
+
+    int IHttpStatusResponse.Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static Status<TCode, TBody> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<TBody>(body));
 }
 
 /// <summary>
@@ -54,10 +60,15 @@ public sealed record Status<TCode, TBody>(TBody Body)
 /// </para>
 /// </remarks>
 /// <typeparam name="TCode">The status, as a marker type. See <see cref="Http"/>.</typeparam>
-public sealed record Status<TCode> : IHttpStatusResponse
+public sealed record Status<TCode> : IHttpStatusResponse, IResponseExpectation<Status<TCode>>
     where TCode : IStatusCode {
 
-    int IHttpStatusResponse.Status => TCode.Status;
+    public static int StatusCode => TCode.Status;
+
+    int IHttpStatusResponse.Status => StatusCode;
 
     public bool HasBody => false;
+
+    public static Status<TCode> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) => new();
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Unauthorized.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Unauthorized.cs
@@ -24,13 +24,15 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(401)]
 public sealed record Unauthorized(string? Detail = null, AuthorizationChallenge? Challenge = null)
-    : IHttpStatusResponse, IProvidesResponseHeaders {
+    : IHttpStatusResponse, IProvidesResponseHeaders, IDeclaresStatus {
 
     public string Type => ProblemTypes.Unauthorized;
 
     public string Title => "Unauthorized";
 
-    public int Status => 401;
+    public static int StatusCode => 401;
+
+    public int Status => StatusCode;
 
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
         var challenge = Challenge ?? AuthorizationChallenge.AuthenticationRequired();

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnauthorizedOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnauthorizedOfT.cs
@@ -26,13 +26,16 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(401)]
 public sealed record Unauthorized<T>(T Body, AuthorizationChallenge? Challenge = null)
-    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders {
+    : IHttpStatusResponse, ICarriesResponseBody, IProvidesResponseHeaders,
+        IResponseExpectation<Unauthorized<T>> {
 
     public string Type => ProblemTypes.Unauthorized;
 
     public string Title => "Unauthorized";
 
-    public int Status => 401;
+    public static int StatusCode => 401;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
     public void ApplyHeaders(IDictionary<string, StringValues> headers) {
@@ -40,4 +43,10 @@ public sealed record Unauthorized<T>(T Body, AuthorizationChallenge? Challenge =
 
         headers[AuthorizationChallenge.HeaderName] = challenge.HeaderValue;
     }
+
+    public static Unauthorized<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body),
+            ResponseExpectation.OptionalHeader(headers, AuthorizationChallenge.HeaderName)
+                is { } challenge ? AuthorizationChallenge.Parse(challenge) : null);
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnprocessableContent.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnprocessableContent.cs
@@ -19,11 +19,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(422)]
-public sealed record UnprocessableContent(string? Detail = null) : IHttpStatusResponse {
+public sealed record UnprocessableContent(string? Detail = null)
+    : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.UnprocessableContent;
 
     public string Title => "Unprocessable Content";
 
-    public int Status => 422;
+    public static int StatusCode => 422;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnprocessableContentOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnprocessableContentOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(422)]
 public sealed record UnprocessableContent<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<UnprocessableContent<T>> {
 
     public string Type => ProblemTypes.UnprocessableContent;
 
     public string Title => "Unprocessable Content";
 
-    public int Status => 422;
+    public static int StatusCode => 422;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static UnprocessableContent<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnsupportedMediaType.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnsupportedMediaType.cs
@@ -16,11 +16,14 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </para>
 /// </remarks>
 [HttpStatus(415)]
-public sealed record UnsupportedMediaType(string? Detail = null) : IHttpStatusResponse {
+public sealed record UnsupportedMediaType(string? Detail = null)
+    : IHttpStatusResponse, IDeclaresStatus {
 
     public string Type => ProblemTypes.UnsupportedMediaType;
 
     public string Title => "Unsupported Media Type";
 
-    public int Status => 415;
+    public static int StatusCode => 415;
+
+    public int Status => StatusCode;
 }

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnsupportedMediaTypeOfT.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnsupportedMediaTypeOfT.cs
@@ -23,13 +23,19 @@ namespace Hardened.Requests.Abstract.Responses;
 /// </remarks>
 [HttpStatus(415)]
 public sealed record UnsupportedMediaType<T>(T Body)
-    : IHttpStatusResponse, ICarriesResponseBody {
+    : IHttpStatusResponse, ICarriesResponseBody, IResponseExpectation<UnsupportedMediaType<T>> {
 
     public string Type => ProblemTypes.UnsupportedMediaType;
 
     public string Title => "Unsupported Media Type";
 
-    public int Status => 415;
+    public static int StatusCode => 415;
+
+    public int Status => StatusCode;
 
     object? ICarriesResponseBody.Body => Body;
+
+    public static UnsupportedMediaType<T> FromResponse(
+        object? body, IReadOnlyDictionary<string, string> headers) =>
+        new(ResponseExpectation.Body<T>(body));
 }


### PR DESCRIPTION
Groundwork for the client testing libraries. Two interfaces on `Hardened.Requests.Abstract.Responses`, implemented across all 46 built-in response records.

## `IDeclaresStatus`

```csharp
public interface IDeclaresStatus {
    static abstract int StatusCode { get; }
}
```

Three readers ask a response type for its status and each can only reach one answer. The generator reads `[HttpStatus]` at compile time. The pipeline reads `IHttpStatusResponse.Status` off an instance. A test has neither — the client throws its own model or hands back an envelope, so there is no instance to read and no compilation of the handler to inspect. This is the third answer, and it also makes the other two agree by construction: every record now reads `Status => StatusCode`, so there is one literal per type where there were two.

Separate from `IHttpStatusResponse` because a `static abstract` added there would break every implementation already compiled against it, an application's own response types included. Separate from `IStatusCode`, which names a status that has no record of its own, because a response already carries an instance `Status` and a type cannot declare a static and an instance member under one name.

## `IResponseExpectation<TSelf>`

```csharp
static abstract TSelf FromResponse(object? body, IReadOnlyDictionary<string, string> headers);
```

Turns what came back over the wire into the response type the contract names, which is what `Returns<NotFound<Problem>>()` needs. The headers are passed because several of these carry one — 201 its `Location`, 429 its `Retry-After`, 401 its challenge. Each type reads the headers that are its own; the alternative is that knowledge living in a test helper as parameter-name matching, written once per client library and silently wrong the day a record's parameter is renamed.

27 types implement it: the generic body-carrying forms, the bodyless ones, `MethodNotAllowed`, and both arities of `Status<TCode, …>`.

**19 do not, deliberately.** A non-generic error record states something the handler knew and the wire does not carry back in any recoverable form — `NotFound(string Resource)` names what was looked for, `Conflict(string? Detail)` the message. Naming one as an expectation is a compile error that points at the generic form, which is the one that says what body to expect. `AResponseStatingWhatTheWireDoesNotCarry_IsNotAnExpectation` pins that.

## Also here

`ResponseExpectation` holds the body cast and the header lookups, so the failure messages are the same across every response type and every client library reading them. Header lookup is case-insensitive whatever comparer the caller's dictionary uses, because a client reporting `location` is not reporting a different header. `Retry-After` reads the delta-seconds form only; the HTTP-date form needs a clock and would make two runs of the same assertion disagree, so it is refused by name.

`AuthorizationChallenge.Parse` is the other direction of `HeaderValue`. Without it `Unauthorized<T>.FromResponse` would have to return the challenge as null on a response that carried one.

## Testing

`FromResponse` is header names and a body cast, and both are wrong silently — a record that writes `Location` and reads `location` compiles. So the sweep writes each response through its own `ApplyHeaders` and reads it back through its own `FromResponse`, naming no header, which is what makes it hold for a response type added later. The reflection tests in `BuiltInResponseTypeTests` cover `IDeclaresStatus` on all 46 and `IResponseExpectation` on every generic form, so a type added later is covered without anyone remembering to add it.

Every challenge `AuthorizationChallenge` can produce is round-tripped through its own header, so a parameter added to `Format` and not to the parser fails there.

## Checks

- 870 tests in `Hardened.Requests.Abstract.Tests`, 33 assemblies green across the solution.
- `ContinuousIntegrationBuild=true` Release build clean.
- Public API re-approved. The diff is additive: 48 `StatusCode` getters, 27 `FromResponse` methods, the three new types, and `Parse`. Nothing was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)