### PR TITLE
Drive the template's socket test through the generated client

### DIFF
--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1SocketTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1SocketTests.cs
@@ -16,8 +16,8 @@ namespace Hardened1.Tests;
 /// The attribute is the one the application names its host with, and Bootstrap.cs is what makes
 /// it mean "run here" on a test. It goes on this class and not on the assembly, because every
 /// test carrying it binds and stops a server of its own. Everything a test holds is the same
-/// here: ITestWebApp sends to the socket, a [Mock] behind a route is the same substitute, and a
-/// client parameter sends to the socket too.
+/// here: a client parameter sends to the socket, a [Mock] behind a route is the same substitute,
+/// and ITestWebApp sends to the socket too, for a request the client cannot make.
 /// </remarks>
 #if (kestrel)
 [KestrelRuntime]
@@ -26,6 +26,31 @@ namespace Hardened1.Tests;
 [AspNetCoreRuntime]
 #endif
 public class TemplateModuleNameSocketTests {
+#if (kiotaClient)
+
+    [HardenedTest]
+    public async Task ListTodos_OverTheSocket(TemplateModuleNameClient client) {
+        var todos = await client.Todos.GetAsync().Returns<Ok<List<ClientModels.Todo>>>();
+
+        Assert.Equal([1, 2], todos.Value.Select(todo => todo.Id!.Value));
+        Assert.True(todos.Headers!.ContainsKey("Date"), "a header only a server writes");
+    }
+#endif
+#if (refitClient)
+
+    [HardenedTest]
+    public async Task ListTodos_OverTheSocket(ITemplateModuleNameClient client) {
+#if (codeFirst)
+        var todos = await client.All().Returns<Ok<ICollection<ClientModels.Todo>>>();
+#else
+        var todos = await client.ListTodos().Returns<Ok<ICollection<ClientModels.Todo>>>();
+#endif
+
+        Assert.Equal([1, 2], todos.Value.Select(todo => todo.Id));
+        Assert.True(todos.Headers!.ContainsKey("Date"), "a header only a server writes");
+    }
+#endif
+#if (!hasClient)
 
     [HardenedTest]
     public async Task ListTodos_OverTheSocket(ITestWebApp app) {
@@ -34,4 +59,5 @@ public class TemplateModuleNameSocketTests {
         response.Assert.Ok();
         Assert.True(response.Headers.ContainsKey("Date"), "a header only a server writes");
     }
+#endif
 }


### PR DESCRIPTION
## What

Rewrites `tests/Hardened1.Tests/Hardened1SocketTests.cs` so the socket smoke test takes the generated client rather than `ITestWebApp`. The Kiota variant calls `client.Todos.GetAsync()`, the Refit variant `client.All()` code-first or `client.ListTodos()` spec-first, and each asserts with `Returns<Ok<...>>()` and reads the `Date` header off the `Ok` it hands back, so "a header only a server writes" is still asserted. The `--client none` row keeps the `ITestWebApp` form, having no client. One file: the variants are `#if` blocks inside it, as the Refit `TodoTests` already do for code-first names.

## Why

The template's AGENTS.md states the rule already: the client drives every request it can make, and `ITestWebApp` is for the ones it cannot. The socket test was the one test outside it. A client parameter on a `[KestrelRuntime]` class already sends to the socket, which the test's own remarks said; now the test does it.

Five rows scaffolded from the packed template build with zero warnings and pass, socket test included: kestrel code-first with Kiota, with Refit and with no client; kestrel openapi with Refit; aspnet code-first with Kiota. The kestrel and aspnet socket tests differ only in the host lines, as the script's host-independence check requires. `scripts/verify-templates.sh` was still running when this opened; its result follows as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
