### PR TITLE
Scaffold one socket smoke test in the web template

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -546,8 +546,22 @@ if [ -d "$A" ] && [ -d "$B" ]; then
     # reasons that have nothing to do with the host.
     # The client too: it is generated from the library's document and references nothing from
     # the host, so it has no reason to differ.
+    # The socket smoke test names the host it runs on, by design - [KestrelRuntime] or
+    # [AspNetCoreRuntime], the attribute the application names its host with - and Bootstrap.cs
+    # names the testing package that answers for it, so those attributes, their usings, and the
+    # one package line in the test csproj are the whole of what may differ in the test project.
+    # The rest of that project, and everything else, may not: a test project that referenced the
+    # host project would still fail here.
+    same_but_the_host() {
+        local host='Hardened\.Web\.Kestrel\.\|Hardened\.Web\.AspNetCore\.\|^\[KestrelRuntime\]\|^\[AspNetCoreRuntime\]\|^\[assembly: KestrelTesting\]\|^\[assembly: AspNetCoreTesting\]'
+        diff <(grep -v "$host" "$1") <(grep -v "$host" "$2") >/dev/null 2>&1
+    }
     for PART in src/Sample src/Sample.Client tests/Sample.Tests; do
-        if diff -r -x bin -x obj "$A/$PART" "$B/$PART" >/dev/null 2>&1; then
+        if diff -r -x bin -x obj -x SampleSocketTests.cs -x Sample.Tests.csproj -x Bootstrap.cs "$A/$PART" "$B/$PART" >/dev/null 2>&1 \
+           && { [ "$PART" != tests/Sample.Tests ] \
+                || { same_but_the_host "$A/$PART/Sample.Tests.csproj" "$B/$PART/Sample.Tests.csproj" \
+                     && same_but_the_host "$A/$PART/SampleSocketTests.cs" "$B/$PART/SampleSocketTests.cs" \
+                     && same_but_the_host "$A/$PART/Bootstrap.cs" "$B/$PART/Bootstrap.cs"; }; }; then
             echo "   identical across hosts: $PART"
         else
             echo "   FAILED: $PART differs between kestrel and aspnet"

--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
@@ -227,10 +227,12 @@
           ]
         },
         {
+          "comment": "The socket smoke test runs the application on the host it deploys to, and a Lambda application has none to bind.",
           "condition": "(lambda)",
           "exclude": [
             "src/Hardened1.Host/Program.cs",
-            "Hardened1.sln"
+            "Hardened1.sln",
+            "tests/Hardened1.Tests/Hardened1SocketTests.cs"
           ],
           "rename": {
             "Hardened1.Lambda.sln": "Hardened1.sln"

--- a/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
@@ -50,6 +50,12 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
 <!--#endif -->
     <PackageVersion Include="Hardened.Web.Testing" Version="$(HardenedVersion)" />
+<!--#if (kestrel) -->
+    <PackageVersion Include="Hardened.Web.Kestrel.Testing" Version="$(HardenedVersion)" />
+<!--#endif -->
+<!--#if (aspnet) -->
+    <PackageVersion Include="Hardened.Web.AspNetCore.Testing" Version="$(HardenedVersion)" />
+<!--#endif -->
   </ItemGroup>
 <!--#if (kiotaClient) -->
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Bootstrap.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Bootstrap.cs
@@ -1,6 +1,12 @@
 using Hardened.Shared.Testing.Attributes;
 using Hardened.Web.Testing;
 using Hardened1;
+#if (kestrel)
+using Hardened.Web.Kestrel.Testing;
+#endif
+#if (aspnet)
+using Hardened.Web.AspNetCore.Testing;
+#endif
 #if (kiotaClient)
 using Hardened.Kiota.Testing;
 #endif
@@ -12,6 +18,17 @@ using Hardened.Refit.Testing;
 // applied and startup services run, so there is no separate test wiring to keep in step.
 [assembly: WebTesting]
 [assembly: HardenedTestEntryPoint(typeof(TemplateModuleNameLibrary))]
+#if (kestrel || aspnet)
+
+// The host. After this, the attribute the application names its host with - [KestrelRuntime] or
+// [AspNetCoreRuntime] - runs a test carrying it on a real socket; Hardened1SocketTests does.
+#endif
+#if (kestrel)
+[assembly: KestrelTesting]
+#endif
+#if (aspnet)
+[assembly: AspNetCoreTesting]
+#endif
 #if (hasClient)
 
 // And the generated client. After this every client of the generator's shape is a test parameter,

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1.Tests.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1.Tests.csproj
@@ -16,6 +16,14 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 <!--#endif -->
     <PackageReference Include="Hardened.Web.Testing" />
+<!--#if (kestrel) -->
+    <!-- The host Hardened1SocketTests runs the application on: a package, not the host project. -->
+    <PackageReference Include="Hardened.Web.Kestrel.Testing" />
+<!--#endif -->
+<!--#if (aspnet) -->
+    <!-- The host Hardened1SocketTests runs the application on: a package, not the host project. -->
+    <PackageReference Include="Hardened.Web.AspNetCore.Testing" />
+<!--#endif -->
 <!--#if (kiotaClient) -->
     <!-- Builds the generated client for a test parameter; see Bootstrap.cs and Hardened1ClientTests.cs. -->
     <PackageReference Include="Hardened.Kiota.Testing" />

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1SocketTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1SocketTests.cs
@@ -1,0 +1,37 @@
+#if (kestrel)
+using Hardened.Web.Kestrel.Runtime;
+#endif
+#if (aspnet)
+using Hardened.Web.AspNetCore.Runtime;
+#endif
+
+namespace Hardened1.Tests;
+
+/// <summary>
+/// One test on a real socket. Everything else in this project runs the pipeline in-process,
+/// which is fast and sees everything but the host; this one runs the application on the host
+/// it deploys to, on a loopback port the kernel picks, and reads what the server itself wrote.
+/// </summary>
+/// <remarks>
+/// The attribute is the one the application names its host with, and Bootstrap.cs is what makes
+/// it mean "run here" on a test. It goes on this class and not on the assembly, because every
+/// test carrying it binds and stops a server of its own. Everything a test holds is the same
+/// here: ITestWebApp sends to the socket, a [Mock] behind a route is the same substitute, and a
+/// client parameter sends to the socket too.
+/// </remarks>
+#if (kestrel)
+[KestrelRuntime]
+#endif
+#if (aspnet)
+[AspNetCoreRuntime]
+#endif
+public class TemplateModuleNameSocketTests {
+
+    [HardenedTest]
+    public async Task ListTodos_OverTheSocket(ITestWebApp app) {
+        var response = await app.Get("/todos");
+
+        response.Assert.Ok();
+        Assert.True(response.Headers.ContainsKey("Date"), "a header only a server writes");
+    }
+}


### PR DESCRIPTION
## What

`hardened-web` scaffolds one test on a real socket beside the in-process ones: `Hardened1SocketTests`, carrying `[KestrelRuntime]` when the template was generated for Kestrel and `[AspNetCoreRuntime]` for ASP.NET Core, with `Bootstrap.cs` naming the testing package that answers for it, `[assembly: KestrelTesting]` or `[assembly: AspNetCoreTesting]`, and the package pinned in `Directory.Packages.props`. A Lambda application has no host to bind and gets no such test.

## Why

The guide has told every suite to budget one smoke test against a real socket since the 0.19 trial found defects only there; now the scaffold does it. The test project keeps referencing the library and not the host project, which its csproj comment still describes correctly: the host it runs the application on is a package, and the attribute is the one the application names its host with.

## Held by

`scripts/verify-templates.sh`, every combination: the generated project restores, builds and its tests pass on both hosts. Its host-independence check, which held the generated test project identical between the Kestrel and ASP.NET rows, now allows exactly what names the host: the attribute and its using in the smoke test, the opt-in and its using in `Bootstrap.cs`, and the one package line in the csproj. Everything else in that project, and everything in the application and the client, still may not differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
