### PR TITLE
Drop the Hardened prefix from the two Enable markers

### DIFF
--- a/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT.Tests/FortunesTests.cs
+++ b/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT.Tests/FortunesTests.cs
@@ -9,7 +9,7 @@ namespace Hardened.IntegrationTests.Benchmark.SUT.Tests;
 /// End to end this covers the whole template path: <c>[Template&lt;Views.Fortunes&gt;]</c> on the
 /// implementation reaches the generated handler as an assignment to
 /// <c>Response.TemplateFactory</c>, <c>TemplateResponseSerializer</c> claims the response ahead of
-/// JSON, and the view - which inherits the base <c>[Enable&lt;HardenedRazorTemplate&gt;]</c>
+/// JSON, and the view - which inherits the base <c>[Enable&lt;RazorTemplates&gt;]</c>
 /// generated - renders the model to the body.
 ///
 /// <para>

--- a/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT/BenchmarkTestApp.cs
+++ b/src/IntegrationTests/Benchmark/Hardened.IntegrationTests.Benchmark.SUT/BenchmarkTestApp.cs
@@ -8,12 +8,12 @@ namespace Hardened.IntegrationTests.Benchmark.SUT;
 /// The TechEmpower routes as one Hardened application.
 /// </summary>
 /// <remarks>
-/// <c>[Enable&lt;HardenedRazorTemplates&gt;]</c> generates
+/// <c>[Enable&lt;RazorTemplates&gt;]</c> generates
 /// <c>BenchmarkTestAppRazorTemplates&lt;TModel&gt;</c>, which Views/Fortunes.cshtml inherits.
 /// Naming the marker is what references the package, so there is nothing to detect and nothing to
 /// register - the view renders itself.
 /// </remarks>
 [HardenedModule]
 [HardenedWebModule]
-[Enable<HardenedRazorTemplates>]
+[Enable<RazorTemplates>]
 public partial class BenchmarkTestApp;

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/CompressionTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/CompressionTests.cs
@@ -7,7 +7,7 @@ namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
 
 /// <summary>
 /// Compression in both directions, through the real pipeline: the application-wide default that
-/// <c>[Enable&lt;HardenedCompression&gt;]</c> installs on this fixture, the per-operation
+/// <c>[Enable&lt;ResponseCompression&gt;]</c> installs on this fixture, the per-operation
 /// declarations on <see cref="CompressionController"/>, and the request-side filter every
 /// application gets.
 ///

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Application.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Application.cs
@@ -31,7 +31,7 @@ namespace Hardened.IntegrationTests.WebApp.SUT;
 [HardenedModule]
 [WebLibrary(Test = "test")]
 [Enable<OpenApiDocumentPublishing>]
-[Enable<HardenedCompression>]
+[Enable<ResponseCompression>]
 [HardenedOpenApiUi(Title = "Integration Tests")]
 [HardenedOpenApiUi(Path = "/docs/internal", Title = "Internal", DocumentPath = "/internal.json")]
 [HardenedMemoryResponseCache]

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Templates.RazorBlade.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Templates.RazorBlade.approved.txt
@@ -11,8 +11,8 @@ namespace Hardened.Templates.RazorBlade
     }
     [Hardened.Requests.Abstract.Templates.TemplateBase(typeof(Hardened.Templates.RazorBlade.HardenedHtmlTemplate<TModel>))]
     [Hardened.Requests.Abstract.Templates.TemplateContentType("text/html; charset=utf-8")]
-    public sealed class HardenedRazorTemplates
+    public sealed class RazorTemplates
     {
-        public HardenedRazorTemplates() { }
+        public RazorTemplates() { }
     }
 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
@@ -165,18 +165,18 @@ namespace Hardened.Web.Runtime.Compression
     }
     [DependencyModules.Runtime.Attributes.DependencyModule]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class HardenedCompression : DependencyModules.Runtime.Interfaces.IDependencyModule, DependencyModules.Runtime.Interfaces.IServiceCollectionConfiguration
+    public class ResponseCompression : DependencyModules.Runtime.Interfaces.IDependencyModule, DependencyModules.Runtime.Interfaces.IServiceCollectionConfiguration
     {
-        public HardenedCompression() { }
+        public ResponseCompression() { }
         public void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public void PopulateServiceCollection(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Parameter, AllowMultiple=true)]
-    public class HardenedCompressionAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider
+    public class ResponseCompressionAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider
     {
-        public HardenedCompressionAttribute() { }
+        public ResponseCompressionAttribute() { }
         public DependencyModules.Runtime.Interfaces.IDependencyModule GetModule() { }
     }
     public sealed class ResponseCompressionFilter : Hardened.Requests.Abstract.Execution.IExecutionFilter

--- a/src/Requests/Hardened.Requests.Runtime/Compression/CompressionServiceCollectionExtensions.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Compression/CompressionServiceCollectionExtensions.cs
@@ -21,7 +21,7 @@ public static class CompressionServiceCollectionExtensions {
     /// </example>
     /// <remarks>
     /// An amender rather than a replacement value, so this composes with the defaults the request
-    /// module registers and runs whether or not <c>[Enable&lt;HardenedCompression&gt;]</c> is written:
+    /// module registers and runs whether or not <c>[Enable&lt;ResponseCompression&gt;]</c> is written:
     /// the request-side cap applies to every application.
     /// </remarks>
     public static IServiceCollection ConfigureCompression(

--- a/src/Requests/Hardened.Requests.Runtime/Filters/RequestTimeouts.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/RequestTimeouts.cs
@@ -92,7 +92,7 @@ public partial class RequestTimeouts : IServiceCollectionConfiguration {
     /// </summary>
     /// <remarks>
     /// By value rather than by type, which is where this differs from <c>ConditionalGet</c> and
-    /// <c>HardenedCompression</c>: every install of those is the same install, and every install of
+    /// <c>ResponseCompression</c>: every install of those is the same install, and every install of
     /// this carries a number.
     /// </remarks>
     public override bool Equals(object? obj) =>

--- a/src/Shared/Hardened.Shared.Runtime/Attributes/EnableAttribute.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Attributes/EnableAttribute.cs
@@ -5,7 +5,7 @@ namespace Hardened.Shared.Runtime.Attributes;
 ///
 /// <code>
 /// [HardenedModule]
-/// [Enable&lt;HardenedRazorTemplates&gt;]
+/// [Enable&lt;RazorTemplates&gt;]
 /// public partial class Application { }
 /// </code>
 ///
@@ -15,8 +15,8 @@ namespace Hardened.Shared.Runtime.Attributes;
 /// </para>
 ///
 /// <para>
-/// <b>It replaces detection.</b> To write <c>[Enable&lt;HardenedRazorTemplates&gt;]</c> you have to
-/// be able to name <c>HardenedRazorTemplates</c>, so the package is referenced or your own code does
+/// <b>It replaces detection.</b> To write <c>[Enable&lt;RazorTemplates&gt;]</c> you have to
+/// be able to name <c>RazorTemplates</c>, so the package is referenced or your own code does
 /// not compile. There is nothing left for a generator to probe for: no
 /// <c>GetTypeByMetadataName</c>, no <c>CompilationProvider</c> gate, and no incrementality concern
 /// from having one. Same principle as <c>[Template&lt;T&gt;]</c> - name the type and let the

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/EnabledFeatureTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/EnabledFeatureTests.cs
@@ -52,7 +52,7 @@ public class EnabledFeatureTests {
               namespace Other.Engine {
                   [TemplateBase(typeof(EngineHtmlTemplate<>))]
                   [TemplateContentType("text/html")]
-                  public sealed class HardenedRazorTemplate { }
+                  public sealed class RazorTemplates { }
 
                   [TemplateBase(typeof(EngineTextTemplate<>))]
                   [TemplateContentType("text/plain")]
@@ -94,14 +94,13 @@ public class EnabledFeatureTests {
 
     /// <summary>
     /// The base is named from the marker and the entry point together — the entry point supplies
-    /// the prefix that scopes it to a module, and the marker supplies the rest with a leading
-    /// <c>Hardened</c> stripped.
+    /// the prefix that scopes it to a module, and the marker supplies the rest as written.
     /// </summary>
     [Fact]
     public void ATemplateBaseIsNamedFromTheEntryPointAndTheMarker() {
-        var result = Generate("[Enable<HardenedRazorTemplate>]").AssertNoErrors();
+        var result = Generate("[Enable<RazorTemplates>]").AssertNoErrors();
 
-        Assert.Contains(result.GeneratedSources.Keys, name => name.Contains("TestAppRazorTemplate"));
+        Assert.Contains(result.GeneratedSources.Keys, name => name.Contains("TestAppRazorTemplates"));
     }
 
     /// <summary>
@@ -111,7 +110,7 @@ public class EnabledFeatureTests {
     /// </summary>
     [Fact]
     public void ATemplateBaseDerivesFromTheMarkersBaseAndCarriesItsContentType() {
-        var source = Generate("[Enable<HardenedRazorTemplate>]")
+        var source = Generate("[Enable<RazorTemplates>]")
             .AssertNoErrors()
             .SourceContaining("RazorTemplate");
 
@@ -125,10 +124,10 @@ public class EnabledFeatureTests {
     /// </summary>
     [Fact]
     public void TwoMarkersProduceTwoDistinctlyNamedBases() {
-        var result = Generate("[Enable<HardenedRazorTemplate>]\n    [Enable<FluidTemplate>]")
+        var result = Generate("[Enable<RazorTemplates>]\n    [Enable<FluidTemplate>]")
             .AssertNoErrors();
 
-        Assert.Contains(result.GeneratedSources.Keys, name => name.Contains("TestAppRazorTemplate"));
+        Assert.Contains(result.GeneratedSources.Keys, name => name.Contains("TestAppRazorTemplates"));
         Assert.Contains(result.GeneratedSources.Keys, name => name.Contains("TestAppFluidTemplate"));
     }
 
@@ -148,9 +147,9 @@ public class EnabledFeatureTests {
     /// no views would have nothing to look at — no diagnostic, and a base that simply never appears.
     /// </summary>
     [Theory]
-    [InlineData("[Enable<HardenedRazorTemplate>]")]
-    [InlineData("[EnableAttribute<HardenedRazorTemplate>]")]
-    [InlineData("[Hardened.Shared.Runtime.Attributes.Enable<HardenedRazorTemplate>]")]
+    [InlineData("[Enable<RazorTemplates>]")]
+    [InlineData("[EnableAttribute<RazorTemplates>]")]
+    [InlineData("[Hardened.Shared.Runtime.Attributes.Enable<RazorTemplates>]")]
     public void EverySpellingOfEnableProducesTheBase(string enables) {
         var result = Generate(enables).AssertNoErrors();
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/EnabledFeatureSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/EnabledFeatureSelector.cs
@@ -12,7 +12,7 @@ namespace Hardened.SourceGenerator.Shared;
 /// This is what replaces feature detection. A generator used to ask the compilation whether a type
 /// was present - <c>GetTypeByMetadataName</c> against a marker, or a <c>CompilationProvider</c>
 /// gate - which costs incrementality and is wrong whenever the thing being probed for is itself
-/// generated. To write <c>[Enable&lt;HardenedRazorTemplate&gt;]</c> you must be able to name the
+/// generated. To write <c>[Enable&lt;RazorTemplates&gt;]</c> you must be able to name the
 /// marker, so the reference is a compile-time requirement rather than something to discover.
 /// </para>
 /// <para>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Templates/TemplateBaseGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Templates/TemplateBaseGenerator.cs
@@ -15,13 +15,13 @@ namespace Hardened.SourceGenerator.Templates;
 /// marker's <c>[TemplateBase]</c> points at:
 /// </para>
 /// <code>
-/// public abstract class ApplicationRazorTemplate&lt;TModel&gt; : HardenedHtmlTemplate&lt;TModel&gt; {
+/// public abstract class ApplicationRazorTemplates&lt;TModel&gt; : HardenedHtmlTemplate&lt;TModel&gt; {
 ///     public override string ContentType => "text/html; charset=utf-8";
 /// }
 /// </code>
 /// <para>
 /// <b>The name derives from the marker</b>, so two markers on one module produce
-/// <c>ApplicationRazorTemplate&lt;T&gt;</c> and <c>ApplicationFluidTemplate&lt;T&gt;</c> -
+/// <c>ApplicationRazorTemplates&lt;T&gt;</c> and <c>ApplicationFluidTemplate&lt;T&gt;</c> -
 /// multi-engine by design rather than retrofitted. The entry point supplies the prefix, which is
 /// what scopes the type to a module: an assembly with two entry points would otherwise have two
 /// generators racing for one name.
@@ -38,14 +38,6 @@ public static class TemplateBaseGenerator {
 
     /// <summary>The facet naming what templates on that base produce.</summary>
     public const string ContentTypeFacet = "TemplateContentType";
-
-    /// <summary>
-    /// Markers stripped of this prefix when the generated name is derived, so Hardened's own
-    /// <c>HardenedRazorTemplate</c> produces <c>ApplicationRazorTemplate</c> rather than
-    /// <c>ApplicationHardenedRazorTemplate</c>. A third-party marker names itself and keeps its
-    /// name.
-    /// </summary>
-    private const string MarkerPrefix = "Hardened";
 
     private const string ModelParameter = "TModel";
 
@@ -67,17 +59,11 @@ public static class TemplateBaseGenerator {
     }
 
     /// <summary>
-    /// What a view names in its <c>@inherits</c> directive.
+    /// What a view names in its <c>@inherits</c> directive: the entry point's name followed by the
+    /// marker's.
     /// </summary>
-    public static string TypeName(EntryPointSelector.Model appModel, EnabledFeatureModel feature) {
-        var marker = feature.MarkerType.Name;
-
-        if (marker.StartsWith(MarkerPrefix, StringComparison.Ordinal) && marker.Length > MarkerPrefix.Length) {
-            marker = marker.Substring(MarkerPrefix.Length);
-        }
-
-        return appModel.EntryPointType.Name + marker;
-    }
+    public static string TypeName(EntryPointSelector.Model appModel, EnabledFeatureModel feature) =>
+        appModel.EntryPointType.Name + feature.MarkerType.Name;
 
     private static string Write(
         EntryPointSelector.Model appModel, EnabledFeatureModel feature, ITypeDefinition baseType) {
@@ -92,7 +78,7 @@ public static class TemplateBaseGenerator {
             $"Generated from [Enable<{feature.MarkerType.Name}>].";
 
         // Closed over this class's own parameter, so a view writing
-        // @inherits ApplicationRazorTemplate<FortunePage> gets HardenedHtmlTemplate<FortunePage>
+        // @inherits ApplicationRazorTemplates<FortunePage> gets HardenedHtmlTemplate<FortunePage>
         // and its typed Model.
         definition.AddBaseType(new GenericTypeDefinition(
             TypeDefinitionEnum.ClassDefinition,

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Templates/TemplateBaseGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Templates/TemplateBaseGeneratorTests.cs
@@ -14,7 +14,7 @@ namespace Hardened.Web.SourceGenerator.Tests.Templates;
 /// <remarks>
 /// <para>
 /// The marker is resolved and read, never recognised by name. These tests declare their own
-/// markers and bases rather than using <c>HardenedRazorTemplate</c>, which is the assertion that
+/// markers and bases rather than using <c>RazorTemplates</c>, which is the assertion that
 /// matters: a package the generator has never heard of gets the same treatment, so a Fluid or
 /// Mustache engine needs no change here. A test using Hardened's own marker would pass equally
 /// well against a generator that switched on its name.

--- a/src/Templates/Hardened.Templates.RazorBlade/README.md
+++ b/src/Templates/Hardened.Templates.RazorBlade/README.md
@@ -14,7 +14,7 @@ Turn it on by naming the marker, which is what references the package:
 [HardenedModule]
 [HardenedWebModule]
 [KestrelRuntime]
-[Enable<HardenedRazorTemplates>]
+[Enable<RazorTemplates>]
 public partial class Application { }
 ```
 
@@ -81,7 +81,7 @@ From the marker, which is to say from the base class:
 
 | Marker | Base | Content type |
 |---|---|---|
-| `HardenedRazorTemplates` | `HardenedHtmlTemplate<T>` | `text/html; charset=utf-8` |
+| `RazorTemplates` | `HardenedHtmlTemplate<T>` | `text/html; charset=utf-8` |
 
 A handler that sets `Response.ContentType` itself keeps it — rendering only fills in a blank.
 

--- a/src/Templates/Hardened.Templates.RazorBlade/RazorTemplates.cs
+++ b/src/Templates/Hardened.Templates.RazorBlade/RazorTemplates.cs
@@ -7,7 +7,7 @@ namespace Hardened.Templates.RazorBlade;
 ///
 /// <code>
 /// [HardenedModule]
-/// [Enable&lt;HardenedRazorTemplates&gt;]
+/// [Enable&lt;RazorTemplates&gt;]
 /// public partial class Application { }
 /// </code>
 ///
@@ -32,4 +32,4 @@ namespace Hardened.Templates.RazorBlade;
 /// </summary>
 [TemplateBase(typeof(HardenedHtmlTemplate<>))]
 [TemplateContentType("text/html; charset=utf-8")]
-public sealed class HardenedRazorTemplates { }
+public sealed class RazorTemplates { }

--- a/src/Web/Hardened.Web.Runtime.Tests/Compression/CompressAttributeTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Compression/CompressAttributeTests.cs
@@ -90,7 +90,7 @@ public class CompressAttributeTests {
     public void TheModuleDefaultStandsDownForAHandlerThatDeclaresItsOwn() {
         var services = new ServiceCollection();
 
-        new HardenedCompression().ConfigureServices(services);
+        new ResponseCompression().ConfigureServices(services);
 
         var provider = Assert.Single(services.BuildServiceProvider().GetServices<IRequestFilterProvider>());
 
@@ -101,7 +101,7 @@ public class CompressAttributeTests {
 
     [Fact]
     public void EveryInstallOfTheModuleIsTheSameInstall() {
-        Assert.Equal(new HardenedCompression(), new HardenedCompression());
-        Assert.Equal(new HardenedCompression().GetHashCode(), new HardenedCompression().GetHashCode());
+        Assert.Equal(new ResponseCompression(), new ResponseCompression());
+        Assert.Equal(new ResponseCompression().GetHashCode(), new ResponseCompression().GetHashCode());
     }
 }

--- a/src/Web/Hardened.Web.Runtime/Compression/CompressAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Compression/CompressAttribute.cs
@@ -21,7 +21,7 @@ namespace Hardened.Web.Runtime.Compression;
 /// </para>
 /// <para>
 /// An operation carrying this is left alone by the application-wide default that
-/// <c>[Enable&lt;HardenedCompression&gt;]</c> installs, so the declaration on the operation is the
+/// <c>[Enable&lt;ResponseCompression&gt;]</c> installs, so the declaration on the operation is the
 /// one that applies.
 /// </para>
 /// </summary>

--- a/src/Web/Hardened.Web.Runtime/Compression/ResponseCompression.cs
+++ b/src/Web/Hardened.Web.Runtime/Compression/ResponseCompression.cs
@@ -11,7 +11,7 @@ namespace Hardened.Web.Runtime.Compression;
 ///
 /// <code>
 /// [HardenedModule]
-/// [Enable&lt;HardenedCompression&gt;]
+/// [Enable&lt;ResponseCompression&gt;]
 /// [KestrelRuntime]
 /// public partial class Application { }
 /// </code>
@@ -36,7 +36,7 @@ namespace Hardened.Web.Runtime.Compression;
 /// </para>
 /// </summary>
 [DependencyModule]
-public partial class HardenedCompression : IServiceCollectionConfiguration {
+public partial class ResponseCompression : IServiceCollectionConfiguration {
 
     public void ConfigureServices(IServiceCollection services) {
         services.AddGlobalFilter(
@@ -47,7 +47,7 @@ public partial class HardenedCompression : IServiceCollectionConfiguration {
     /// <summary>
     /// Every install is the same install, so writing this twice registers one default.
     /// </summary>
-    public override bool Equals(object? obj) => obj is HardenedCompression;
+    public override bool Equals(object? obj) => obj is ResponseCompression;
 
-    public override int GetHashCode() => typeof(HardenedCompression).GetHashCode();
+    public override int GetHashCode() => typeof(ResponseCompression).GetHashCode();
 }

--- a/src/Web/Hardened.Web.Runtime/Compression/ResponseCompressionFilter.cs
+++ b/src/Web/Hardened.Web.Runtime/Compression/ResponseCompressionFilter.cs
@@ -28,7 +28,7 @@ namespace Hardened.Web.Runtime.Compression;
 /// </para>
 /// <para>
 /// Installed by <c>[Compress]</c> on an operation or a class, or on every handler by
-/// <c>[Enable&lt;HardenedCompression&gt;]</c>. A second registration on the same handler finds the
+/// <c>[Enable&lt;ResponseCompression&gt;]</c>. A second registration on the same handler finds the
 /// body already wrapped and stands down, so a slip cannot produce two encoders.
 /// </para>
 /// </remarks>


### PR DESCRIPTION
## What

Renames `[Enable<HardenedCompression>]` to `[Enable<ResponseCompression>]` and `[Enable<HardenedRazorTemplates>]` to `[Enable<RazorTemplates>]`, moving each marker's file with it. Every reference in code and comments, the web and benchmark SUTs and the RazorBlade package README follow, and both public API approval files are re-approved: six lines, the two markers and the generated `ResponseCompressionAttribute`.

The templates generator's `MarkerPrefix` strip is removed. The generated base is now the entry point's name followed by the marker's, unaltered, so `ApplicationRazorTemplates<TModel>` is unchanged and no view moves. The OpenAPI generator's `EnabledFeatureTests` asserted the strip and now use a `RazorTemplates` fixture instead. Three comments that said `HardenedRazorTemplate` in the singular are corrected.

## Why

The other four markers, `OpenApiDocumentPublishing`, `RequestTimeouts`, `ConditionalGet` and `SpecEndpoint`, never carried the prefix, and inside `Enable<>` it says nothing. `ResponseCompression` also names the direction: request decompression is always on and separate. `RazorTemplates` matches the generated base, which is what lets the strip go and makes the README's "the entry point's name plus the marker's" literally true. `HardenedHtmlTemplate<T>` keeps its prefix because it derives from RazorBlade's own `HtmlTemplate`.

This is a source break for anything writing the old names. The Hardened.Docs pages that show them are left for the documentation re-write in progress.

The shipped generator source could not be validated against Hardened.Amz locally: Amz main does not yet build against Framework main (the DependencyModules pin, then `Hardened.Generation.Shared` types its sibling compile does not include), and none of its errors names the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
