### PR TITLE
Convert a bare shipped record into a response set's declared case

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/ScalarSuccessBodyTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/ScalarSuccessBodyTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Primitives;
 
+using Hardened.Requests.Abstract.Responses;
+
 namespace Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests;
 
 /// <summary>
@@ -44,8 +46,12 @@ public class ScalarSuccessBodyTests {
 
         var problem = response.Deserialize<Problem>();
 
-        Assert.Equal("No such label", problem!.Title);
+        // The handler returned the framework's NotFound; the conversion the build wrote filled the
+        // contract's Problem from it, title and status from the record and the detail from the
+        // handler.
+        Assert.Equal("Not Found", problem!.Title);
         Assert.Equal(404, problem.Status);
+        Assert.Equal("No such label", problem.Detail);
     }
 
     /// <summary>
@@ -82,7 +88,9 @@ public class ScalarSuccessBodyTests {
 
         var problem = response.Deserialize<Problem>();
 
+        // NotFound.Default, converted to the cached case: the generic detail, and the status.
         Assert.Equal(404, problem!.Status);
+        Assert.Equal(NotFound.Default.Detail, problem.Detail);
     }
 
     private static async Task<string> Body(TestWebResponse response) {

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
@@ -19,10 +19,14 @@ namespace Hardened.IntegrationTests.OpenApi.ResponseModel.SUT;
 [Handler]
 public class LabelServiceImpl : ILabelService {
 
+    /// <summary>
+    /// The 404 is the framework's own record. The build wrote the conversion into the case the
+    /// contract declares, NotFound&lt;Problem&gt;, with the Problem's title and status filled from
+    /// the record and the detail from here.
+    /// </summary>
     public Task<GetLabelResponse> GetLabel(string labelId) {
         if (labelId == "missing") {
-            return Task.FromResult<GetLabelResponse>(
-                new NotFound<Problem>(new Problem { Title = "No such label", Status = 404 }));
+            return Task.FromResult<GetLabelResponse>(new NotFound("label", "No such label"));
         }
 
         return Task.FromResult<GetLabelResponse>(new GetLabelOk($"Label {labelId}"));
@@ -32,10 +36,10 @@ public class LabelServiceImpl : ILabelService {
         return Task.FromResult<CreateLabelResponse>(body);
     }
 
+    /// <summary>The shared instance, for a handler with nothing to add: no allocation for the 404.</summary>
     public Task<ArchiveLabelResponse> ArchiveLabel(string labelId) {
         if (labelId == "missing") {
-            return Task.FromResult<ArchiveLabelResponse>(
-                new NotFound<Problem>(new Problem { Title = "No such label", Status = 404 }));
+            return Task.FromResult<ArchiveLabelResponse>(NotFound.Default);
         }
 
         return Task.FromResult<ArchiveLabelResponse>(new ArchiveLabelNoContent());

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Specs/labels.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Specs/labels.yaml
@@ -98,3 +98,5 @@ components:
         status:
           type: integer
           format: int32
+        detail:
+          type: string

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DeclaredStatusTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DeclaredStatusTests.cs
@@ -65,9 +65,10 @@ public class DeclaredStatusTests {
     /// And carries the body the document declared for it, rather than nothing.
     /// </summary>
     /// <remarks>
-    /// The status and its reason phrase are facts about the response - RFC 7807 defines
-    /// <c>status</c> as the HTTP status code, so filling it is conformance. Nothing else is filled,
-    /// because nothing else could be without inventing a domain value.
+    /// The status, its reason phrase and its problem type are facts about the response - RFC 7807
+    /// defines <c>status</c> as the HTTP status code, so filling it is conformance, and the type is
+    /// the same URI a code-first handler's <c>NotFound</c> sends. Nothing else is filled, because
+    /// nothing else could be without inventing a domain value.
     /// </remarks>
     [HardenedTest]
     public async Task GetPet_CarriesTheDeclaredProblemBodyOnTheNotFound(ITestWebApp testWebApp) {
@@ -78,7 +79,7 @@ public class DeclaredStatusTests {
         Assert.NotNull(problem);
         Assert.Equal(404, problem.Status);
         Assert.Equal("Not Found", problem.Title);
-        Assert.Equal("about:blank", problem.Type);
+        Assert.Equal(Hardened.Requests.Abstract.Responses.ProblemTypes.NotFound, problem.Type);
     }
 
     /// <summary>

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -803,6 +803,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(502)]
     public sealed class BadGateway : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadGateway>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.BadGateway Default;
         public BadGateway(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -824,6 +825,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(400)]
     public sealed class BadRequest : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.BadRequest>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.BadRequest Default;
         public BadRequest(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -845,6 +847,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(409)]
     public sealed class Conflict : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Conflict>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.Conflict Default;
         public Conflict(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -866,6 +869,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(413)]
     public sealed class ContentTooLarge : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.ContentTooLarge>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.ContentTooLarge Default;
         public ContentTooLarge(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -898,6 +902,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(403)]
     public sealed class Forbidden : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Forbidden>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.Forbidden Default;
         public Forbidden(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -919,6 +924,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(504)]
     public sealed class GatewayTimeout : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.GatewayTimeout>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.GatewayTimeout Default;
         public GatewayTimeout(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -940,6 +946,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(410)]
     public sealed class Gone : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.Gone>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.Gone Default;
         public Gone(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1156,6 +1163,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(500)]
     public sealed class InternalServerError : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.InternalServerError>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.InternalServerError Default;
         public InternalServerError(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1217,6 +1225,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(404)]
     public sealed class NotFound : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotFound>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.NotFound Default;
         public NotFound(string Resource, string? Detail = null) { }
         public string? Detail { get; init; }
         public string Resource { get; init; }
@@ -1239,6 +1248,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(501)]
     public sealed class NotImplemented : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.NotImplemented>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.NotImplemented Default;
         public NotImplemented(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1283,6 +1293,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(402)]
     public sealed class PaymentRequired : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PaymentRequired>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.PaymentRequired Default;
         public PaymentRequired(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1304,6 +1315,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(412)]
     public sealed class PreconditionFailed : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionFailed>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.PreconditionFailed Default;
         public PreconditionFailed(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1325,6 +1337,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(428)]
     public sealed class PreconditionRequired : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.PreconditionRequired>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.PreconditionRequired Default;
         public PreconditionRequired(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1394,6 +1407,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(408)]
     public sealed class RequestTimeout : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.RequestTimeout>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.RequestTimeout Default;
         public RequestTimeout(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1570,6 +1584,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(503)]
     public sealed class ServiceUnavailable : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.ServiceUnavailable>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.ServiceUnavailable Default;
         public ServiceUnavailable(System.TimeSpan? After = default, string? Detail = null) { }
         public System.TimeSpan? After { get; init; }
         public string? Detail { get; init; }
@@ -1619,6 +1634,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(401)]
     public sealed class Unauthorized : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, Hardened.Requests.Abstract.Responses.IProvidesResponseHeaders, System.IEquatable<Hardened.Requests.Abstract.Responses.Unauthorized>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.Unauthorized Default;
         public Unauthorized(string? Detail = null, Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge = null) { }
         public Hardened.Requests.Abstract.Authorization.AuthorizationChallenge? Challenge { get; init; }
         public string? Detail { get; init; }
@@ -1644,6 +1660,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(422)]
     public sealed class UnprocessableContent : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnprocessableContent>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.UnprocessableContent Default;
         public UnprocessableContent(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }
@@ -1665,6 +1682,7 @@ namespace Hardened.Requests.Abstract.Responses
     [Hardened.Requests.Abstract.Responses.HttpStatus(415)]
     public sealed class UnsupportedMediaType : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.UnsupportedMediaType>
     {
+        public static readonly Hardened.Requests.Abstract.Responses.UnsupportedMediaType Default;
         public UnsupportedMediaType(string? Detail = null) { }
         public string? Detail { get; init; }
         public int Status { get; }

--- a/src/Requests/Hardened.Requests.Abstract.Tests/Responses/DefaultInstanceTests.cs
+++ b/src/Requests/Hardened.Requests.Abstract.Tests/Responses/DefaultInstanceTests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using Hardened.Requests.Abstract.Responses;
+
+namespace Hardened.Requests.Abstract.Tests.Responses;
+
+/// <summary>
+/// The shared instance each bare error record offers for a handler with nothing to add.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>return NotFound.Default;</c> is the whole of a 404 that has nothing more to say, and it
+/// allocates nothing: the instance is a static, and a response set holds it by reference. The
+/// sweep finds every record that has one rather than naming them, so a record added later is held
+/// to the same shape.
+/// </para>
+/// <para>
+/// Which records have one is a rule rather than a list: every problem-kind record whose
+/// constructor needs nothing a caller would have to supply. <c>RateLimited</c> needs a delay and
+/// <c>MethodNotAllowed</c> an <c>Allow</c>; <c>NotAcceptable</c> carries no message.
+/// </para>
+/// </remarks>
+public class DefaultInstanceTests {
+
+    public static TheoryData<Type> RecordsWithADefault {
+        get {
+            var data = new TheoryData<Type>();
+
+            foreach (var type in Records()) {
+                data.Add(type);
+            }
+
+            return data;
+        }
+    }
+
+    /// <summary>Every response record with a static <c>Default</c>, found rather than named.</summary>
+    private static IEnumerable<Type> Records() {
+        foreach (var type in typeof(NotFound).Assembly.GetExportedTypes()) {
+            if (type.IsGenericTypeDefinition || type.GetCustomAttribute<HttpStatusAttribute>() == null) {
+                continue;
+            }
+
+            if (type.GetField("Default", BindingFlags.Public | BindingFlags.Static) != null) {
+                yield return type;
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RecordsWithADefault))]
+    public void ADefault_IsAnInstanceOfItsOwnTypeAtItsOwnStatus(Type type) {
+        var field = type.GetField("Default", BindingFlags.Public | BindingFlags.Static)!;
+        var instance = field.GetValue(null);
+
+        Assert.True(field.IsInitOnly);
+        Assert.IsType(type, instance);
+        Assert.Equal(
+            type.GetCustomAttribute<HttpStatusAttribute>()!.StatusCode,
+            ((IHttpStatusResponse)instance!).Status);
+    }
+
+    /// <summary>The message is generic, and there is one: the point is a body that says something.</summary>
+    [Theory]
+    [MemberData(nameof(RecordsWithADefault))]
+    public void ADefault_CarriesAGenericDetail(Type type) {
+        var instance = type.GetField("Default", BindingFlags.Public | BindingFlags.Static)!.GetValue(null);
+        var detail = (string?)type.GetProperty("Detail")!.GetValue(instance);
+
+        Assert.False(string.IsNullOrWhiteSpace(detail));
+        Assert.EndsWith(".", detail);
+    }
+
+    /// <summary>
+    /// Every problem-kind record whose constructor a caller need not feed has one, and the three
+    /// that cannot have one do not.
+    /// </summary>
+    [Fact]
+    public void EveryRecordThatCanHaveADefaultDoes() {
+        var withDefault = new HashSet<Type>(Records());
+
+        Assert.Equal(18, withDefault.Count);
+        Assert.Contains(typeof(NotFound), withDefault);
+        Assert.Contains(typeof(Unauthorized), withDefault);
+        Assert.Contains(typeof(ServiceUnavailable), withDefault);
+        Assert.DoesNotContain(typeof(RateLimited), withDefault);
+        Assert.DoesNotContain(typeof(MethodNotAllowed), withDefault);
+        Assert.DoesNotContain(typeof(NotAcceptable), withDefault);
+    }
+
+    [Fact]
+    public void NotFound_DefaultNamesNoParticularResource() {
+        Assert.Equal("resource", NotFound.Default.Resource);
+        Assert.Equal(404, NotFound.Default.Status);
+    }
+
+    /// <summary>Returning the same instance twice is the same answer; nothing is built per return.</summary>
+    [Fact]
+    public void ADefault_IsOneInstance() {
+        Assert.Same(NotFound.Default, NotFound.Default);
+        Assert.Same(Conflict.Default, Conflict.Default);
+    }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadGateway.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadGateway.cs
@@ -18,6 +18,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(502)]
 public sealed record BadGateway(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The BadGateway with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly BadGateway Default = new("An upstream service answered badly.");
+
     public string Type => ProblemTypes.BadGateway;
 
     public string Title => "Bad Gateway";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/BadRequest.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/BadRequest.cs
@@ -20,6 +20,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(400)]
 public sealed record BadRequest(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The BadRequest with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly BadRequest Default = new("The request could not be understood.");
+
     public string Type => ProblemTypes.BadRequest;
 
     public string Title => "Bad Request";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Conflict.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Conflict.cs
@@ -11,6 +11,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(409)]
 public sealed record Conflict(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The Conflict with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly Conflict Default = new("The request conflicts with the current state.");
+
     public string Type => ProblemTypes.Conflict;
 
     public string Title => "Conflict";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ContentTooLarge.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ContentTooLarge.cs
@@ -18,6 +18,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(413)]
 public sealed record ContentTooLarge(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The ContentTooLarge with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly ContentTooLarge Default = new("The request body is too large.");
+
     public string Type => ProblemTypes.ContentTooLarge;
 
     public string Title => "Content Too Large";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Forbidden.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Forbidden.cs
@@ -13,6 +13,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(403)]
 public sealed record Forbidden(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The Forbidden with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly Forbidden Default = new("This request is not permitted.");
+
     public string Type => ProblemTypes.Forbidden;
 
     public string Title => "Forbidden";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/GatewayTimeout.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/GatewayTimeout.cs
@@ -18,6 +18,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(504)]
 public sealed record GatewayTimeout(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The GatewayTimeout with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly GatewayTimeout Default = new("An upstream service did not answer in time.");
+
     public string Type => ProblemTypes.GatewayTimeout;
 
     public string Title => "Gateway Timeout";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Gone.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Gone.cs
@@ -11,6 +11,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(410)]
 public sealed record Gone(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The Gone with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly Gone Default = new("The resource is no longer available.");
+
     public string Type => ProblemTypes.Gone;
 
     public string Title => "Gone";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/InternalServerError.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/InternalServerError.cs
@@ -21,6 +21,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record InternalServerError(string? Detail = null)
     : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The InternalServerError with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly InternalServerError Default = new("An unexpected error occurred.");
+
     public string Type => ProblemTypes.InternalServerError;
 
     public string Title => "Internal Server Error";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotFound.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotFound.cs
@@ -22,6 +22,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record NotFound(string Resource, string? Detail = null)
     : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The NotFound with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly NotFound Default = new("resource", "The requested resource does not exist.");
+
     public string Type => ProblemTypes.NotFound;
 
     public string Title => "Not Found";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/NotImplemented.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/NotImplemented.cs
@@ -17,6 +17,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(501)]
 public sealed record NotImplemented(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The NotImplemented with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly NotImplemented Default = new("This operation is not implemented.");
+
     public string Type => ProblemTypes.NotImplemented;
 
     public string Title => "Not Implemented";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PaymentRequired.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PaymentRequired.cs
@@ -18,6 +18,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(402)]
 public sealed record PaymentRequired(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The PaymentRequired with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly PaymentRequired Default = new("Payment is required.");
+
     public string Type => ProblemTypes.PaymentRequired;
 
     public string Title => "Payment Required";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailed.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionFailed.cs
@@ -13,6 +13,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record PreconditionFailed(string? Detail = null)
     : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The PreconditionFailed with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly PreconditionFailed Default = new("A precondition on the request did not hold.");
+
     public string Type => ProblemTypes.PreconditionFailed;
 
     public string Title => "Precondition Failed";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequired.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/PreconditionRequired.cs
@@ -20,6 +20,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record PreconditionRequired(string? Detail = null)
     : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The PreconditionRequired with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly PreconditionRequired Default = new("The request must carry a precondition.");
+
     public string Type => ProblemTypes.PreconditionRequired;
 
     public string Title => "Precondition Required";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/RequestTimeout.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/RequestTimeout.cs
@@ -19,6 +19,12 @@ namespace Hardened.Requests.Abstract.Responses;
 [HttpStatus(408)]
 public sealed record RequestTimeout(string? Detail = null) : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The RequestTimeout with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly RequestTimeout Default = new("The request took too long.");
+
     public string Type => ProblemTypes.RequestTimeout;
 
     public string Title => "Request Timeout";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailable.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ServiceUnavailable.cs
@@ -24,6 +24,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record ServiceUnavailable(TimeSpan? After = null, string? Detail = null)
     : IHttpStatusResponse, IProvidesResponseHeaders, IDeclaresStatus {
 
+    /// <summary>
+    /// The ServiceUnavailable with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly ServiceUnavailable Default = new(Detail: "The service is temporarily unavailable.");
+
     public string Type => ProblemTypes.ServiceUnavailable;
 
     public string Title => "Service Unavailable";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/Unauthorized.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/Unauthorized.cs
@@ -26,6 +26,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record Unauthorized(string? Detail = null, AuthorizationChallenge? Challenge = null)
     : IHttpStatusResponse, IProvidesResponseHeaders, IDeclaresStatus {
 
+    /// <summary>
+    /// The Unauthorized with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly Unauthorized Default = new("Authentication is required.");
+
     public string Type => ProblemTypes.Unauthorized;
 
     public string Title => "Unauthorized";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnprocessableContent.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnprocessableContent.cs
@@ -22,6 +22,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record UnprocessableContent(string? Detail = null)
     : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The UnprocessableContent with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly UnprocessableContent Default = new("The request could not be processed.");
+
     public string Type => ProblemTypes.UnprocessableContent;
 
     public string Title => "Unprocessable Content";

--- a/src/Requests/Hardened.Requests.Abstract/Responses/UnsupportedMediaType.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/UnsupportedMediaType.cs
@@ -19,6 +19,12 @@ namespace Hardened.Requests.Abstract.Responses;
 public sealed record UnsupportedMediaType(string? Detail = null)
     : IHttpStatusResponse, IDeclaresStatus {
 
+    /// <summary>
+    /// The UnsupportedMediaType with a generic message, for a handler with nothing more to say than the status.
+    /// Shared, so returning it allocates nothing.
+    /// </summary>
+    public static readonly UnsupportedMediaType Default = new("The request's media type is not supported.");
+
     public string Type => ProblemTypes.UnsupportedMediaType;
 
     public string Title => "Unsupported Media Type";

--- a/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
@@ -93,7 +93,21 @@ internal static class DefaultErrorBody {
     /// member cannot be filled without inventing a value.
     /// </summary>
     public static IReadOnlyList<string>? Arguments(
-        IReadOnlyList<SchemaModel> schemas, string schemaName, int statusCode) {
+        IReadOnlyList<SchemaModel> schemas, string schemaName, int statusCode) =>
+        Arguments(schemas, schemaName, statusCode, BodySource.ForStatus(statusCode));
+
+    /// <summary>
+    /// The same arguments with <c>type</c>, <c>title</c>, <c>status</c> and <c>detail</c> read off a
+    /// shipped record - the body <c>return new NotFound("todo", "...")</c> converts into - rather
+    /// than derived from the status alone.
+    /// </summary>
+    /// <param name="record">The expression that holds the record, in the generated code.</param>
+    public static IReadOnlyList<string>? ArgumentsFromRecord(
+        IReadOnlyList<SchemaModel> schemas, string schemaName, int statusCode, string record) =>
+        Arguments(schemas, schemaName, statusCode, BodySource.ForRecord(statusCode, record));
+
+    private static IReadOnlyList<string>? Arguments(
+        IReadOnlyList<SchemaModel> schemas, string schemaName, int statusCode, BodySource source) {
         var schema = Find(schemas, schemaName);
 
         if (schema == null || schema.Kind != SchemaKind.Object) {
@@ -105,7 +119,7 @@ internal static class DefaultErrorBody {
 
         foreach (var property in SchemaShape.Constructor(schema)) {
             var csType = TypeMapper.MapPropertyToCSharpType(property);
-            var value = Value(property, csType, statusCode, isProblem, schema.IsErrorShape);
+            var value = Value(property, csType, source, isProblem, schema.IsErrorShape);
 
             if (value != null) {
                 arguments.Add(value);
@@ -135,7 +149,7 @@ internal static class DefaultErrorBody {
     }
 
     private static string? Value(
-        PropertyModel property, string csType, int statusCode, bool isProblem, bool isErrorShape) {
+        PropertyModel property, string csType, BodySource source, bool isProblem, bool isErrorShape) {
         // The document's own default first. It is the one source here that is not an inference.
         var declared = DefaultLiteral.Format(property.Default, csType);
 
@@ -150,7 +164,7 @@ internal static class DefaultErrorBody {
         // because { message: string } is an ordinary shape and an ordinary payload's message is
         // not this.
         if (isErrorShape && property.Name == "message" && csType == "string") {
-            return "\"" + ReasonPhrase(statusCode) + "\"";
+            return source.Message;
         }
 
         if (!isProblem) {
@@ -159,13 +173,77 @@ internal static class DefaultErrorBody {
 
         switch (property.Name) {
             case "type" when csType == "string":
-                return "\"about:blank\"";
+                return source.Type;
             case "title" when csType == "string":
-                return "\"" + ReasonPhrase(statusCode) + "\"";
+                return source.Title;
             case "status" when csType == "int" || csType == "long":
-                return statusCode.ToString(CultureInfo.InvariantCulture);
+                return source.Status;
+            case "detail" when csType == "string" || csType == "string?":
+                return source.Detail;
             default:
                 return null;
+        }
+    }
+
+    /// <summary>
+    /// Where the members a problem body can be filled from come from: the status alone, for the
+    /// body a null return writes, or a shipped record, for the body a returned record converts
+    /// into.
+    /// </summary>
+    /// <remarks>
+    /// The status source writes <c>type</c> as the framework's problem type for the status - the
+    /// URI a code-first handler's record sends - and <c>about:blank</c> only where the framework
+    /// declares none, so a null return and a returned <c>NotFound</c> answer with one <c>type</c>.
+    /// The record source reads the four members off the record, and fills a Smithy <c>message</c>
+    /// with the detail, or the title where no detail was given, which is the same act as the reason
+    /// phrase going into it.
+    /// </remarks>
+    private readonly struct BodySource {
+        private BodySource(string type, string title, string status, string? detail, string message) {
+            Type = type;
+            Title = title;
+            Status = status;
+            Detail = detail;
+            Message = message;
+        }
+
+        public string Type { get; }
+
+        public string Title { get; }
+
+        public string Status { get; }
+
+        public string? Detail { get; }
+
+        public string Message { get; }
+
+        public static BodySource ForStatus(int statusCode) {
+            var phrase = "\"" + ReasonPhrase(statusCode) + "\"";
+            var problemType = ShippedResponses.ProblemType(statusCode);
+
+            return new BodySource(
+                problemType == null
+                    ? "\"about:blank\""
+                    : "global::" + ShippedResponses.Namespace + ".ProblemTypes." + problemType,
+                phrase,
+                statusCode.ToString(CultureInfo.InvariantCulture),
+                detail: null,
+                phrase);
+        }
+
+        public static BodySource ForRecord(int statusCode, string record) {
+            // MethodNotAllowed and NotAcceptable carry a status and nothing else a problem body
+            // reads, so their bodies are the status's rather than the record's.
+            if (!ShippedResponses.HasProblemMembers(statusCode)) {
+                var fromStatus = ForStatus(statusCode);
+
+                return new BodySource(
+                    fromStatus.Type, fromStatus.Title, record + ".Status", detail: null, fromStatus.Message);
+            }
+
+            return new BodySource(
+                record + ".Type", record + ".Title", record + ".Status", record + ".Detail",
+                "(" + record + ".Detail ?? " + record + ".Title)");
         }
     }
 
@@ -178,7 +256,7 @@ internal static class DefaultErrorBody {
     /// beside it often enough for this to be worth loosening, and the cost of a false positive is a
     /// status code written into a member that never meant one.
     /// </remarks>
-    private static bool IsProblemDetails(SchemaModel schema) {
+    public static bool IsProblemDetails(SchemaModel schema) {
         var hasTitle = false;
         var hasStatus = false;
 

--- a/src/SourceGenerators/Hardened.Generation.Shared/ProblemConversion.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/ProblemConversion.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using Hardened.Generation.Models;
+
+namespace Hardened.Generation;
+
+/// <summary>
+/// The conversion a declared error offers from the bare shipped record for its status: what
+/// <c>return new NotFound("todo", "...")</c> becomes in a response set.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A declared error reaches a response set as a case carrying the contract's own body -
+/// <c>NotFound&lt;Problem&gt;</c> for an anonymous OpenAPI error, a generated
+/// <c>TodoNotFoundError</c> for a named Smithy one - and a handler that only wants to say
+/// "not found, and here is why" had to build that body by hand: type, title and status filled in
+/// from what the case already knew. This is the rule for when the build can do that instead. The
+/// record knows the facts of its status, the schema says which members hold them, and
+/// <see cref="DefaultErrorBody"/> already maps one onto the other for the body a null return
+/// writes. What a handler adds is the detail.
+/// </para>
+/// <para>
+/// One rule, asked by the emitter that writes the operator on the set and by the one that writes
+/// the method the operator calls, so the two cannot disagree about which cases convert.
+/// </para>
+/// </remarks>
+internal static class ProblemConversion {
+
+    /// <summary>The holder's name, which is the file's plus a suffix, reserved by the allocator.</summary>
+    public static string HolderName(string specFileName) =>
+        NamingHelper.ToPascalCase(specFileName) + "Problems";
+
+    /// <summary>The expression the generated method reads the record through.</summary>
+    public const string Record = "value";
+
+    /// <summary>The body's constructor arguments, read off <paramref name="record"/>.</summary>
+    /// <remarks>Never null for a plan <see cref="For"/> returned, which checked the same call.</remarks>
+    public static IReadOnlyList<string> Arguments(
+        Plan plan, IReadOnlyList<SchemaModel> schemas, string record) =>
+        DefaultErrorBody.ArgumentsFromRecord(schemas, plan.SchemaName, plan.StatusCode, record)!;
+
+    internal readonly struct Plan {
+        public Plan(
+            int statusCode, string bareRecord, string schemaName, string caseTypeName,
+            bool caseIsShipped) {
+            StatusCode = statusCode;
+            BareRecord = bareRecord;
+            SchemaName = schemaName;
+            CaseTypeName = caseTypeName;
+            CaseIsShipped = caseIsShipped;
+        }
+
+        public int StatusCode { get; }
+
+        /// <summary>The shipped record the operator converts from - <c>NotFound</c>.</summary>
+        public string BareRecord { get; }
+
+        /// <summary>The contract's body schema, as named in the document.</summary>
+        public string SchemaName { get; }
+
+        /// <summary>
+        /// The case the set holds: the shipped generic form's name, or the generated case type's.
+        /// </summary>
+        public string CaseTypeName { get; }
+
+        /// <summary>Whether the case is a shipped generic record over the body, or a generated type.</summary>
+        public bool CaseIsShipped { get; }
+
+        /// <summary>The generated method's name, unique per record and body.</summary>
+        public string MethodName => BareRecord + NamingHelper.ToPascalCase(SchemaName);
+
+        /// <summary>A stable key for one plan across the operations that share it.</summary>
+        public string Key => StatusCode + ":" + SchemaName;
+    }
+
+    /// <summary>
+    /// The conversion this error offers, or null where there is nothing to build it from.
+    /// </summary>
+    /// <remarks>
+    /// Null for an error with no body, whose case already is the bare record; for one declaring
+    /// a header, whose case carries a value no record has; for a body that is not problem shaped,
+    /// or a Smithy error shape with a required member nothing can fill; and for a status the
+    /// framework ships no record for.
+    /// </remarks>
+    public static Plan? For(ErrorResponseModel error, IReadOnlyList<SchemaModel> schemas) {
+        if (error.Ref == null || error.Headers.Count > 0) {
+            return null;
+        }
+
+        var bare = ShippedResponses.BareForm(error.StatusCode);
+
+        if (bare == null || error.StatusCode == 304) {
+            return null;
+        }
+
+        var schemaName = TypeMapper.GetRefName(error.Ref);
+        var schema = DefaultErrorBody.Find(schemas, schemaName);
+
+        if (schema == null) {
+            return null;
+        }
+
+        var binding = ShippedResponses.For(error);
+
+        if (binding != null) {
+            // A shipped generic record over the contract's body, which converts when the body is
+            // RFC 7807 shaped. A marker form - Status<Http.Locked, Problem> - has no bare record.
+            if (binding.Value.Marker != null || !DefaultErrorBody.IsProblemDetails(schema)) {
+                return null;
+            }
+
+            return Fillable(schemas, schemaName, error.StatusCode)
+                ? new Plan(error.StatusCode, bare, schemaName, binding.Value.TypeName, caseIsShipped: true)
+                : null;
+        }
+
+        // A generated case type carrying a named error shape: Smithy's @error structure, whose
+        // message the record's detail fills. Anything else it requires has no source.
+        if (error.TypeName == null || !schema.IsErrorShape) {
+            return null;
+        }
+
+        return Fillable(schemas, schemaName, error.StatusCode)
+            ? new Plan(error.StatusCode, bare, schemaName, error.TypeName, caseIsShipped: false)
+            : null;
+    }
+
+    /// <summary>Whether every required member of the body has a source on the record.</summary>
+    private static bool Fillable(IReadOnlyList<SchemaModel> schemas, string schemaName, int statusCode) =>
+        DefaultErrorBody.ArgumentsFromRecord(schemas, schemaName, statusCode, Record) != null;
+}

--- a/src/SourceGenerators/Hardened.Generation.Shared/ShippedResponses.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/ShippedResponses.cs
@@ -181,6 +181,45 @@ internal static class ShippedResponses {
     }
 
     /// <summary>The bare shipped record for a status, or null.</summary>
+    /// <summary>
+    /// Whether the bare record for the status carries <c>Type</c>, <c>Title</c> and <c>Detail</c>,
+    /// which every problem-kind record does and <c>MethodNotAllowed</c> and <c>NotAcceptable</c>
+    /// do not.
+    /// </summary>
+    public static bool HasProblemMembers(int statusCode) =>
+        GenericForm(statusCode) != null && statusCode != 405 && statusCode != 406;
+
+    /// <summary>
+    /// The <c>ProblemTypes</c> constant naming the status's problem kind, or null where the
+    /// framework declares none. The constant is named after the record.
+    /// </summary>
+    public static string? ProblemType(int statusCode) =>
+        HasProblemMembers(statusCode) ? GenericForm(statusCode) : null;
+
+    /// <summary>
+    /// Whether the bare record for the status has a <c>Default</c> instance - one built with a
+    /// generic message and nothing a caller would have to supply. <c>RateLimited</c> needs a delay
+    /// and <c>MethodNotAllowed</c> an <c>Allow</c>, so neither has one; <c>NotAcceptable</c> carries
+    /// no message to be generic about.
+    /// </summary>
+    public static bool HasDefaultInstance(int statusCode) =>
+        HasProblemMembers(statusCode) && statusCode != 429;
+
+    /// <summary>
+    /// The generic form's constructor arguments, from the body a bare record converts into and
+    /// the record itself. Four records carry a header the generic form takes beside the body, in
+    /// the order that form declares.
+    /// </summary>
+    public static string GenericArguments(int statusCode, string body, string record) {
+        switch (statusCode) {
+            case 401: return body + ", " + record + ".Challenge";
+            case 405: return body + ", " + record + ".Allow";
+            case 429: return record + ".RetryAfter, " + body;
+            case 503: return body + ", " + record + ".After";
+            default: return body;
+        }
+    }
+
     public static string? BareForm(int statusCode) =>
         statusCode == 304 ? "NotModified"
             : statusCode == 406 ? "NotAcceptable"

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ProblemConversionEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ProblemConversionEmitter.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSharpAuthor;
+using Hardened.Generation;
+using Hardened.Generation.Models;
+
+namespace Hardened.Idl.Emitters;
+
+/// <summary>
+/// Writes the methods a response set's conversion from a bare shipped record calls.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One static holder per file, <c>{File}Problems</c>, with one method per record and body pair the
+/// file's response sets convert: <c>NotFoundProblem(NotFound value)</c> builds the
+/// <c>NotFound&lt;Problem&gt;</c> case with the contract's <c>Problem</c> filled from the record.
+/// Two operations declaring one 404 over one schema share the method, which is why it is not on
+/// the set.
+/// </para>
+/// <para>
+/// A record's <c>Default</c> instance converts to a cached case rather than a new one, so
+/// <c>return NotFound.Default;</c> allocates nothing in either contract style. Compared by
+/// reference, because the point is the instance a handler chose to share; an equal record built by
+/// hand is a new answer and gets a new body.
+/// </para>
+/// <para>
+/// Which cases convert is <see cref="ProblemConversion"/>'s decision, taken once for this and for
+/// the operator <see cref="UnionResponseEmitter"/> writes on the set. In union mode the set is a
+/// <c>union</c> declaration with no body for an operator, so a handler calls the method here
+/// itself; the holder is public for that reason.
+/// </para>
+/// </remarks>
+internal static class ProblemConversionEmitter {
+
+    public static ClassDefinition? Emit(
+        IConstructContainer container, IReadOnlyList<SchemaModel> schemas,
+        IReadOnlyList<ProblemConversion.Plan> plans, string modelsNamespace, string specFileName) {
+        if (plans.Count == 0) {
+            return null;
+        }
+
+        var holder = container.AddClass(ProblemConversion.HolderName(specFileName));
+
+        holder.Modifiers |= ComponentModifier.Public | ComponentModifier.Static;
+        holder.Comment = DocComment.Format(
+            "The cases a response set builds from a bare shipped record - what " +
+            "`return new NotFound(\"todo\", \"...\")` becomes - with the contract's body filled " +
+            "from what the record knows about its status. One method per record and body.");
+
+        // One method per record and body however many operations declare the pair, and ordered,
+        // so the emitted file is byte-stable between builds whatever order the operations were
+        // walked in.
+        var written = new HashSet<string>(System.StringComparer.Ordinal);
+
+        foreach (var plan in plans.OrderBy(candidate => candidate.Key, System.StringComparer.Ordinal)) {
+            if (written.Add(plan.Key)) {
+                EmitMethod(holder, schemas, plan, modelsNamespace);
+            }
+        }
+
+        return holder;
+    }
+
+    private static void EmitMethod(
+        ClassDefinition holder, IReadOnlyList<SchemaModel> schemas, ProblemConversion.Plan plan,
+        string modelsNamespace) {
+        var record = "global::" + ShippedResponses.Namespace + "." + plan.BareRecord;
+        var body = "global::" + modelsNamespace + "." + NamingHelper.ToPascalCase(plan.SchemaName);
+        var caseType = CaseType(plan, modelsNamespace, body);
+        var construction = Construction(plan, schemas, body, caseType, ProblemConversion.Record);
+
+        if (ShippedResponses.HasDefaultInstance(plan.StatusCode)) {
+            var cached = plan.MethodName + "Default";
+
+            holder.AddComponent(new CodeOutputComponent(
+                $"private static readonly {caseType} {cached} = " +
+                Construction(plan, schemas, body, caseType, record + ".Default") + ";") {
+                Indented = true
+            });
+
+            holder.AddComponent(new CodeOutputComponent(
+                $"public static {caseType} {plan.MethodName}({record} {ProblemConversion.Record}) => " +
+                $"ReferenceEquals({ProblemConversion.Record}, {record}.Default) ? {cached} : {construction};") {
+                Indented = true
+            });
+
+            return;
+        }
+
+        holder.AddComponent(new CodeOutputComponent(
+            $"public static {caseType} {plan.MethodName}({record} {ProblemConversion.Record}) => {construction};") {
+            Indented = true
+        });
+    }
+
+    /// <summary>The case the method returns: the shipped generic form over the body, or the generated type.</summary>
+    private static string CaseType(ProblemConversion.Plan plan, string modelsNamespace, string body) =>
+        plan.CaseIsShipped
+            ? "global::" + ShippedResponses.Namespace + "." + plan.CaseTypeName + "<" + body + ">"
+            : "global::" + modelsNamespace + "." + plan.CaseTypeName;
+
+    /// <summary>The case built from <paramref name="record"/>: its body, and for four records the header beside it.</summary>
+    private static string Construction(
+        ProblemConversion.Plan plan, IReadOnlyList<SchemaModel> schemas, string body, string caseType,
+        string record) {
+        var arguments = string.Join(", ", ProblemConversion.Arguments(plan, schemas, record));
+        var payload = "new " + body + "(" + arguments + ")";
+
+        return plan.CaseIsShipped
+            ? "new " + caseType + "(" + ShippedResponses.GenericArguments(plan.StatusCode, payload, record) + ")"
+            : "new " + caseType + "(" + payload + ")";
+    }
+}

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
@@ -89,7 +89,8 @@ internal static class SpecFileEmitter {
                     UnionResponseEmitter.Emit(
                         models, service, modelsNamespace,
                         asLanguageUnion: responseModel == SpecResponseModel.Union,
-                        responseModel: responseModel));
+                        responseModel: responseModel,
+                        schemas: model.Schemas, specFileName: model.FileName));
             }
 
             // The types a declared error needs, once each for the whole document rather than once
@@ -129,6 +130,17 @@ internal static class SpecFileEmitter {
             // the contract the implementation implements.
             DefaultErrorBodyEmitter.Emit(
                 models, model.Schemas, NullResponseBodies(model), modelsNamespace);
+
+            // The cases a bare shipped record converts into, one method per record and body the
+            // file's response sets need. Beside the null-return bodies, which fill the same members
+            // from the status alone.
+            var problems = ProblemConversionEmitter.Emit(
+                models, model.Schemas, ProblemConversions(model, responseModel), modelsNamespace,
+                model.FileName);
+
+            if (problems != null) {
+                Coverage.Apply(problems, excludeFromCoverage);
+            }
         }
 
         Coverage.Apply(
@@ -237,6 +249,31 @@ internal static class SpecFileEmitter {
     /// verbs can produce an error body this way. Restricted to statuses the operation itself
     /// declares - a document that never mentions 404 for an operation is not given one here.
     /// </remarks>
+    /// <summary>
+    /// Every conversion the file's response sets offer, once each: an error two operations share
+    /// converts through one method.
+    /// </summary>
+    private static IReadOnlyList<ProblemConversion.Plan> ProblemConversions(
+        ServiceSpecModel model, SpecResponseModel responseModel) {
+        var plans = new Dictionary<string, ProblemConversion.Plan>(System.StringComparer.Ordinal);
+
+        foreach (var service in model.Services) {
+            foreach (var operation in service.Operations) {
+                if (!ResponseSetPlan.RequiresResponseSet(operation, responseModel)) {
+                    continue;
+                }
+
+                foreach (var error in operation.ErrorResponses) {
+                    if (ProblemConversion.For(error, model.Schemas) is { } plan) {
+                        plans[plan.Key] = plan;
+                    }
+                }
+            }
+        }
+
+        return new List<ProblemConversion.Plan>(plans.Values);
+    }
+
     private static IReadOnlyCollection<(string SchemaName, int StatusCode)> NullResponseBodies(
         ServiceSpecModel model) {
         var wanted = new HashSet<(string, int)>();

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/UnionResponseEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/UnionResponseEmitter.cs
@@ -56,7 +56,8 @@ internal static class UnionResponseEmitter {
     /// </remarks>
     public static IReadOnlyList<ClassDefinition> Emit(
         IConstructContainer container, ServiceModel service, string modelsNamespace,
-        bool asLanguageUnion = false, SpecResponseModel responseModel = SpecResponseModel.Response) {
+        bool asLanguageUnion = false, SpecResponseModel responseModel = SpecResponseModel.Response,
+        IReadOnlyList<SchemaModel>? schemas = null, string? specFileName = null) {
         var emitted = new List<ClassDefinition>();
 
         foreach (var operation in service.Operations) {
@@ -101,11 +102,24 @@ internal static class UnionResponseEmitter {
                 branches.Add(TypeDefinition.Get(modelsNamespace, name));
             }
 
+            var conversions = new List<ProblemConversion.Plan>();
+
             foreach (var error in operation.ErrorResponses) {
                 branches.Add(ErrorBranchType(error, modelsNamespace));
+
+                // The shorthand from the bare record, where the build can fill the body: the
+                // schemas say which bodies are problem shaped, and the file name says where the
+                // method that fills one lives. A caller passing neither gets the set without it.
+                if (schemas != null && specFileName != null &&
+                    ProblemConversion.For(error, schemas) is { } plan) {
+                    conversions.Add(plan);
+                }
             }
 
-            emitted.Add(EmitContainer(container, operation, branches, asLanguageUnion));
+            emitted.Add(EmitContainer(
+                container, operation, branches, asLanguageUnion, conversions,
+                specFileName == null ? null : ProblemConversion.HolderName(specFileName),
+                modelsNamespace));
         }
 
         return emitted;
@@ -397,7 +411,9 @@ internal static class UnionResponseEmitter {
     /// </remarks>
     private static ClassDefinition EmitContainer(
         IConstructContainer container, OperationModel operation,
-        IReadOnlyList<ITypeDefinition> branchTypes, bool asLanguageUnion) {
+        IReadOnlyList<ITypeDefinition> branchTypes, bool asLanguageUnion,
+        IReadOnlyList<ProblemConversion.Plan> conversions, string? problemsHolder,
+        string modelsNamespace) {
         var name = ResponseSetPlan.ContainerName(operation);
 
         var branches = new List<string>();
@@ -427,6 +443,9 @@ internal static class UnionResponseEmitter {
                 type.AddUnionCase(branchType);
             }
 
+            // No conversion from the bare record here: a union declaration is written without a
+            // body, so it has nowhere to carry one. The holder the conversion would call is still
+            // emitted, and a union-mode handler calls it directly.
             return type;
         }
 
@@ -456,6 +475,8 @@ internal static class UnionResponseEmitter {
                 });
         }
 
+        EmitConversions(type, name, conversions, problemsHolder, modelsNamespace);
+
         var toString = type.AddMethod("ToString");
 
         toString.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
@@ -463,6 +484,35 @@ internal static class UnionResponseEmitter {
         toString.AddIndentedStatement("return Value?.ToString() ?? \"\"");
 
         return type;
+    }
+
+    /// <summary>
+    /// The shorthand: the bare shipped record converts into the case that carries the contract's
+    /// body, with the body filled from the record.
+    /// </summary>
+    /// <remarks>
+    /// One more conversion per case that can be filled, so a status the operation does not declare
+    /// is still a compile error - there is no operator for it to land on. The record is spelled as
+    /// the branches spell a shipped type, without <c>global::</c>, so the set reads as one list of
+    /// conversions.
+    /// </remarks>
+    private static void EmitConversions(
+        ClassDefinition type, string name, IReadOnlyList<ProblemConversion.Plan> conversions,
+        string? problemsHolder, string modelsNamespace) {
+        if (problemsHolder == null) {
+            return;
+        }
+
+        foreach (var conversion in conversions) {
+            var record = ShippedResponses.Namespace + "." + conversion.BareRecord;
+
+            type.AddComponent(
+                new CodeOutputComponent(
+                    $"public static implicit operator {name}({record} value) => " +
+                    $"new(global::{modelsNamespace}.{problemsHolder}.{conversion.MethodName}(value));") {
+                    Indented = true
+                });
+        }
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
@@ -246,6 +246,9 @@ internal static class NameAllocator {
             // non-generic static class, so unlike the wrappers below it has nowhere else to go.
             file + "Errors",
 
+            // The static class the conversions from a bare record call into, for the same reason.
+            file + "Problems",
+
             // Exactly the names the type mapper resolves by spelling - no more. It looks a type up
             // by its rendered name, so a schema called DateTime became System.DateTime everywhere
             // it was referenced; Zoom declares one, and it is a date range with `from` and `to`,

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DefaultErrorBodyTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/DefaultErrorBodyTests.cs
@@ -131,7 +131,55 @@ public class DefaultErrorBodyTests {
         };
 
         Assert.Equal(
-            ["\"about:blank\"", "\"Not Found\"", "404", "default"],
+            ["global::Hardened.Requests.Abstract.Responses.ProblemTypes.NotFound", "\"Not Found\"", "404", "default"],
             DefaultErrorBody.Arguments(schemas, "Problem", 404));
+    }
+
+    /// <summary>
+    /// The <c>type</c> is the framework's own problem type for the status, which is what a
+    /// code-first handler's record sends, so a null return and a returned record answer alike.
+    /// Only a status the framework declares no kind for falls back to <c>about:blank</c>.
+    /// </summary>
+    [Fact]
+    public void AStatusWithNoProblemKindWritesAboutBlank() {
+        var schemas = new[] {
+            Schema("Problem", isErrorShape: false,
+                String("type", required: false),
+                new PropertyModel { Name = "status", Type = "integer", IsRequired = false },
+                String("title", required: false))
+        };
+
+        Assert.Equal(
+            ["\"about:blank\"", "405", "\"Method Not Allowed\""],
+            DefaultErrorBody.Arguments(schemas, "Problem", 405));
+    }
+
+    /// <summary>
+    /// The same members read off a record instead - the body a returned <c>NotFound</c> converts
+    /// into - so the detail is the handler's and the rest is what the record already knows.
+    /// </summary>
+    [Fact]
+    public void AProblemIsFilledFromARecord() {
+        var schemas = new[] {
+            Schema("Problem", isErrorShape: false,
+                String("type", required: false),
+                String("title", required: false),
+                new PropertyModel { Name = "status", Type = "integer", IsRequired = false },
+                String("detail", required: false))
+        };
+
+        Assert.Equal(
+            ["value.Type", "value.Title", "value.Status", "value.Detail"],
+            DefaultErrorBody.ArgumentsFromRecord(schemas, "Problem", 404, "value"));
+    }
+
+    /// <summary>A Smithy message is the detail, or the title where the record carries none.</summary>
+    [Fact]
+    public void AnErrorShapesMessageIsFilledFromTheRecordsDetail() {
+        var schemas = new[] { Schema("TodoNotFound", isErrorShape: true, String("message", required: true)) };
+
+        Assert.Equal(
+            ["(value.Detail ?? value.Title)"],
+            DefaultErrorBody.ArgumentsFromRecord(schemas, "TodoNotFound", 404, "value"));
     }
 }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ProblemConversionEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ProblemConversionEmitterTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using Hardened.Generation;
+using Hardened.Generation.Models;
+using Hardened.Idl.Emitters;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The holder a response set's conversion from a bare shipped record calls, as written.
+/// </summary>
+/// <remarks>
+/// Which cases convert is <c>ProblemConversionRuleTests</c>' subject; this holds the emitted text
+/// to what a handler's return has to compile against, and to the shape that lets a record's
+/// <c>Default</c> convert without allocating.
+/// </remarks>
+public class ProblemConversionEmitterTests {
+
+    private const string Shipped = "global::Hardened.Requests.Abstract.Responses.";
+
+    private const string Models = "global::" + EmitterHarness.ModelsNamespace + ".";
+
+    private static SchemaModel Problem(string name = "Problem", bool withDetail = true) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object };
+
+        schema.Properties.Add(new PropertyModel { Name = "type", Type = "string" });
+        schema.Properties.Add(new PropertyModel { Name = "title", Type = "string" });
+        schema.Properties.Add(new PropertyModel { Name = "status", Type = "integer" });
+
+        if (withDetail) {
+            schema.Properties.Add(new PropertyModel { Name = "detail", Type = "string" });
+        }
+
+        return schema;
+    }
+
+    private static SchemaModel Plain(string name) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object };
+
+        schema.Properties.Add(new PropertyModel { Name = "message", Type = "string" });
+
+        return schema;
+    }
+
+    /// <summary>A Smithy error shape: @error, a message, and whatever else the model requires.</summary>
+    private static SchemaModel ErrorShape(string name, params string[] requiredBesideMessage) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object, IsErrorShape = true };
+
+        schema.Properties.Add(new PropertyModel { Name = "message", Type = "string", IsRequired = true });
+        schema.Required.Add("message");
+
+        foreach (var member in requiredBesideMessage) {
+            schema.Properties.Add(new PropertyModel { Name = member, Type = "string", IsRequired = true });
+            schema.Required.Add(member);
+        }
+
+        return schema;
+    }
+
+    private static ErrorResponseModel Error(int status, string schema) =>
+        new() { StatusCode = status, Ref = "#/components/schemas/" + schema };
+
+    private static ErrorResponseModel Named(int status, string schema, string caseType) =>
+        new() { StatusCode = status, Ref = "#/components/schemas/" + schema, Name = schema, TypeName = caseType };
+
+    private static string Holder(IReadOnlyList<SchemaModel> schemas, params ErrorResponseModel[] errors) {
+        var plans = new List<ProblemConversion.Plan>();
+
+        foreach (var error in errors) {
+            if (ProblemConversion.For(error, schemas) is { } plan) {
+                plans.Add(plan);
+            }
+        }
+
+        return EmitterHarness.Write(ns => ProblemConversionEmitter.Emit(
+            ns, schemas, plans, EmitterHarness.ModelsNamespace, "petstore"));
+    }
+
+    [Fact]
+    public void TheMethodBuildsTheCaseFromTheRecord() {
+        var emitted = Holder([Problem()], Error(404, "Problem"));
+
+        Assert.Contains("public static class PetstoreProblems", emitted);
+        Assert.Contains(
+            $"public static {Shipped}NotFound<{Models}Problem> NotFoundProblem({Shipped}NotFound value) =>",
+            emitted);
+        Assert.Contains(
+            $"new {Shipped}NotFound<{Models}Problem>(new {Models}Problem(value.Type, value.Title, value.Status, value.Detail))",
+            emitted);
+    }
+
+    /// <summary>The record's Default converts to one shared case, so returning it allocates nothing.</summary>
+    [Fact]
+    public void TheDefaultInstanceConvertsToACachedCase() {
+        var emitted = Holder([Problem()], Error(404, "Problem"));
+
+        Assert.Contains($"ReferenceEquals(value, {Shipped}NotFound.Default) ? NotFoundProblemDefault :", emitted);
+        Assert.Contains(
+            $"private static readonly {Shipped}NotFound<{Models}Problem> NotFoundProblemDefault = " +
+            $"new {Shipped}NotFound<{Models}Problem>(new {Models}Problem(" +
+            $"{Shipped}NotFound.Default.Type, {Shipped}NotFound.Default.Title, " +
+            $"{Shipped}NotFound.Default.Status, {Shipped}NotFound.Default.Detail));",
+            emitted);
+    }
+
+    /// <summary>A record that carries a header hands it to the generic form beside the body.</summary>
+    [Fact]
+    public void AHeaderCarryingRecordPassesItsHeaderOn() {
+        var emitted = Holder([Problem()], Error(429, "Problem"), Error(503, "Problem"));
+
+        Assert.Contains($"new {Shipped}RateLimited<{Models}Problem>(value.RetryAfter, new {Models}Problem(", emitted);
+        Assert.Contains($"new {Shipped}ServiceUnavailable<{Models}Problem>(new {Models}Problem(", emitted);
+        Assert.Contains("), value.After)", emitted);
+        // No Default for a record that needs a delay.
+        Assert.DoesNotContain("RateLimitedProblemDefault", emitted);
+    }
+
+    /// <summary>MethodNotAllowed carries no problem members, so its body is the status's.</summary>
+    [Fact]
+    public void ARecordWithNoProblemMembersFillsTheBodyFromTheStatus() {
+        var emitted = Holder([Problem()], Error(405, "Problem"));
+
+        Assert.Contains(
+            $"new {Models}Problem(\"about:blank\", \"Method Not Allowed\", value.Status, default), value.Allow)",
+            emitted);
+    }
+
+    [Fact]
+    public void ASmithyErrorShapeIsFilledFromTheDetailOrTheTitle() {
+        var emitted = Holder([ErrorShape("TodoNotFound")], Named(404, "TodoNotFound", "TodoNotFoundError"));
+
+        Assert.Contains(
+            $"public static {Models}TodoNotFoundError NotFoundTodoNotFound({Shipped}NotFound value) =>",
+            emitted);
+        Assert.Contains(
+            $"new {Models}TodoNotFoundError(new {Models}TodoNotFound((value.Detail ?? value.Title)))",
+            emitted);
+    }
+
+    /// <summary>One method per record and body, however many operations declare the pair.</summary>
+    [Fact]
+    public void TwoOperationsSharingAnErrorShareTheMethod() {
+        var emitted = Holder([Problem()], Error(404, "Problem"), Error(404, "Problem"));
+
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(emitted, "NotFoundProblem\\("));
+    }
+
+    [Fact]
+    public void NothingIsWrittenWhenNothingConverts() {
+        var emitted = Holder([Plain("ApiError")], Error(404, "ApiError"));
+
+        Assert.DoesNotContain("PetstoreProblems", emitted);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ProblemConversionRuleTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ProblemConversionRuleTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using Hardened.Generation;
+using Hardened.Generation.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// The conversion a response set offers from a bare shipped record - what
+/// <c>return new NotFound("todo", "...")</c> becomes - as a rule, before anything is written.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rule is one decision asked twice: by the set, which writes the operator, and by the holder,
+/// which writes the method the operator calls. These tests hold it to the cases it must refuse.
+/// The emitted text is <c>ProblemConversionEmitterTests</c>' subject.
+/// </para>
+/// <para>
+/// Linked into the Roslyn generator's test project as well, because that generator compiles the
+/// shared rules in as source and the rule has to hold there too.
+/// </para>
+/// </remarks>
+public class ProblemConversionRuleTests {
+
+
+
+    private static SchemaModel Problem(string name = "Problem", bool withDetail = true) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object };
+
+        schema.Properties.Add(new PropertyModel { Name = "type", Type = "string" });
+        schema.Properties.Add(new PropertyModel { Name = "title", Type = "string" });
+        schema.Properties.Add(new PropertyModel { Name = "status", Type = "integer" });
+
+        if (withDetail) {
+            schema.Properties.Add(new PropertyModel { Name = "detail", Type = "string" });
+        }
+
+        return schema;
+    }
+
+    private static SchemaModel Plain(string name) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object };
+
+        schema.Properties.Add(new PropertyModel { Name = "message", Type = "string" });
+
+        return schema;
+    }
+
+    /// <summary>A Smithy error shape: @error, a message, and whatever else the model requires.</summary>
+    private static SchemaModel ErrorShape(string name, params string[] requiredBesideMessage) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object, IsErrorShape = true };
+
+        schema.Properties.Add(new PropertyModel { Name = "message", Type = "string", IsRequired = true });
+        schema.Required.Add("message");
+
+        foreach (var member in requiredBesideMessage) {
+            schema.Properties.Add(new PropertyModel { Name = member, Type = "string", IsRequired = true });
+            schema.Required.Add(member);
+        }
+
+        return schema;
+    }
+
+    private static ErrorResponseModel Error(int status, string schema) =>
+        new() { StatusCode = status, Ref = "#/components/schemas/" + schema };
+
+    private static ErrorResponseModel Named(int status, string schema, string caseType) =>
+        new() { StatusCode = status, Ref = "#/components/schemas/" + schema, Name = schema, TypeName = caseType };
+
+
+
+    [Fact]
+    public void AProblemShapedBodyOnAShippedRecordConverts() {
+        var plan = ProblemConversion.For(Error(404, "Problem"), [Problem()]);
+
+        Assert.NotNull(plan);
+        Assert.Equal("NotFound", plan.Value.BareRecord);
+        Assert.Equal("NotFound", plan.Value.CaseTypeName);
+        Assert.True(plan.Value.CaseIsShipped);
+        Assert.Equal("NotFoundProblem", plan.Value.MethodName);
+    }
+
+    /// <summary>A body that is not 7807 shaped has no members the record's facts belong in.</summary>
+    [Fact]
+    public void APlainBodyDoesNot() {
+        Assert.Null(ProblemConversion.For(Error(404, "ApiError"), [Plain("ApiError")]));
+    }
+
+    /// <summary>An error with no body already has the bare record as its case.</summary>
+    [Fact]
+    public void ABodylessErrorDoesNot() {
+        Assert.Null(ProblemConversion.For(new ErrorResponseModel { StatusCode = 404 }, [Problem()]));
+    }
+
+    /// <summary>A declared header is a value no record carries.</summary>
+    [Fact]
+    public void AnErrorDeclaringAHeaderDoesNot() {
+        var error = Error(404, "Problem");
+        error.Headers.Add(new ResponseHeaderModel { Name = "X-Reason", ParameterName = "reason" });
+
+        Assert.Null(ProblemConversion.For(error, [Problem()]));
+    }
+
+    /// <summary>A status the framework ships no record for has nothing to convert from.</summary>
+    [Fact]
+    public void AStatusWithNoShippedRecordDoesNot() {
+        Assert.Null(ProblemConversion.For(Error(423, "Problem"), [Problem()]));
+    }
+
+    [Fact]
+    public void ASmithyErrorShapeWithAMessageConverts() {
+        var plan = ProblemConversion.For(
+            Named(404, "TodoNotFound", "TodoNotFoundError"), [ErrorShape("TodoNotFound")]);
+
+        Assert.NotNull(plan);
+        Assert.Equal("NotFound", plan.Value.BareRecord);
+        Assert.Equal("TodoNotFoundError", plan.Value.CaseTypeName);
+        Assert.False(plan.Value.CaseIsShipped);
+    }
+
+    /// <summary>A required member beside the message has no source, so the shape is not filled.</summary>
+    [Fact]
+    public void ASmithyErrorShapeRequiringMoreThanAMessageDoesNot() {
+        Assert.Null(ProblemConversion.For(
+            Named(404, "TodoNotFound", "TodoNotFoundError"), [ErrorShape("TodoNotFound", "todoId")]));
+    }
+
+
+    /// <summary>The body's arguments the holder writes, read off the record it is handed.</summary>
+    [Fact]
+    public void TheArgumentsAreReadOffTheRecord() {
+        var plan = ProblemConversion.For(Error(404, "Problem"), [Problem()])!.Value;
+
+        Assert.Equal(
+            ["value.Type", "value.Title", "value.Status", "value.Detail"],
+            ProblemConversion.Arguments(plan, [Problem()], "value"));
+    }
+
+    [Fact]
+    public void TheHolderIsNamedForTheFile() {
+        Assert.Equal("PetstoreProblems", ProblemConversion.HolderName("petstore"));
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnionResponseEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnionResponseEmitterTests.cs
@@ -70,6 +70,25 @@ public class UnionResponseEmitterTests {
             EmitterHarness.ModelsNamespace,
             asLanguageUnion));
 
+    /// <summary>The same, with the schemas the errors' bodies resolve against, which is what the shorthand needs.</summary>
+    private static string EmitWithSchemas(IReadOnlyList<SchemaModel> schemas, params OperationModel[] operations) =>
+        EmitterHarness.Write(ns => UnionResponseEmitter.Emit(
+            ns,
+            new ServiceModel { Tag = "pets", Operations = new List<OperationModel>(operations) },
+            EmitterHarness.ModelsNamespace,
+            schemas: schemas,
+            specFileName: "petstore"));
+
+    private static SchemaModel ProblemSchema(string name) {
+        var schema = new SchemaModel { Name = name, Kind = SchemaKind.Object };
+
+        schema.Properties.Add(new PropertyModel { Name = "title", Type = "string" });
+        schema.Properties.Add(new PropertyModel { Name = "status", Type = "integer" });
+        schema.Properties.Add(new PropertyModel { Name = "detail", Type = "string" });
+
+        return schema;
+    }
+
     #region the case types
 
     /// <summary>
@@ -239,6 +258,43 @@ public class UnionResponseEmitterTests {
         Assert.Contains(
             $"implicit operator GetPetResponse({Shipped("NotFound")}<Test.Api.Models.ApiError> value)",
             emitted);
+    }
+
+    /// <summary>
+    /// The shorthand: the bare shipped record converts too, through the holder that fills the
+    /// contract's body from it, so a handler returns <c>new NotFound("pet", "...")</c>.
+    /// </summary>
+    [Fact]
+    public void TheContainerConvertsFromTheBareRecordWhereTheBodyCanBeFilled() {
+        var emitted = EmitWithSchemas(
+            [ProblemSchema("ApiError")], Operation(errors: [Error(404, "#/components/schemas/ApiError")]));
+
+        Assert.Contains(
+            $"public static implicit operator GetPetResponse({Shipped("NotFound")} value) => " +
+            "new(global::Test.Api.Models.PetstoreProblems.NotFoundApiError(value));",
+            emitted);
+    }
+
+    /// <summary>
+    /// A body the record's facts have no members in gets no shorthand, so the wrong shape is a
+    /// compile error rather than a body with nothing in it.
+    /// </summary>
+    [Fact]
+    public void ABodyThatIsNotProblemShapedGetsNoShorthand() {
+        var plain = new SchemaModel { Name = "ApiError", Kind = SchemaKind.Object };
+        plain.Properties.Add(new PropertyModel { Name = "message", Type = "string" });
+
+        var emitted = EmitWithSchemas([plain], Operation(errors: [Error(404, "#/components/schemas/ApiError")]));
+
+        Assert.DoesNotContain($"operator GetPetResponse({Shipped("NotFound")} value)", emitted);
+    }
+
+    /// <summary>Without the schemas there is no way to tell, and nothing is written.</summary>
+    [Fact]
+    public void WithoutSchemasNoShorthandIsWritten() {
+        var emitted = Emit(Operation(errors: [Error(404, "#/components/schemas/ApiError")]));
+
+        Assert.DoesNotContain("PetstoreProblems", emitted);
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Hardened.SourceGenerator.Tests.csproj
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Hardened.SourceGenerator.Tests.csproj
@@ -55,4 +55,18 @@
         <None Include="Web/Fixtures/**/*.cs"/>
     </ItemGroup>
 
+    <!--
+        The shared generation rules are compiled into this generator as source, so they are this
+        assembly's code as much as the build tasks', and the tests that hold them are linked in
+        from the OpenAPI build task's project the way the Smithy build task links its emitter tests.
+    -->
+    <ItemGroup>
+        <Compile Include="../Hardened.OpenApi.BuildTask.Tests/DefaultErrorBodyTests.cs"
+                 Link="Shared/DefaultErrorBodyTests.cs"/>
+        <Compile Include="../Hardened.OpenApi.BuildTask.Tests/ShippedResponsesTests.cs"
+                 Link="Shared/ShippedResponsesTests.cs"/>
+        <Compile Include="../Hardened.OpenApi.BuildTask.Tests/ProblemConversionRuleTests.cs"
+                 Link="Shared/ProblemConversionRuleTests.cs"/>
+    </ItemGroup>
+
 </Project>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
@@ -29,16 +29,13 @@ public class TodoService : ITodosService {
         _store = store;
     }
 
-    // The one thing the two contract languages do not agree on. An OpenAPI description declares a
-    // shared Problem schema for every error; a Smithy model declares a named @error structure per
-    // failure. The signatures either produces are identical, so isolating the body here keeps every
-    // call site below the same in both.
+#if (throwsMode)
+    // The body a thrown error carries. An OpenAPI description declares a shared Problem schema for
+    // every error; a Smithy model declares a named @error structure per failure. Only the throw
+    // below builds one by hand - a returned case is built by the conversion the build writes.
 #if (openapi)
     private static Problem NotFoundBody(string detail) =>
         new() { Type = "about:blank", Title = "Not Found", Status = 404, Detail = detail };
-
-    private static Problem ConflictBody(string detail) =>
-        new() { Type = "about:blank", Title = "Conflict", Status = 409, Detail = detail };
 #endif
 #if (smithy)
     private static TodoNotFound NotFoundBody(string message) => new(message);
@@ -46,30 +43,7 @@ public class TodoService : ITodosService {
     private static TodoTitleTaken ConflictBody(string message) => new(message);
 #endif
 
-    // And the type that carries the body to the wire, which is where the languages diverge again.
-    //
-    // An anonymous OpenAPI error binds to the record the framework already ships for its status -
-    // NotFound<Problem>, Conflict<Problem> - so the build generates nothing for it and the same
-    // type serves a code-first handler. A Smithy error is a named shape, so the build generates one
-    // type named for the shape and every operation binding it uses that one. Neither is named after
-    // an operation, which is why adding a second operation with the same 404 adds no type.
-#if (declaredMode)
-#if (openapi)
-    private static NotFound<Problem> NotFoundCase(string detail) => new(NotFoundBody(detail));
 #endif
-#if (smithy)
-    private static TodoNotFoundError NotFoundCase(string message) => new(NotFoundBody(message));
-#endif
-#endif
-#if (openapi)
-    private static Conflict<Problem> ConflictCase(string detail) => new(ConflictBody(detail));
-#endif
-#if (smithy)
-#if (declaredMode)
-    private static TodoTitleTakenError ConflictCase(string message) => new(ConflictBody(message));
-#endif
-#endif
-
     /// <summary>
     /// Every todo, as the array the contract declares.
     /// </summary>
@@ -112,8 +86,11 @@ public class TodoService : ITodosService {
     /// </remarks>
     public Task<CreateTodoResponse> CreateTodo(NewTodo body) {
         if (_store.TitleExists(body.Title)) {
+            // The framework's own Conflict, converted by the build into the case the contract
+            // declares: its Problem, with type, title and status filled from the record and the
+            // detail from here.
             return Task.FromResult<CreateTodoResponse>(
-                ConflictCase($"A todo titled '{body.Title}' already exists."));
+                new Conflict($"A todo titled '{body.Title}' already exists."));
         }
 
         var created = _store.Add(body.Title);
@@ -164,23 +141,48 @@ public class TodoService : ITodosService {
     /// The build generated one case per declared response and a container that holds exactly one of
     /// them, so there is no null to interpret and no exception to remember. Returning the wrong
     /// status for this operation is a compile error rather than a wrong answer.
+    ///
+    /// The 404 is the framework's own NotFound. The build wrote the conversion into the case the
+    /// contract declares - the declared body with type, title and status filled from the record and
+    /// the detail from here - so a handler says why and nothing else. NotFound.Default is the same
+    /// answer with a generic detail, shared, for a handler with nothing to add.
     /// </remarks>
-    public Task<GetTodoResponse> GetTodo(int id) {
-        var todo = _store.Find(id);
-
-        if (todo is null) {
-            return Task.FromResult<GetTodoResponse>(
-                NotFoundCase($"No todo has id {id}."));
-        }
-
-        return Task.FromResult<GetTodoResponse>(todo);
-    }
+#if (responseMode)
+    public Task<GetTodoResponse> GetTodo(int id) =>
+        Task.FromResult<GetTodoResponse>(
+            _store.Find(id) is { } todo ? todo : new NotFound("todo", $"No todo has id {id}."));
+#else
+    // A union is declared without a body, so the conversion the response model gets cannot be
+    // written on it. The Problems holder is the method that conversion calls - named for the
+    // contract file under OpenAPI and for the module under Smithy - and calling it here is the
+    // same one line.
+    public Task<GetTodoResponse> GetTodo(int id) =>
+        Task.FromResult<GetTodoResponse>(
+            _store.Find(id) is { } todo
+                ? todo
+#if (openapi)
+                : TodosProblems.NotFoundProblem(new NotFound("todo", $"No todo has id {id}.")));
+#endif
+#if (smithy)
+                : TemplateModuleNameProblems.NotFoundTodoNotFound(new NotFound("todo", $"No todo has id {id}.")));
+#endif
+#endif
 
     /// <summary>201 with the new todo, or 409.</summary>
     public Task<CreateTodoResponse> CreateTodo(NewTodo body) {
         if (_store.TitleExists(body.Title)) {
+#if (responseMode)
             return Task.FromResult<CreateTodoResponse>(
-                ConflictCase($"A todo titled '{body.Title}' already exists."));
+                new Conflict($"A todo titled '{body.Title}' already exists."));
+#endif
+#if (unionMode && openapi)
+            return Task.FromResult<CreateTodoResponse>(
+                TodosProblems.ConflictProblem(new Conflict($"A todo titled '{body.Title}' already exists.")));
+#endif
+#if (unionMode && smithy)
+            return Task.FromResult<CreateTodoResponse>(
+                TemplateModuleNameProblems.ConflictTodoTitleTaken(new Conflict($"A todo titled '{body.Title}' already exists.")));
+#endif
         }
 
         var created = _store.Add(body.Title);
@@ -204,13 +206,18 @@ public class TodoService : ITodosService {
     /// nothing. Before that existed this operation's response set held only the 404 and there was
     /// no way to say it had worked.
     /// </remarks>
-    public Task<RemoveTodoResponse> RemoveTodo(int id) {
-        if (!_store.Remove(id)) {
-            return Task.FromResult<RemoveTodoResponse>(
-                NotFoundCase($"No todo has id {id}."));
-        }
-
-        return Task.FromResult<RemoveTodoResponse>(new RemoveTodoNoContent());
-    }
+    public Task<RemoveTodoResponse> RemoveTodo(int id) =>
+        Task.FromResult<RemoveTodoResponse>(
+            _store.Remove(id)
+                ? new RemoveTodoNoContent()
+#if (responseMode)
+                : new NotFound("todo", $"No todo has id {id}."));
+#endif
+#if (unionMode && openapi)
+                : TodosProblems.NotFoundProblem(new NotFound("todo", $"No todo has id {id}.")));
+#endif
+#if (unionMode && smithy)
+                : TemplateModuleNameProblems.NotFoundTodoNotFound(new NotFound("todo", $"No todo has id {id}.")));
+#endif
 #endif
 }


### PR DESCRIPTION
A specification-first handler answering a declared 404 used to build the contract's `Problem` by hand, `type`, `title` and `status` filled in from what the case already knew, and then wrap it in `NotFound<Problem>`. Four layers for a 404, and the trial found the sample getting one of them wrong. The build now writes the conversion.

## The shape

```csharp
public Task<GetTodoResponse> GetTodo(int id) =>
    Task.FromResult<GetTodoResponse>(
        _store.Find(id) is { } todo ? todo : new NotFound("todo", $"No todo has id {id}."));

public Task<ArchiveLabelResponse> ArchiveLabel(string labelId) =>
    Task.FromResult<ArchiveLabelResponse>(labelId == "missing" ? NotFound.Default : new ArchiveLabelNoContent());
```

`NotFound` is the framework's own record. Where the declared body is RFC 7807 shaped - `title` and `status` in 7807's types, the same test the null-return body already uses - or a Smithy `@error` shape whose only required member is `message`, the response set gains one implicit operator from the bare record:

```csharp
public static implicit operator GetTodoResponse(Hardened.Requests.Abstract.Responses.NotFound value) =>
    new(global::Todos.Models.TodosProblems.NotFoundProblem(value));
```

and a `{File}Problems` holder carries one method per record and body, filling the contract's body from the record - `type`, `title`, `status` and `detail` off it, a Smithy `message` from `Detail ?? Title` - through the same member mapping `DefaultErrorBodies` uses. One operator per case that can be filled, so a status the operation does not declare still has no operator to land on and stays a compile error. Both union modes get it: a `union` is a class, and the operator is a member like any other.

## Default instances

Every bare error record whose constructor needs nothing a caller would have to supply has a static `Default` with a generic message - eighteen of them; `RateLimited` needs a delay, `MethodNotAllowed` an `Allow`, and `NotAcceptable` carries no message. The holder hands back one cached case for a `Default`, compared by reference, so `return NotFound.Default;` allocates nothing in either contract style.

## Also here

- `DefaultErrorBodies` writes `type` as the framework's `ProblemTypes` URI for the status rather than `about:blank`, so a throws-mode null return and a returned record send one `type`; `about:blank` remains for a status the framework declares no kind for. `ProblemConversion` in `Hardened.Generation.Shared` is the one rule both emitters ask.
- The template's specification-first `TodoService` loses its four helper methods; only the throws-mode throw still builds a body by hand, which is what a throw is. The response-model integration application returns the bare record and its `Default`, its `Problem` gained a `detail`, and its tests follow the body.
- Design decisions taken in discussion: one operator per case rather than a base-class operator, which could only refuse a wrong status at run time; `NotFound` keeps `(Resource, Detail)`. Ninety operators measured at about 6 KB of IL.
- Docs: the site's responses page, on ipjohnson/Hardened.Docs#28.

## Checks

- Rebased onto main after #271 merged; the branch carries the one commit.
- `Hardened.OpenApi.BuildTask.Tests` 563 (the rule, the holder, the operator, the record-sourced arguments), `Hardened.Smithy.BuildTask.Tests` 227, `Hardened.Requests.Abstract.Tests` 909 (a sweep over every record with a `Default`), the response-model integration application 8 (the real conversion, and the cached `Default` case on the wire), the OpenAPI integration application 128, the union integration application 6 under the .NET 11 compiler.
- Release build with `ContinuousIntegrationBuild=true` clean apart from the pre-existing HSMT031; 35 assemblies green in Release. Public API re-approved: purely additive, the 18 `Default` fields.
- `scripts/verify-templates.sh` on `kestrel:openapi`, `kestrel:openapi:throws`, `kestrel:openapi:union`, `kestrel:smithy`, `kestrel:smithy:throws` and `kestrel:smithy:union`, with the pinned Smithy CLI on the path locally, plus the library, dotted-name and Lambda rows: verified. Under union the set is a `union` declaration with no body, so the union-mode sample calls the holder directly; the response-mode sample returns the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
