### PR TITLE
Make the sample handlers async, and write the bare-record conversion on a union too

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ public partial class TodosLibrary;
 
 public class TodoController {
     [Get("/{id}")]
-    public Response<Todo, NotFound> ById(ITodoStore store, int id) {
-        var todo = store.Find(id);
+    public async Task<Response<Todo, NotFound>> ById(ITodoStore store, int id) {
+        var todo = await store.Find(id);
 
         if (todo is null) {
             return new NotFound("todo", $"No todo has id {id}.");
@@ -125,23 +125,20 @@ from the document, so neither is restated in C#.
 
 ```csharp
 [Handler]
-public class TodoService : ITodosService {
-    private readonly ITodoStore _store;
-
-    public TodoService(ITodoStore store) => _store = store;
-
-    // GetTodoResponse, GetTodoOk and GetTodoNotFound are generated from the two declared
-    // statuses, one case each. The set is the return type, so a 404 the contract declares and the
-    // handler never returns is a compiler error rather than a document nothing answers to.
-    public Task<GetTodoResponse> GetTodo(int id) {
-        var todo = _store.Find(id);
+public class TodoService(ITodoStore store) : ITodosService {
+    // GetTodoResponse is generated from the two declared statuses, one case each: the Todo, and the
+    // 404 carrying the document's Problem. The set is the return type, so a 404 the contract
+    // declares and the handler never returns is a compiler error rather than a document nothing
+    // answers to. The 404 itself is the framework's own NotFound; the build wrote the conversion
+    // that fills the Problem from it.
+    public async Task<GetTodoResponse> GetTodo(int id) {
+        var todo = await store.Find(id);
 
         if (todo is null) {
-            return Task.FromResult<GetTodoResponse>(
-                new GetTodoNotFound(new Problem { Detail = $"No todo has id {id}." }));
+            return new NotFound("todo", $"No todo has id {id}.");
         }
 
-        return Task.FromResult<GetTodoResponse>(new GetTodoOk(todo));
+        return todo;
     }
 }
 ```
@@ -231,8 +228,8 @@ implicit conversion per case, so the handler returns payloads and never names th
 
 ```csharp
 [Get("/{id}")]
-public Response<Todo, NotFound> ById(ITodoStore store, int id) {
-    var todo = store.Find(id);
+public async Task<Response<Todo, NotFound>> ById(ITodoStore store, int id) {
+    var todo = await store.Find(id);
 
     if (todo is null) {
         return new NotFound("todo", $"No todo has id {id}.");
@@ -257,8 +254,8 @@ rest with `[Throws<NotFound>]` - the attribute the mode is named for.
 ```csharp
 [Get("/{id}")]
 [Throws<NotFound>]
-public Todo ById(ITodoStore store, int id) {
-    var todo = store.Find(id);
+public async Task<Todo> ById(ITodoStore store, int id) {
+    var todo = await store.Find(id);
 
     if (todo is null) {
         throw new NotFound("todo", $"No todo has id {id}.").AsException();
@@ -275,7 +272,7 @@ pattern-match on the result. The handler body is identical to the `Response` ver
 public union TodoResult(Todo, NotFound);
 
 [Get("/{id}")]
-public TodoResult ById(ITodoStore store, int id) { /* same body */ }
+public async Task<TodoResult> ById(ITodoStore store, int id) { /* same body */ }
 ```
 
 Unions need `net11.0` and `<LangVersion>preview</LangVersion>`, which rules out AWS Lambda's

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ProblemConversionEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ProblemConversionEmitter.cs
@@ -25,9 +25,8 @@ namespace Hardened.Idl.Emitters;
 /// </para>
 /// <para>
 /// Which cases convert is <see cref="ProblemConversion"/>'s decision, taken once for this and for
-/// the operator <see cref="UnionResponseEmitter"/> writes on the set. In union mode the set is a
-/// <c>union</c> declaration with no body for an operator, so a handler calls the method here
-/// itself; the holder is public for that reason.
+/// the operator <see cref="UnionResponseEmitter"/> writes on the set - a member of the struct, or
+/// of the body a <c>union</c> declaration is given for it - so the two cannot disagree.
 /// </para>
 /// </remarks>
 internal static class ProblemConversionEmitter {

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/UnionResponseEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/UnionResponseEmitter.cs
@@ -443,9 +443,16 @@ internal static class UnionResponseEmitter {
                 type.AddUnionCase(branchType);
             }
 
-            // No conversion from the bare record here: a union declaration is written without a
-            // body, so it has nowhere to carry one. The holder the conversion would call is still
-            // emitted, and a union-mode handler calls it directly.
+            // The shorthand from the bare record, as the struct gets it, in a body the union
+            // otherwise does without. The compiler synthesises a constructor and a conversion per
+            // case from the header, so the body carries only these - and a set with none to write
+            // stays the one-line declaration.
+            if (problemsHolder != null && conversions.Count > 0) {
+                type.TerminateWithSemicolon = false;
+
+                EmitConversions(type, name, conversions, problemsHolder, modelsNamespace);
+            }
+
             return type;
         }
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnionResponseEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnionResponseEmitterTests.cs
@@ -72,10 +72,15 @@ public class UnionResponseEmitterTests {
 
     /// <summary>The same, with the schemas the errors' bodies resolve against, which is what the shorthand needs.</summary>
     private static string EmitWithSchemas(IReadOnlyList<SchemaModel> schemas, params OperationModel[] operations) =>
+        EmitWithSchemas(schemas, asLanguageUnion: false, operations);
+
+    private static string EmitWithSchemas(
+        IReadOnlyList<SchemaModel> schemas, bool asLanguageUnion, params OperationModel[] operations) =>
         EmitterHarness.Write(ns => UnionResponseEmitter.Emit(
             ns,
             new ServiceModel { Tag = "pets", Operations = new List<OperationModel>(operations) },
             EmitterHarness.ModelsNamespace,
+            asLanguageUnion,
             schemas: schemas,
             specFileName: "petstore"));
 
@@ -327,7 +332,7 @@ public class UnionResponseEmitterTests {
     /// <summary>
     /// Union mode declares the container with the keyword. Every member the struct spells out - the
     /// constructors, the conversions, Value - the compiler synthesises from the case list, which is
-    /// why the declaration is the whole of it.
+    /// why the declaration is the whole of it where there is no shorthand to write.
     /// </summary>
     [Fact]
     public void UnionModeDeclaresTheContainerWithTheKeyword() {
@@ -339,6 +344,38 @@ public class UnionResponseEmitterTests {
             "public union GetPetResponse(Pet, NotFound<ApiError>, ServiceUnavailable);", emitted);
 
         Assert.DoesNotContain("public struct GetPetResponse", emitted);
+        Assert.DoesNotContain("implicit operator GetPetResponse", emitted);
+    }
+
+    /// <summary>
+    /// The shorthand from the bare record is written in union mode too, as the one kind of member
+    /// in a body the declaration otherwise does without - so a handler returns
+    /// <c>new NotFound("pet", "...")</c> whichever container the module chose.
+    /// </summary>
+    [Fact]
+    public void UnionModeWritesTheShorthandInABody() {
+        var emitted = EmitWithSchemas(
+            [ProblemSchema("ApiError")], asLanguageUnion: true,
+            Operation(errors: [Error(404, "#/components/schemas/ApiError")]));
+
+        Assert.Contains("public union GetPetResponse(Pet, NotFound<ApiError>)", emitted);
+        Assert.DoesNotContain("public union GetPetResponse(Pet, NotFound<ApiError>);", emitted);
+        Assert.Contains(
+            $"public static implicit operator GetPetResponse({Shipped("NotFound")} value) => " +
+            "new(global::Test.Api.Models.PetstoreProblems.NotFoundApiError(value));",
+            emitted);
+    }
+
+    /// <summary>A body the shorthand cannot fill leaves the union on one line.</summary>
+    [Fact]
+    public void UnionModeStaysOnOneLineWithoutAShorthandToWrite() {
+        var plain = new SchemaModel { Name = "ApiError", Kind = SchemaKind.Object };
+        plain.Properties.Add(new PropertyModel { Name = "message", Type = "string" });
+
+        var emitted = EmitWithSchemas(
+            [plain], asLanguageUnion: true, Operation(errors: [Error(404, "#/components/schemas/ApiError")]));
+
+        Assert.Contains("public union GetPetResponse(Pet, NotFound<ApiError>);", emitted);
         Assert.DoesNotContain("implicit operator GetPetResponse", emitted);
     }
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -152,7 +152,7 @@ To add an error path: throw. To make it part of the contract, move to `--respons
 **Response.** Each handler returns the whole set it can answer with:
 
 ```csharp
-public Response<Todo, NotFound> ById(ITodoStore store, int id)
+public async Task<Response<Todo, NotFound>> ById(ITodoStore store, int id)
 ```
 #endif
 #if (unionMode)
@@ -161,7 +161,7 @@ public Response<Todo, NotFound> ById(ITodoStore store, int id)
 ```csharp
 public union TodoResult(Todo, NotFound);
 
-public TodoResult ById(ITodoStore store, int id)
+public async Task<TodoResult> ById(ITodoStore store, int id)
 ```
 
 This needs the .NET 11 SDK and `LangVersion preview`, both pinned — `global.json` and

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -89,7 +89,7 @@ A route is an attribute on a method of a plain class - no base type, no interfac
 
 ```csharp
 [Get("/{id}")]
-public #if (throwsMode)Todo#endif#if (responseMode)Response<Todo, NotFound>#endif#if (unionMode)TodoResult#endif ById(ITodoStore store, int id)
+public async Task<#if (throwsMode)Todo#endif#if (responseMode)Response<Todo, NotFound>#endif#if (unionMode)TodoResult#endif> ById(ITodoStore store, int id)
 ```
 
 `[BasePath]` on `TemplateModuleNameLibrary` prefixes every route in the assembly, so that one is
@@ -158,8 +158,8 @@ Generate with `--response-model response` to put the whole set in the return typ
 This application is in **response** mode. A handler returns everything it can answer with:
 
 ```csharp
-public Response<Todo, NotFound> ById(ITodoStore store, int id) {
-    var todo = store.Find(id);
+public async Task<Response<Todo, NotFound>> ById(ITodoStore store, int id) {
+    var todo = await store.Find(id);
 
     if (todo is null) {
         return new NotFound("todo", $"No todo has id {id}.");
@@ -176,7 +176,7 @@ answer with:
 ```csharp
 public union TodoResult(Todo, NotFound);
 
-public TodoResult ById(ITodoStore store, int id) { ... }
+public async Task<TodoResult> ById(ITodoStore store, int id) { ... }
 ```
 
 That needs the .NET 11 SDK, pinned in `global.json`, and `LangVersion preview` on the library -

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
@@ -30,6 +30,9 @@ public union RemovedTodoResult(NoContent, NotFound);
 /// <remarks>
 /// Services arrive as method parameters, alongside the route and body values. Anything the
 /// container knows about can be asked for here, and nothing has to be stored on the class.
+///
+/// Every handler awaits the store and returns its answer directly. The generator reads a return
+/// type through Task&lt;T&gt;, so an async handler declares the same thing a synchronous one would.
 /// </remarks>
 public class TodoController {
 
@@ -40,7 +43,7 @@ public class TodoController {
     /// generated document without anything here describing it.
     /// </remarks>
     [Get("/")]
-    public IReadOnlyList<Todo> All(ITodoStore store) => store.All();
+    public Task<IReadOnlyList<Todo>> All(ITodoStore store) => store.All();
 
 #if (throwsMode)
     /// <summary>One todo, or 404.</summary>
@@ -50,8 +53,8 @@ public class TodoController {
     /// identical either way - what differs is whether the compiler knows the route can answer it.
     /// </remarks>
     [Get("/{id}")]
-    public Todo ById(ITodoStore store, int id) {
-        var todo = store.Find(id);
+    public async Task<Todo> ById(ITodoStore store, int id) {
+        var todo = await store.Find(id);
 
         if (todo is null) {
             throw new NotFound("todo", $"No todo has id {id}.").AsException();
@@ -68,20 +71,20 @@ public class TodoController {
     /// value. Compare the same method under --response-model response, where 201 is in the type.
     /// </remarks>
     [Post("/")]
-    public Todo Create(ITodoStore store, NewTodo request) {
-        if (store.TitleExists(request.Title)) {
+    public async Task<Todo> Create(ITodoStore store, NewTodo request) {
+        if (await store.TitleExists(request.Title)) {
             throw new Conflict($"A todo titled '{request.Title}' already exists.").AsException();
         }
 
-        return store.Add(request.Title);
+        return await store.Add(request.Title);
     }
 
     /// <summary>Removes one, or 404. Answers 200 with the removed todo, for the reason above.</summary>
     [Delete("/{id}")]
-    public Todo Remove(ITodoStore store, int id) {
-        var todo = store.Find(id);
+    public async Task<Todo> Remove(ITodoStore store, int id) {
+        var todo = await store.Find(id);
 
-        if (todo is null || !store.Remove(id)) {
+        if (todo is null || !await store.Remove(id)) {
             throw new NotFound("todo", $"No todo has id {id}.").AsException();
         }
 
@@ -97,8 +100,8 @@ public class TodoController {
     /// signature rather than in a throw somewhere down the call stack.
     /// </remarks>
     [Get("/{id}")]
-    public Response<Todo, NotFound> ById(ITodoStore store, int id) {
-        var todo = store.Find(id);
+    public async Task<Response<Todo, NotFound>> ById(ITodoStore store, int id) {
+        var todo = await store.Find(id);
 
         if (todo is null) {
             return new NotFound("todo", $"No todo has id {id}.");
@@ -113,12 +116,12 @@ public class TodoController {
     /// the case rather than from anything this method does.
     /// </remarks>
     [Post("/")]
-    public Response<Created<Todo>, Conflict> Create(ITodoStore store, NewTodo request) {
-        if (store.TitleExists(request.Title)) {
+    public async Task<Response<Created<Todo>, Conflict>> Create(ITodoStore store, NewTodo request) {
+        if (await store.TitleExists(request.Title)) {
             return new Conflict($"A todo titled '{request.Title}' already exists.");
         }
 
-        var todo = store.Add(request.Title);
+        var todo = await store.Add(request.Title);
 
         return new Created<Todo>(todo, $"/todos/{todo.Id}");
     }
@@ -129,8 +132,8 @@ public class TodoController {
     /// answers 204 with an empty body rather than 200 with "null" in it.
     /// </remarks>
     [Delete("/{id}")]
-    public Response<NoContent, NotFound> Remove(ITodoStore store, int id) {
-        if (store.Find(id) is null || !store.Remove(id)) {
+    public async Task<Response<NoContent, NotFound>> Remove(ITodoStore store, int id) {
+        if (await store.Find(id) is null || !await store.Remove(id)) {
             return new NotFound("todo", $"No todo has id {id}.");
         }
 
@@ -145,8 +148,8 @@ public class TodoController {
     /// so moving between the two rewrites no handler body and changes no generated dispatch.
     /// </remarks>
     [Get("/{id}")]
-    public TodoResult ById(ITodoStore store, int id) {
-        var todo = store.Find(id);
+    public async Task<TodoResult> ById(ITodoStore store, int id) {
+        var todo = await store.Find(id);
 
         if (todo is null) {
             return new NotFound("todo", $"No todo has id {id}.");
@@ -157,20 +160,20 @@ public class TodoController {
 
     /// <summary>Creates one at 201 with a Location header, or 409 when the title is taken.</summary>
     [Post("/")]
-    public NewTodoResult Create(ITodoStore store, NewTodo request) {
-        if (store.TitleExists(request.Title)) {
+    public async Task<NewTodoResult> Create(ITodoStore store, NewTodo request) {
+        if (await store.TitleExists(request.Title)) {
             return new Conflict($"A todo titled '{request.Title}' already exists.");
         }
 
-        var todo = store.Add(request.Title);
+        var todo = await store.Add(request.Title);
 
         return new Created<Todo>(todo, $"/todos/{todo.Id}");
     }
 
     /// <summary>Removes one at 204, or 404.</summary>
     [Delete("/{id}")]
-    public RemovedTodoResult Remove(ITodoStore store, int id) {
-        if (store.Find(id) is null || !store.Remove(id)) {
+    public async Task<RemovedTodoResult> Remove(ITodoStore store, int id) {
+        if (await store.Find(id) is null || !await store.Remove(id)) {
             return new NotFound("todo", $"No todo has id {id}.");
         }
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoService.cs
@@ -17,22 +17,20 @@ namespace Hardened1;
 /// and this class stops satisfying the interface, which is the point: the specification and the
 /// code cannot drift apart without the build saying so.
 ///
+/// Every method awaits the store and returns the value itself - a Todo, a NotFound - which the
+/// compiler converts into the type the signature names. Nothing here wraps a value in a Task; the
+/// store does that, once, for the in-memory case.
+///
 /// Build, then read obj/<configuration>/<tfm>/openapi/generated/ to see the interface, the models, the
 /// routing table and the validation the contract's constraints produced.
 /// </remarks>
 [Handler]
-public class TodoService : ITodosService {
-
-    private readonly ITodoStore _store;
-
-    public TodoService(ITodoStore store) {
-        _store = store;
-    }
+public class TodoService(ITodoStore store) : ITodosService {
 
 #if (throwsMode)
     // The body a thrown error carries. An OpenAPI description declares a shared Problem schema for
-    // every error; a Smithy model declares a named @error structure per failure. Only the throw
-    // below builds one by hand - a returned case is built by the conversion the build writes.
+    // every error; a Smithy model declares a named @error structure per failure. Only a throw builds
+    // one by hand - a returned case is built by the conversion the build writes.
 #if (openapi)
     private static Problem NotFoundBody(string detail) =>
         new() { Type = "about:blank", Title = "Not Found", Status = 404, Detail = detail };
@@ -52,8 +50,7 @@ public class TodoService : ITodosService {
     /// is nothing for a declared set to hold. A named list is not a C# type of its own in either
     /// contract language, so both generate List&lt;Todo&gt; and this method is written once.
     /// </remarks>
-    public Task<List<Todo>> ListTodos() =>
-        Task.FromResult(_store.All().ToList());
+    public async Task<List<Todo>> ListTodos() => (await store.All()).ToList();
 
 #if (throwsMode)
     /// <summary>
@@ -67,8 +64,7 @@ public class TodoService : ITodosService {
     /// A handler that wants to explain the refusal throws the generated exception type instead,
     /// which carries a body it wrote. Null is the "nothing to add" answer.
     /// </remarks>
-    public Task<Todo?> GetTodo(int id) =>
-        Task.FromResult(_store.Find(id));
+    public Task<Todo?> GetTodo(int id) => store.Find(id);
 
 #if (openapi)
     /// <summary>
@@ -84,33 +80,31 @@ public class TodoService : ITodosService {
     /// The 409 is a case rather than a throw for the same reason: once an operation has a set, the
     /// set is where all of its statuses live.
     /// </remarks>
-    public Task<CreateTodoResponse> CreateTodo(NewTodo body) {
-        if (_store.TitleExists(body.Title)) {
+    public async Task<CreateTodoResponse> CreateTodo(NewTodo body) {
+        if (await store.TitleExists(body.Title)) {
             // The framework's own Conflict, converted by the build into the case the contract
             // declares: its Problem, with type, title and status filled from the record and the
             // detail from here.
-            return Task.FromResult<CreateTodoResponse>(
-                new Conflict($"A todo titled '{body.Title}' already exists."));
+            return new Conflict($"A todo titled '{body.Title}' already exists.");
         }
 
-        var created = _store.Add(body.Title);
+        var created = await store.Add(body.Title);
 
         // Routes is generated from the same contract, so this link cannot drift from the route it
         // points at - rename the path in the contract and this stops compiling.
-        return Task.FromResult<CreateTodoResponse>(
-            new CreateTodoCreated(created, TemplateModuleNameLibrary.Routes.Todos.GetTodo(created.Id)));
+        return new CreateTodoCreated(created, TemplateModuleNameLibrary.Routes.Todos.GetTodo(created.Id));
     }
 #endif
 #if (smithy)
     /// <summary>
     /// 409 by throwing, because this operation declares one success and the signature names it.
     /// </summary>
-    public Task<Todo> CreateTodo(NewTodo body) {
-        if (_store.TitleExists(body.Title)) {
+    public async Task<Todo> CreateTodo(NewTodo body) {
+        if (await store.TitleExists(body.Title)) {
             throw ConflictBody($"A todo titled '{body.Title}' already exists.").AsException();
         }
 
-        return Task.FromResult(_store.Add(body.Title));
+        return await store.Add(body.Title);
     }
 #endif
 
@@ -120,8 +114,8 @@ public class TodoService : ITodosService {
     /// turning a response into a thrown one, and the build generates the overload that reaches a
     /// declared error's body - so the type is named once rather than beside the body it carries.
     /// </remarks>
-    public Task RemoveTodo(int id) {
-        if (!_store.Remove(id)) {
+    public async Task RemoveTodo(int id) {
+        if (!await store.Remove(id)) {
 #if (openapi)
             throw new NotFound<Problem>(NotFoundBody($"No todo has id {id}.")).AsException();
 #endif
@@ -129,8 +123,6 @@ public class TodoService : ITodosService {
             throw NotFoundBody($"No todo has id {id}.").AsException();
 #endif
         }
-
-        return Task.CompletedTask;
     }
 #endif
 #if (declaredMode)
@@ -147,54 +139,31 @@ public class TodoService : ITodosService {
     /// the detail from here - so a handler says why and nothing else. NotFound.Default is the same
     /// answer with a generic detail, shared, for a handler with nothing to add.
     /// </remarks>
-#if (responseMode)
-    public Task<GetTodoResponse> GetTodo(int id) =>
-        Task.FromResult<GetTodoResponse>(
-            _store.Find(id) is { } todo ? todo : new NotFound("todo", $"No todo has id {id}."));
-#else
-    // A union is declared without a body, so the conversion the response model gets cannot be
-    // written on it. The Problems holder is the method that conversion calls - named for the
-    // contract file under OpenAPI and for the module under Smithy - and calling it here is the
-    // same one line.
-    public Task<GetTodoResponse> GetTodo(int id) =>
-        Task.FromResult<GetTodoResponse>(
-            _store.Find(id) is { } todo
-                ? todo
-#if (openapi)
-                : TodosProblems.NotFoundProblem(new NotFound("todo", $"No todo has id {id}.")));
-#endif
-#if (smithy)
-                : TemplateModuleNameProblems.NotFoundTodoNotFound(new NotFound("todo", $"No todo has id {id}.")));
-#endif
-#endif
+    public async Task<GetTodoResponse> GetTodo(int id) {
+        var todo = await store.Find(id);
 
-    /// <summary>201 with the new todo, or 409.</summary>
-    public Task<CreateTodoResponse> CreateTodo(NewTodo body) {
-        if (_store.TitleExists(body.Title)) {
-#if (responseMode)
-            return Task.FromResult<CreateTodoResponse>(
-                new Conflict($"A todo titled '{body.Title}' already exists."));
-#endif
-#if (unionMode && openapi)
-            return Task.FromResult<CreateTodoResponse>(
-                TodosProblems.ConflictProblem(new Conflict($"A todo titled '{body.Title}' already exists.")));
-#endif
-#if (unionMode && smithy)
-            return Task.FromResult<CreateTodoResponse>(
-                TemplateModuleNameProblems.ConflictTodoTitleTaken(new Conflict($"A todo titled '{body.Title}' already exists.")));
-#endif
+        if (todo is null) {
+            return new NotFound("todo", $"No todo has id {id}.");
         }
 
-        var created = _store.Add(body.Title);
+        return todo;
+    }
+
+    /// <summary>201 with the new todo, or 409.</summary>
+    public async Task<CreateTodoResponse> CreateTodo(NewTodo body) {
+        if (await store.TitleExists(body.Title)) {
+            return new Conflict($"A todo titled '{body.Title}' already exists.");
+        }
+
+        var created = await store.Add(body.Title);
 
 #if (openapi)
         // The 201 declares a Location, so its case carries one beside the payload. Routes is
         // generated from the same contract, so the link cannot drift from the route it points at.
-        return Task.FromResult<CreateTodoResponse>(
-            new CreateTodoCreated(created, TemplateModuleNameLibrary.Routes.Todos.GetTodo(created.Id)));
+        return new CreateTodoCreated(created, TemplateModuleNameLibrary.Routes.Todos.GetTodo(created.Id));
 #endif
 #if (smithy)
-        return Task.FromResult<CreateTodoResponse>(created);
+        return created;
 #endif
     }
 
@@ -206,18 +175,12 @@ public class TodoService : ITodosService {
     /// nothing. Before that existed this operation's response set held only the 404 and there was
     /// no way to say it had worked.
     /// </remarks>
-    public Task<RemoveTodoResponse> RemoveTodo(int id) =>
-        Task.FromResult<RemoveTodoResponse>(
-            _store.Remove(id)
-                ? new RemoveTodoNoContent()
-#if (responseMode)
-                : new NotFound("todo", $"No todo has id {id}."));
-#endif
-#if (unionMode && openapi)
-                : TodosProblems.NotFoundProblem(new NotFound("todo", $"No todo has id {id}.")));
-#endif
-#if (unionMode && smithy)
-                : TemplateModuleNameProblems.NotFoundTodoNotFound(new NotFound("todo", $"No todo has id {id}.")));
-#endif
+    public async Task<RemoveTodoResponse> RemoveTodo(int id) {
+        if (!await store.Remove(id)) {
+            return new NotFound("todo", $"No todo has id {id}.");
+        }
+
+        return new RemoveTodoNoContent();
+    }
 #endif
 }

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoStore.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoStore.cs
@@ -23,6 +23,10 @@ public record NewTodo(string Title);
 /// Where the todos live.
 /// </summary>
 /// <remarks>
+/// Task-based, because a store is where a real implementation waits on I/O. The handlers await it
+/// and return their answers directly; the one in-memory implementation below wraps its answers in
+/// Task.FromResult, so that wrapping is written here once rather than around every return.
+///
 /// An interface, and not only for testability. A handler parameter is bound from the request unless
 /// the generator can tell it is a service, and an unattributed concrete class is taken as the body -
 /// so injecting TodoStore directly generates DeserializeRequestBody&lt;TodoStore&gt;, and on a route
@@ -30,15 +34,15 @@ public record NewTodo(string Title);
 /// </remarks>
 public interface ITodoStore {
 
-    IReadOnlyList<Todo> All();
+    Task<IReadOnlyList<Todo>> All();
 
-    Todo? Find(int id);
+    Task<Todo?> Find(int id);
 
-    bool TitleExists(string title);
+    Task<bool> TitleExists(string title);
 
-    Todo Add(string title);
+    Task<Todo> Add(string title);
 
-    bool Remove(int id);
+    Task<bool> Remove(int id);
 }
 
 /// <summary>
@@ -64,21 +68,24 @@ public class TodoStore : ITodoStore {
 
     private int _nextId = 3;
 
-    public IReadOnlyList<Todo> All() => _todos.Values.ToList();
+    public Task<IReadOnlyList<Todo>> All() =>
+        Task.FromResult<IReadOnlyList<Todo>>(_todos.Values.ToList());
 
-    public Todo? Find(int id) => _todos.TryGetValue(id, out var todo) ? todo : null;
+    public Task<Todo?> Find(int id) =>
+        Task.FromResult(_todos.TryGetValue(id, out var todo) ? todo : null);
 
     /// <summary>Titles are unique, which is what gives the sample a real 409.</summary>
-    public bool TitleExists(string title) =>
-        _todos.Values.Any(todo => string.Equals(todo.Title, title, StringComparison.OrdinalIgnoreCase));
+    public Task<bool> TitleExists(string title) =>
+        Task.FromResult(
+            _todos.Values.Any(todo => string.Equals(todo.Title, title, StringComparison.OrdinalIgnoreCase)));
 
-    public Todo Add(string title) {
+    public Task<Todo> Add(string title) {
         var todo = new Todo(_nextId++, title, false);
 
         _todos[todo.Id] = todo;
 
-        return todo;
+        return Task.FromResult(todo);
     }
 
-    public bool Remove(int id) => _todos.Remove(id);
+    public Task<bool> Remove(int id) => Task.FromResult(_todos.Remove(id));
 }


### PR DESCRIPTION
## What

The sample handlers are async and return the value itself. `ITodoStore` in the `hardened-web` template is Task-based, the spec-first `TodoService` and the code-first `TodoController` await it and return the payload or the framework's bare record, and the one `Task.FromResult` sits in the in-memory store. The spec-first sample that read

```csharp
return Task.FromResult<GetTodoResponse>(new GetTodoNotFound(new Problem { Detail = $"No todo has id {id}." }));
```

now reads

```csharp
var todo = await store.Find(id);

if (todo is null) {
    return new NotFound("todo", $"No todo has id {id}.");
}

return todo;
```

in every response model and both contract languages.

## How

The generated service interface returns `Task<T>`, so a synchronous implementation wrapped every return in `Task.FromResult<GetTodoResponse>(...)`, which hid the conversion from the bare record that #274 built. `async` lets `return` hand back the case and the compiler apply the conversion; a Task-based store makes every await real, so no scaffold reports CS1998. The code-first controller awaits the same store, and the generator already reads a response set through `Task<T>`, so nothing in the dispatch moves.

Union mode had no operator from the bare record, because CSharpAuthor wrote the union as a one-line declaration. A C# 15 `union` accepts a body (probed on SDK 11.0.100-preview.7), and `TerminateWithSemicolon` stays settable after `TypeKeyword = Union`, so `UnionResponseEmitter.EmitContainer` turns it off and writes the conversions when there are any and leaves a set with none on one line. The code-first selector discovers cases from constructors, so an operator on the union changes no case list. The template's union variant therefore reads the same as its response variant, and the helper methods it needed are gone.

The root README's four handler samples, and the template's own README and AGENTS, follow the template.

## Held by

- `UnionResponseEmitterTests`: the union carries the operator in a body when a body can be filled, and stays on one line when it cannot.
- `scripts/verify-templates.sh` over all 14 rows (code, openapi and smithy in response, throws and union; the three refit rows; `--client none`; the aspnet host), with the pinned Smithy CLI on PATH: every row builds, tests and answers, with zero compiler warnings in every scaffold; the aws-lambda, host-independence and renamed-value closing checks pass.
- `Hardened.Smithy.BuildTask.Tests`, `Hardened.SourceGenerator.Tests`, `Hardened.OpenApi.SourceGenerator.Tests` and the full solution's tests pass; the CI-parity Release build has no errors.

## Notes

- Companion Docs PR: ipjohnson/Hardened.Docs#29.
- No public surface changes; nothing in `src/PublicApi` moves.
- The hardened-function template and the integration applications are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
