### PR TITLE
Run the startup services once under [WebTesting]

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/StartupServicesRunOnceTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/StartupServicesRunOnceTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// A startup service runs once per test container.
+/// </summary>
+/// <remarks>
+/// Until 2026-09-05 it ran twice. <c>[HardenedTestEntryPoint]</c> runs the registered services
+/// through <c>ApplicationLogic.Start</c>, which guards a provider against a second run, and
+/// <c>[WebTesting]</c> looped them again on its own with no guard; the runner awaits both, in an
+/// order that is a sort rather than a declaration. The chain carried <c>AuthenticationMiddleware</c>
+/// and <c>CorsFilter</c> twice, behind the handler, and the authorization filter provider was
+/// registered twice. Nothing asserted on it, so nothing noticed.
+/// </remarks>
+public class StartupServicesRunOnceTests {
+
+    [HardenedTest]
+    [CountingStartupService]
+    public void AStartupServiceRunsOncePerContainer(CountingStartupService service) {
+        Assert.Equal(1, service.Runs);
+    }
+
+    /// <summary>The chain the services composed still answers, with the handler behind them.</summary>
+    [HardenedTest]
+    [CountingStartupService]
+    public async Task TheChainAnswersAfterTheOneRun(CountingStartupService service, ITestWebApp app) {
+        var response = await app.Get("/verbs/item/1");
+
+        response.Assert.Ok();
+        Assert.Equal("got:1", response.Deserialize<string>());
+        Assert.Equal(1, service.Runs);
+    }
+}
+
+public sealed class CountingStartupService : IStartupService {
+    private int _runs;
+
+    public int Runs => _runs;
+
+    public Task<bool> Startup(IServiceProvider rootProvider) {
+        Interlocked.Increment(ref _runs);
+
+        return Task.FromResult(true);
+    }
+}
+
+/// <summary>Registers <see cref="CountingStartupService"/> beside the application's own startup services.</summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class CountingStartupServiceAttribute : Attribute, IHardenedTestDependencyRegistrationAttribute {
+
+    public void RegisterDependencies(
+        AttributeCollection attributeCollection,
+        MethodInfo methodInfo,
+        IHardenedEnvironment environment,
+        IServiceCollection serviceCollection) {
+        serviceCollection.AddSingleton<CountingStartupService>();
+        serviceCollection.AddSingleton<IStartupService>(sp => sp.GetRequiredService<CountingStartupService>());
+    }
+}

--- a/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
+++ b/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
@@ -127,10 +127,14 @@ public class WebTestingAttribute : Attribute, ITestServiceSetupAttribute, ITestS
     public async Task StartupAsync(ITestMethodContext testMethod, IServiceProvider serviceProvider) {
         var entryPoint = testMethod.Method.GetTestAttribute<HardenedTestEntryPointAttribute>();
 
-        // Run registered startup services (CORS, filters, etc.)
-        foreach (var startupService in serviceProvider.GetServices<IStartupService>()) {
-            await startupService.Startup(serviceProvider);
-        }
+        // Through the guard rather than a loop of this attribute's own. HardenedTestEntryPoint
+        // runs the same services through ApplicationLogic.Start, and the runner awaits both
+        // attributes in an order that is a sort rather than a declaration, so a loop here ran
+        // every startup service a second time per container: the authentication middleware and
+        // the CORS filter were each in the chain twice, behind the handler, and the authorization
+        // filter provider was registered twice. The guard runs them once whichever attribute the
+        // runner reaches first, and still runs them here for a test with no entry point attribute.
+        await ApplicationLogic.Start(serviceProvider, null);
 
         if (entryPoint != null && !typeof(IApplicationRoot).IsAssignableFrom(entryPoint.EntryPoint)) {
             var handler = serviceProvider.GetRequiredService<IWebExecutionHandlerService>();


### PR DESCRIPTION
## What

`WebTestingAttribute.StartupAsync` runs the registered `IStartupService`s through `ApplicationLogic.Start`, the guarded path, instead of looping them itself.

## Why

`HardenedTestEntryPointAttribute.StartupAsync` already runs them through `ApplicationLogic.StartWithWait`, which guards a provider against a second run. `WebTestingAttribute` looped `GetServices<IStartupService>()` again with no guard. Both are `ITestStartupAttribute`s on the assembly and the runner awaits both, in an order that is a sort rather than a declaration, so every startup service ran twice per container. A probe reflecting `MiddlewareService._filters` from inside a `[HardenedTest]` in the web SUT read the chain as:

```
ResponseFinalizerFilter, CorrelationHeaderFilter, AuthenticationMiddleware, CorsFilter,
WebExecutionHandlerService, AuthenticationMiddleware, CorsFilter
```

The duplicates sit behind the handler, so a routed request never reached them, but `AuthorizationStartupService` registered its filter provider twice and a test counting runs of an `IStartupService` of its own got two. `KestrelHostingTests.StartAsync_RunsTheRegisteredStartupServices` holds the Kestrel host to one; nothing held the harness to it. The test hosts planned in `TEST-HOST-PLAN.md` would have run the services a third time, which is why this goes first.

## Tests

`StartupServicesRunOnceTests` in the web SUT registers a counting `IStartupService` through an `IHardenedTestDependencyRegistrationAttribute` and holds it to one run, once on its own and once after a request through `ITestWebApp`. Both fail on main (`Expected: 1, Actual: 2`) and pass here. The whole solution, 7054 tests, passes in Release with the CI flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
