### PR TITLE
Close the defects the 0.20.0-rc1000 trial found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ unmeasured rather than untested.
 ## Releasing
 
 A `v*` tag drives `release.yaml`, and the tag is the source of truth for the version. The current
-line is `0.17.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
+line is `0.20.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
 
 **The pack list in `release.yaml` is hand-maintained and has drifted four times.** A new packable
 project has to be added to it *and* to `EXPECTED`, which is a literal on purpose. Adding it to the

--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -138,13 +138,16 @@ makes it the body parameter, and the build fails as a `CS7036` inside `obj/**/ge
 file the author did not write, naming neither the convention that decided this nor the parameter
 whose meaning changed.
 
-Reported narrowly, because the two shapes are otherwise indistinguishable: a body model is a
-concrete class too. What separates them is that the deserializer cannot construct an interface, so
-a type whose every public constructor takes one has no reading as a body at all. A body model with
-a parameterless constructor, and an immutable one whose constructor takes its own data, are left
-alone — as is a service the deserializer could construct, which arrives empty instead. Both fixes
-in the message work; `[FromServices]` is the one that does not require the service to have an
-interface.
+Reported on two signals, because the two shapes are otherwise indistinguishable: a body model is a
+concrete class too. The first is the constructor: the deserializer cannot construct an interface,
+so a type whose every public constructor takes one has no reading as a body at all. The second is
+the registration: a type carrying `[SingletonService]`, `[ScopedService]` or `[TransientService]`
+is a service whatever its constructors take, and a body model never carries one. The 0.20 trial's
+`TodoStore` - parameterless, and registered - passed the first test and was caught by neither; it
+bound from the body, answered 400 on every request and published a request body on a GET. A body
+model with a parameterless constructor, and an immutable one whose constructor takes its own data,
+are left alone. Both fixes in the message work; `[FromServices]` is the one that does not require
+the service to have an interface.
 
 ### HRDR008 — more than one routing generator is compiling this assembly
 
@@ -163,9 +166,46 @@ the reference says PrivateAssets="all". Add it to the one that brought the secon
 
 The same marker HRDR006 reads for absence answers this one by being declared twice — it is
 `partial` so that the second declaration merges rather than raising a `CS0101` that says nothing
-about why there are two. The generators are named from the paths Roslyn gives generated files,
-which start with the generator's assembly, because the fix is on whichever reference brought the
-second one rather than anywhere in the code.
+about why there are two. The generators are named from the paths Roslyn gives generated files -
+`<base>/<generator assembly>/<generator type>/<hint name>` - because the fix is on whichever
+reference brought the second one rather than anywhere in the code. The assembly is the third
+segment from the end: with `EmitCompilerGeneratedFiles` on, which the templates turn on, the base
+is an absolute directory, and reading the first segment made both generators `Users` and reported
+nothing, which is how this sat silent through the 0.20 trial.
+
+### HRDR009 — more than one parameter binds from the request body
+
+Two parameters that name no route token and are not interfaces, on one handler.
+
+```
+'EventController.Handle' reads 'counter' and 'reading' from the request body, and a request
+carries one body. A parameter that names no route token and is not an interface binds from the
+body: mark a service [FromServices] or type it as the interface it is registered against, and
+bind a value with [FromQueryString], [FromHeader], [FromForm] or a route token.
+```
+
+A request carries one body, so the second parameter was dropped from the generated invocation, and
+the build failed as a `CS7036` inside `obj/**/generated/**` naming neither the parameter nor the
+convention that discarded it. That `CS7036` still appears beside this; this is the line that says
+what it means. An error, with no `NoWarn`.
+
+### HRDR010 — parameter binds from the body of a request that carries none
+
+One body parameter on a `GET`, `HEAD`, `OPTIONS` or `TRACE` handler, where nothing else explains
+how it got there.
+
+```
+Parameter 'reading' of 'EventController.Handle' is read from the request body, and a GET carries
+none, so a request that sends no body is refused before the handler runs and the published
+document gives the operation a body it should not have. Bind 'reading' with [FromQueryString] or
+[FromHeader], mark it [FromServices] if it is a service, or suppress HRDR010 if this operation
+deliberately reads a body from a GET.
+```
+
+HRDR005 reports the parameter a route token displaced and HRDR007 the one that is a service; this
+is the remainder. A warning rather than an error, because a `GET` carrying a body is a thing some
+APIs deliberately do, and `<NoWarn>HRDR010</NoWarn>` is how they say so. `DELETE` is not treated
+as bodyless, for the reason HRDR005 gives.
 
 ## Validation
 
@@ -316,6 +356,38 @@ A **warning**, unlike the two above. The check reads the entry point's module at
 where `[HardenedMemoryResponseCache]` goes; a store registered by hand inside `ConfigureServices` is
 a legitimate arrangement and invisible to it. `<NoWarn>HRDW005</NoWarn>` if that is what you are
 doing.
+
+Asked of the application, which is the compilation whose entry point applies a web runtime -
+`[KestrelRuntime]`, `[AspNetCoreRuntime]` or `[LambdaWebModule]`. The template splits an
+application into a library that declares the handlers and a host that applies the runtime, and the
+store goes beside the runtime; asked of the library, this warned whatever the host registered. A
+library compilation now says nothing, and the host is handed the cached handlers of every module it
+imports, read from their metadata, so the report names a library's handlers from the host that
+forgot the store. Putting the store on the library module instead is also fine, and is what makes
+the store visible to a test project that boots the library - see `docs/response-caching.md`; a
+host importing such a library is told nothing, since the store arrives with the import.
+
+Reported by both routing tables. The described one never called the shared report, so a
+specification-first application whose `[Handler]` implementation declared `[CacheResponse]` was
+told nothing and found out from a request.
+
+## Timeouts
+
+### HRDW006 — `[Timeout]` declares no budget
+
+A `[Timeout]` reaching a handler - on the operation, its class or its assembly - whose
+`Milliseconds` is zero or less.
+
+```
+'RatesController.Read' is bounded by a [Timeout] declaring 0 milliseconds, on the operation, its
+class or its assembly. A budget has to be greater than zero; a handler that should not be bounded
+declares no timeout instead. The runtime refuses this on the first request, and the document would
+publish x-hardened-timeout: 0.
+```
+
+The runtime already refuses it, as the handler's chain is composed, naming the handler and the
+rung - but that is the first request, answered 500, and the document export runs ahead of it. An
+error, with no `NoWarn`: there is no reading of zero that means anything else.
 
 ## Other diagnostics
 

--- a/docs/response-caching.md
+++ b/docs/response-caching.md
@@ -27,6 +27,21 @@ module is `HRDW005`, a warning naming every handler that would fail. A store reg
 `ConfigureServices` is invisible to that check, so it is a warning rather than an error and
 `<NoWarn>HRDW005</NoWarn>` turns it off.
 
+The check is asked of the application: the compilation whose entry point applies a web runtime.
+In the layout the template scaffolds - a library that declares the handlers, a host that applies
+`[KestrelRuntime]` - the host is where the warning is reported, naming the library's handlers,
+because the host is where the store goes. The library itself is not asked, since it cannot see
+what its host registered. There is one reason to put the store on the library module anyway: the
+test harness boots the library, not the host, so a cached handler driven through `ITestWebApp`
+finds a store only if the library applies one.
+
+```csharp
+[HardenedModule]
+[HardenedWebModule]
+[HardenedMemoryResponseCache]      // the tests see this; the host would see one of its own
+public partial class TodosLibrary;
+```
+
 Past the build, a request to such a handler fails with `ResponseCacheStoreMissingException` naming
 the handler, the package to reference and the attribute to add. The attribute never silently does
 nothing.
@@ -245,8 +260,10 @@ The tag covers the bytes as sent. Behind the compression filter a gzip client an
 client hold different tags for one resource, as they do for a compressed static file, and each
 is revalidated against its own.
 
-Do not declare it on a handler returning `IAsyncEnumerable<T>`, for the reason given for the
-cache below: holding a stream back is buffering it.
+A handler returning `IAsyncEnumerable<T>` gets nothing from it, from the attribute or from
+`[Enable<ConditionalGet>]`: holding a stream back is buffering it, and an event stream enabled
+application-wide arrived as one packet after the last event, with an `ETag` on it, before the
+filter learned to stand down. `IExecutionRequestHandlerInfo.StreamsResponse` is what it reads.
 
 ### A handler's own validator
 
@@ -393,6 +410,7 @@ decides when the memory is freed, not what a request is answered with.
 
 Do not put `[CacheResponse]` on a handler returning `IAsyncEnumerable<T>`. Capturing a response
 means buffering it, and buffering a stream defeats the point of streaming it and holds the whole
-sequence in memory first. Nothing refuses this yet: whether a handler streams is decided by the
-generator picking `AsyncEnumerableIoFilter`, and it is not on
-`IExecutionRequestHandlerInfo`, so the filter cannot read it the way it reads `Requirement`.
+sequence in memory first. Nothing refuses this: it works, as a cache of the whole sequence, and a
+handler that wants exactly that can have it. The conditional-GET stage is the one that stands
+down, reading `IExecutionRequestHandlerInfo.StreamsResponse`, because a 304 buys nothing on a
+stream and the buffering it costs is the whole of what a stream exists to avoid.

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -1146,7 +1146,7 @@
           "Binding"
         ],
         "operationId": "queryList",
-        "summary": "A list query parameter, which is how OpenAPI's default array style arrives: ?symbols=EUR&amp;symbols=GBP. The joined form, ?symbols=EUR,GBP, is the same parameter written with explode: false and binds to the same list.",
+        "summary": "A list query parameter, which is how OpenAPI's default array style arrives: ?symbols=EUR&symbols=GBP. The joined form, ?symbols=EUR,GBP, is the same parameter written with explode: false and binds to the same list.",
         "parameters": [
           {
             "name": "symbols",
@@ -3388,7 +3388,7 @@
         ],
         "operationId": "registerDeclaring422",
         "summary": "The same model on an operation that says what a validation refusal answers.",
-        "description": "[Throws&lt;RequestValidationError&gt;(422)] puts the 422 in the published document, and the same declaration is what the runtime reads: one vocabulary carrying both, rather than an assertion on a verb attribute that the document would have to be told about separately. A specification-first operation declaring 422 has answered it since 0.18; this is how a hand-written one says the same thing.",
+        "description": "[Throws<RequestValidationError>(422)] puts the 422 in the published document, and the same declaration is what the runtime reads: one vocabulary carrying both, rather than an assertion on a verb attribute that the document would have to be told about separately. A specification-first operation declaring 422 has answered it since 0.18; this is how a hand-written one says the same thing.",
         "requestBody": {
           "required": true,
           "content": {
@@ -4995,7 +4995,7 @@
           "HttpMethod"
         ],
         "operationId": "createLocated",
-        "summary": "A 201 that says where the thing now lives, as a case in a response set rather than a status on the attribute: carries the Location beside the body, so a client can be held to having received both. The 400 is what makes it a set - code-first, the return type alone decides, and a lone Created&lt;T&gt; is an ordinary body at 200.",
+        "summary": "A 201 that says where the thing now lives, as a case in a response set rather than a status on the attribute: carries the Location beside the body, so a client can be held to having received both. The 400 is what makes it a set - code-first, the return type alone decides, and a lone Created<T> is an ordinary body at 200.",
         "requestBody": {
           "required": true,
           "content": {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -414,6 +414,7 @@ namespace Hardened.Requests.Abstract.Execution
         string Path { get; }
         System.Collections.Generic.IReadOnlyList<string> ProducedContentTypes { get; }
         Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; }
+        bool StreamsResponse { get; }
         int? SuccessStatus { get; }
         Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? Timeout { get; }
         int? ValidationErrorStatus { get; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -341,7 +341,7 @@ namespace Hardened.Requests.Runtime.Execution
     }
     public class ExecutionRequestHandlerInfo : Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo
     {
-        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null, Hardened.Requests.Abstract.Authorization.Requirement? requirement = null, int? successStatus = default, object? nullResponseBody = null, System.Collections.Generic.IReadOnlyList<string>? producedContentTypes = null, string? bodyParameterName = null, int? validationErrorStatus = default, Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? timeout = null) { }
+        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null, Hardened.Requests.Abstract.Authorization.Requirement? requirement = null, int? successStatus = default, object? nullResponseBody = null, System.Collections.Generic.IReadOnlyList<string>? producedContentTypes = null, string? bodyParameterName = null, int? validationErrorStatus = default, Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? timeout = null, bool streamsResponse = false) { }
         public string? BodyParameterName { get; }
         public System.Type HandlerType { get; }
         public string InvokeMethod { get; }
@@ -352,6 +352,7 @@ namespace Hardened.Requests.Runtime.Execution
         public string Path { get; }
         public System.Collections.Generic.IReadOnlyList<string> ProducedContentTypes { get; }
         public Hardened.Requests.Abstract.Authorization.Requirement? Requirement { get; }
+        public bool StreamsResponse { get; }
         public int? SuccessStatus { get; }
         public Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? Timeout { get; }
         public int? ValidationErrorStatus { get; }
@@ -635,8 +636,13 @@ namespace Hardened.Requests.Runtime.Logging
         protected void LogRequestFinished(string httpMethod, string path, int? statusCode, System.TimeSpan durationMs) { }
         [Microsoft.Extensions.Logging.LoggerMessage(EventId=78001, Level=Microsoft.Extensions.Logging.LogLevel.Information, Message="{httpMethod} {path} mapped to {typeName}.{methodName}")]
         protected void LogRequestMapped(string httpMethod, string path, string typeName, string methodName) { }
+        [Microsoft.Extensions.Logging.LoggerMessage(EventId=78004, Level=Microsoft.Extensions.Logging.LogLevel.Warning, Message="{httpMethod} {path} refused with {statusCode}: {reason}")]
+        protected void LogRequestRefused(string httpMethod, string path, int statusCode, string reason) { }
         [Microsoft.Extensions.Logging.LoggerMessage(EventId=78000, Level=Microsoft.Extensions.Logging.LogLevel.Information, Message="{httpMethod} {path} started")]
         protected void LogRequestStarted(string httpMethod, string path) { }
+        [Microsoft.Extensions.Logging.LoggerMessage(EventId=78005, Level=Microsoft.Extensions.Logging.LogLevel.Warning, Message="{httpMethod} {path} did not finish inside its {milliseconds} ms budget, answered " +
+            "{statusCode}")]
+        protected void LogRequestTimedOut(string httpMethod, string path, int milliseconds, int statusCode) { }
         [Microsoft.Extensions.Logging.LoggerMessage(EventId=78003, Level=Microsoft.Extensions.Logging.LogLevel.Information, Message="{httpMethod} {path} Resource Not Found")]
         protected void LogResourceNotFound(string httpMethod, string path) { }
         public void RequestBegin(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
@@ -877,7 +883,7 @@ namespace Hardened.Requests.Runtime.Serializer
         "stead.")]
     public class SystemTextJsonRequestDeserializer : Hardened.Requests.Abstract.Serializer.IRequestDeserializer
     {
-        public SystemTextJsonRequestDeserializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration, Microsoft.Extensions.Logging.ILogger<Hardened.Requests.Runtime.Serializer.SystemTextJsonRequestDeserializer> logger, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
+        public SystemTextJsonRequestDeserializer(Microsoft.Extensions.Options.IOptions<Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration> configuration, System.Collections.Generic.IEnumerable<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver> resolvers) { }
         public bool IsDefaultSerializer { get; }
         public bool CanProcessContext(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
         public System.Threading.Tasks.ValueTask<T?> DeserializeRequestBody<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
@@ -118,6 +118,26 @@ public interface IExecutionRequestHandlerInfo {
     IReadOnlyList<object> Metadata => Array.Empty<object>();
 
     /// <summary>
+    /// Whether the handler answers with a stream - an <c>IAsyncEnumerable&lt;T&gt;</c> written
+    /// item by item - rather than a value serialized once.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set by the generator from the return type, which is the only place the answer is known: at
+    /// run time the choice between the buffered and the streaming IO filter has already been
+    /// made, and nothing downstream can read it back. A filter that would buffer the response -
+    /// the conditional-GET stage holding a body back to hash it - reads this to stand down, because
+    /// holding a stream back is the one thing a stream exists not to have done to it.
+    /// </para>
+    /// <para>
+    /// A default rather than an abstract member, so an implementation compiled before it existed
+    /// keeps loading and reads as buffered, which is what every handler was before streaming had a
+    /// flag.
+    /// </para>
+    /// </remarks>
+    bool StreamsResponse => false;
+
+    /// <summary>
     /// What this handler requires of its caller, or null if nothing does.
     /// </summary>
     /// <remarks>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/AsyncEnumerableIoFilterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/AsyncEnumerableIoFilterTests.cs
@@ -609,4 +609,92 @@ public class AsyncEnumerableIoFilterTests {
     }
 
     #endregion
+
+    #region a body that refuses synchronous writes
+
+    private static string Rejecting(IExecutionContext context) =>
+        Encoding.UTF8.GetString(((SynchronousWritesRejectedStream)context.Response.Body).ToArray());
+
+    /// <summary>
+    /// Every byte a framing writes goes through <c>WriteAsync</c>. The transport behind a real host
+    /// refuses a synchronous write, and a framing that wrote its prefix that way answered 500 on
+    /// every event stream while passing every test here over a <c>MemoryStream</c>.
+    /// </summary>
+    [Theory]
+    [InlineData("sse", "id: 1\ndata: alpha\n\ndata: beta\n\n")]
+    [InlineData("ndjson", "alpha\nbeta\n\n")]
+    public async Task AFramingWritesNothingSynchronously(string framing, string expected) {
+        var context = Pipeline.Context();
+
+        context.Response.Body = new SynchronousWritesRejectedStream();
+
+        await Pipeline.Chain(context, Filter<object>(framing: Framing(framing)),
+            new Pipeline.Inline(c => {
+                // An event with an id for the SSE framing, so the field line is written too;
+                // plain items for NDJSON, which frames whatever it is handed as it is.
+                c.Context.Response.ResponseValue = framing == "sse" ? Events() : Items("alpha", "beta");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Null(context.Response.ExceptionValue);
+        Assert.Equal(expected, Rejecting(context));
+    }
+
+    /// <summary>The completion of an empty stream is a write too, in both framings.</summary>
+    [Theory]
+    [InlineData("sse", ":\n\n")]
+    [InlineData("ndjson", "\n")]
+    public async Task AnEmptyStreamsCompletionIsWrittenAsynchronously(string framing, string expected) {
+        var context = Pipeline.Context();
+
+        context.Response.Body = new SynchronousWritesRejectedStream();
+
+        await Pipeline.Chain(context, Filter<string>(framing: Framing(framing)),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = Items();
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Null(context.Response.ExceptionValue);
+        Assert.Equal(expected, Rejecting(context));
+    }
+
+    /// <summary>And so is the heartbeat, which #262 added synchronously beside the others.</summary>
+    [Fact]
+    public async Task AHeartbeatIsWrittenAsynchronously() {
+        var context = Pipeline.Context();
+
+        context.Response.Body = new SynchronousWritesRejectedStream();
+
+        await Pipeline.Chain(context,
+            Filter<string>(framing: SseFraming.Instance, heartbeat: TimeSpan.FromMilliseconds(10)),
+            new Pipeline.Inline(c => {
+                c.Context.Response.ResponseValue = Slowly("late");
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Null(context.Response.ExceptionValue);
+        Assert.Contains(": keep-alive\n\n", Rejecting(context));
+        Assert.EndsWith("data: late\n\n", Rejecting(context));
+    }
+
+    /// <summary>One event carrying an id, one bare, so both the field and the data lines are covered.</summary>
+    private static async IAsyncEnumerable<object> Events() {
+        yield return new SseItem<string>("alpha", Id: "1");
+
+        await Task.Yield();
+
+        yield return "beta";
+    }
+
+    private static async IAsyncEnumerable<string> Slowly(string value) {
+        await Task.Delay(100);
+
+        yield return value;
+    }
+
+    #endregion
 }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Logging/RequestLoggerTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Logging/RequestLoggerTests.cs
@@ -1,0 +1,173 @@
+using Hardened.Requests.Abstract.Timeouts;
+using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Logging;
+using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Logging;
+
+/// <summary>
+/// One line per failed request, at the level the answer decides.
+/// </summary>
+/// <remarks>
+/// A malformed body, a non-integer path value, an unsupported coding and a deadline the operation
+/// declared were all logged at Error with a stack trace, and the bind failures twice - once as
+/// "failed to bind parameters" and again as "request failed", with the same stack. A 400 is the
+/// caller's mistake and a declared 504 is the operation's own decision; neither is a fault, and a
+/// log that reports them as faults buries the ones that are.
+/// </remarks>
+public class RequestLoggerTests {
+
+    private sealed class Line {
+        public LogLevel Level { get; init; }
+        public string Message { get; init; } = "";
+        public Exception? Exception { get; init; }
+    }
+
+    private sealed class Capturing : ILogger<RequestLogger> {
+        public List<Line> Lines { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Lines.Add(new Line { Level = logLevel, Message = formatter(state, exception), Exception = exception });
+    }
+
+    private static (RequestLogger Logger, Capturing Log) Logger() {
+        var capturing = new Capturing();
+
+        return (new RequestLogger(capturing), capturing);
+    }
+
+    private static void Started(Abstract.Execution.IExecutionContext context) =>
+        context.Response.Body.WriteByte((byte)'{');
+
+    [Fact]
+    public void ARefusalIsOneWarningLineWithoutAStack() {
+        var (logger, log) = Logger();
+        var context = Pipeline.Context("POST", "/todos");
+
+        context.Response.Status = 400;
+
+        logger.RequestFailed(context, new FormatException("The input string 'abc' was not in a correct format."));
+
+        var line = Assert.Single(log.Lines);
+
+        Assert.Equal(LogLevel.Warning, line.Level);
+        Assert.Null(line.Exception);
+        Assert.Contains("POST /todos refused with 400", line.Message);
+        Assert.Contains("not in a correct format", line.Message);
+    }
+
+    /// <summary>A throws-mode 404 is a refusal too, however it was raised.</summary>
+    [Fact]
+    public void AThrownNotFoundIsAWarning() {
+        var (logger, log) = Logger();
+        var context = Pipeline.Context(path: "/todos/999");
+
+        context.Response.Status = 404;
+
+        logger.RequestFailed(context, new InvalidOperationException("No todo has id 999."));
+
+        Assert.Equal(LogLevel.Warning, Assert.Single(log.Lines).Level);
+    }
+
+    [Fact]
+    public void AServerFaultIsAnErrorWithTheException() {
+        var (logger, log) = Logger();
+        var context = Pipeline.Context();
+        var fault = new InvalidOperationException("boom");
+
+        context.Response.Status = 500;
+
+        logger.RequestFailed(context, fault);
+
+        var line = Assert.Single(log.Lines);
+
+        Assert.Equal(LogLevel.Error, line.Level);
+        Assert.Same(fault, line.Exception);
+    }
+
+    /// <summary>The hosts log an escaped exception before any status is assigned; that is a fault.</summary>
+    [Fact]
+    public void AFailureWithNoStatusIsAnError() {
+        var (logger, log) = Logger();
+
+        logger.RequestFailed(Pipeline.Context(), new InvalidOperationException("boom"));
+
+        Assert.Equal(LogLevel.Error, Assert.Single(log.Lines).Level);
+    }
+
+    /// <summary>
+    /// A budget the operation declared, answered with the status it declared, is not a fault and
+    /// not a stack ending in Task.Delay: it is one line saying how long the operation was given.
+    /// </summary>
+    [Theory]
+    [InlineData(504)]
+    [InlineData(503)]
+    public void ADeclaredDeadlineIsOneWarningLineNamingTheBudget(int status) {
+        var (logger, log) = Logger();
+        var context = Pipeline.Context(path: "/rates");
+
+        context.HandlerInfo = new ExecutionRequestHandlerInfo(
+            "/rates", "GET", typeof(object), "Read", timeout: new TimeoutPolicy(200, status));
+        context.Response.Status = status;
+
+        logger.RequestFailed(context, new TaskCanceledException());
+
+        var line = Assert.Single(log.Lines);
+
+        Assert.Equal(LogLevel.Warning, line.Level);
+        Assert.Null(line.Exception);
+        Assert.Contains("GET /rates did not finish inside its 200 ms budget", line.Message);
+        Assert.Contains(status.ToString(), line.Message);
+    }
+
+    /// <summary>A cancellation on a handler nothing bounded is whatever the converter made of it.</summary>
+    [Fact]
+    public void ACancellationWithNoBudgetIsAnError() {
+        var (logger, log) = Logger();
+        var context = Pipeline.Context();
+
+        context.Response.Status = 500;
+
+        logger.RequestFailed(context, new TaskCanceledException());
+
+        Assert.Equal(LogLevel.Error, Assert.Single(log.Lines).Level);
+    }
+
+    /// <summary>
+    /// After the response has started the status on it is the one already sent, whatever it says,
+    /// and a failure past that point tore the body: a fault.
+    /// </summary>
+    [Fact]
+    public void AFailureAfterTheResponseStartedIsAnErrorWhateverTheStatus() {
+        var (logger, log) = Logger();
+        var context = Pipeline.Context();
+
+        context.Response.Status = 200;
+        Started(context);
+
+        logger.RequestFailed(context, new IOException("torn"));
+
+        Assert.Equal(LogLevel.Error, Assert.Single(log.Lines).Level);
+    }
+
+    /// <summary>
+    /// The bind line is the detail behind the one RequestFailed writes once the status is known,
+    /// not a second Error with the same stack.
+    /// </summary>
+    [Fact]
+    public void ABindFailureIsLoggedAtDebug() {
+        var (logger, log) = Logger();
+
+        logger.RequestParameterBindFailed(Pipeline.Context(), new FormatException("bad"));
+
+        Assert.Equal(LogLevel.Debug, Assert.Single(log.Lines).Level);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/JsonRequestDeserializerTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/JsonRequestDeserializerTests.cs
@@ -40,7 +40,6 @@ public class JsonRequestDeserializerTests {
         nameof(SystemTextJsonRequestDeserializer) =>
             new SystemTextJsonRequestDeserializer(
                 Config(),
-                NullLogger<SystemTextJsonRequestDeserializer>.Instance,
                 Array.Empty<IJsonTypeInfoResolver>()),
         nameof(AotRequestDeserializer) =>
             new AotRequestDeserializer(

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResolverPrecedenceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/ResolverPrecedenceTests.cs
@@ -11,7 +11,6 @@ using Hardened.Requests.Runtime.Tests.Support;
 using Hardened.Shared.Runtime.Json;
 using IRequestsJsonConfiguration = Hardened.Requests.Runtime.Configuration.IJsonSerializerConfiguration;
 using RequestsJsonConfiguration = Hardened.Requests.Runtime.Configuration.JsonSerializerConfiguration;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using NSubstitute;
@@ -127,7 +126,6 @@ public class ResolverPrecedenceTests {
     public async Task DeserializeRequestBody_HonoursTheRegisteredContextForAnEnum() {
         var deserializer = new SystemTextJsonRequestDeserializer(
             Config(),
-            NullLogger<SystemTextJsonRequestDeserializer>.Instance,
             new IJsonTypeInfoResolver[] { CatalogContext.Default });
 
         var listing = await deserializer.DeserializeRequestBody<Listing>(

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Support/SynchronousWritesRejectedStream.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Support/SynchronousWritesRejectedStream.cs
@@ -1,0 +1,63 @@
+namespace Hardened.Requests.Runtime.Tests.Support;
+
+/// <summary>
+/// A response body that refuses synchronous writes, the way a real server's does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Kestrel's <c>HttpResponseStream</c> throws <c>InvalidOperationException: Synchronous
+/// operations are disallowed</c> unless <c>AllowSynchronousIO</c> is turned on, and it is off by
+/// default on both the Kestrel and the ASP.NET host. A <c>MemoryStream</c> accepts synchronous
+/// writes happily, so a test that streams into one cannot tell the difference between a framing
+/// that is safe on a server and one that is not.
+/// </para>
+/// <para>
+/// That gap is how the streaming defect shipped: every framing test wrote into a
+/// <c>MemoryStream</c>, and <c>SseFraming</c> and <c>NdjsonFraming</c> wrote their prefixes and
+/// newlines synchronously, so every event stream answered 500 on a socket while the suite was
+/// green. The same stand-in <c>Hardened.Templates.RazorBlade.Tests</c> keeps for the same reason.
+/// </para>
+/// </remarks>
+public sealed class SynchronousWritesRejectedStream : Stream {
+    private readonly MemoryStream _written = new();
+
+    public byte[] ToArray() => _written.ToArray();
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => _written.Length;
+
+    public override long Position {
+        get => _written.Position;
+        set => throw new NotSupportedException();
+    }
+
+    private static Exception Rejected() =>
+        new InvalidOperationException(
+            "Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO " +
+            "to true instead.");
+
+    public override void Write(byte[] buffer, int offset, int count) => throw Rejected();
+
+    public override void Write(ReadOnlySpan<byte> buffer) => throw Rejected();
+
+    public override void WriteByte(byte value) => throw Rejected();
+
+    public override void Flush() {
+        // Kestrel allows a synchronous Flush that writes nothing; only writes are rejected.
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token) =>
+        _written.WriteAsync(buffer, offset, count, token);
+
+    public override ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer, CancellationToken token = default) =>
+        _written.WriteAsync(buffer, token);
+
+    public override Task FlushAsync(CancellationToken token) => _written.FlushAsync(token);
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+}

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -139,8 +139,8 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
         // logs, not for whoever made the request, and it is the one message here nobody chose with a
         // caller in mind.
         //
-        // Nothing is lost: IRequestLogger.RequestFailed already logs the exception with its stack,
-        // method and path at Error, which is where it belongs.
+        // Nothing is lost: IRequestLogger.RequestFailed logs a server fault with its stack, method
+        // and path at Error, which is where it belongs.
         return (500, ServerError);
     }
 

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
@@ -18,7 +18,8 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         IReadOnlyList<string>? producedContentTypes = null,
         string? bodyParameterName = null,
         int? validationErrorStatus = null,
-        TimeoutPolicy? timeout = null) {
+        TimeoutPolicy? timeout = null,
+        bool streamsResponse = false) {
         Path = path;
         Method = method;
         HandlerType = handlerType;
@@ -32,6 +33,7 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         BodyParameterName = bodyParameterName;
         ValidationErrorStatus = validationErrorStatus;
         Timeout = timeout ?? IExecutionRequestHandlerInfo.TimeoutFrom(Metadata);
+        StreamsResponse = streamsResponse;
     }
 
     /// <summary>
@@ -74,7 +76,8 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
             source.ProducedContentTypes,
             source.BodyParameterName,
             source.ValidationErrorStatus,
-            timeout ?? source.Timeout) { }
+            timeout ?? source.Timeout,
+            source.StreamsResponse) { }
 
     public string Path { get; }
 
@@ -109,6 +112,9 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
 
     /// <inheritdoc />
     public int? ValidationErrorStatus { get; }
+
+    /// <inheritdoc />
+    public bool StreamsResponse { get; }
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/Requests/Hardened.Requests.Runtime/Filters/NdjsonFraming.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/NdjsonFraming.cs
@@ -17,13 +17,19 @@ public class NdjsonFraming : IStreamFraming {
     /// <summary>The one instance, because it holds nothing.</summary>
     public static readonly NdjsonFraming Instance = new();
 
+    /// <summary>
+    /// The line terminator, written asynchronously for the reason <see cref="SseFraming"/>
+    /// gives: a synchronous <c>WriteByte</c> is refused by Kestrel's response body.
+    /// </summary>
+    private static readonly byte[] Newline = "\n"u8.ToArray();
+
     public string ContentType => KnownContentType.NdJson;
 
     public async ValueTask WriteItem(
         IExecutionContext context, Func<IExecutionContext, Task> serialize) {
         await serialize(context);
 
-        context.Response.Body.WriteByte((byte)'\n');
+        await context.Response.Body.WriteAsync(Newline, 0, Newline.Length, context.CancellationToken);
     }
 
     /// <summary>
@@ -34,10 +40,8 @@ public class NdjsonFraming : IStreamFraming {
     /// downstream reader waiting on one hangs. It costs a byte on a stream that produced nothing
     /// and it is what stops an empty result being indistinguishable from a hung one.
     /// </remarks>
-    public ValueTask WriteCompletion(IExecutionContext context) {
-        context.Response.Body.WriteByte((byte)'\n');
-
-        return default;
+    public async ValueTask WriteCompletion(IExecutionContext context) {
+        await context.Response.Body.WriteAsync(Newline, 0, Newline.Length, context.CancellationToken);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Filters/SseFraming.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/SseFraming.cs
@@ -23,6 +23,12 @@ namespace Hardened.Requests.Runtime.Filters;
 /// <c>data:</c> lines, which is why <see cref="ContentType"/> resolves to a JSON serializer and
 /// nothing else claims it.
 /// </para>
+/// <para>
+/// <b>Every write is asynchronous.</b> Kestrel's response body refuses a synchronous
+/// <c>Write</c> unless the host turns <c>AllowSynchronousIO</c> on, and neither host does - so a
+/// framing that wrote its prefix synchronously answered 500 on a real socket while passing every
+/// test over a <c>MemoryStream</c>, which accepts either.
+/// </para>
 /// </remarks>
 public class SseFraming : IStreamFraming {
     /// <summary>The one instance, because it holds nothing.</summary>
@@ -58,40 +64,58 @@ public class SseFraming : IStreamFraming {
     public async ValueTask WriteItem(
         IExecutionContext context, Func<IExecutionContext, Task> serialize) {
         var body = context.Response.Body;
+        var cancellationToken = context.CancellationToken;
 
         if (context.Response.ResponseValue is ISseEvent metadata) {
-            WriteField(body, "id", metadata.Id);
-            WriteField(body, "event", metadata.Event);
-            WriteField(body, "retry",
-                metadata.Retry?.ToString(CultureInfo.InvariantCulture));
+            await WriteField(body, "id", metadata.Id, cancellationToken);
+            await WriteField(body, "event", metadata.Event, cancellationToken);
+            await WriteField(body, "retry",
+                metadata.Retry?.ToString(CultureInfo.InvariantCulture), cancellationToken);
 
             // The payload is what the handler yielded, not the wrapper around it - serializing the
             // wrapper would put the id and the event name inside data as well as beside it.
             context.Response.ResponseValue = metadata.Data;
         }
 
-        body.Write(DataPrefix, 0, DataPrefix.Length);
+        await body.WriteAsync(DataPrefix, 0, DataPrefix.Length, cancellationToken);
 
         await serialize(context);
 
-        body.Write(EventTerminator, 0, EventTerminator.Length);
+        await body.WriteAsync(EventTerminator, 0, EventTerminator.Length, cancellationToken);
     }
 
-    public ValueTask WriteCompletion(IExecutionContext context) {
+    public async ValueTask WriteCompletion(IExecutionContext context) {
         // Only when nothing was written, a heartbeat included. Every event already ends with a
         // blank line, so a stream that produced anything is complete, and adding to it would
         // dispatch an empty event.
-        if (context.Response.Body.Position == 0) {
-            context.Response.Body.Write(EmptyStreamComment, 0, EmptyStreamComment.Length);
+        if (NothingWritten(context)) {
+            await context.Response.Body.WriteAsync(
+                EmptyStreamComment, 0, EmptyStreamComment.Length, context.CancellationToken);
         }
-
-        return default;
     }
 
-    public ValueTask<bool> WriteHeartbeat(IExecutionContext context) {
-        context.Response.Body.Write(Heartbeat, 0, Heartbeat.Length);
+    /// <summary>
+    /// Whether the stream has put nothing on the wire yet.
+    /// </summary>
+    /// <remarks>
+    /// Asked of the body's position where the body can answer - a buffer the cache or a test
+    /// holds - and of the response otherwise. Kestrel's response body throws
+    /// <c>NotSupportedException</c> from <c>Position</c>, so reading it unconditionally ended
+    /// every event stream on a real socket with a logged fault after the last event had already
+    /// gone out. On a transport the filter flushes after every item and every heartbeat, so a
+    /// response that has started is one that carried something.
+    /// </remarks>
+    private static bool NothingWritten(IExecutionContext context) {
+        var body = context.Response.Body;
 
-        return new ValueTask<bool>(true);
+        return body.CanSeek ? body.Position == 0 : !context.Response.ResponseStarted;
+    }
+
+    public async ValueTask<bool> WriteHeartbeat(IExecutionContext context) {
+        await context.Response.Body.WriteAsync(
+            Heartbeat, 0, Heartbeat.Length, context.CancellationToken);
+
+        return true;
     }
 
     /// <summary>
@@ -104,7 +128,8 @@ public class SseFraming : IStreamFraming {
     /// specification says an id containing U+0000 must be ignored and says nothing useful about
     /// newlines, which is exactly the gap somebody eventually puts a header value into.
     /// </remarks>
-    private static void WriteField(Stream body, string name, string? value) {
+    private static async ValueTask WriteField(
+        Stream body, string name, string? value, CancellationToken cancellationToken) {
         if (string.IsNullOrEmpty(value) ||
             value!.IndexOf('\n') >= 0 || value.IndexOf('\r') >= 0) {
             return;
@@ -112,6 +137,6 @@ public class SseFraming : IStreamFraming {
 
         var line = Encoding.UTF8.GetBytes(name + ": " + value + "\n");
 
-        body.Write(line, 0, line.Length);
+        await body.WriteAsync(line, 0, line.Length, cancellationToken);
     }
 }

--- a/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
@@ -287,13 +287,58 @@ public partial class RequestLogger : IRequestLogger {
         CloseCorrelationScope(context);
     }
 
+    /// <summary>
+    /// Debug rather than Error. The failure is recorded on the response and answered through
+    /// <c>ExceptionResponseSerializer</c>, which calls <see cref="RequestFailed"/> once the
+    /// status is decided - so this line is the detail behind that one, not a second copy of it.
+    /// A malformed body used to be logged here at Error with its stack, and again from
+    /// <see cref="RequestFailed"/> at Error with the same stack, for a 400.
+    /// </summary>
     public void RequestParameterBindFailed(IExecutionContext context, Exception? exp) {
-        _logger.LogError(exp, "{method} {path} failed to bind parameters",
+        _logger.LogDebug(exp, "{method} {path} failed to bind parameters",
             context.Request.Method, context.Request.Path);
     }
 
+    /// <summary>
+    /// One line per failed request, at the level the answer decides.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A refusal is the caller's mistake: a 400 for a body that did not parse, a 404 a throws-mode
+    /// handler raised, a 415 for a coding the service does not decode. Those are answered, not
+    /// failed, and a stack trace for each of them at Error buries the faults that are. They go out
+    /// as one Warning line carrying the status and the exception's message, which is what the
+    /// caller was told. The same rule <see cref="RequestEnd"/> applies to the span: Unset below
+    /// 500, Error at it.
+    /// </para>
+    /// <para>
+    /// A budget that ran out is the one 5xx that is not a fault either. The operation declared the
+    /// deadline and the framework answered the status it declared, so the line says how long the
+    /// operation was given and nothing about a stack that ends in <c>Task.Delay</c>.
+    /// </para>
+    /// <para>
+    /// Everything else - and anything after the response started, whatever status was on it - is
+    /// a fault, logged at Error with the exception, which is where an unhandled exception belongs.
+    /// The status is read off the response, which <c>ExceptionResponseSerializer</c> assigns before
+    /// calling this and the hosts assign before calling this for an exception that escaped the
+    /// chain.
+    /// </para>
+    /// </remarks>
     public void RequestFailed(IExecutionContext context, Exception exp) {
-        _logger.LogError(exp, "{method} {path} request failed", context.Request.Method, context.Request.Path);
+        var status = context.Response.Status;
+        var started = context.Response.ResponseStarted;
+
+        if (!started && exp is OperationCanceledException &&
+            context.HandlerInfo?.Timeout is { } budget && status == budget.Status) {
+            LogRequestTimedOut(
+                context.Request.Method, context.Request.Path, budget.Milliseconds, budget.Status);
+        }
+        else if (!started && status is >= 400 and < 500) {
+            LogRequestRefused(context.Request.Method, context.Request.Path, status.Value, exp.Message);
+        }
+        else {
+            _logger.LogError(exp, "{method} {path} request failed", context.Request.Method, context.Request.Path);
+        }
 
         if (!_spans.TryGetValue(context, out var span)) {
             return;
@@ -340,4 +385,16 @@ public partial class RequestLogger : IRequestLogger {
         Level = LogLevel.Information,
         Message = "{httpMethod} {path} Resource Not Found")]
     protected partial void LogResourceNotFound(string httpMethod, string path);
+
+    [LoggerMessage(
+        EventId = 78004,
+        Level = LogLevel.Warning,
+        Message = "{httpMethod} {path} refused with {statusCode}: {reason}")]
+    protected partial void LogRequestRefused(string httpMethod, string path, int statusCode, string reason);
+
+    [LoggerMessage(
+        EventId = 78005,
+        Level = LogLevel.Warning,
+        Message = "{httpMethod} {path} did not finish inside its {milliseconds} ms budget, answered {statusCode}")]
+    protected partial void LogRequestTimedOut(string httpMethod, string path, int milliseconds, int statusCode);
 }

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonRequestDeserializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonRequestDeserializer.cs
@@ -6,7 +6,6 @@ using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Configuration;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Hardened.Requests.Runtime.Serializer;
@@ -35,7 +34,6 @@ public class SystemTextJsonRequestDeserializer : IRequestDeserializer {
         "AOT-published application, which registers the source-generated serializers instead.";
 
     private readonly JsonSerializerOptions _serializerOptions;
-    private readonly ILogger<SystemTextJsonRequestDeserializer> _logger;
 
     /// <param name="resolvers">
     /// Every <c>IJsonTypeInfoResolver</c> the application registered, ahead of reflection. The
@@ -43,9 +41,7 @@ public class SystemTextJsonRequestDeserializer : IRequestDeserializer {
     /// to govern how it is read, or the application answers 400 to its own output.
     /// </param>
     public SystemTextJsonRequestDeserializer(IOptions<IJsonSerializerConfiguration> configuration,
-        ILogger<SystemTextJsonRequestDeserializer> logger,
         IEnumerable<IJsonTypeInfoResolver> resolvers) {
-        _logger = logger;
         _serializerOptions =
             Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
                 configuration.Value.DeSerializerOptions ??
@@ -63,8 +59,6 @@ public class SystemTextJsonRequestDeserializer : IRequestDeserializer {
     /// Reads the body as it is. A compressed body was decoded by <c>RequestDecompressionFilter</c>
     /// before the bind, which is why this no longer looks at <c>Content-Encoding</c>.
     /// </summary>
-    public async ValueTask<T?> DeserializeRequestBody<T>(IExecutionContext context) {
-        _logger.LogInformation($"Deserialize with option convert count {_serializerOptions.Converters.Count}");
-        return await System.Text.Json.JsonSerializer.DeserializeAsync<T>(context.Request.Body, _serializerOptions);
-    }
+    public ValueTask<T?> DeserializeRequestBody<T>(IExecutionContext context) =>
+        System.Text.Json.JsonSerializer.DeserializeAsync<T>(context.Request.Body, _serializerOptions);
 }

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SerializerPrecedenceTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/SerializerPrecedenceTests.cs
@@ -50,7 +50,6 @@ public class SerializerPrecedenceTests {
     private static IRequestDeserializer SystemTextJsonReader() =>
         new SystemTextJsonRequestDeserializer(
             JsonConfiguration(),
-            NullLogger<SystemTextJsonRequestDeserializer>.Instance,
             Array.Empty<IJsonTypeInfoResolver>());
 
     private static SerializationLocatorService Locator(

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
@@ -108,6 +108,9 @@
         <Compile Include="../Hardened.SourceGenerator/Web/StreamFramingDiagnostics.cs">
             <Link>Web\StreamFramingDiagnostics.cs</Link>
         </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Web/TimeoutDeclarationDiagnostics.cs">
+            <Link>Web\TimeoutDeclarationDiagnostics.cs</Link>
+        </Compile>
     </ItemGroup>
 
     <!--

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecRoutingTableGenerator.cs
@@ -45,6 +45,12 @@ internal static class SpecRoutingTableGenerator {
         IReadOnlyList<RouteConstraintModel> constraints,
         bool excludeFromCoverage = false,
         DocumentIdentity? identity = null) {
+        // Per application, as the attribute-routed table reports it: a described operation whose
+        // implementation declares [CacheResponse], or one in a module this application imports,
+        // fails every request in an application that registers no store - and a described
+        // application was told nothing.
+        ResponseCacheStoreDiagnostics.Report(context, models.Left, models.Right);
+
         var outputString = GenerateCSharpRouteFile(
             models.Left, models.Right, handlerInfos, specRegistrations,
             context.CancellationToken, excludeFromCoverage, constraints);

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/CollidingRoutingGenerators.cs
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/CollidingRoutingGenerators.cs
@@ -57,9 +57,10 @@ internal static class CollidingRoutingGenerators {
             return;
         }
 
-        var generators = Emitters(marker);
-
-        if (generators.Count < 2) {
+        // One declaration per generator that ran, whatever their files are called. Counted here
+        // rather than after the names are read, so two generators the path cannot tell apart are
+        // still two generators.
+        if (marker.DeclaringSyntaxReferences.Length < 2) {
             return;
         }
 
@@ -67,37 +68,62 @@ internal static class CollidingRoutingGenerators {
         // travel through the incremental caches, which compare for equality to decide whether to
         // regenerate. The message carries the names instead.
         context.ReportDiagnostic(Diagnostic.Create(
-            Descriptor(), Location.None, Join(generators)));
+            Descriptor(), Location.None, Join(Emitters(marker))));
     }
 
     /// <summary>
     /// Which generators declared the marker, read off the paths Roslyn gives generated files.
     /// </summary>
     /// <remarks>
-    /// A generated file's path is the generator's assembly, then its type, then the hint name.
-    /// Both routing generators use the same hint name, so the assembly is what tells them apart -
-    /// and naming them is most of what makes the message actionable, because the fix is on the
-    /// reference that brought one of them.
+    /// Naming them is most of what makes the message actionable, because the fix is on the
+    /// reference that brought one of them. Distinct, because the count was settled above and a
+    /// name repeated in the sentence would read as one generator that ran twice.
     /// </remarks>
     private static IReadOnlyList<string> Emitters(INamedTypeSymbol marker) {
         var names = new List<string>();
 
         foreach (var declaration in marker.DeclaringSyntaxReferences) {
-            var assembly = declaration.SyntaxTree.FilePath
-                .Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries)
-                .FirstOrDefault();
-
-            // A path Roslyn shaped differently still counts towards the collision; it just cannot
-            // be named. Reporting "two generators" beats reporting nothing.
-            names.Add(string.IsNullOrEmpty(assembly) ? "an unnamed generator" : assembly!);
+            names.Add(GeneratorName(declaration.SyntaxTree.FilePath));
         }
 
         return names.Distinct().OrderBy(name => name, StringComparer.Ordinal).ToList();
     }
 
-    /// <summary>The names as a sentence subject: "A and B", or "A, B and C".</summary>
-    private static string Join(IReadOnlyList<string> names) =>
-        names.Count == 2
+    /// <summary>
+    /// The generator that wrote a generated file, read off the path Roslyn gives it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A generated tree's path is <c>&lt;base&gt;/&lt;generator assembly&gt;/&lt;generator
+    /// type&gt;/&lt;hint name&gt;</c>, where the base is the generated-files directory when the
+    /// build writes them out and nothing otherwise. So the assembly is the third segment from the
+    /// end, never the first. Read as the first, an absolute base - which every project with
+    /// <c>EmitCompilerGeneratedFiles</c> on has, the templates included - made both generators
+    /// <c>Users</c> or <c>home</c>, and a distinct-count of one reported nothing. That is how the
+    /// 0.20 trial referenced two routing generators and got the CS0102s this exists to explain.
+    /// </para>
+    /// <para>
+    /// A path shaped some other way still counts towards the collision; it just cannot be named.
+    /// Reporting "two generators" beats reporting nothing.
+    /// </para>
+    /// </remarks>
+    internal static string GeneratorName(string filePath) {
+        var segments = filePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+
+        return segments.Length >= 3 ? segments[segments.Length - 3] : "an unnamed generator";
+    }
+
+    /// <summary>
+    /// The names as a sentence subject: "A and B", or "A, B and C" - or, when every path read
+    /// the same, the one name and a count.
+    /// </summary>
+    private static string Join(IReadOnlyList<string> names) {
+        if (names.Count == 1) {
+            return "Two copies of " + names[0];
+        }
+
+        return names.Count == 2
             ? names[0] + " and " + names[1]
             : string.Join(", ", names.Take(names.Count - 1)) + " and " + names[names.Count - 1];
+    }
 }

--- a/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Library.SourceGenerator/Hardened.Library.SourceGenerator.csproj
@@ -25,6 +25,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Hardened.Web.SourceGenerator.Tests"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
         <None Include="../Hardened.DependencyModules.SourceGenerator/bin/$(Configuration)/$(TargetFramework)/Hardened.DependencyModules.SourceGenerator.dll"
               Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DescribedBodyDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/DescribedBodyDiagnosticsTests.cs
@@ -1,0 +1,55 @@
+using Hardened.SourceGeneration.Testing;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// A described operation reading a body on a verb that carries none.
+/// </summary>
+/// <remarks>
+/// OpenAPI permits a <c>requestBody</c> on a GET and says it should be avoided; the generated
+/// handler reads it, and a request that sends none is refused before the handler runs. The same
+/// <c>HRDR010</c> a hand-written GET with a body parameter gets, from the same shared emit stage,
+/// and the same <c>NoWarn</c> for a description that means it.
+/// </remarks>
+public class DescribedBodyDiagnosticsTests {
+
+    private static string Spec(string verb) =>
+        $$"""
+          openapi: "3.0.0"
+          info: { title: Things, version: "1.0" }
+          paths:
+            /things/search:
+              {{verb}}:
+                tags: [Thing]
+                operationId: searchThings
+                requestBody:
+                  required: true
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          name: { type: string }
+                responses:
+                  '200': { description: ok }
+          """;
+
+    private static IEnumerable<Diagnostic> Reported(GeneratorResult result) =>
+        result.GeneratorDiagnostics.Where(diagnostic => diagnostic.Id == "HRDR010");
+
+    [Fact]
+    public void ADescribedGetWithABodyIsHRDR010() {
+        var diagnostic = Assert.Single(Reported(OpenApiGenerator.Run(Spec("get"))));
+
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("a GET carries none", diagnostic.GetMessage());
+        Assert.Contains("HRDR010", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void ADescribedPostWithABodyReportsNothing() {
+        Assert.Empty(Reported(OpenApiGenerator.Run(Spec("post")).AssertNoErrors()));
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/OpenApiGenerator.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/OpenApiGenerator.cs
@@ -57,7 +57,8 @@ internal static class OpenApiGenerator {
     internal static GeneratorResult Run(
         IReadOnlyDictionary<string, string> specs,
         string source,
-        IReadOnlyDictionary<string, string>? buildProperties = null) {
+        IReadOnlyDictionary<string, string>? buildProperties = null,
+        IReadOnlyList<Microsoft.CodeAnalysis.MetadataReference>? additionalReferences = null) {
         // Must resolve exactly as the generator does, and against the same defaults the harness
         // supplies. The two halves emit into one namespace and bind across it, so a harness that
         // resolves differently produces a handler referencing a service interface that was emitted
@@ -109,7 +110,9 @@ internal static class OpenApiGenerator {
             models[ModelFileNameFor(spec.Key)] = SpecModelSerializer.Write(model);
         }
 
-        var result = GeneratorTestHarness.Run(sources, [new SpecSourceGenerator()], Anchors, models, buildProperties);
+        var result = GeneratorTestHarness.Run(
+            sources, [new SpecSourceGenerator()], Anchors, models, buildProperties,
+            additionalReferences: additionalReferences);
 
         // GeneratedSources carries both halves, because that is what the project ends up compiling.
         // Splitting them would make every assertion depend on which side of the task/generator line

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseCacheStoreDiagnosticTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/ResponseCacheStoreDiagnosticTests.cs
@@ -1,0 +1,175 @@
+using Hardened.Requests.Runtime.Caching;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// <c>[CacheResponse]</c> in a described application that registers no store.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The attribute-routed table reported this from the day the store shipped; the described table
+/// never called the shared report, so a specification-first application was told nothing and found
+/// out from a request. Both tables report it now, from the same code, which is why these read like
+/// the attribute-routed tests.
+/// </para>
+/// <para>
+/// The runtime and store attributes are matched by name, which is why stand-ins declared in the
+/// test source are enough - this project references neither host nor the store package.
+/// </para>
+/// </remarks>
+public class ResponseCacheStoreDiagnosticTests {
+
+    private const string Spec =
+        """
+        openapi: "3.0.0"
+        info: { title: Things, version: "1.0" }
+        paths:
+          /things:
+            get:
+              tags: [Thing]
+              operationId: listThings
+              responses:
+                '200': { description: ok }
+        """;
+
+    private const string CachingImplementation =
+        """
+        [Handler]
+        public class ThingServiceImpl : IThingService {
+            [CacheResponse<VaryByRoute>(Duration = 60)]
+            public Task ListThings() => Task.CompletedTask;
+        }
+        """;
+
+    private static string Host(string moduleAttributes, string implementation = "") =>
+        $$"""
+          using System.Threading.Tasks;
+          using Hardened.Requests.Abstract.Attributes;
+          using Hardened.Requests.Runtime.Caching;
+          using Hardened.Shared.Runtime.Attributes;
+          using Hardened.Web.Runtime.Caching;
+          using TestNamespace.Services;
+
+          namespace TestNamespace;
+
+          [HardenedModule]
+          {{moduleAttributes}}
+          public partial class TestApp {
+          }
+
+          public class KestrelRuntimeAttribute : System.Attribute { }
+
+          public class HardenedMemoryResponseCacheAttribute : System.Attribute { }
+
+          {{implementation}}
+          """;
+
+    private static IEnumerable<Diagnostic> Reported(GeneratorResult result) =>
+        result.GeneratorDiagnostics.Where(diagnostic => diagnostic.Id == "HRDW005");
+
+    // ---------------------------------------------------------------- the implementation caches
+
+    [Fact]
+    public void ADescribedOperationCachedByItsImplementationWithNoStoreIsHRDW005() {
+        var diagnostic = Assert.Single(Reported(
+            OpenApiGenerator.Run(Spec, Host("[KestrelRuntime]", CachingImplementation))));
+
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("ListThings", diagnostic.GetMessage());
+        Assert.Contains("[HardenedMemoryResponseCache]", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void ADescribedOperationCachedWithTheStoreReportsNothing() {
+        Assert.Empty(Reported(OpenApiGenerator.Run(
+            Spec, Host("[KestrelRuntime] [HardenedMemoryResponseCache]", CachingImplementation))));
+    }
+
+    /// <summary>A described library, hosted by some other compilation, is not asked.</summary>
+    [Fact]
+    public void ADescribedLibraryModuleReportsNothing() {
+        Assert.Empty(Reported(OpenApiGenerator.Run(Spec, Host("", CachingImplementation))));
+    }
+
+    [Fact]
+    public void ADescribedOperationThatDoesNotCacheReportsNothing() {
+        Assert.Empty(Reported(OpenApiGenerator.Run(Spec, Host("[KestrelRuntime]"))));
+    }
+
+    // ---------------------------------------------------------------- an imported module caches
+
+    /// <summary>
+    /// An attribute-routed library beside the described application, compiled without generators:
+    /// the module attribute DependencyModules would write is written by hand, and so is the store
+    /// attribute for the variant that carries one.
+    /// </summary>
+    private static string Library(bool carriesTheStore) =>
+        $$"""
+          using Hardened.Requests.Runtime.Caching;
+          using Hardened.Web.Runtime.Attributes;
+          using Hardened.Web.Runtime.Caching;
+
+          namespace Hardened.Requests.Caching.Memory {
+              public class HardenedMemoryResponseCacheAttribute : System.Attribute { }
+          }
+
+          namespace Catalog {
+              {{(carriesTheStore ? "[Hardened.Requests.Caching.Memory.HardenedMemoryResponseCache]" : "")}}
+              public partial class CatalogLibrary { }
+
+              public class CatalogLibraryAttribute : System.Attribute { }
+
+              public class CatalogController {
+                  [Get("/catalog")]
+                  [CacheResponse<VaryByRoute>(Duration = 60)]
+                  public string Catalog() => "catalog";
+
+                  [Get("/offers")]
+                  public string Offers() => "offers";
+              }
+
+              [CacheResponse<VaryByRoute>(Duration = 60)]
+              public class OffersController {
+                  [Get("/deals")]
+                  public string Deals() => "deals";
+
+                  public string NotARoute() => "helper";
+              }
+          }
+          """;
+
+    private static GeneratorResult Importing(string moduleAttributes, bool libraryCarriesTheStore = false) {
+        var (reference, _) = GeneratorTestHarness.CompileLibrary(
+            Library(libraryCarriesTheStore),
+            libraryCarriesTheStore ? "SpecCatalogWithStore" : "SpecCatalog",
+            [typeof(GetAttribute), typeof(CacheResponseAttribute<>)]);
+
+        return OpenApiGenerator.Run(
+            new Dictionary<string, string> { ["petstore.yaml"] = Spec },
+            Host(moduleAttributes + " [Catalog.CatalogLibrary]"),
+            additionalReferences: [reference]);
+    }
+
+    [Fact]
+    public void AHostImportingACachingLibraryWithNoStoreIsToldWhichHandlersFail() {
+        var diagnostic = Assert.Single(Reported(Importing("[KestrelRuntime]")));
+
+        Assert.Contains("CatalogController.Catalog", diagnostic.GetMessage());
+        Assert.Contains("OffersController.Deals", diagnostic.GetMessage());
+        Assert.DoesNotContain("NotARoute", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void AHostImportingACachingLibraryWithTheStoreReportsNothing() {
+        Assert.Empty(Reported(Importing("[KestrelRuntime] [HardenedMemoryResponseCache]")));
+    }
+
+    [Fact]
+    public void AHostImportingALibraryThatCarriesTheStoreReportsNothing() {
+        Assert.Empty(Reported(Importing("[KestrelRuntime]", libraryCarriesTheStore: true)));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/XmlDocumentationTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/XmlDocumentationTests.cs
@@ -84,4 +84,39 @@ public class XmlDocumentationTests {
         Assert.Null(description);
         Assert.Null(XmlDocumentation.ReadParameter(method, "id"));
     }
+
+    private const string Entities = """
+        class C {
+            /// <summary>Created&lt;T&gt; carries the body &amp; the Location, &quot;both&quot;.</summary>
+            /// <remarks>Copyright &#169; and &#x263A; are characters too; a stray & is prose.</remarks>
+            public string Create() => "";
+        }
+        """;
+
+    private static MethodDeclarationSyntax Entity(DocumentationMode mode) =>
+        CSharpSyntaxTree
+            .ParseText(Entities, new CSharpParseOptions(documentationMode: mode),
+                cancellationToken: TestContext.Current.CancellationToken)
+            .GetRoot(TestContext.Current.CancellationToken)
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single();
+
+    /// <summary>
+    /// A doc comment has to write <c>&amp;lt;</c> to say <c>&lt;</c>, and the template's own
+    /// exported document carried <c>Created&amp;lt;T&amp;gt;</c> through as text. Both paths decode.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Modes))]
+    public void AnEntityIsTheCharacterItStandsFor(DocumentationMode mode) =>
+        Assert.Equal(
+            "Created<T> carries the body & the Location, \"both\".",
+            XmlDocumentation.Read(Entity(mode)).Summary);
+
+    [Theory]
+    [MemberData(nameof(Modes))]
+    public void ANumericEntityIsDecodedAndAStrayAmpersandIsKept(DocumentationMode mode) =>
+        Assert.Equal(
+            "Copyright \u00a9 and \u263a are characters too; a stray & is prose.",
+            XmlDocumentation.Read(Entity(mode)).Description);
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RequestParameterInformationTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/RequestParameterInformationTests.cs
@@ -64,4 +64,31 @@ public class RequestParameterInformationTests {
         Assert.Equal(left, right);
         Assert.Equal(left.GetHashCode(), right.GetHashCode());
     }
+
+    /// <summary>
+    /// <c>RegisteredAsService</c> rides on the model for the reason
+    /// <c>ConstructorRequiresServices</c> does: adding <c>[SingletonService]</c> to the type has to
+    /// break the model's equality, or HRDR007 waits for whatever else forces a regeneration.
+    /// </summary>
+    [Fact]
+    public void ARegisteredServiceDoesNotCompareEqualToAnOrdinaryBody() {
+        var body = Body();
+        var service = new RequestParameterInformation(
+            TypeDefinition.Get("TestApp", "EventStore"),
+            "store", true, null, ParameterBindType.Body, "store", 0,
+            registeredAsService: true);
+
+        Assert.NotEqual(body, service);
+        Assert.NotEqual(body.GetHashCode(), service.GetHashCode());
+    }
+
+    [Fact]
+    public void MovingARegisteredServiceKeepsItRegistered() {
+        var original = new RequestParameterInformation(
+            TypeDefinition.Get("TestApp", "EventStore"),
+            "store", true, null, ParameterBindType.Body, "store", 0,
+            registeredAsService: true);
+
+        Assert.True(original.WithIndex(3).RegisteredAsService);
+    }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/Fixtures/WebPipeline/streaming-response/FeedController_Feed.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/Fixtures/WebPipeline/streaming-response/FeedController_Feed.cs
@@ -6,7 +6,7 @@ namespace TestApp.Generated
     public partial class FeedController_Feed : global::Hardened.Requests.Runtime.Execution.BaseExecutionHandler<global::TestApp.FeedController>
     {
         private static readonly object[] _metadata = new object[] { new global::Hardened.Web.Runtime.Attributes.ServerSentEventsAttribute() };
-        private static readonly global::Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo _handlerInfo =         new global::Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo("/feed", "GET", typeof(global::TestApp.FeedController), "Feed", null, _metadata)
+        private static readonly global::Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo _handlerInfo =         new global::Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo("/feed", "GET", typeof(global::TestApp.FeedController), "Feed", null, _metadata, streamsResponse: true)
 ;
 
         public FeedController_Feed(global::System.IServiceProvider serviceProvider, string? routePath = null)

--- a/src/SourceGenerators/Hardened.SourceGenerator/Links/LinkGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Links/LinkGenerator.cs
@@ -5,6 +5,7 @@ using Hardened.SourceGenerator.Models.Request;
 using Hardened.SourceGenerator.Shared;
 using Hardened.SourceGenerator.Web.Routing;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Hardened.SourceGenerator.Links;
 
@@ -135,7 +136,12 @@ public static class LinkGenerator {
 
         foreach (var handler in handlers.OrderBy(h => h.Name.Path, StringComparer.Ordinal)
                      .ThenBy(h => h.Name.Method, StringComparer.Ordinal)) {
-            var link = Build(handler, basePath);
+            // A route HRDR002 has already refused - {id?}, {id=5}, {} - has no link. Its handler is
+            // still emitted so that diagnostic stands alone, and a link method declaring a
+            // parameter named `id?` would bury it under a dozen CS1003s instead.
+            if (Build(handler, basePath) is not { } link) {
+                continue;
+            }
 
             // Two handlers whose links would have the same signature - the same group, name and
             // parameter types - cannot both be declared. C# forbids it, and emitting both would
@@ -155,12 +161,13 @@ public static class LinkGenerator {
 
     /// <summary>
     /// One handler as a link: the route template with its tokens replaced by the parameters that
-    /// bind to them.
+    /// bind to them. Null for a route whose tokens cannot be parameters.
     /// </summary>
-    private static Link Build(RequestHandlerModel handler, string basePath) {
+    private static Link? Build(RequestHandlerModel handler, string basePath) {
         var template = RoutePath.Combine(basePath, handler.Name.Path);
         var body = new StringBuilder();
         var parameters = new List<Parameter>();
+        var names = new HashSet<string>(StringComparer.Ordinal);
         var literal = new StringBuilder();
 
         var index = 0;
@@ -186,6 +193,13 @@ public static class LinkGenerator {
 
             var token = template.Substring(open + 1, close - open - 1);
             var name = RouteTokens.Name(token);
+
+            // A token that is not an identifier, or one the route declares twice, is a link method
+            // that does not compile. The route itself is reported by HRDR002.
+            if (!SyntaxFacts.IsValidIdentifier(name) || !names.Add(name)) {
+                return null;
+            }
+
             var parameter = Bound(handler, name);
 
             if (literal.Length > 0) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -69,6 +69,7 @@ public class RequestHandlerModel {
             DeclaredSecuritySchemes = DeclaredSecuritySchemes,
             ParameterEnums = ParameterEnums,
             MisplacedSchemeAttributes = MisplacedSchemeAttributes,
+            AdditionalBodyParameters = AdditionalBodyParameters,
             HasGeneratedValidation = HasGeneratedValidation
         };
 
@@ -260,6 +261,18 @@ public class RequestHandlerModel {
     public IReadOnlyList<string> MisplacedSchemeAttributes { get; set; } =
         System.Array.Empty<string>();
 
+    /// <summary>
+    /// The parameters after the first that fell to the request body, by name, for <c>HRDR009</c>.
+    /// </summary>
+    /// <remarks>
+    /// A request carries one body, so the bridge that rebuilds the parameter list keeps the first
+    /// body parameter and this remembers the rest. Without it the second was dropped from the
+    /// generated invocation, which reads as a CS7036 in <c>obj/**/generated/**</c> naming neither
+    /// the parameter nor the convention that discarded it.
+    /// </remarks>
+    public IReadOnlyList<string> AdditionalBodyParameters { get; set; } =
+        System.Array.Empty<string>();
+
     public override bool Equals(object obj) {
         if (obj is not RequestHandlerModel requestHandlerModel) {
             return false;
@@ -373,6 +386,11 @@ public class RequestHandlerModel {
             return false;
         }
 
+        if (!AdditionalBodyParameters.SequenceEqual(
+                requestHandlerModel.AdditionalBodyParameters, StringComparer.Ordinal)) {
+            return false;
+        }
+
         for (var i = 0; i < MisplacedSchemeAttributes.Count; i++) {
             if (!string.Equals(
                     MisplacedSchemeAttributes[i], requestHandlerModel.MisplacedSchemeAttributes[i],
@@ -416,6 +434,7 @@ public class RequestHandlerModel {
             hashCode = (hashCode * 397) ^ HandlerMethod.GetHashCode();
             hashCode = (hashCode * 397) ^ InvokeHandlerType.GetHashCode();
             hashCode = (hashCode * 397) ^ RequestParameterInformationList.GetHashCodeAggregation();
+            hashCode = (hashCode * 397) ^ AdditionalBodyParameters.Count;
             hashCode = (hashCode * 397) ^ ResponseInformation.GetHashCode();
             hashCode = (hashCode * 397) ^ ResponseSchemas.GetHashCodeAggregation();
             hashCode = (hashCode * 397) ^ Filters.GetHashCodeAggregation();

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestParameterInformation.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestParameterInformation.cs
@@ -15,9 +15,10 @@ public class RequestParameterInformation {
         string bindingName,
         int parameterIndex,
         AttributeModel? customAttribute = null,
-        bool constructorRequiresServices = false) {
+        bool constructorRequiresServices = false,
+        bool registeredAsService = false) {
         ConstructorRequiresServices = constructorRequiresServices;
-
+        RegisteredAsService = registeredAsService;
 
 
         ParameterType = parameterType;
@@ -122,6 +123,14 @@ public class RequestParameterInformation {
     /// </remarks>
     public bool ConstructorRequiresServices { get; }
 
+    /// <summary>
+    /// Whether the parameter's type carries a DependencyModules registration -
+    /// <c>[SingletonService]</c>, <c>[ScopedService]</c> or <c>[TransientService]</c> - and so is
+    /// a service whatever its constructors look like. Asked only of a parameter that fell to the
+    /// body; the other half of what <c>HRDR007</c> reads.
+    /// </summary>
+    public bool RegisteredAsService { get; }
+
     public int ParameterIndex {
         get;
     }
@@ -145,7 +154,8 @@ public class RequestParameterInformation {
             BindingName,
             parameterIndex,
             CustomAttribute,
-            ConstructorRequiresServices) {
+            ConstructorRequiresServices,
+            RegisteredAsService) {
             Description = Description,
             SpecParameter = SpecParameter,
             SchemaFacets = SchemaFacets,
@@ -206,6 +216,10 @@ public class RequestParameterInformation {
             return false;
         }
 
+        if (RegisteredAsService != requestParameterInformation.RegisteredAsService) {
+            return false;
+        }
+
         return true;
     }
 
@@ -227,6 +241,7 @@ public class RequestParameterInformation {
             }
 
             hashCode = (hashCode * 397) ^ ConstructorRequiresServices.GetHashCode();
+            hashCode = (hashCode * 397) ^ RegisteredAsService.GetHashCode();
             
             return hashCode;
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/XmlDocumentation.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/XmlDocumentation.cs
@@ -23,6 +23,12 @@ namespace Hardened.SourceGenerator.OpenApiDocument;
 /// not choose its host's parse options, so relying on that would make the document depend on
 /// whether the project happens to emit an XML documentation file.
 /// </para>
+/// <para>
+/// An entity is the character it stands for. A doc comment has to write <c>Created&amp;lt;T&amp;gt;</c>
+/// to say <c>Created&lt;T&gt;</c>, and the template's own exported document carried the entities
+/// through as text; both paths decode them, the structured one through the entity token Roslyn
+/// already produces and the raw one by hand.
+/// </para>
 /// </remarks>
 internal static class XmlDocumentation {
 
@@ -177,7 +183,70 @@ internal static class XmlDocumentation {
             }
         }
 
-        return Collapse(builder.ToString());
+        return Collapse(DecodeEntities(builder.ToString()));
+    }
+
+    /// <summary>
+    /// The five named entities XML defines and the numeric forms, as their characters. Anything
+    /// else is left as written: a stray <c>&amp;</c> in prose is prose.
+    /// </summary>
+    private static string DecodeEntities(string text) {
+        if (text.IndexOf('&') < 0) {
+            return text;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        var index = 0;
+
+        while (index < text.Length) {
+            var ampersand = text.IndexOf('&', index);
+
+            if (ampersand < 0) {
+                builder.Append(text, index, text.Length - index);
+
+                break;
+            }
+
+            builder.Append(text, index, ampersand - index);
+
+            var semicolon = text.IndexOf(';', ampersand);
+
+            if (semicolon > ampersand && Decode(text.Substring(ampersand + 1, semicolon - ampersand - 1)) is { } decoded) {
+                builder.Append(decoded);
+                index = semicolon + 1;
+            }
+            else {
+                builder.Append('&');
+                index = ampersand + 1;
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string? Decode(string entity) {
+        switch (entity) {
+            case "lt": return "<";
+            case "gt": return ">";
+            case "amp": return "&";
+            case "quot": return "\"";
+            case "apos": return "'";
+        }
+
+        if (entity.Length < 2 || entity[0] != '#') {
+            return null;
+        }
+
+        var hex = entity[1] == 'x' || entity[1] == 'X';
+        var digits = entity.Substring(hex ? 2 : 1);
+
+        return int.TryParse(
+            digits,
+            hex ? System.Globalization.NumberStyles.HexNumber : System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out var codePoint) && codePoint > 0 && codePoint <= 0x10FFFF
+            ? char.ConvertFromUtf32(codePoint)
+            : null;
     }
 
     private static string? Element(DocumentationCommentTriviaSyntax comment, string name) {
@@ -208,6 +277,7 @@ internal static class XmlDocumentation {
         foreach (var token in element.Content.SelectMany(node => node.DescendantTokens())) {
             switch (token.Kind()) {
                 case SyntaxKind.XmlTextLiteralToken:
+                case SyntaxKind.XmlEntityLiteralToken:
                     builder.Append(token.ValueText);
                     break;
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -63,6 +63,11 @@ public abstract class BaseRequestModelGenerator {
         // assembling it: what the attributes declare for the published document.
         SecurityDeclarationSelector.Apply(context, methodDeclaration, model, cancellationToken);
 
+        // And what Compose set aside. A request has one body, so the bridge keeps the first
+        // parameter that fell to it; the rest are remembered here for HRDR009, because a
+        // parameter silently dropped from the invocation is a CS7036 in a file nobody wrote.
+        model.AdditionalBodyParameters = AdditionalBodyParameters(parameters);
+
         model.DeclaredTimeout = DeclaredTimeoutSelector.Read(context, methodDeclaration);
 
         model.ParameterEnums = ParameterEnums(context, methodDeclaration);
@@ -326,6 +331,27 @@ public abstract class BaseRequestModelGenerator {
         MethodDeclarationSyntax methodDeclaration,
         CancellationToken cancellation);
 
+    /// <summary>The names of every body parameter after the first, in declaration order.</summary>
+    private static IReadOnlyList<string> AdditionalBodyParameters(
+        IReadOnlyList<RequestParameterInformation> parameters) {
+        List<string>? additional = null;
+        var seen = false;
+
+        foreach (var parameter in parameters) {
+            if (parameter.BindingType != ParameterBindType.Body) {
+                continue;
+            }
+
+            if (seen) {
+                (additional ??= new List<string>()).Add(parameter.Name);
+            }
+
+            seen = true;
+        }
+
+        return (IReadOnlyList<string>?)additional ?? Array.Empty<string>();
+    }
+
     protected abstract ITypeDefinition GetInvokeHandlerType(
         GeneratorSyntaxContext context,
         MethodDeclarationSyntax methodDeclaration,
@@ -490,7 +516,57 @@ public abstract class BaseRequestModelGenerator {
 
         return CreateRequestParameterInformation(
             parameter, parameterType, ParameterBindType.Body, parameterIndex,
-            constructorRequiresServices: ConstructorRequiresServices(generatorSyntaxContext, parameter));
+            constructorRequiresServices: ConstructorRequiresServices(generatorSyntaxContext, parameter),
+            registeredAsService: RegisteredAsService(generatorSyntaxContext, parameter));
+    }
+
+    /// <summary>
+    /// The DependencyModules registration attributes, which settle what a concrete class is where
+    /// the constructor test cannot: a body model is never registered, and a service registered
+    /// this way is one whatever its constructors take.
+    /// </summary>
+    private static readonly string[] RegistrationAttributes = {
+        "SingletonServiceAttribute", "ScopedServiceAttribute", "TransientServiceAttribute"
+    };
+
+    private const string RegistrationNamespace = "DependencyModules.Runtime.Attributes";
+
+    /// <summary>
+    /// Whether the type is registered as a service by attribute.
+    /// </summary>
+    /// <remarks>
+    /// Asked only of a parameter that has fallen to the body, and answered from the semantic model
+    /// because the attribute sits on the type's declaration rather than on the parameter. The
+    /// trial's <c>TodoStore</c> - a parameterless class with <c>[SingletonService]</c> - passed
+    /// the constructor test above, so it bound from the body, answered 400 on every request, and
+    /// reached the published document as a request body on a GET.
+    /// </remarks>
+    private static bool RegisteredAsService(
+        GeneratorSyntaxContext generatorSyntaxContext,
+        ParameterSyntax parameter) {
+        if (parameter.Type == null) {
+            return false;
+        }
+
+        if (generatorSyntaxContext.SemanticModel.GetTypeInfo(parameter.Type).Type
+            is not INamedTypeSymbol type) {
+            return false;
+        }
+
+        foreach (var attribute in type.GetAttributes()) {
+            var attributeClass = attribute.AttributeClass;
+
+            if (attributeClass == null ||
+                Array.IndexOf(RegistrationAttributes, attributeClass.Name) < 0) {
+                continue;
+            }
+
+            if (attributeClass.ContainingNamespace?.ToDisplayString() == RegistrationNamespace) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -554,7 +630,8 @@ public abstract class BaseRequestModelGenerator {
         bool? required = null,
         string? bindingName = null,
         AttributeModel? customAttribute = null,
-        bool constructorRequiresServices = false) {
+        bool constructorRequiresServices = false,
+        bool registeredAsService = false) {
         if (!parameterType.IsNullable && parameter.ToFullString().Contains("?")) {
             parameterType = parameterType.MakeNullable();
         }
@@ -574,7 +651,8 @@ public abstract class BaseRequestModelGenerator {
             bindingName ?? string.Empty,
             parameterIndex,
             customAttribute,
-            constructorRequiresServices);
+            constructorRequiresServices,
+            registeredAsService);
     }
 
     protected abstract RequestParameterInformation? GetParameterInfoFromAttributes(

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
@@ -121,6 +121,13 @@ public static class HandlerInfoCodeGenerator {
             declaredArgs += $", validationErrorStatus: {validationStatus}";
         }
 
+        // Whether the handler streams, which only the return type knows. The conditional-GET stage
+        // reads it to stand down rather than buffer an event stream; nothing at run time could
+        // otherwise tell a streamed handler from a buffered one before the first item is written.
+        if (handlerModel.ResponseInformation.IsAsyncEnumerable) {
+            declaredArgs += ", streamsResponse: true";
+        }
+
         // The type is handed over rather than named, so it is still a type when the file is
         // serialized: written qualified in a file that qualifies, and counted in the using list.
         // Spelled into the string it was neither, and resolved only while some other part of the

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/EntryPointSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/EntryPointSelector.cs
@@ -30,6 +30,19 @@ public static class EntryPointSelector {
         /// </summary>
         public IReadOnlyList<ImportedLinksModel> ImportedLinks { get; set; } =
             Array.Empty<ImportedLinksModel>();
+
+        /// <summary>
+        /// The handlers declaring <c>[CacheResponse]</c> in the modules this entry point imports,
+        /// so <c>HRDW005</c> can be asked where the store is registered. See
+        /// <see cref="ImportedCachedHandlers"/>.
+        /// </summary>
+        public IReadOnlyList<string> ImportedCachedHandlers { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// Whether a module this entry point imports applies a response cache store itself. See
+        /// <see cref="Shared.ImportedCachedHandlers.ImportsAStore"/>.
+        /// </summary>
+        public bool ImportsAStore { get; set; }
     }
 
     public class Comparer : IEqualityComparer<Model> {
@@ -50,7 +63,9 @@ public static class EntryPointSelector {
                    CompareMethodDefinitions(x, y) &&
                    CompareProperties(x, y) &&
                    x.EnabledFeatures.SequenceEqual(y.EnabledFeatures) &&
-                   x.ImportedLinks.SequenceEqual(y.ImportedLinks);
+                   x.ImportedLinks.SequenceEqual(y.ImportedLinks) &&
+                   x.ImportedCachedHandlers.SequenceEqual(y.ImportedCachedHandlers, StringComparer.Ordinal) &&
+                   x.ImportsAStore == y.ImportsAStore;
         }
 
         private bool CompareProperties(Model x, Model y) {
@@ -131,6 +146,8 @@ public static class EntryPointSelector {
             IReadOnlyList<AttributeModel> attributes = Array.Empty<AttributeModel>();
             IReadOnlyList<EnabledFeatureModel> features = Array.Empty<EnabledFeatureModel>();
             IReadOnlyList<ImportedLinksModel> importedLinks = Array.Empty<ImportedLinksModel>();
+            IReadOnlyList<string> importedCachedHandlers = Array.Empty<string>();
+            var importsAStore = false;
 
             if (syntaxContext.Node is ClassDeclarationSyntax classDeclarationSyntax) {
                 attributes = AttributeModelHelper
@@ -146,6 +163,10 @@ public static class EntryPointSelector {
                 // reach, and what survives is names and type definitions that compare by value.
                 importedLinks =
                     ImportedLinksModel.Read(syntaxContext, classDeclarationSyntax, attributes);
+
+                // And for the same reason again: which of the imported modules' handlers cache.
+                importedCachedHandlers = ImportedCachedHandlers.Read(syntaxContext, attributes);
+                importsAStore = ImportedCachedHandlers.ImportsAStore(syntaxContext, attributes);
             }
 
             return new Model {
@@ -155,7 +176,9 @@ public static class EntryPointSelector {
                 AttributeModels = attributes,
                 PropertyDefinitions = GeneratePropertyDefinitions(syntaxContext),
                 EnabledFeatures = features,
-                ImportedLinks = importedLinks
+                ImportedLinks = importedLinks,
+                ImportedCachedHandlers = importedCachedHandlers,
+                ImportsAStore = importsAStore
             };
         };
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/ImportedCachedHandlers.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/ImportedCachedHandlers.cs
@@ -1,0 +1,212 @@
+using System.Collections.Immutable;
+using CSharpAuthor;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// The handlers declaring <c>[CacheResponse]</c> in the modules an entry point imports, by name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>HRDW005</c> is asked of the compilation that hosts the runtime, because that is the one
+/// whose module attributes say whether a store is registered. The handlers, in the layout the
+/// template scaffolds, are in a library that compilation only references - so the question has to
+/// be answered by reading the library's metadata, which is the arrangement
+/// <see cref="ImportedLinksModel"/> already relies on for links.
+/// </para>
+/// <para>
+/// Read here, at the syntax transform, while the compilation is in reach. What survives into the
+/// model is a sorted list of names, comparable by value, so it keys the incremental cache like
+/// everything else on the entry point.
+/// </para>
+/// </remarks>
+public static class ImportedCachedHandlers {
+    private const string CacheAttributeName = "CacheResponseAttribute";
+
+    private const string CacheAttributeNamespace = "Hardened.Requests.Runtime.Caching";
+
+    private const string VerbAttributeNamespace = "Hardened.Web.Runtime.Attributes";
+
+    private static readonly string[] VerbAttributeNames = {
+        "GetAttribute", "PostAttribute", "PutAttribute", "PatchAttribute", "DeleteAttribute"
+    };
+
+    /// <summary>
+    /// The module attributes that bring a store, as <c>ResponseCacheStoreDiagnostics</c> names
+    /// them - repeated here because that class is not compiled into every generator this file is.
+    /// </summary>
+    private static readonly string[] StoreModuleAttributes = {
+        "HardenedMemoryResponseCacheAttribute"
+    };
+
+    /// <summary>
+    /// Whether any module the attributes apply carries a store module attribute itself.
+    /// </summary>
+    /// <remarks>
+    /// A library module that applies <c>[HardenedMemoryResponseCache]</c> registers the store for
+    /// every application that imports it - and for the test harness that boots it, which is the
+    /// reason the caching guide gives for putting it there. The host that imports such a library
+    /// has a store, whatever its own attributes say.
+    /// </remarks>
+    public static bool ImportsAStore(
+        GeneratorSyntaxContext syntaxContext, IReadOnlyList<AttributeModel> attributes) {
+        var compilation = syntaxContext.SemanticModel.Compilation;
+
+        foreach (var attribute in attributes) {
+            var module = ModuleType(compilation, attribute);
+
+            if (module == null) {
+                continue;
+            }
+
+            foreach (var applied in module.GetAttributes()) {
+                if (applied.AttributeClass != null &&
+                    Array.IndexOf(StoreModuleAttributes, applied.AttributeClass.Name) >= 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The module class an attribute applies: the attribute's name without its suffix, in the
+    /// attribute's namespace, which is how DependencyModules names the generated companion.
+    /// </summary>
+    private static INamedTypeSymbol? ModuleType(Compilation compilation, AttributeModel attribute) {
+        var ns = attribute.TypeDefinition.Namespace;
+        var name = attribute.TypeDefinition.Name;
+
+        if (name.EndsWith("Attribute", StringComparison.Ordinal)) {
+            name = name.Substring(0, name.Length - "Attribute".Length);
+        }
+
+        var prefix = string.IsNullOrEmpty(ns) ? "" : ns + ".";
+
+        return compilation.GetTypeByMetadataName(prefix + name);
+    }
+
+    /// <summary>
+    /// <c>Type.Method</c> for every cached handler in every module the attributes apply, sorted.
+    /// </summary>
+    public static IReadOnlyList<string> Read(
+        GeneratorSyntaxContext syntaxContext, IReadOnlyList<AttributeModel> attributes) {
+        var compilation = syntaxContext.SemanticModel.Compilation;
+        var visited = new HashSet<IAssemblySymbol>(SymbolEqualityComparer.Default);
+
+        List<string>? found = null;
+
+        foreach (var attribute in attributes) {
+            var assembly = ModuleAssembly(compilation, attribute);
+
+            // The entry point's own assembly is the one the routing table already reports on, and
+            // an assembly reached through two attributes is walked once.
+            if (assembly == null ||
+                SymbolEqualityComparer.Default.Equals(assembly, compilation.Assembly) ||
+                !visited.Add(assembly)) {
+                continue;
+            }
+
+            Walk(assembly.GlobalNamespace, found ??= new List<string>());
+        }
+
+        if (found == null) {
+            return Array.Empty<string>();
+        }
+
+        found.Sort(StringComparer.Ordinal);
+
+        return found;
+    }
+
+    /// <summary>
+    /// The assembly declaring the module an attribute applies, or null for an attribute that is
+    /// not a module's, or one whose type the compilation cannot see.
+    /// </summary>
+    /// <remarks>
+    /// Both spellings of the name reach here depending on how the attribute was written, so both
+    /// are tried; the generated companion of a module is named after the module with the suffix.
+    /// </remarks>
+    private static IAssemblySymbol? ModuleAssembly(Compilation compilation, AttributeModel attribute) {
+        var ns = attribute.TypeDefinition.Namespace;
+        var name = attribute.TypeDefinition.Name;
+
+        var prefix = string.IsNullOrEmpty(ns) ? "" : ns + ".";
+
+        var symbol = compilation.GetTypeByMetadataName(prefix + name) ??
+                     compilation.GetTypeByMetadataName(prefix + name + "Attribute");
+
+        return symbol?.ContainingAssembly;
+    }
+
+    private static void Walk(INamespaceSymbol ns, List<string> found) {
+        foreach (var member in ns.GetMembers()) {
+            switch (member) {
+                case INamespaceSymbol child:
+                    Walk(child, found);
+                    break;
+
+                case INamedTypeSymbol type:
+                    Visit(type, found);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A method declaring caching counts however it is routed; under a class-level declaration
+    /// only the methods carrying a verb attribute do, which is what the class's declaration
+    /// reaches.
+    /// </summary>
+    private static void Visit(INamedTypeSymbol type, List<string> found) {
+        var classDeclares = DeclaresCaching(type.GetAttributes());
+
+        foreach (var member in type.GetMembers()) {
+            if (member is not IMethodSymbol { MethodKind: MethodKind.Ordinary } method) {
+                continue;
+            }
+
+            var attributes = method.GetAttributes();
+
+            if (DeclaresCaching(attributes) || (classDeclares && IsRoute(attributes))) {
+                found.Add(type.Name + "." + method.Name);
+            }
+        }
+
+        foreach (var nested in type.GetTypeMembers()) {
+            Visit(nested, found);
+        }
+    }
+
+    /// <summary>
+    /// Either form: the generic attribute's symbol has the same name and namespace, with an arity.
+    /// </summary>
+    private static bool DeclaresCaching(ImmutableArray<AttributeData> attributes) {
+        foreach (var attribute in attributes) {
+            var attributeClass = attribute.AttributeClass;
+
+            if (attributeClass?.Name == CacheAttributeName &&
+                attributeClass.ContainingNamespace?.ToDisplayString() == CacheAttributeNamespace) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsRoute(ImmutableArray<AttributeData> attributes) {
+        foreach (var attribute in attributes) {
+            var attributeClass = attribute.AttributeClass;
+
+            if (attributeClass != null &&
+                Array.IndexOf(VerbAttributeNames, attributeClass.Name) >= 0 &&
+                attributeClass.ContainingNamespace?.ToDisplayString() == VerbAttributeNamespace) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/OperationSymbols.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/OperationSymbols.cs
@@ -71,6 +71,12 @@ public sealed class OperationSymbols {
     /// </remarks>
     public bool RequestBodyRequiresServices { get; set; }
 
+    /// <summary>
+    /// Whether the body parameter's type is registered as a service by attribute. Carried for the
+    /// reason <see cref="RequestBodyRequiresServices"/> is: the other half of what HRDR007 reads.
+    /// </summary>
+    public bool RequestBodyRegisteredAsService { get; set; }
+
     /// <summary>Parameter types by parameter name, for the ones already resolved.</summary>
     public Dictionary<string, ITypeDefinition>? ParameterTypes { get; set; }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -339,7 +339,8 @@ internal static class SpecHandlerModelBuilder {
                 ParameterBindType.Body,
                 "",
                 index++,
-                constructorRequiresServices: symbols?.RequestBodyRequiresServices ?? false));
+                constructorRequiresServices: symbols?.RequestBodyRequiresServices ?? false,
+                registeredAsService: symbols?.RequestBodyRegisteredAsService ?? false));
         } else if (operation.RequestBodyRef != null) {
             var bodyTypeName = NamingHelper.ToPascalCase(TypeMapper.GetRefName(operation.RequestBodyRef));
             var bodyType = TypeDefinition.Get(modelsNamespace, bodyTypeName);

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/BodyParameterDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/BodyParameterDiagnostics.cs
@@ -1,0 +1,159 @@
+using Hardened.SourceGenerator.Models.Request;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Web.Routing;
+
+/// <summary>
+/// A request body read where there is none to read: two parameters that both fell to it, or one
+/// on a verb that carries no body.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A parameter that names no route token and is not an interface binds from the body. Two of them
+/// on one handler are two readings of a body the request carries once, and the bridge that
+/// rebuilds the parameter list keeps the first - so the second was dropped from the generated
+/// invocation and the build failed as a CS7036 inside <c>obj/**/generated/**</c>, naming neither
+/// the parameter nor the convention that discarded it. That is <c>HRDR009</c>, an error.
+/// </para>
+/// <para>
+/// One body parameter on a GET is the same convention landing somewhere the request cannot
+/// follow. The handler compiled, the route matched, and every request answered 400 "The input
+/// does not contain any JSON tokens" - while the published document gave the GET a request body
+/// and put the parameter's type in its schemas. <c>HRDR005</c> reports this where a route token
+/// displaced the parameter and <c>HRDR007</c> where the type is a service; <c>HRDR010</c> is the
+/// remainder, a warning, because a GET carrying a body is a thing some APIs deliberately do and
+/// <c>NoWarn</c> is how they say so.
+/// </para>
+/// </remarks>
+public static class BodyParameterDiagnostics {
+
+    /// <summary>
+    /// <c>HRDR009</c>. <c>HRDR007</c> reports a body parameter that is a service; this reports a
+    /// second body parameter of any kind.
+    /// </summary>
+    public const string SeveralBodiesDiagnosticId = "HRDR009";
+
+    /// <summary>
+    /// <c>HRDR010</c>. <c>HRDR005</c> reports a body parameter a route token displaced; this
+    /// reports one on a verb that carries no body, whatever put it there.
+    /// </summary>
+    public const string BodylessVerbDiagnosticId = "HRDR010";
+
+    /// <summary>Verbs whose requests carry no body to read a parameter out of. As HRDR005 lists them.</summary>
+    private static readonly HashSet<string> BodylessVerbs =
+        new(StringComparer.OrdinalIgnoreCase) { "GET", "HEAD", "OPTIONS", "TRACE" };
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the reason
+    /// <c>RouteBindingDiagnostics.Descriptor</c> is: RS2008 looks for the field, and these projects
+    /// set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor SeveralBodies() => new(
+        id: SeveralBodiesDiagnosticId,
+        title: "More than one parameter binds from the request body",
+        messageFormat:
+        "'{0}.{1}' reads {2} from the request body, and a request carries one body. A parameter " +
+        "that names no route token and is not an interface binds from the body: mark a service " +
+        "[FromServices] or type it as the interface it is registered against, and bind a value " +
+        "with [FromQueryString], [FromHeader], [FromForm] or a route token.",
+        category: "Hardened.Routing",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static DiagnosticDescriptor BodylessVerb() => new(
+        id: BodylessVerbDiagnosticId,
+        title: "Parameter binds from the body of a request that carries none",
+        messageFormat:
+        "Parameter '{0}' of '{1}.{2}' is read from the request body, and a {3} carries none, so a " +
+        "request that sends no body is refused before the handler runs and the published " +
+        "document gives the operation a body it should not have. Bind '{0}' with " +
+        "[FromQueryString] or [FromHeader], mark it [FromServices] if it is a service, or " +
+        "suppress " + BodylessVerbDiagnosticId + " if this operation deliberately reads a body " +
+        "from a {3}.",
+        category: "Hardened.Routing",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// The body parameters a bodyless verb reads that nothing else reports.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Report"/> because a <c>SourceProductionContext</c> only exists
+    /// inside a running generator, and the decision is worth testing on its own. A parameter
+    /// <c>HRDR005</c> or <c>HRDR007</c> already names is left to that report, which says more
+    /// about why it is where it is.
+    /// </remarks>
+    public static IReadOnlyList<RequestParameterInformation> FindOnBodylessVerb(RequestHandlerModel model) {
+        if (model.Name.IsDispatched || !BodylessVerbs.Contains(model.Name.Method)) {
+            return Array.Empty<RequestParameterInformation>();
+        }
+
+        HashSet<string>? displaced = null;
+
+        foreach (var finding in RouteBindingDiagnostics.Find(model)) {
+            (displaced ??= new HashSet<string>(StringComparer.Ordinal)).Add(finding.BodyParameter);
+        }
+
+        List<RequestParameterInformation>? found = null;
+
+        foreach (var parameter in model.RequestParameterInformationList) {
+            if (parameter.BindingType != ParameterBindType.Body ||
+                parameter.ConstructorRequiresServices ||
+                parameter.RegisteredAsService ||
+                displaced?.Contains(parameter.Name) == true) {
+                continue;
+            }
+
+            (found ??= new List<RequestParameterInformation>()).Add(parameter);
+        }
+
+        return (IReadOnlyList<RequestParameterInformation>?)found
+               ?? Array.Empty<RequestParameterInformation>();
+    }
+
+    /// <summary>Reports both findings, if the handler has either.</summary>
+    public static void Report(SourceProductionContext context, RequestHandlerModel model) {
+        // Location.None, as everywhere else models are reported from: a syntax location would
+        // travel with the model through the incremental caches, which compare models for
+        // equality to decide whether to regenerate. The message carries the handler instead.
+        if (model.AdditionalBodyParameters.Count > 0) {
+            context.ReportDiagnostic(Diagnostic.Create(
+                SeveralBodies(),
+                Location.None,
+                model.ControllerType.Name,
+                model.HandlerMethod,
+                BodyNames(model)));
+        }
+
+        foreach (var parameter in FindOnBodylessVerb(model)) {
+            context.ReportDiagnostic(Diagnostic.Create(
+                BodylessVerb(),
+                Location.None,
+                parameter.Name,
+                model.ControllerType.Name,
+                model.HandlerMethod,
+                model.Name.Method.ToUpperInvariant()));
+        }
+    }
+
+    /// <summary>Every body parameter, quoted: "'counter' and 'reading'".</summary>
+    private static string BodyNames(RequestHandlerModel model) {
+        var names = new List<string>();
+
+        foreach (var parameter in model.RequestParameterInformationList) {
+            if (parameter.BindingType == ParameterBindType.Body) {
+                names.Add("'" + parameter.Name + "'");
+
+                break;
+            }
+        }
+
+        foreach (var name in model.AdditionalBodyParameters) {
+            names.Add("'" + name + "'");
+        }
+
+        return names.Count == 2
+            ? names[0] + " and " + names[1]
+            : string.Join(", ", names.Take(names.Count - 1)) + " and " + names[names.Count - 1];
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/ResponseCacheStoreDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/ResponseCacheStoreDiagnostics.cs
@@ -24,6 +24,15 @@ namespace Hardened.SourceGenerator.Web.Routing;
 /// it, and that is a legitimate arrangement - so this says "nothing here registers one" and lets
 /// an author who knows better carry on.
 /// </para>
+/// <para>
+/// <b>Asked of the application, not of a library.</b> The template splits an application into a
+/// library that declares the handlers and a host that applies the runtime, and the store goes
+/// beside the runtime. Asked of the library, this warned whatever the host had registered - the
+/// 0.20 trial's first finding against the template's own layout. So a compilation whose entry
+/// point applies no web runtime says nothing, and the compilation that does is handed the cached
+/// handlers of every module it imports, read from their metadata, so the question is still
+/// answered for the layout that split it.
+/// </para>
 /// </remarks>
 public static class ResponseCacheStoreDiagnostics {
     public const string DiagnosticId = "HRDW005";
@@ -39,6 +48,17 @@ public static class ResponseCacheStoreDiagnostics {
     /// </summary>
     private static readonly string[] StoreModuleAttributes = {
         "HardenedMemoryResponseCacheAttribute"
+    };
+
+    /// <summary>
+    /// The module attributes that make an entry point an application: the web runtimes this
+    /// repository ships, and the Lambda web runtime Hardened.Amz ships. Named for the reason the
+    /// store attributes are.
+    /// </summary>
+    private static readonly string[] WebRuntimeModuleAttributes = {
+        "KestrelRuntimeAttribute",
+        "AspNetCoreRuntimeAttribute",
+        "LambdaWebModuleAttribute"
     };
 
     /// <summary>
@@ -67,15 +87,27 @@ public static class ResponseCacheStoreDiagnostics {
         model.Filters.Any(filter => IsCacheResponse(filter.TypeDefinition));
 
     /// <summary>
-    /// Whether the entry point applies a module that registers a store.
+    /// Whether the entry point applies a module that registers a store, itself or through a
+    /// module it imports.
     /// </summary>
     /// <remarks>
     /// Off the entry point's attributes, which carry the class's and the assembly's both - the same
-    /// place <c>[BasePath]</c> and <c>[RequireAuthorization]</c> are read from.
+    /// place <c>[BasePath]</c> and <c>[RequireAuthorization]</c> are read from - and off the
+    /// modules those attributes apply, since a library that carries the store attribute registers
+    /// it for whoever imports the library.
     /// </remarks>
     public static bool RegistersAStore(EntryPointSelector.Model applicationModel) =>
+        applicationModel.ImportsAStore ||
+        (applicationModel.AttributeModels?.Any(
+            attribute => StoreModuleAttributes.Contains(attribute.TypeDefinition.Name)) ?? false);
+
+    /// <summary>
+    /// Whether the entry point applies a web runtime, and so is the application rather than a
+    /// library some other compilation hosts.
+    /// </summary>
+    public static bool IsApplication(EntryPointSelector.Model applicationModel) =>
         applicationModel.AttributeModels?.Any(
-            attribute => StoreModuleAttributes.Contains(attribute.TypeDefinition.Name)) ?? false;
+            attribute => WebRuntimeModuleAttributes.Contains(attribute.TypeDefinition.Name)) ?? false;
 
     /// <summary>
     /// One report per assembly, naming every handler that would fail.
@@ -89,13 +121,15 @@ public static class ResponseCacheStoreDiagnostics {
         SourceProductionContext context,
         EntryPointSelector.Model applicationModel,
         IReadOnlyList<RequestHandlerModel> handlers) {
-        if (RegistersAStore(applicationModel)) {
+        if (!IsApplication(applicationModel) || RegistersAStore(applicationModel)) {
             return;
         }
 
         var declaring = handlers
             .Where(DeclaresCaching)
             .Select(handler => handler.ControllerType.Name + "." + handler.HandlerMethod)
+            .Concat(applicationModel.ImportedCachedHandlers)
+            .Distinct()
             .ToList();
 
         if (declaring.Count == 0) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/ServiceParameterDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/ServiceParameterDiagnostics.cs
@@ -15,11 +15,19 @@ namespace Hardened.SourceGenerator.Web.Routing;
 /// that decided this nor the parameter whose meaning changed.
 /// </para>
 /// <para>
-/// The rule is narrow because the two shapes are otherwise indistinguishable: a body model is a
+/// The rule was narrow because the two shapes are otherwise indistinguishable: a body model is a
 /// concrete class too. What separates them is that the deserializer cannot construct an interface,
 /// so a type whose every public constructor takes one has no reading as a body at all. That test
 /// is made at the syntax transform, where the semantic model is in hand, and carried on
 /// <see cref="RequestParameterInformation.ConstructorRequiresServices"/>.
+/// </para>
+/// <para>
+/// The other statement that settles it is the registration. A type carrying
+/// <c>[SingletonService]</c>, <c>[ScopedService]</c> or <c>[TransientService]</c> is a service
+/// whatever its constructors take, and a body model never carries one - so a parameterless
+/// service that passed the constructor test, bound from the body, answered 400 on every request
+/// and published a request body on a GET, which is what the 0.20 trial's <c>TodoStore</c> did. It
+/// travels on <see cref="RequestParameterInformation.RegisteredAsService"/>.
 /// </para>
 /// </remarks>
 public static class ServiceParameterDiagnostics {
@@ -45,7 +53,8 @@ public static class ServiceParameterDiagnostics {
         isEnabledByDefault: true);
 
     /// <summary>
-    /// Every body parameter whose type can only be constructed from services.
+    /// Every body parameter whose type can only be constructed from services, or is registered as
+    /// one.
     /// </summary>
     /// <remarks>
     /// Split from <see cref="Report"/> for the reason <c>RouteBindingDiagnostics.Find</c> is: a
@@ -57,7 +66,7 @@ public static class ServiceParameterDiagnostics {
 
         foreach (var parameter in model.RequestParameterInformationList) {
             if (parameter.BindingType == ParameterBindType.Body &&
-                parameter.ConstructorRequiresServices) {
+                (parameter.ConstructorRequiresServices || parameter.RegisteredAsService)) {
                 (found ??= new List<RequestParameterInformation>()).Add(parameter);
             }
         }
@@ -71,10 +80,16 @@ public static class ServiceParameterDiagnostics {
     /// type as well as the parameter.
     /// </summary>
     public static string Advice(RequestParameterInformation parameter) =>
-        $"A parameter that names no route token and is not an interface binds from the body, and " +
-        $"'{parameter.ParameterType.Name}' has no constructor that does not take one, so no body " +
-        $"can be read into it. Mark '{parameter.Name}' [FromServices], or type it as the " +
-        $"interface it is registered against.";
+        parameter.RegisteredAsService
+            ? $"A parameter that names no route token and is not an interface binds from the " +
+              $"body, and '{parameter.ParameterType.Name}' is registered as a service by its " +
+              $"[SingletonService], [ScopedService] or [TransientService] attribute, so it was " +
+              $"never a body. Mark '{parameter.Name}' [FromServices], or type it as the interface " +
+              $"it is registered against."
+            : $"A parameter that names no route token and is not an interface binds from the " +
+              $"body, and '{parameter.ParameterType.Name}' has no constructor that does not take " +
+              $"one, so no body can be read into it. Mark '{parameter.Name}' [FromServices], or " +
+              $"type it as the interface it is registered against.";
 
     /// <summary>Reports every finding, if the handler has any.</summary>
     public static void Report(SourceProductionContext context, RequestHandlerModel model) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/TimeoutDeclarationDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/TimeoutDeclarationDiagnostics.cs
@@ -1,0 +1,54 @@
+using Hardened.SourceGenerator.Models.Request;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Web;
+
+/// <summary>
+/// A <c>[Timeout]</c> whose budget is zero or less.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The runtime refuses it - <c>TimeoutResolver</c> fails as the handler's chain is composed,
+/// naming the handler and the rung - but that is the first request, answered 500. And the
+/// document export ran ahead of it: an operation under <c>[Timeout(Milliseconds = 0)]</c>
+/// published <c>x-hardened-timeout: 0</c>, a contract that fails on the first request of any
+/// service regenerated from it.
+/// </para>
+/// <para>
+/// An error with no <c>NoWarn</c>, like <see cref="CompressDiagnostics"/>: a handler that should
+/// not be bounded declares no timeout, and there is no reading of zero that means anything else.
+/// </para>
+/// </remarks>
+public static class TimeoutDeclarationDiagnostics {
+    public const string DiagnosticId = "HRDW006";
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the reason
+    /// <c>AmbiguousRouteDiagnostics.Descriptor</c> is: RS2008 looks for the field, and these
+    /// projects set <c>EnforceExtendedAnalyzerRules</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "[Timeout] declares no budget",
+        messageFormat:
+        "'{0}' is bounded by a [Timeout] declaring {1} milliseconds, on the operation, its class " +
+        "or its assembly. A budget has to be greater than zero; a handler that should not be " +
+        "bounded declares no timeout instead. The runtime refuses this on the first request, and " +
+        "the document would publish x-hardened-timeout: {1}.",
+        category: "Hardened.Web",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static void Report(SourceProductionContext context, RequestHandlerModel model) {
+        if (model.DeclaredTimeout is not { Milliseconds: <= 0 } declared) {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                Descriptor(),
+                Location.None,
+                model.ControllerType.Name + "." + model.HandlerMethod,
+                declared.Milliseconds));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
@@ -61,6 +61,13 @@ public class WebExecutionHandlerCodeGenerator {
         // silently over the class's.
         CompressDiagnostics.Report(sourceProductionContext, requestHandlerModel);
 
+        // Two body parameters compile into a CS7036 in generated code, and one body parameter on
+        // a GET compiles into a handler that refuses every request.
+        BodyParameterDiagnostics.Report(sourceProductionContext, requestHandlerModel);
+
+        // A zero budget compiles, publishes, and fails the first request.
+        TimeoutDeclarationDiagnostics.Report(sourceProductionContext, requestHandlerModel);
+
         var sourceFile = GenerateFile(requestHandlerModel, sourceProductionContext.CancellationToken, excludeFromCoverage);
 
         sourceProductionContext.AddSource(requestHandlerModel.InvokeHandlerType.Name, GeneratedSource.Header(sourceFile));

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
@@ -395,6 +395,7 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
                 RequestBodyType = body?.ParameterType,
                 RequestBodyName = body?.Name,
                 RequestBodyRequiresServices = body?.ConstructorRequiresServices ?? false,
+                RequestBodyRegisteredAsService = body?.RegisteredAsService ?? false,
                 ParameterOrder = parameters.OrderBy(p => p.ParameterIndex).Select(Wire).ToList(),
                 ParameterTypes = described.ToDictionary(Wire, p => p.ParameterType, StringComparer.Ordinal),
                 ParameterBindings = described.ToDictionary(Wire, p => p.BindingType, StringComparer.Ordinal),

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/BodyParameterDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/BodyParameterDiagnosticsTests.cs
@@ -1,0 +1,173 @@
+using DependencyModules.Runtime.Attributes;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.Web.Routing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// The request body read where there is none: two parameters that both fell to it, one on a verb
+/// that carries no body, and a registered service that fell to it because its constructor was
+/// ordinary.
+/// </summary>
+/// <remarks>
+/// Three findings from the 0.20 trial's probe controller. A GET taking the template's own
+/// <c>TodoStore</c> built clean, answered 400 on every request and published a request body on a
+/// GET; a POST taking a counter and a payload built with a CS7036 in generated code. Nothing named
+/// the convention that decided either.
+/// </remarks>
+public class BodyParameterDiagnosticsTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),              // Hardened.Web.Runtime
+        typeof(FromBodyAttribute),         // Hardened.Requests.Abstract
+        typeof(SingletonServiceAttribute)  // DependencyModules.Runtime
+    ];
+
+    private static GeneratorResult Generate(string handler) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Test.cs"] = $$"""
+                    using DependencyModules.Runtime.Attributes;
+                    using Hardened.Requests.Abstract.Attributes;
+                    using Hardened.Shared.Runtime.Attributes;
+                    using Hardened.Web.Runtime.Attributes;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    public partial class TestApplication { }
+
+                    public interface ICounter { }
+
+                    [SingletonService]
+                    public class Counter : ICounter { }
+
+                    public record Reading(string Sensor, int Value);
+
+                    public class EventController {
+                    {{handler}}
+                    }
+                    """
+            },
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors);
+
+    private static IEnumerable<Diagnostic> Reported(GeneratorResult result, string id) =>
+        result.GeneratorDiagnostics.Where(reported => reported.Id == id);
+
+    // ---------------------------------------------------------------- HRDR009
+
+    [Fact]
+    public void TwoBodyParametersAreAnErrorNamingBoth() {
+        var result = Generate("""
+            [Post("/events")]
+            public string Handle(Reading first, Reading second) => "";
+            """);
+
+        var diagnostic = Assert.Single(Reported(result, BodyParameterDiagnostics.SeveralBodiesDiagnosticId));
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("EventController.Handle", diagnostic.GetMessage());
+        Assert.Contains("'first' and 'second'", diagnostic.GetMessage());
+        Assert.Contains("[FromServices]", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void OneBodyParameterIsNotReported() {
+        var result = Generate("""
+            [Post("/events")]
+            public string Handle(Reading reading) => "";
+            """).AssertNoErrors();
+
+        Assert.Empty(Reported(result, BodyParameterDiagnostics.SeveralBodiesDiagnosticId));
+    }
+
+    // ---------------------------------------------------------------- HRDR007, the registered service
+
+    /// <summary>
+    /// A parameterless service passes the constructor test HRDR007 was built on, and its
+    /// registration attribute is the statement that settles it.
+    /// </summary>
+    [Theory]
+    [InlineData("Get")]
+    [InlineData("Post")]
+    public void ARegisteredServiceParameterIsHRDR007WhateverTheVerb(string verb) {
+        var result = Generate($$"""
+            [{{verb}}("/events")]
+            public string Handle(Counter counter) => "";
+            """);
+
+        var diagnostic = Assert.Single(Reported(result, ServiceParameterDiagnostics.DiagnosticId));
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("'Counter' is registered as a service", diagnostic.GetMessage());
+        Assert.Contains("[SingletonService]", diagnostic.GetMessage());
+        Assert.Contains("[FromServices]", diagnostic.GetMessage());
+        Assert.Empty(Reported(result, BodyParameterDiagnostics.BodylessVerbDiagnosticId));
+    }
+
+    [Fact]
+    public void TheSameServiceAsItsInterfaceReportsNothing() {
+        var result = Generate("""
+            [Get("/events")]
+            public string Handle(ICounter counter) => "";
+            """).AssertNoErrors();
+
+        Assert.Empty(Reported(result, ServiceParameterDiagnostics.DiagnosticId));
+        Assert.Empty(Reported(result, BodyParameterDiagnostics.BodylessVerbDiagnosticId));
+    }
+
+    // ---------------------------------------------------------------- HRDR010
+
+    [Theory]
+    [InlineData("Get")]
+    [InlineData("Delete")]
+    public void ABodyParameterOnABodylessVerbIsAWarning(string verb) {
+        var result = Generate($$"""
+            [{{verb}}("/events")]
+            public string Handle(Reading reading) => "";
+            """);
+
+        var reported = Reported(result, BodyParameterDiagnostics.BodylessVerbDiagnosticId).ToList();
+
+        if (verb == "Delete") {
+            // DELETE is not bodyless: HTTP permits a body on one and some APIs send it.
+            Assert.Empty(reported);
+
+            return;
+        }
+
+        var diagnostic = Assert.Single(reported);
+
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("'reading'", diagnostic.GetMessage());
+        Assert.Contains("a GET carries none", diagnostic.GetMessage());
+        Assert.Contains("HRDR010", diagnostic.GetMessage());
+    }
+
+    /// <summary>A parameter a route token displaced is HRDR005's, which says why it moved.</summary>
+    [Fact]
+    public void AParameterHRDR005ReportsIsLeftToIt() {
+        var result = Generate("""
+            [Get("/events/{eventid}")]
+            public string Handle(string eventId) => eventId;
+            """);
+
+        Assert.Single(Reported(result, RouteBindingDiagnostics.DiagnosticId));
+        Assert.Empty(Reported(result, BodyParameterDiagnostics.BodylessVerbDiagnosticId));
+    }
+
+    [Fact]
+    public void ABodyOnAPostIsNotReported() {
+        var result = Generate("""
+            [Post("/events")]
+            public string Handle(Reading reading) => "";
+            """).AssertNoErrors();
+
+        Assert.Empty(Reported(result, BodyParameterDiagnostics.BodylessVerbDiagnosticId));
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/CollidingRoutingGeneratorsTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/CollidingRoutingGeneratorsTests.cs
@@ -144,4 +144,25 @@ public class CollidingRoutingGeneratorsTests {
 
         Assert.True(errors.Count == 0, string.Join(" | ", errors));
     }
+
+    /// <summary>
+    /// The generator's name is the third path segment from the end, never the first. With
+    /// <c>EmitCompilerGeneratedFiles</c> on - the templates turn it on - a generated tree's path is
+    /// absolute, so reading the first segment made every generator <c>Users</c> and a
+    /// distinct-count of one reported nothing. That is how this diagnostic sat silent through the
+    /// 0.20 trial's two-generator build.
+    /// </summary>
+    [Theory]
+    [InlineData(
+        "/Users/someone/app/obj/Debug/net8.0/generated/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.SpecSourceGenerator/Hardened.Web.Marker.g.cs",
+        "Hardened.Idl.SourceGenerator")]
+    [InlineData(
+        "C:\\app\\obj\\Debug\\net8.0\\generated\\Hardened.Web.SourceGenerator\\Hardened.Web.SourceGenerator.WebLibrarySourceGenerator\\Hardened.Web.Marker.g.cs",
+        "Hardened.Web.SourceGenerator")]
+    [InlineData(
+        "Hardened.Web.SourceGenerator/Hardened.Web.SourceGenerator.WebLibrarySourceGenerator/Hardened.Web.Marker.g.cs",
+        "Hardened.Web.SourceGenerator")]
+    [InlineData("Hardened.Web.Marker.g.cs", "an unnamed generator")]
+    public void TheGeneratorIsNamedFromTheEndOfThePath(string path, string expected) =>
+        Assert.Equal(expected, CollidingRoutingGenerators.GeneratorName(path));
 }

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/ResponseCacheStoreDiagnosticTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/ResponseCacheStoreDiagnosticTests.cs
@@ -13,9 +13,18 @@ namespace Hardened.Web.SourceGenerator.Tests.Routing;
 /// <c>[CacheResponse]</c> in an application that registers no store.
 /// </summary>
 /// <remarks>
+/// <para>
 /// One of the five mistakes the 0.19 trial's arm B made deliberately, and one of the five that
 /// built clean. The attribute is inert without the store package, so every cached route answered an
 /// error at run time - which is where each arm found out.
+/// </para>
+/// <para>
+/// Asked of the application, which is the compilation whose entry point applies a web runtime. The
+/// 0.20 trial put the store beside the runtime in the template's host, as the docs say to, and the
+/// library that declares the handlers warned anyway - so a library says nothing now, and the host
+/// is told what the modules it imports cache. The runtime attribute is matched by name, which is
+/// why a stand-in declared in the test source is enough.
+/// </para>
 /// </remarks>
 public class ResponseCacheStoreDiagnosticTests {
 
@@ -37,8 +46,11 @@ public class ResponseCacheStoreDiagnosticTests {
             namespace TestApp;
 
             [HardenedModule]
+            [KestrelRuntime]
             {{moduleAttributes}}
             public partial class TestApplication { }
+
+            public class KestrelRuntimeAttribute : System.Attribute { }
 
             public class CatalogController {
             {{handlers}}
@@ -121,7 +133,10 @@ public class ResponseCacheStoreDiagnosticTests {
             namespace TestApp;
 
             [HardenedModule]
+            [KestrelRuntime]
             public partial class TestApplication { }
+
+            public class KestrelRuntimeAttribute : System.Attribute { }
 
             [CacheResponse<VaryByRoute>(Duration = 60)]
             public class CatalogController {
@@ -142,5 +157,133 @@ public class ResponseCacheStoreDiagnosticTests {
 
         Assert.Contains("Hardened.Requests.Caching.Memory", message);
         Assert.Contains("[HardenedMemoryResponseCache]", message);
+    }
+
+    // ---------------------------------------------------------------- where the question is asked
+
+    private const string Library = """
+        using Hardened.Requests.Runtime.Caching;
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+        using Hardened.Web.Runtime.Caching;
+        using Hardened.Web.Runtime.DependencyInjection;
+
+        namespace Catalog;
+
+        [HardenedModule]
+        [HardenedWebModule]
+        public partial class CatalogLibrary { }
+
+        // What DependencyModules would generate for the module, written by hand because the
+        // library is compiled without generators.
+        public class CatalogLibraryAttribute : System.Attribute { }
+
+        public class CatalogController {
+            [Get("/catalog")]
+            [CacheResponse<VaryByRoute>(Duration = 60)]
+            public string Catalog() => "catalog";
+
+            [Get("/offers")]
+            public string Offers() => "offers";
+        }
+
+        [CacheResponse<VaryByRoute>(Duration = 60)]
+        public class OffersController {
+            [Get("/deals")]
+            public string Deals() => "deals";
+
+            public string NotARoute() => "helper";
+        }
+        """;
+
+    private static GeneratorResult Host(string moduleAttributes, bool libraryCarriesTheStore = false) {
+        var library = libraryCarriesTheStore
+            ? Library.Replace("[HardenedWebModule]", "[HardenedWebModule]\n        [Hardened.Requests.Caching.Memory.HardenedMemoryResponseCache]")
+            : Library;
+
+        var (reference, _) = GeneratorTestHarness.CompileLibrary(
+            library, libraryCarriesTheStore ? "CatalogWithStore" : "Catalog", Anchors);
+
+        return GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Host.cs"] = $$"""
+                    using Catalog;
+                    using Hardened.Requests.Caching.Memory;
+                    using Hardened.Shared.Runtime.Attributes;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    {{moduleAttributes}}
+                    [CatalogLibrary]
+                    public partial class Application { }
+
+                    public class KestrelRuntimeAttribute : System.Attribute { }
+                    """
+            },
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors,
+            additionalReferences: [reference]);
+    }
+
+    /// <summary>
+    /// The template's layout: the handlers in a library, the runtime and the store in a host. The
+    /// library's compilation applies no runtime, so it is not the application and says nothing.
+    /// </summary>
+    [Fact]
+    public void ALibraryModuleReportsNothingWhateverItCaches() {
+        var result = GeneratorTestHarness.Run(
+            """
+            using Hardened.Requests.Runtime.Caching;
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+            using Hardened.Web.Runtime.Caching;
+            using Hardened.Web.Runtime.DependencyInjection;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            [HardenedWebModule]
+            public partial class CatalogLibrary { }
+
+            public class CatalogController {
+                [Get("/catalog")]
+                [CacheResponse<VaryByRoute>(Duration = 60)]
+                public string Catalog() => "catalog";
+            }
+            """,
+            new WebLibrarySourceGenerator(),
+            Anchors);
+
+        Assert.Empty(Reported(result));
+    }
+
+    /// <summary>
+    /// And the host is told, by name, what the library it imports caches - read from the
+    /// library's metadata, since the host's compilation holds none of its syntax.
+    /// </summary>
+    [Fact]
+    public void AHostImportingACachingLibraryWithNoStoreIsToldWhichHandlersFail() {
+        var diagnostic = Assert.Single(Reported(Host("[KestrelRuntime]")));
+
+        Assert.Contains("CatalogController.Catalog", diagnostic.GetMessage());
+        Assert.Contains("OffersController.Deals", diagnostic.GetMessage());
+        Assert.DoesNotContain("Offers", diagnostic.GetMessage().Replace("OffersController", ""));
+        Assert.DoesNotContain("NotARoute", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void AHostImportingACachingLibraryWithTheStoreReportsNothing() {
+        Assert.Empty(Reported(Host("[KestrelRuntime] [HardenedMemoryResponseCache]")));
+    }
+
+    /// <summary>
+    /// The caching guide's arrangement for the template's layout: the library applies the store,
+    /// so the test harness that boots the library sees it. The host imports the library, and with
+    /// it the store, so it has nothing to be told.
+    /// </summary>
+    [Fact]
+    public void AHostImportingALibraryThatCarriesTheStoreReportsNothing() {
+        Assert.Empty(Reported(Host("[KestrelRuntime]", libraryCarriesTheStore: true)));
     }
 }

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/UnlinkableRouteTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/UnlinkableRouteTests.cs
@@ -1,0 +1,66 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// A route HRDR002 refuses has no link, so HRDR002 stands alone.
+/// </summary>
+/// <remarks>
+/// The handler for <c>{id?}</c> is still emitted so the diagnostic is not buried under the CS0246s
+/// a missing class would raise - and the links type then declared <c>string id?</c> as a parameter
+/// and buried it under a dozen CS1003s instead. Twelve syntax errors ahead of the one line that
+/// said what was wrong, in the 0.20 trial.
+/// </remarks>
+public class UnlinkableRouteTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)   // Hardened.Requests.Abstract
+    ];
+
+    private static GeneratorResult Generate(string route) =>
+        GeneratorTestHarness.Run(
+            $$"""
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            public class ItemController {
+                [Get("{{route}}")]
+                public string Item(string id) => id;
+
+                [Get("/items/{id}/name")]
+                public string Name(string id) => id;
+            }
+            """,
+            new WebLibrarySourceGenerator(),
+            Anchors);
+
+    [Theory]
+    [InlineData("/items/{id?}")]
+    [InlineData("/items/{id=5}")]
+    [InlineData("/items/{id}/x/{id}")]
+    public void ARefusedRouteIsReportedOnceAndCompiles(string route) {
+        var result = Generate(route);
+
+        Assert.Contains(result.GeneratorDiagnostics, diagnostic => diagnostic.Id == "HRDR002");
+        Assert.DoesNotContain(result.Errors, diagnostic => diagnostic.Id.StartsWith("CS", StringComparison.Ordinal));
+    }
+
+    /// <summary>The routes beside it keep their links.</summary>
+    [Fact]
+    public void TheOtherRoutesAreStillLinkable() {
+        var links = Generate("/items/{id?}").SourceContaining("TestApplication.Links");
+
+        Assert.Contains("Name(", links);
+        Assert.DoesNotContain("id?", links);
+    }
+}

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Streaming/ServerSentEventsDiagnosticTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Streaming/ServerSentEventsDiagnosticTests.cs
@@ -91,4 +91,35 @@ public class ServerSentEventsDiagnosticTests {
 
         Assert.Empty(Reported(result));
     }
+
+    /// <summary>
+    /// The one fact about a handler only the return type knows, written onto its handler info so
+    /// the conditional-GET stage can stand down rather than buffer the stream. Both framings, and
+    /// not a buffered handler.
+    /// </summary>
+    [Theory]
+    [InlineData("[ServerSentEvents]")]
+    [InlineData("")]
+    public void AStreamingHandlerSaysSoOnItsHandlerInfo(string framing) {
+        var result = Generate($$"""
+            [Get("/feed")]
+            {{framing}}
+            public async IAsyncEnumerable<string> Feed() {
+                yield return "one";
+                await Task.CompletedTask;
+            }
+            """).AssertNoErrors();
+
+        Assert.Contains("streamsResponse: true", result.SourceContaining("FeedController_Feed"));
+    }
+
+    [Fact]
+    public void ABufferedHandlerDoesNotClaimToStream() {
+        var result = Generate("""
+            [Get("/latest")]
+            public Task<List<string>> Latest() => Task.FromResult(new List<string>());
+            """).AssertNoErrors();
+
+        Assert.DoesNotContain("streamsResponse", result.SourceContaining("FeedController_Latest"));
+    }
 }

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/TimeoutDeclarationDiagnosticTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/TimeoutDeclarationDiagnosticTests.cs
@@ -1,0 +1,82 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.Web;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests;
+
+/// <summary>
+/// <c>[Timeout]</c> declaring no budget.
+/// </summary>
+/// <remarks>
+/// The runtime refuses a zero budget as the handler's chain is composed, which is the first
+/// request, answered 500 - and the document export ran ahead of it, publishing
+/// <c>x-hardened-timeout: 0</c> from the 0.20 trial's probe. <c>HRDW006</c> is the build saying
+/// so.
+/// </remarks>
+public class TimeoutDeclarationDiagnosticTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute),  // Hardened.Requests.Abstract
+        typeof(TimeoutAttribute)    // Hardened.Requests.Runtime
+    ];
+
+    private static GeneratorResult Generate(string classAttributes, string handlerAttributes) =>
+        GeneratorTestHarness.Run(
+            $$"""
+            using Hardened.Requests.Runtime.Filters;
+            using Hardened.Shared.Runtime.Attributes;
+            using Hardened.Web.Runtime.Attributes;
+
+            namespace TestApp;
+
+            [HardenedModule]
+            public partial class TestApplication { }
+
+            {{classAttributes}}
+            public class RatesController {
+                [Get("/rates")]
+                {{handlerAttributes}}
+                public string Read() => "rates";
+            }
+            """,
+            new WebLibrarySourceGenerator(),
+            Anchors);
+
+    private static IEnumerable<Diagnostic> Reported(GeneratorResult result) =>
+        result.GeneratorDiagnostics.Where(d => d.Id == TimeoutDeclarationDiagnostics.DiagnosticId);
+
+    [Theory]
+    [InlineData("[Timeout(Milliseconds = 0)]")]
+    [InlineData("[Timeout(Milliseconds = -5)]")]
+    public void AZeroOrNegativeBudgetOnTheOperationIsHRDW006(string attribute) {
+        var diagnostic = Assert.Single(Reported(Generate("", attribute)));
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("RatesController.Read", diagnostic.GetMessage());
+        Assert.Contains("greater than zero", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void AZeroBudgetOnTheClassIsReportedForItsOperations() {
+        Assert.Single(Reported(Generate("[Timeout(Milliseconds = 0)]", "")));
+    }
+
+    [Fact]
+    public void ABudgetReportsNothing() {
+        var result = Generate("", "[Timeout(Milliseconds = 2000)]").AssertNoErrors();
+
+        Assert.Empty(Reported(result));
+    }
+
+    [Fact]
+    public void NoDeclarationReportsNothing() {
+        var result = Generate("", "").AssertNoErrors();
+
+        Assert.Empty(Reported(result));
+    }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -37,8 +37,9 @@ Change the thing it was generated from.
 | Duplicate definitions under `obj/**/generated/` | A generator was renamed and its old output is still there. Delete `obj/`. |
 | `HRDR008` | Two routing generators reached this project. Add `PrivateAssets="all"` to the reference that brought the second. |
 | Builds clean, every route answers 404 | The routing generator is absent. The runtime packages carry no analyzers. |
-| `HRDR007` on a handler parameter | A concrete class as a handler parameter is bound from the request body. Type it as an interface, or mark it `[FromServices]`. |
-| A handler parameter arrives empty, or `CS0128` on `contentSerializationService` | The same mistake with a type the deserializer can construct, so `HRDR007` does not fire. Same two fixes. |
+| `HRDR007` on a handler parameter | A concrete class as a handler parameter is bound from the request body - its constructor takes services, or it carries `[SingletonService]`. Type it as an interface, or mark it `[FromServices]`. |
+| `HRDR009` | Two handler parameters both fell to the request body. One of them is a service or a value: `[FromServices]`, an interface, or `[FromQueryString]`. |
+| `HRDR010` on a `GET` | A parameter typed as a plain class, so it is read from a body a `GET` does not carry. Same fixes, or `NoWarn` if the body is deliberate. |
 #if (specFirst)
 | `HOAT001` naming a contract that exists | The path in the csproj does not match the file |
 #endif
@@ -99,9 +100,9 @@ method's exact signature.
 
 **Services arrive as handler parameters**, alongside route and body values — `ITodoStore store` in
 every handler here. Ask for an interface. A parameter typed as a concrete class is bound from the
-request body instead. Where the class can only be constructed from services, that is `HRDR007`;
-where the deserializer could construct it, the parameter simply arrives empty, and on a route that
-also takes a body it generates two body reads and does not compile.
+request body instead. Where the class can only be constructed from services, or is registered with
+`[SingletonService]` and its siblings, that is `HRDR007`; a second parameter that fell to the body
+is `HRDR009`, and one on a `GET` is `HRDR010`.
 #endif
 
 ## How this application declares its responses

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -94,11 +94,17 @@ served at `/todos/{id}`. `[Get]`, `[Post]`, `[Put]`, `[Delete]` and `[Patch]` al
 way.
 
 Services arrive as parameters, and you ask for an interface. A parameter typed as a concrete class
-is bound from the request body instead - `HRDR007`, where the class can only be constructed from
-services. A service is registered next to the class it belongs to,
+is bound from the request body instead - `HRDR007`, where the class is registered as a service or
+can only be constructed from one. A service is registered next to the class it belongs to,
 with `[SingletonService]`, `[ScopedService]` or `[TransientService]` - the module lists nothing, so
 it cannot fall out of step.
 #endif
+
+Every route is in the published document, and `tests/Hardened1.Tests/DocumentStatusTests.cs` holds
+the document to the statuses this suite exercises, operation by operation. Adding a route fails
+that test until its `Expected` table names the new operation and the statuses a test drives - which
+is the point: a status the document declares and nothing answers is the defect a reference page
+cannot show.
 #if (specFirst)
 #if (openapi)
 The contract is `src/Hardened1/contracts/todos.yaml`.

--- a/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetCoreRequestHandler.cs
+++ b/src/Web/Hardened.Web.AspNetCore.Runtime/Impl/AspNetCoreRequestHandler.cs
@@ -95,13 +95,14 @@ public class AspNetCoreRequestHandler : IAspNetCoreRequestHandler {
             await _middlewareService.GetExecutionChain(executionContext).Next();
         }
         catch (Exception exception) {
-            _requestLogger.RequestFailed(executionContext, exception);
-
             // Once the response has started the status line is already on the wire and there is
-            // nothing left to say. Setting it would throw in its own right.
+            // nothing left to say. Setting it would throw in its own right. Decided before the
+            // logger is told, because the logger reads the status to pick its level.
             if (!executionContext.Response.ResponseStarted) {
                 executionContext.Response.Status = 500;
             }
+
+            _requestLogger.RequestFailed(executionContext, exception);
         }
     }
 

--- a/src/Web/Hardened.Web.Kestrel.Runtime.Tests/StreamingOverASocketTests.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime.Tests/StreamingOverASocketTests.cs
@@ -1,0 +1,232 @@
+using System.Net;
+using System.Text;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Logging;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Hardened.Web.Kestrel.Runtime.Tests;
+
+/// <summary>
+/// A streamed response over a real Kestrel socket: server-sent events and newline-delimited JSON,
+/// through the filter that writes them and the body the host actually hands it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every streaming test in the repository ran through <c>ITestWebApp</c> or the filter tests,
+/// both of which write into a <c>MemoryStream</c>. Kestrel's response body refuses a synchronous
+/// write unless <c>AllowSynchronousIO</c> is turned on, and the framings wrote their prefixes and
+/// newlines synchronously - so every event stream answered 500 with an empty body on both hosts,
+/// and the first newline-delimited item ended the stream, while the suite was green. This is the
+/// test that would have said so.
+/// </para>
+/// <para>
+/// No routing and no generated handler, as in the other socket tests beside this: the chain is
+/// the IO filter and something terminal that hands it a sequence, which is enough to put the
+/// framing on the wire.
+/// </para>
+/// </remarks>
+public class StreamingOverASocketTests {
+
+    [Fact]
+    public async Task AnEventStreamReachesTheClientWithItsFraming() {
+        await using var harness = await Harness.Start(SseFraming.Instance, TestContext.Current.CancellationToken);
+
+        using var response = await harness.Get(TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/event-stream", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(
+            "id: 1\ndata: alpha\n\ndata: beta\n\n",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// The completion of an empty event stream is the one write that asked the body where it was,
+    /// and Kestrel's body does not say: the comment went unwritten and the request logged a fault
+    /// after answering 200.
+    /// </summary>
+    [Fact]
+    public async Task AnEmptyEventStreamEndsWithItsCommentAndNoFault() {
+        await using var harness = await Harness.Start(SseFraming.Instance, TestContext.Current.CancellationToken, empty: true);
+
+        using var response = await harness.Get(TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(":\n\n", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(harness.Failures);
+    }
+
+    /// <summary>And a stream that produced events does not get the comment, nor a fault.</summary>
+    [Fact]
+    public async Task AnEventStreamThatProducedEventsLogsNoFault() {
+        await using var harness = await Harness.Start(SseFraming.Instance, TestContext.Current.CancellationToken);
+
+        using var response = await harness.Get(TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(":\n\n", await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(harness.Failures);
+    }
+
+    [Fact]
+    public async Task ANewlineDelimitedStreamReachesTheClientWhole() {
+        await using var harness = await Harness.Start(NdjsonFraming.Instance, TestContext.Current.CancellationToken);
+
+        using var response = await harness.Get(TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/x-ndjson", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(
+            "alpha\nbeta\n\n",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A real Kestrel listening on a port the OS picked, with the streaming IO filter composed as
+    /// middleware over a filter that produces the sequence. <c>AllowSynchronousIO</c> is left at
+    /// its default, which is the whole point.
+    /// </summary>
+    private sealed class Harness : IAsyncDisposable {
+        private HardenedKestrelApplication _app = null!;
+        private readonly HttpClient _client;
+
+        private Harness(HttpClient client) {
+            _client = client;
+        }
+
+        /// <summary>What the request logger was told failed, which a 200 with a full body hides.</summary>
+        public List<Exception> Failures { get; } = [];
+
+        public static async Task<Harness> Start(
+            IStreamFraming framing, CancellationToken cancellationToken, bool empty = false) {
+            var harness = new Harness(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
+
+            harness._app = Build(harness);
+
+            harness.Compose(framing, empty);
+
+            await harness._app.StartAsync(cancellationToken);
+
+            harness._client.BaseAddress = new Uri(harness._app.Addresses.First());
+
+            return harness;
+        }
+
+        public async Task<HttpResponseMessage> Get(CancellationToken cancellationToken) {
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/feed");
+
+            return await _client.SendAsync(
+                request, HttpCompletionOption.ResponseContentRead, cancellationToken);
+        }
+
+        public async ValueTask DisposeAsync() {
+            _client.Dispose();
+
+            await _app.DisposeAsync();
+        }
+
+        private static HardenedKestrelApplication Build(Harness harness) {
+            var services = new ServiceCollection();
+
+            services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Warning));
+            services.AddTransient<IHardenedEnvironment>(_ => new EnvironmentImpl("test"));
+
+            new KestrelRuntime().PopulateServiceCollection(services);
+
+            // Ahead of the runtime's own, which registers with Try. A fault after the response
+            // started is invisible to the client, so the logger is where it shows.
+            services.AddSingleton<IRequestLogger>(new Recording(harness.Failures));
+
+            // Port 0, so the OS picks one and concurrent test classes cannot collide.
+            return HardenedKestrelApplication.Create(
+                services, kestrel => kestrel.Listen(IPAddress.Loopback, 0));
+        }
+
+        private void Compose(IStreamFraming framing, bool empty) {
+            var middleware = _app.Services.GetRequiredService<IMiddlewareService>();
+
+            middleware.Use(_ => new AsyncEnumerableIoFilter<object>(
+                _ => Task.FromResult<IExecutionRequestParameters>(EmptyParameters.Instance),
+                WriteValue,
+                null,
+                framing));
+            middleware.Use(_ => new Producing(ReferenceEquals(framing, SseFraming.Instance), empty));
+        }
+
+        /// <summary>Keeps what the pipeline reported as failed, and nothing else.</summary>
+        private sealed class Recording : IRequestLogger {
+            private readonly List<Exception> _failures;
+
+            public Recording(List<Exception> failures) {
+                _failures = failures;
+            }
+
+            public void RequestBegin(IExecutionContext context) { }
+
+            public void RequestMapped(IExecutionContext context) { }
+
+            public void RequestEnd(IExecutionContext context) { }
+
+            public void RequestParameterBindFailed(IExecutionContext context, Exception? exp) {
+                if (exp != null) {
+                    _failures.Add(exp);
+                }
+            }
+
+            public void RequestFailed(IExecutionContext context, Exception exp) => _failures.Add(exp);
+
+            public void ResourceNotFound(IExecutionContext context) { }
+        }
+
+        /// <summary>
+        /// Stands in for the serializer by writing the item's text, asynchronously, so what the
+        /// test measures is the framing around it.
+        /// </summary>
+        private static Task WriteValue(IExecutionContext context) {
+            var bytes = Encoding.UTF8.GetBytes(context.Response.ResponseValue?.ToString() ?? "");
+
+            return context.Response.Body.WriteAsync(bytes, 0, bytes.Length, context.CancellationToken);
+        }
+
+        /// <summary>
+        /// The terminal filter: hands the IO filter a sequence. For the event stream the first item
+        /// carries an id, so the field line is on the wire too; the newline-delimited framing is
+        /// handed plain items, since it frames whatever it is given as it is.
+        /// </summary>
+        private sealed class Producing : IExecutionFilter {
+            private readonly bool _events;
+            private readonly bool _empty;
+
+            public Producing(bool events, bool empty) {
+                _events = events;
+                _empty = empty;
+            }
+
+            public Task Execute(IExecutionChain chain) {
+                chain.Context.Response.ResponseValue = _empty ? Nothing() : Items(_events);
+
+                return Task.CompletedTask;
+            }
+
+            private static async IAsyncEnumerable<object> Nothing() {
+                await Task.Yield();
+
+                yield break;
+            }
+
+            private static async IAsyncEnumerable<object> Items(bool events) {
+                yield return events ? new SseItem<string>("alpha", Id: "1") : "alpha";
+
+                await Task.Yield();
+
+                yield return "beta";
+            }
+        }
+    }
+}

--- a/src/Web/Hardened.Web.Kestrel.Runtime/Impl/HardenedHttpApplication.cs
+++ b/src/Web/Hardened.Web.Kestrel.Runtime/Impl/HardenedHttpApplication.cs
@@ -90,13 +90,14 @@ public class HardenedHttpApplication : IHttpApplication<HardenedHttpApplication.
             await _middlewareService.GetExecutionChain(execution).Next();
         }
         catch (Exception exception) {
-            _requestLogger.RequestFailed(execution, exception);
-
             // Once the response has started the status line is already on the wire and there is
-            // nothing left to say; the connection will be torn down by the server.
+            // nothing left to say; the connection will be torn down by the server. Decided before
+            // the logger is told, because the logger reads the status to pick its level.
             if (!execution.Response.ResponseStarted) {
                 execution.Response.Status = 500;
             }
+
+            _requestLogger.RequestFailed(execution, exception);
         }
         finally {
             // Required by Kestrel. A response that wrote no body — a 204, or a 500 set above —

--- a/src/Web/Hardened.Web.Runtime.Tests/Conditional/ConditionalGetAttributeTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Conditional/ConditionalGetAttributeTests.cs
@@ -19,6 +19,10 @@ public class ConditionalGetAttributeTests {
     private static ExecutionRequestHandlerInfo Handler(string method, params object[] metadata) =>
         new("/rates", method, typeof(Controller), "Read", metadata: metadata);
 
+    /// <summary>A handler the generator marked as streaming, which the flag is the only sign of.</summary>
+    private static ExecutionRequestHandlerInfo Streaming(string method, params object[] metadata) =>
+        new("/feed", method, typeof(Controller), "Feed", metadata: metadata, streamsResponse: true);
+
     /// <summary>
     /// A HEAD reaches the GET handler through the routing table, so a handler declared for GET is
     /// the one a HEAD is revalidated at.
@@ -82,6 +86,30 @@ public class ConditionalGetAttributeTests {
         Assert.Single(provider.GetFilters(Handler("GET")));
         Assert.Empty(provider.GetFilters(Handler("GET", new ConditionalGetAttribute())));
         Assert.Empty(provider.GetFilters(Handler("POST")));
+    }
+
+    /// <summary>
+    /// Tagging a response means holding it back until it is all there, and a stream held back is
+    /// not a stream: enabled application-wide, this arrived a server-sent event feed as one packet
+    /// after the last event, with an ETag on it. So the default stands down for a handler that
+    /// streams, and so does a declaration reaching one from its class.
+    /// </summary>
+    [Fact]
+    public void AStreamingHandlerGetsNothingFromTheModuleDefault() {
+        var services = new ServiceCollection();
+
+        new ConditionalGet().ConfigureServices(services);
+
+        var provider = Assert.Single(services.BuildServiceProvider().GetServices<IRequestFilterProvider>());
+
+        Assert.Empty(provider.GetFilters(Streaming("GET")));
+        Assert.Single(provider.GetFilters(Handler("GET")));
+    }
+
+    [Fact]
+    public void AStreamingHandlerGetsNothingFromTheAttribute() {
+        Assert.Empty(new ConditionalGetAttribute().GetFilters(Streaming("GET")));
+        Assert.Empty(new ConditionalGetAttribute().GetFilters(Streaming("HEAD")));
     }
 
     [Fact]

--- a/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGet.cs
+++ b/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGet.cs
@@ -27,6 +27,13 @@ namespace Hardened.Web.Runtime.Conditional;
 /// installed here is a global provider that stands down for any handler whose metadata carries
 /// one, so explicit beats convention without the registration having to say so.
 /// </para>
+/// <para>
+/// A handler that streams gets nothing from this either. Tagging a response means holding it
+/// back until it is all there, and a stream held back until it is all there is not a stream: a
+/// server-sent event feed enabled application-wide arrived as one packet, after the last event,
+/// with an <c>ETag</c> on it. <c>IExecutionRequestHandlerInfo.StreamsResponse</c> is what the
+/// provider reads to leave those alone.
+/// </para>
 /// </summary>
 /// <remarks>
 /// No module attribute is generated for this class, so that <c>[ConditionalGet]</c> can be the
@@ -40,7 +47,8 @@ public partial class ConditionalGet : IServiceCollectionConfiguration {
     public void ConfigureServices(IServiceCollection services) {
         services.AddGlobalFilter(
             new ConditionalGetAttribute(),
-            when: handlerInfo => !ConditionalGetAttribute.Declares(handlerInfo));
+            when: handlerInfo =>
+                !ConditionalGetAttribute.Declares(handlerInfo) && !handlerInfo.StreamsResponse);
     }
 
     /// <summary>

--- a/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGetAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGetAttribute.cs
@@ -31,6 +31,13 @@ namespace Hardened.Web.Runtime.Conditional;
 /// conditionals mean a 412, which this does not answer - so a class-level declaration on a
 /// controller that also writes installs nothing on the writes.
 /// </para>
+/// <para>
+/// Nothing on a handler that streams either. Tagging a response means holding it back to hash
+/// it, which turns an <c>IAsyncEnumerable&lt;T&gt;</c> answered item by item into one buffered
+/// body sent after the last item - so a declaration reaching such a handler, from its class or
+/// from <c>[Enable&lt;ConditionalGet&gt;]</c>, installs nothing, the way it installs nothing on
+/// a write.
+/// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
 public sealed class ConditionalGetAttribute : Attribute, IRequestFilterProvider {
@@ -41,7 +48,7 @@ public sealed class ConditionalGetAttribute : Attribute, IRequestFilterProvider 
     /// <see cref="FilterOrder.Conditional"/>.
     /// </summary>
     public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
-        if (!ConditionalGetFilter.IsGetOrHead(handlerInfo.Method)) {
+        if (!ConditionalGetFilter.IsGetOrHead(handlerInfo.Method) || handlerInfo.StreamsResponse) {
             yield break;
         }
 


### PR DESCRIPTION
Closes the defects the 0.20.0-rc1000 trial found. The trial was run as a consumer, from `dotnet new hardened-web` against the packages on nuget.org; every item below was reproduced there before it was fixed here, and the fixed packages were packed into a local feed and driven through the same scaffolded application on a real Kestrel socket afterwards.

## Streamed responses failed on a real socket

`SseFraming` wrote its `data:` prefix, the field lines, the event terminator, the empty-stream comment and the heartbeat with a synchronous `Stream.Write`, and `NdjsonFraming` wrote its newlines with `WriteByte`. Kestrel refuses both unless `AllowSynchronousIO` is on, and neither host turns it on, so every `[ServerSentEvents]` route answered 500 with an empty body on both hosts and a newline-delimited stream ended after its first item. Nothing in the repository drove a stream over a socket: the harness and the filter tests write into a `MemoryStream`, which accepts either.

Every write is `WriteAsync` now. `SynchronousWritesRejectedStream` (the stand-in the RazorBlade tests already keep) is copied into the request runtime tests and both framings run through it, and `StreamingOverASocketTests` puts an event stream and a newline-delimited stream through a real Kestrel with the default `AllowSynchronousIO`.

Driving the packed packages through the scaffolded application found one more behind it: `SseFraming.WriteCompletion` read `Body.Position` to decide whether the empty-stream comment was due, and Kestrel's response body throws from `Position`, so every event stream ended with a logged fault after its last event and an empty stream lost its comment. It asks the body only where the body can answer and the response otherwise; the socket test now covers an empty stream and asserts nothing was reported as failed.

## `[Enable<ConditionalGet>]` buffered every streaming GET

The application-wide default installed the conditional-GET filter on `IAsyncEnumerable<T>` handlers too, and holding a stream back to hash it turned a two-event feed into one packet after the last event, carrying an `ETag`. `IExecutionRequestHandlerInfo.StreamsResponse` is new: a default interface member the generator sets from the return type, which the module's provider and `[ConditionalGet]` itself read to stand down. The docs said this gap was why nothing refused it.

## HRDW005 warned on the template's own layout

The check read the entry point's module attributes, so the library that declares the handlers warned whatever the host registered. It is now asked of the compilation whose entry point applies a web runtime, and that compilation is handed the cached handlers of every module it imports, read from their metadata (`ImportedCachedHandlers`, the arrangement `ImportedLinksModel` already uses), and told whether one of those modules applies the store itself. The library says nothing; the host that forgot the store is told which of the library's handlers fail; a host importing a library that carries `[HardenedMemoryResponseCache]` - the arrangement that lets the test harness see the store - is told nothing. The described routing table never called the shared report at all, so a specification-first application was never told; it reports now, from the same code.

## HRDR008 never fired

`CollidingRoutingGenerators` named each generator from the first segment of its generated file's path. With `EmitCompilerGeneratedFiles` on, which the templates turn on, that path is absolute, so both generators were `Users` and a distinct-count of one reported nothing. The name is the third segment from the end now, and the count is the marker's declaring syntax references rather than the distinct names.

## Two body-binding traps compiled clean

- A parameter typed as a registered service with a parameterless constructor (`TodoStore store` on a GET) passed HRDR007's constructor test, bound from the body, answered 400 on every request, and put a `requestBody` and the service's schema into the published document. `RequestParameterInformation.RegisteredAsService` reads `[SingletonService]`, `[ScopedService]` and `[TransientService]` off the type, and HRDR007 reports it with its own advice. Carried through `OperationSymbols` like the constructor flag.
- Two parameters that both fell to the body lost the second in the spec bridge, which became a CS7036 in generated code. `RequestHandlerModel.AdditionalBodyParameters` remembers them and **HRDR009** (error) names both. **HRDR010** (warning, `NoWarn`) is the remainder: a body parameter on a GET, HEAD, OPTIONS or TRACE that neither HRDR005 nor HRDR007 explains.

## Smaller

- `{id?}` produced twelve C# syntax errors in the generated links type ahead of HRDR002. A route whose token is not an identifier, or repeats one, has no link.
- **HRDW006** (error): `[Timeout]` declaring a budget of zero or less, which the runtime refused on the first request and the document exported as `x-hardened-timeout: 0`.
- Doc-comment entities reached the document as text (`Created&lt;T&gt;`). Both reading paths decode them; the Web integration application's exported document changes in two places.
- Logging: a 400, 404, 415 or a declared 504 was logged at Error with a stack trace, and bind failures twice. `RequestFailed` writes one Warning line for a refusal, one Warning line naming the budget for a declared deadline, and Error with the exception for anything else or anything after the response started; the hosts assign their 500 before logging so the level is right there too. `RequestParameterBindFailed` is Debug. The `Deserialize with option convert count` line is gone, and with it the deserializer's logger parameter.

## Not done

- Responses are compressed at any size (a 131-byte body went out as 101 bytes of gzip); ASP.NET Core's own middleware has no threshold either, so left as a design choice.
- The synthesized 400 is written after the declared responses (200, 404, 400); every synthesized response would need folding into the ordering, and the change is cosmetic.
- The Smithy CLI on this machine is 1.56.0 against the 1.73.0 pin and Homebrew would not upgrade it here, so the CI-style build was run with `-p:HardenedSmithyPinCliVersion=false`.

Public API: `IExecutionRequestHandlerInfo.StreamsResponse`, an optional `streamsResponse` constructor parameter on `ExecutionRequestHandlerInfo`, and the removed `ILogger` parameter on `SystemTextJsonRequestDeserializer`; the approved files are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
