### PR TITLE
Add [Operation] and align the code-first sample with its contracts

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -401,6 +401,7 @@ error, with no `NoWarn`: there is no reading of zero that means anything else.
 | `HRDOA001` | `<HardenedOpenApiVersion>` is not 3.0.0, 3.1.0 or 3.2.0. |
 | `HRDOA002` | Warning. A streamed response under a document version with no `itemSchema`; the operation is described without a schema. |
 | `HRDOA003` | Warning. `[Enable<OpenApiDocumentPublishing>]` sits on a module declaring no routes, so the document is empty. |
+| `HRDOA004` | Two handlers declare the same `[Operation]` id. An operationId names one operation, so give each handler its own. |
 | `HRDOA018`, `019`, `028`–`030` | The document export, reported under the code-first prefix. The numbers mean the same under `HOAT` and `HSMT`; see below. |
 
 ## Description build tasks (HOAT, HSMT)

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
@@ -18,7 +18,7 @@
         "tags": [
           "Bank"
         ],
-        "operationId": "getBalance",
+        "operationId": "GetBalance",
         "requestBody": {
           "required": true,
           "content": {
@@ -56,7 +56,7 @@
         "tags": [
           "Bank"
         ],
-        "operationId": "transfer",
+        "operationId": "Transfer",
         "requestBody": {
           "required": true,
           "content": {
@@ -96,7 +96,7 @@
         "tags": [
           "PetStore"
         ],
-        "operationId": "listPets",
+        "operationId": "ListPets",
         "parameters": [
           {
             "name": "limit",
@@ -149,7 +149,7 @@
         "tags": [
           "PetStore"
         ],
-        "operationId": "createPet",
+        "operationId": "CreatePet",
         "requestBody": {
           "required": true,
           "content": {
@@ -207,7 +207,7 @@
         "tags": [
           "PetStore"
         ],
-        "operationId": "getSecuredPet",
+        "operationId": "GetSecuredPet",
         "description": "Requires an authenticated caller.",
         "security": [
           {
@@ -251,7 +251,7 @@
         "tags": [
           "PetStore"
         ],
-        "operationId": "getPet",
+        "operationId": "GetPet",
         "description": "Fetch one pet by id.",
         "parameters": [
           {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
@@ -58,6 +58,12 @@ namespace Hardened.Web.Runtime.Attributes
         public string Title { get; }
         public string Version { get; }
     }
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
+    public class OperationAttribute : System.Attribute
+    {
+        public OperationAttribute(string id) { }
+        public string Id { get; }
+    }
     public class PatchAttribute : System.Attribute
     {
         public PatchAttribute(string path = "") { }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -59,6 +59,7 @@ public class RequestHandlerModel {
             RequestSchema = RequestSchema,
             Tag = Tag,
             TagDescription = TagDescription,
+            OperationId = OperationId,
             Summary = Summary,
             Description = Description,
             IsDeprecated = IsDeprecated,
@@ -170,6 +171,13 @@ public class RequestHandlerModel {
 
     /// <summary>The request body's JSON Schema, on the same terms.</summary>
     public HandlerSchema? RequestSchema { get; set; }
+
+    /// <summary>
+    /// The <c>operationId</c> the handler declared with <c>[Operation]</c>, or the one its
+    /// description gave it. Null means the default derivation applies - see
+    /// <c>OpenApiDocumentGenerator.OperationIds</c>.
+    /// </summary>
+    public string? OperationId { get; set; }
 
     /// <summary>
     /// The OpenAPI tag this operation is grouped under, when the controller declared one with
@@ -341,6 +349,10 @@ public class RequestHandlerModel {
             return false;
         }
 
+        if (!string.Equals(OperationId, requestHandlerModel.OperationId, StringComparison.Ordinal)) {
+            return false;
+        }
+
         if (!string.Equals(
                 TagDescription, requestHandlerModel.TagDescription, StringComparison.Ordinal)) {
             return false;
@@ -439,6 +451,7 @@ public class RequestHandlerModel {
             hashCode = (hashCode * 397) ^ ResponseSchemas.GetHashCodeAggregation();
             hashCode = (hashCode * 397) ^ Filters.GetHashCodeAggregation();
             hashCode = (hashCode * 397) ^ (Tag?.GetHashCode() ?? 0);
+            hashCode = (hashCode * 397) ^ (OperationId?.GetHashCode() ?? 0);
             hashCode = (hashCode * 397) ^ (Summary?.GetHashCode() ?? 0);
             hashCode = (hashCode * 397) ^ (Description?.GetHashCode() ?? 0);
             hashCode = (hashCode * 397) ^ IsDeprecated.GetHashCode();

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentDiagnostics.cs
@@ -1,14 +1,66 @@
+using Hardened.SourceGenerator.Models.Request;
 using Microsoft.CodeAnalysis;
 
 namespace Hardened.SourceGenerator.OpenApiDocument;
 
 /// <summary>
-/// What <c>[Enable&lt;OpenApiDocumentPublishing&gt;]</c> reports when it cannot describe anything.
+/// What <c>[Enable&lt;OpenApiDocumentPublishing&gt;]</c> reports when it cannot describe anything,
+/// and what a handler's <c>[Operation]</c> reports when two of them name one operation.
 /// </summary>
 public static class OpenApiDocumentDiagnostics {
 
     /// <summary>The marker is on a module that declares no routes.</summary>
     public const string EmptyDocumentId = "HRDOA003";
+
+    /// <summary>Two handlers declare the same <c>[Operation]</c> id.</summary>
+    public const string DuplicateOperationIdId = "HRDOA004";
+
+    internal static DiagnosticDescriptor DuplicateOperationIdDescriptor() => new(
+        id: DuplicateOperationIdId,
+        title: "Two handlers declare the same operation id",
+        messageFormat:
+        "[Operation(\"{0}\")] is declared on {1}. An operationId names one operation in the " +
+        "document, so a client generated from it would have two methods with one name. Give " +
+        "each handler its own id.",
+        category: "Hardened.OpenApi",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports every id that more than one handler declared.
+    /// </summary>
+    /// <remarks>
+    /// Reported whether or not the module publishes a document: the id is a declaration on the
+    /// handler, and an exported document reads it the same way a served one does.
+    /// </remarks>
+    public static void ReportDuplicateOperationIds(
+        SourceProductionContext context, IReadOnlyList<RequestHandlerModel> handlers) {
+        var byId = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+        foreach (var handler in handlers) {
+            if (handler.OperationId == null) {
+                continue;
+            }
+
+            if (!byId.TryGetValue(handler.OperationId, out var declaredBy)) {
+                declaredBy = new List<string>();
+                byId[handler.OperationId] = declaredBy;
+            }
+
+            declaredBy.Add(handler.ControllerType.Name + "." + handler.HandlerMethod);
+        }
+
+        foreach (var pair in byId) {
+            if (pair.Value.Count > 1) {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DuplicateOperationIdDescriptor(),
+                        Location.None,
+                        pair.Key,
+                        string.Join(" and ", pair.Value)));
+            }
+        }
+    }
 
     /// <summary>
     /// Built per call rather than held in a static field, for the reason

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -929,12 +929,33 @@ public static class OpenApiDocumentGenerator {
     /// the id, so <c>getPet</c> comes back as <c>GetPet</c>. Round-tripping a document through the
     /// build task therefore recovers the method name it started as.
     /// </para>
+    /// <para>
+    /// <c>[Operation]</c> on the handler declares the id outright, and it is written as given: the
+    /// id is what a generated client names its method after, so a declared one holds the contract
+    /// still across a rename. A derived name that collides with a declared one is prefixed with
+    /// its tag, the same way two derived names are. Two declared ones colliding is
+    /// <c>HRDOA004</c>, reported where the handlers are collected.
+    /// </para>
     /// </remarks>
     private static IReadOnlyDictionary<string, string> OperationIds(
         IReadOnlyList<RequestHandlerModel> handlers) {
+        var ids = new Dictionary<string, string>(System.StringComparer.Ordinal);
+        var declared = new HashSet<string>(System.StringComparer.Ordinal);
+
+        foreach (var handler in handlers) {
+            if (handler.OperationId != null) {
+                ids[HandlerKey(handler)] = handler.OperationId;
+                declared.Add(handler.OperationId);
+            }
+        }
+
         var byName = new Dictionary<string, List<RequestHandlerModel>>(System.StringComparer.Ordinal);
 
         foreach (var handler in handlers) {
+            if (handler.OperationId != null) {
+                continue;
+            }
+
             var name = CamelCase(handler.HandlerMethod);
 
             if (!byName.TryGetValue(name, out var sharing)) {
@@ -945,10 +966,8 @@ public static class OpenApiDocumentGenerator {
             sharing.Add(handler);
         }
 
-        var ids = new Dictionary<string, string>(System.StringComparer.Ordinal);
-
         foreach (var pair in byName) {
-            var contested = pair.Value.Count > 1;
+            var contested = pair.Value.Count > 1 || declared.Contains(pair.Key);
 
             foreach (var handler in pair.Value) {
                 ids[HandlerKey(handler)] = contested

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -218,6 +218,7 @@ internal static class SpecHandlerModelBuilder {
             // What the operation says about itself. Carried here rather than left to each caller,
             // because a handler model that has lost its summary cannot be told from one whose
             // operation never had a summary - and the document written from it is silently poorer.
+            OperationId = operation.OperationId,
             Tag = operation.Tag,
             TagDescription = tagDescription,
             Summary = operation.Summary,

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -128,6 +128,8 @@ public static class RoutingTableGenerator {
         // Only for an entry point that asked. The document used to be emitted unconditionally on
         // the grounds that it cost one string, which understated it - see OpenApiDocumentSource -
         // and an application that does not serve one now does not carry one.
+        OpenApiDocumentDiagnostics.ReportDuplicateOperationIds(context, routable);
+
         if (OpenApiDocumentFeature.Path(models.Left) is { } documentPath) {
             // An empty document is the one outcome that looks like success from every angle: the
             // build is clean, the route answers 200, and the reference page renders an API with no

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
@@ -25,6 +25,7 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
         var controller = context.Node.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
 
         model.Tag = GetTagFromController(context, controller, cancellationToken);
+        model.OperationId = GetOperationId(context, context.Node as MethodDeclarationSyntax);
 
         // What the document has to say about the operation beyond its shape, taken from where a
         // developer has already written it rather than from a second set of attributes.
@@ -66,6 +67,34 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
     /// derive one from the class name. Read here rather than there because it needs the syntax
     /// tree, which is gone by the time a document is written.
     /// </summary>
+    /// <summary>
+    /// The id <c>[Operation]</c> declares on the method, or null where the document derives one
+    /// from the method name.
+    /// </summary>
+    private static string? GetOperationId(GeneratorSyntaxContext context, MethodDeclarationSyntax? method) {
+        var attribute = method?.AttributeLists
+            .SelectMany(list => list.Attributes)
+            .FirstOrDefault(candidate => {
+                var name = candidate.Name.ToString();
+                var simple = name.Substring(name.LastIndexOf('.') + 1);
+
+                return simple == "Operation" || simple == "OperationAttribute";
+            });
+
+        var argument = attribute?.ArgumentList?.Arguments.FirstOrDefault();
+
+        if (argument == null) {
+            return null;
+        }
+
+        var constant = context.SemanticModel.GetConstantValue(argument.Expression);
+        var id = constant.HasValue
+            ? constant.Value?.ToString()
+            : argument.Expression.ToString().Trim('"');
+
+        return string.IsNullOrWhiteSpace(id) ? null : id;
+    }
+
     private static string? GetTagFromController(
         GeneratorSyntaxContext context,
         ClassDeclarationSyntax? classDeclaration,

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OperationIdTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OperationIdTests.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using Hardened.SourceGeneration.Testing;
+using Hardened.SourceGenerator.OpenApiDocument;
+using Hardened.Web.SourceGenerator.Tests.Routing;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests;
+
+/// <summary>
+/// The <c>operationId</c> a handler publishes: the method name in camelCase by default, and what
+/// <c>[Operation]</c> declares where it is written.
+/// </summary>
+public class OperationIdTests {
+
+    private static GeneratorResult Run(string controllers) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Test.cs"] = $$"""
+                    using Hardened.Shared.Runtime.Attributes;
+                    using Hardened.Web.Runtime.Attributes;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    {{GeneratedOpenApiDocument.EnableAttribute}}
+                    public partial class TestApplication { }
+
+                    {{controllers}}
+                    """
+            },
+            new[] { new WebLibrarySourceGenerator() },
+            GeneratedRoutingTable.Anchors);
+
+    /// <summary>Every operation's id, keyed "VERB /path".</summary>
+    private static Dictionary<string, string> OperationIds(GeneratorResult result) {
+        using var document = JsonDocument.Parse(
+            GeneratedOpenApiDocument.Extract(result.SourceContaining("OpenApiDocument")));
+
+        var ids = new Dictionary<string, string>();
+
+        foreach (var path in document.RootElement.GetProperty("paths").EnumerateObject()) {
+            foreach (var operation in path.Value.EnumerateObject()) {
+                ids[operation.Name.ToUpperInvariant() + " " + path.Name] =
+                    operation.Value.GetProperty("operationId").GetString()!;
+            }
+        }
+
+        return ids;
+    }
+
+    [Fact]
+    public void TheMethodNameInCamelCaseIsTheDefault() {
+        var ids = OperationIds(Run("""
+            public class TodoController {
+                [Get("/todos")]
+                public string All() => "";
+            }
+            """).AssertNoErrors());
+
+        Assert.Equal("all", ids["GET /todos"]);
+    }
+
+    [Fact]
+    public void ADeclaredIdIsPublishedAsWritten() {
+        var ids = OperationIds(Run("""
+            public class TodoController {
+                [Get("/todos")]
+                [Operation("listTodos")]
+                public string All() => "";
+            }
+            """).AssertNoErrors());
+
+        Assert.Equal("listTodos", ids["GET /todos"]);
+    }
+
+    [Fact]
+    public void AQualifiedAttributeNameIsReadTheSameWay() {
+        var ids = OperationIds(Run("""
+            public class TodoController {
+                [Get("/todos")]
+                [Hardened.Web.Runtime.Attributes.OperationAttribute("listTodos")]
+                public string All() => "";
+            }
+            """).AssertNoErrors());
+
+        Assert.Equal("listTodos", ids["GET /todos"]);
+    }
+
+    /// <summary>
+    /// The declared id is the contract, so the handler that merely derived the same name is the
+    /// one that moves - prefixed with its tag, as two derived names are.
+    /// </summary>
+    [Fact]
+    public void ADerivedNameYieldsToADeclaredOne() {
+        var ids = OperationIds(Run("""
+            public class TodoController {
+                [Get("/todos")]
+                [Operation("all")]
+                public string List() => "";
+            }
+
+            public class OrderController {
+                [Get("/orders")]
+                public string All() => "";
+            }
+            """).AssertNoErrors());
+
+        Assert.Equal("all", ids["GET /todos"]);
+        Assert.Equal("orderAll", ids["GET /orders"]);
+    }
+
+    [Fact]
+    public void TwoHandlersDeclaringOneIdIsAnError() {
+        var result = Run("""
+            public class TodoController {
+                [Get("/todos")]
+                [Operation("list")]
+                public string All() => "";
+            }
+
+            public class OrderController {
+                [Get("/orders")]
+                [Operation("list")]
+                public string All() => "";
+            }
+            """);
+
+        var reported = result.GeneratorDiagnostics.FirstOrDefault(
+            diagnostic => diagnostic.Id == OpenApiDocumentDiagnostics.DuplicateOperationIdId);
+
+        Assert.NotNull(reported);
+        Assert.Equal(DiagnosticSeverity.Error, reported!.Severity);
+        Assert.Contains("\"list\"", reported.GetMessage());
+        Assert.Contains("TodoController.All", reported.GetMessage());
+        Assert.Contains("OrderController.All", reported.GetMessage());
+    }
+
+    [Fact]
+    public void DistinctDeclaredIdsReportNothing() {
+        var result = Run("""
+            public class TodoController {
+                [Get("/todos")]
+                [Operation("listTodos")]
+                public string All() => "";
+
+                [Get("/todos/{id}")]
+                [Operation("getTodo")]
+                public string ById(int id) => "";
+            }
+            """).AssertNoErrors();
+
+        Assert.DoesNotContain(
+            result.GeneratorDiagnostics,
+            diagnostic => diagnostic.Id == OpenApiDocumentDiagnostics.DuplicateOperationIdId);
+    }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -208,11 +208,7 @@ public async Task GetTodo_ReturnsTheTodo(TemplateModuleNameClient client) {
     var todo = await client.Todos[1].GetAsync().Returns<Ok<ClientModels.Todo>>();
 #else
 public async Task GetTodo_ReturnsTheTodo(ITemplateModuleNameClient client) {
-#if (codeFirst)
-    var todo = await client.ById(1).Returns<Ok<ClientModels.Todo>>();
-#else
     var todo = await client.GetTodo(1).Returns<Ok<ClientModels.Todo>>();
-#endif
 #endif
 
 #if (xunit)
@@ -338,26 +334,6 @@ envelope that carries a status and its headers back beside the body, and the mod
 `[assembly: RefitTesting]` in `Bootstrap.cs` is the whole of the wiring - and each call is asserted
 with `Returns<T>()`, naming the response type the contract declares:
 
-#if (codeFirst)
-```csharp
-var created = await client.Create(new ClientModels.NewTodo { Title = "ship it" })
-    .Returns<Created<ClientModels.Todo>>();
-
-#if (xunit)
-Assert.Equal($"/todos/{created.Value.Id}", created.Location);
-#else
-Assert.That(created.Location, Is.EqualTo($"/todos/{created.Value.Id}"));
-#endif
-
-var missing = await client.ById(9999).Returns<NotFound<ClientModels.NotFound>>();
-
-#if (xunit)
-Assert.Contains("9999", missing.Body.Detail);
-#else
-Assert.That(missing.Body.Detail, Does.Contain("9999"));
-#endif
-```
-#else
 ```csharp
 var created = await client.CreateTodo(new ClientModels.NewTodo { Title = "ship it" })
     .Returns<Created<ClientModels.Todo>>();
@@ -368,7 +344,11 @@ Assert.Equal($"/todos/{created.Value.Id}", created.Location);
 Assert.That(created.Location, Is.EqualTo($"/todos/{created.Value.Id}"));
 #endif
 
+#if (codeFirst)
+var missing = await client.GetTodo(9999).Returns<NotFound<ClientModels.NotFound>>();
+#else
 var missing = await client.GetTodo(9999).Returns<NotFound<ClientModels.Problem>>();
+#endif
 
 #if (xunit)
 Assert.Contains("9999", missing.Body.Detail);
@@ -376,7 +356,6 @@ Assert.Contains("9999", missing.Body.Detail);
 Assert.That(missing.Body.Detail, Does.Contain("9999"));
 #endif
 ```
-#endif
 
 That is the status, the body type and the headers the status carries in one word, and nothing
 throws: Refit hands the whole answer back on the envelope, and a refusal's body is read as the

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
@@ -1,5 +1,6 @@
 using Hardened.Requests.Abstract.Responses;
 using Hardened.Web.Runtime.Attributes;
+using ValidationModules.Constraints;
 
 namespace Hardened1;
 
@@ -42,6 +43,10 @@ public class TodoController {
     /// there is nothing to declare beside the success type. The collection becomes an array in the
     /// generated document without anything here describing it.
     /// </remarks>
+    // The operationId the document publishes, which is the name a generated client gives the
+    // call. The spec-first contracts name these same four, so the client reads the same whichever
+    // way the service was written; without it the id is the method name in camelCase.
+    [Operation("listTodos")]
     [Get("/")]
     public Task<IReadOnlyList<Todo>> All(ITodoStore store) => store.All();
 
@@ -52,8 +57,9 @@ public class TodoController {
     /// thrown value is the same NotFound record the declared modes return, so the 404 body is
     /// identical either way - what differs is whether the compiler knows the route can answer it.
     /// </remarks>
+    [Operation("getTodo")]
     [Get("/{id}")]
-    public async Task<Todo> ById(ITodoStore store, int id) {
+    public async Task<Todo> ById(ITodoStore store, [Range(Min = 1)] int id) {
         var todo = await store.Find(id);
 
         if (todo is null) {
@@ -70,6 +76,7 @@ public class TodoController {
     /// body at 200, because the throws-mode dispatch does not read IHttpStatusResponse off a returned
     /// value. Compare the same method under --response-model response, where 201 is in the type.
     /// </remarks>
+    [Operation("createTodo")]
     [Post("/")]
     public async Task<Todo> Create(ITodoStore store, NewTodo request) {
         if (await store.TitleExists(request.Title)) {
@@ -80,8 +87,9 @@ public class TodoController {
     }
 
     /// <summary>Removes one, or 404. Answers 200 with the removed todo, for the reason above.</summary>
+    [Operation("removeTodo")]
     [Delete("/{id}")]
-    public async Task<Todo> Remove(ITodoStore store, int id) {
+    public async Task<Todo> Remove(ITodoStore store, [Range(Min = 1)] int id) {
         var todo = await store.Find(id);
 
         if (todo is null || !await store.Remove(id)) {
@@ -99,8 +107,9 @@ public class TodoController {
     /// wrapper - and the generated document describes both statuses, because both are in the
     /// signature rather than in a throw somewhere down the call stack.
     /// </remarks>
+    [Operation("getTodo")]
     [Get("/{id}")]
-    public async Task<Response<Todo, NotFound>> ById(ITodoStore store, int id) {
+    public async Task<Response<Todo, NotFound>> ById(ITodoStore store, [Range(Min = 1)] int id) {
         var todo = await store.Find(id);
 
         if (todo is null) {
@@ -115,6 +124,7 @@ public class TodoController {
     /// Created&lt;T&gt; carries the body and the Location header together, and the status comes from
     /// the case rather than from anything this method does.
     /// </remarks>
+    [Operation("createTodo")]
     [Post("/")]
     public async Task<Response<Created<Todo>, Conflict>> Create(ITodoStore store, NewTodo request) {
         if (await store.TitleExists(request.Title)) {
@@ -131,8 +141,9 @@ public class TodoController {
     /// NoContent carries no body and the generated dispatch knows not to serialise one, so this
     /// answers 204 with an empty body rather than 200 with "null" in it.
     /// </remarks>
+    [Operation("removeTodo")]
     [Delete("/{id}")]
-    public async Task<Response<NoContent, NotFound>> Remove(ITodoStore store, int id) {
+    public async Task<Response<NoContent, NotFound>> Remove(ITodoStore store, [Range(Min = 1)] int id) {
         if (await store.Find(id) is null || !await store.Remove(id)) {
             return new NotFound("todo", $"No todo has id {id}.");
         }
@@ -147,8 +158,9 @@ public class TodoController {
     /// structurally - a public single-parameter constructor per case and a public object? Value -
     /// so moving between the two rewrites no handler body and changes no generated dispatch.
     /// </remarks>
+    [Operation("getTodo")]
     [Get("/{id}")]
-    public async Task<TodoResult> ById(ITodoStore store, int id) {
+    public async Task<TodoResult> ById(ITodoStore store, [Range(Min = 1)] int id) {
         var todo = await store.Find(id);
 
         if (todo is null) {
@@ -159,6 +171,7 @@ public class TodoController {
     }
 
     /// <summary>Creates one at 201 with a Location header, or 409 when the title is taken.</summary>
+    [Operation("createTodo")]
     [Post("/")]
     public async Task<NewTodoResult> Create(ITodoStore store, NewTodo request) {
         if (await store.TitleExists(request.Title)) {
@@ -171,8 +184,9 @@ public class TodoController {
     }
 
     /// <summary>Removes one at 204, or 404.</summary>
+    [Operation("removeTodo")]
     [Delete("/{id}")]
-    public async Task<RemovedTodoResult> Remove(ITodoStore store, int id) {
+    public async Task<RemovedTodoResult> Remove(ITodoStore store, [Range(Min = 1)] int id) {
         if (await store.Find(id) is null || !await store.Remove(id)) {
             return new NotFound("todo", $"No todo has id {id}.");
         }

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoStore.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoStore.cs
@@ -2,6 +2,9 @@ using DependencyModules.Runtime.Attributes;
 #if (specFirst)
 using Hardened1.Models;
 #endif
+#if (codeFirst)
+using ValidationModules.Constraints;
+#endif
 
 namespace Hardened1;
 
@@ -14,9 +17,10 @@ public record Todo(int Id, string Title, bool Done);
 /// </summary>
 /// <remarks>
 /// Separate from <see cref="Todo"/> because the server assigns the id, and a request model carrying
-/// one invites a client to choose it.
+/// one invites a client to choose it. The length constraint is enforced in front of the handler
+/// and published as the schema's minLength and maxLength, so the document and the code agree.
 /// </remarks>
-public record NewTodo(string Title);
+public record NewTodo([property: StringLength(1, 64)] string Title);
 
 #endif
 /// <summary>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
@@ -18,25 +18,17 @@ namespace Hardened1.Tests;
 public class DocumentStatusTests {
 
     private static readonly Dictionary<string, string[]> Expected = new() {
-#if (codeFirst)
-#if (throwsMode)
+#if (codeFirst && throwsMode)
         // Throws mode documents what the signature declares. The thrown NotFound and Conflict
         // answer at runtime and are invisible here - the declared models close exactly that gap.
+        // The 400s stay: the id and the title are constrained, so binding either can refuse.
         ["GET /todos"] = ["200"],
         ["GET /todos/{id}"] = ["200", "400"],
-        ["POST /todos"] = ["200"],
+        ["POST /todos"] = ["200", "400"],
         ["DELETE /todos/{id}"] = ["200", "400"],
-#endif
-#if (declaredMode)
-        ["GET /todos"] = ["200"],
-        ["GET /todos/{id}"] = ["200", "400", "404"],
-        ["POST /todos"] = ["201", "409"],
-        ["DELETE /todos/{id}"] = ["204", "400", "404"],
-#endif
-#endif
-#if (specFirst)
-        // The contract's statuses, plus the 400 the generated validation answers: the contract
-        // constrains the id and the title, so every operation binding either can refuse.
+#else
+        // The declared statuses, plus the 400 the generated validation answers: the id and the
+        // title are constrained, so every operation binding either can refuse.
         ["GET /todos"] = ["200"],
         ["GET /todos/{id}"] = ["200", "400", "404"],
         ["POST /todos"] = ["201", "400", "409"],

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1SocketTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/Hardened1SocketTests.cs
@@ -32,22 +32,28 @@ public class TemplateModuleNameSocketTests {
     public async Task ListTodos_OverTheSocket(TemplateModuleNameClient client) {
         var todos = await client.Todos.GetAsync().Returns<Ok<List<ClientModels.Todo>>>();
 
+#if (xunit)
         Assert.Equal([1, 2], todos.Value.Select(todo => todo.Id!.Value));
         Assert.True(todos.Headers!.ContainsKey("Date"), "a header only a server writes");
+#else
+        Assert.That(todos.Value.Select(todo => todo.Id!.Value), Is.EqualTo(new[] { 1, 2 }));
+        Assert.That(todos.Headers!.ContainsKey("Date"), Is.True, "a header only a server writes");
+#endif
     }
 #endif
 #if (refitClient)
 
     [HardenedTest]
     public async Task ListTodos_OverTheSocket(ITemplateModuleNameClient client) {
-#if (codeFirst)
-        var todos = await client.All().Returns<Ok<ICollection<ClientModels.Todo>>>();
-#else
         var todos = await client.ListTodos().Returns<Ok<ICollection<ClientModels.Todo>>>();
-#endif
 
+#if (xunit)
         Assert.Equal([1, 2], todos.Value.Select(todo => todo.Id));
         Assert.True(todos.Headers!.ContainsKey("Date"), "a header only a server writes");
+#else
+        Assert.That(todos.Value.Select(todo => todo.Id), Is.EqualTo(new[] { 1, 2 }));
+        Assert.That(todos.Headers!.ContainsKey("Date"), Is.True, "a header only a server writes");
+#endif
     }
 #endif
 #if (!hasClient)

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
@@ -275,18 +275,17 @@ public class TodoTests {
     }
 #endif
 
-#if (specFirst)
     /// <summary>
-    /// The constraints in the contract are enforced before the handler runs.
+    /// The constraints on the request are enforced before the handler runs.
     /// </summary>
     /// <remarks>
-    /// Nothing in this project validates anything. maxLength on the title became a filter in front
-    /// of the generated handler, so a value too long never reaches the code - and the published
+    /// Nothing in this project validates anything by hand. The title's length limit became a filter
+    /// in front of the handler, so a value too long never reaches the code - and the published
     /// document declares the 400 it answers with, so the client has a typed branch for it that
     /// names the field.
     /// </remarks>
     [HardenedTest]
-    public async Task CreateTodo_TitleTheContractDisallows_IsBadRequest(TemplateModuleNameClient client) {
+    public async Task CreateTodo_TitleOverItsLimit_IsBadRequest(TemplateModuleNameClient client) {
         var refused = await client.Todos.PostAsync(new ClientModels.NewTodo { Title = new string('x', 100) })
             .Returns<BadRequest<ClientModels.RequestValidationError>>();
 
@@ -304,16 +303,14 @@ public class TodoTests {
     /// document says so, which DocumentStatusTests holds it to.
     /// </summary>
     [HardenedTest]
-    public async Task GetTodo_IdBelowTheContractsMinimum_IsBadRequest(TemplateModuleNameClient client) {
+    public async Task GetTodo_IdBelowItsMinimum_IsBadRequest(TemplateModuleNameClient client) {
         await client.Todos[0].GetAsync().Returns<BadRequest<ClientModels.RequestValidationError>>();
     }
 
     [HardenedTest]
-    public async Task RemoveTodo_IdBelowTheContractsMinimum_IsBadRequest(TemplateModuleNameClient client) {
+    public async Task RemoveTodo_IdBelowItsMinimum_IsBadRequest(TemplateModuleNameClient client) {
         await client.Todos[0].DeleteAsync().Returns<BadRequest<ClientModels.RequestValidationError>>();
     }
-#endif
-#if (codeFirst)
     /// <summary>
     /// An id the parameter's type cannot carry is refused before the handler, with the same
     /// field-level envelope a failed validation answers - and the published document says so,
@@ -332,5 +329,4 @@ public class TodoTests {
     public async Task RemoveTodo_MalformedId_IsBadRequest(ITestWebApp app) {
         (await app.Delete("/todos/not-a-number")).Assert.BadRequest();
     }
-#endif
 }

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.pipeline.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.pipeline.cs
@@ -123,16 +123,15 @@ public class TodoTests {
 #endif
     }
 #endif
-#if (specFirst)
     /// <summary>
-    /// The constraints in the contract are enforced before the handler runs.
+    /// The constraints on the request are enforced before the handler runs.
     /// </summary>
     /// <remarks>
-    /// Nothing in this project validates anything. maxLength on the title became a filter in front
-    /// of the generated handler, so a value too long never reaches the code.
+    /// Nothing in this project validates anything by hand. The title's length limit became a filter
+    /// in front of the handler, so a value too long never reaches the code.
     /// </remarks>
     [HardenedTest]
-    public async Task AValueTheContractDisallowsIsRejected(ITestWebApp app) {
+    public async Task ATitleOverItsLimitIsRejected(ITestWebApp app) {
         var response = await app.Post(new NewTodoRequest(new string('x', 100)), "/todos");
 
 #if (xunit)
@@ -147,7 +146,7 @@ public class TodoTests {
     /// document says so, which DocumentStatusTests holds it to.
     /// </summary>
     [HardenedTest]
-    public async Task GetTodo_IdBelowTheContractsMinimum_IsBadRequest(ITestWebApp app) {
+    public async Task GetTodo_IdBelowItsMinimum_IsBadRequest(ITestWebApp app) {
 #if (xunit)
         Assert.Equal(400, (await app.Get("/todos/0")).StatusCode);
 #else
@@ -156,15 +155,13 @@ public class TodoTests {
     }
 
     [HardenedTest]
-    public async Task RemoveTodo_IdBelowTheContractsMinimum_IsBadRequest(ITestWebApp app) {
+    public async Task RemoveTodo_IdBelowItsMinimum_IsBadRequest(ITestWebApp app) {
 #if (xunit)
         Assert.Equal(400, (await app.Delete("/todos/0")).StatusCode);
 #else
         Assert.That((await app.Delete("/todos/0")).StatusCode, Is.EqualTo(400));
 #endif
     }
-#endif
-#if (codeFirst)
     /// <summary>
     /// An id the parameter's type cannot carry is refused before the handler, with the same
     /// field-level envelope a failed validation answers - and the published document says so,
@@ -187,5 +184,4 @@ public class TodoTests {
         Assert.That((await app.Delete("/todos/not-a-number")).StatusCode, Is.EqualTo(400));
 #endif
     }
-#endif
 }

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.refit.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.refit.cs
@@ -19,11 +19,7 @@ public class TodoTests {
 
     [HardenedTest]
     public async Task ListTodos_ReturnsEveryTodo(ITemplateModuleNameClient client) {
-#if (codeFirst)
-        var todos = await client.All().Returns<Ok<ICollection<ClientModels.Todo>>>();
-#else
         var todos = await client.ListTodos().Returns<Ok<ICollection<ClientModels.Todo>>>();
-#endif
 
 #if (xunit)
         Assert.Equal([1, 2], todos.Value.Select(todo => todo.Id));
@@ -34,11 +30,7 @@ public class TodoTests {
 
     [HardenedTest]
     public async Task GetTodo_ReturnsTheTodo(ITemplateModuleNameClient client) {
-#if (codeFirst)
-        var todo = await client.ById(1).Returns<Ok<ClientModels.Todo>>();
-#else
         var todo = await client.GetTodo(1).Returns<Ok<ClientModels.Todo>>();
-#endif
 
 #if (xunit)
         Assert.Equal("Read the generated code", todo.Value.Title);
@@ -54,18 +46,18 @@ public class TodoTests {
     /// </summary>
     [HardenedTest]
     public async Task GetTodo_UnknownId_IsAnUntypedNotFound(ITemplateModuleNameClient client) {
-        await client.ById(9999).ReturnsStatus<NotFound>();
+        await client.GetTodo(9999).ReturnsStatus<NotFound>();
     }
 
     [HardenedTest]
     public async Task RemoveTodo_UnknownId_IsAnUntypedNotFound(ITemplateModuleNameClient client) {
-        await client.Remove(9999).ReturnsStatus<NotFound>();
+        await client.RemoveTodo(9999).ReturnsStatus<NotFound>();
     }
 
     /// <summary>Titles are unique, which is what gives the sample a real 409 - thrown and undocumented, like the 404.</summary>
     [HardenedTest]
     public async Task CreateTodo_DuplicateTitle_IsAnUntypedConflict(ITemplateModuleNameClient client) {
-        await client.Create(new ClientModels.NewTodo { Title = "Add an endpoint" }).ReturnsStatus<Conflict>();
+        await client.CreateTodo(new ClientModels.NewTodo { Title = "Add an endpoint" }).ReturnsStatus<Conflict>();
     }
 #endif
 #if (codeFirst && declaredMode)
@@ -76,7 +68,7 @@ public class TodoTests {
     /// </summary>
     [HardenedTest]
     public async Task GetTodo_UnknownId_IsATypedNotFound(ITemplateModuleNameClient client) {
-        var missing = await client.ById(9999).Returns<NotFound<ClientModels.NotFound>>();
+        var missing = await client.GetTodo(9999).Returns<NotFound<ClientModels.NotFound>>();
 
 #if (xunit)
         Assert.Contains("9999", missing.Body.Detail);
@@ -87,7 +79,7 @@ public class TodoTests {
 
     [HardenedTest]
     public async Task RemoveTodo_UnknownId_IsATypedNotFound(ITemplateModuleNameClient client) {
-        var missing = await client.Remove(9999).Returns<NotFound<ClientModels.NotFound>>();
+        var missing = await client.RemoveTodo(9999).Returns<NotFound<ClientModels.NotFound>>();
 
 #if (xunit)
         Assert.Contains("9999", missing.Body.Detail);
@@ -99,7 +91,7 @@ public class TodoTests {
     /// <summary>Titles are unique, which is what gives the sample a real 409 - typed, like the 404.</summary>
     [HardenedTest]
     public async Task CreateTodo_DuplicateTitle_IsATypedConflict(ITemplateModuleNameClient client) {
-        var taken = await client.Create(new ClientModels.NewTodo { Title = "Add an endpoint" })
+        var taken = await client.CreateTodo(new ClientModels.NewTodo { Title = "Add an endpoint" })
             .Returns<Conflict<ClientModels.Conflict>>();
 
 #if (xunit)
@@ -204,7 +196,7 @@ public class TodoTests {
     /// </remarks>
     [HardenedTest]
     public async Task CreateTodo_AnswersTwoHundred(ITemplateModuleNameClient client) {
-        var answer = await client.Create(new ClientModels.NewTodo { Title = "ship it" })
+        var answer = await client.CreateTodo(new ClientModels.NewTodo { Title = "ship it" })
             .Returns<Ok<ClientModels.Todo>>();
 
 #if (xunit)
@@ -217,7 +209,7 @@ public class TodoTests {
     /// <summary>200 with the removed todo, for the same reason.</summary>
     [HardenedTest]
     public async Task RemoveTodo_AnswersTwoHundred(ITemplateModuleNameClient client) {
-        var removed = await client.Remove(2).Returns<Ok<ClientModels.Todo>>();
+        var removed = await client.RemoveTodo(2).Returns<Ok<ClientModels.Todo>>();
 
 #if (xunit)
         Assert.Equal(2, removed.Value.Id);
@@ -243,13 +235,8 @@ public class TodoTests {
     /// </summary>
     [HardenedTest]
     public async Task CreateTodo_AnswersCreatedWithALocation(ITemplateModuleNameClient client) {
-#if (codeFirst)
-        var created = await client.Create(new ClientModels.NewTodo { Title = "ship it" })
-            .Returns<Created<ClientModels.Todo>>();
-#else
         var created = await client.CreateTodo(new ClientModels.NewTodo { Title = "ship it" })
             .Returns<Created<ClientModels.Todo>>();
-#endif
 
 #if (xunit)
         Assert.Equal("ship it", created.Value.Title);
@@ -271,26 +258,21 @@ public class TodoTests {
     /// </remarks>
     [HardenedTest]
     public async Task RemoveTodo_AnswersNoContent(ITemplateModuleNameClient client) {
-#if (codeFirst)
-        await client.Remove(2).Returns<NoContent>();
-#else
         await client.RemoveTodo(2).Returns<NoContent>();
-#endif
     }
 #endif
 
-#if (specFirst)
     /// <summary>
-    /// The constraints in the contract are enforced before the handler runs.
+    /// The constraints on the request are enforced before the handler runs.
     /// </summary>
     /// <remarks>
-    /// Nothing in this project validates anything. maxLength on the title became a filter in front
-    /// of the generated handler, so a value too long never reaches the code - and the published
+    /// Nothing in this project validates anything by hand. The title's length limit became a filter
+    /// in front of the handler, so a value too long never reaches the code - and the published
     /// document declares the 400 it answers with, so the client has a model for it that names the
     /// field.
     /// </remarks>
     [HardenedTest]
-    public async Task CreateTodo_TitleTheContractDisallows_IsBadRequest(ITemplateModuleNameClient client) {
+    public async Task CreateTodo_TitleOverItsLimit_IsBadRequest(ITemplateModuleNameClient client) {
         var refused = await client.CreateTodo(new ClientModels.NewTodo { Title = new string('x', 100) })
             .Returns<BadRequest<ClientModels.RequestValidationError>>();
 
@@ -308,16 +290,14 @@ public class TodoTests {
     /// document says so, which DocumentStatusTests holds it to.
     /// </summary>
     [HardenedTest]
-    public async Task GetTodo_IdBelowTheContractsMinimum_IsBadRequest(ITemplateModuleNameClient client) {
+    public async Task GetTodo_IdBelowItsMinimum_IsBadRequest(ITemplateModuleNameClient client) {
         await client.GetTodo(0).Returns<BadRequest<ClientModels.RequestValidationError>>();
     }
 
     [HardenedTest]
-    public async Task RemoveTodo_IdBelowTheContractsMinimum_IsBadRequest(ITemplateModuleNameClient client) {
+    public async Task RemoveTodo_IdBelowItsMinimum_IsBadRequest(ITemplateModuleNameClient client) {
         await client.RemoveTodo(0).Returns<BadRequest<ClientModels.RequestValidationError>>();
     }
-#endif
-#if (codeFirst)
     /// <summary>
     /// An id the parameter's type cannot carry is refused before the handler, with the same
     /// field-level envelope a failed validation answers - and the published document says so,
@@ -336,5 +316,4 @@ public class TodoTests {
     public async Task RemoveTodo_MalformedId_IsBadRequest(ITestWebApp app) {
         (await app.Delete("/todos/not-a-number")).Assert.BadRequest();
     }
-#endif
 }

--- a/src/Web/Hardened.Web.Runtime/Attributes/OperationAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Attributes/OperationAttribute.cs
@@ -1,0 +1,29 @@
+namespace Hardened.Web.Runtime.Attributes;
+
+/// <summary>
+/// The <c>operationId</c> this handler publishes, when the method name is not the right answer.
+///
+/// <para>
+/// The default is the method name in camelCase, so <c>ListTodos</c> publishes <c>listTodos</c>,
+/// and where two controllers share a method name the tag is prefixed to tell them apart. The id
+/// is what a generated client names its method after - a Refit interface's <c>ListTodos()</c> is
+/// the operation <c>listTodos</c> - so it is part of the contract, and deriving it from the method
+/// name makes a rename in C# a breaking change on the wire. Declaring it holds it still.
+/// </para>
+///
+/// <para>
+/// Use it where the method's name and the operation's public name differ - a code-first service
+/// whose document has to match a contract written elsewhere, or a handler named for an internal
+/// concept - and wherever the id has to survive a refactor. It is written to the document as
+/// given. Two handlers declaring one id is an error, <c>HRDOA004</c>: the ids in a document name
+/// one operation each.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public class OperationAttribute : Attribute {
+    public OperationAttribute(string id) {
+        Id = id;
+    }
+
+    public string Id { get; }
+}


### PR DESCRIPTION
## What

`[Operation("listTodos")]` on a code-first handler declares the `operationId` the document publishes. The generator carries it on the handler model beside `Tag`, writes it as given, prefixes a derived name that collides with a declared one with its tag (as it already does for two derived names), and reports two handlers declaring one id as `HRDOA004`, an error. Spec-first handlers carry their description's id verbatim instead of a camel-cased round trip, so the Smithy fixture's exported document moves from `getPet` to `GetPet`, which is what Smithy's own conversion writes.

The template's code-first sample declares the contract's four ids and the contract's constraints, `[Range(Min = 1)]` on the id and `[StringLength(1, 64)]` on the title. Its document now declares the same 400s with the same `RequestValidationError` schema, the `minimum` and `minLength`/`maxLength` the contract has, and the same operation ids, so the Refit method names, the three constraint tests and the two malformed-id tests run in every contract mode with no `codeFirst` or `specFirst` branch. `DocumentStatusTests` keeps one expectation set for every mode that declares its statuses; code-first throws mode keeps its own.

The socket test's Kiota and Refit blocks gain the NUnit assert pair #284 put around every other assert. Merged after #284, #283 had left them xUnit-only, so the script's `kestrel:code:response:kiota:nunit` row does not compile on main.

## Why

A code-first handler's id was the method name, so the client generated from a code-first service differed from the one generated from the same service written spec-first, and the template's tests had to know which way the service was written. The id is part of the contract: a Refit interface names its methods after it, and deriving it from the method name made a C# rename a breaking change on the wire. With the ids and the constraints declared, one client comes out whichever way the service was written, which is what lets one test file cover both.

Verified: the CI-parity build, the full suite (7266 tests, the Smithy fixture's export re-approved by the build and the public API re-approved for the attribute), six new generator tests for the id derivation and the diagnostic, and six template rows scaffolded from a pack of this tree with zero warnings and 15 tests passing each: kestrel code-first with Kiota, Kiota under NUnit, Refit, Refit in throws mode and no client, and kestrel openapi with Refit. `scripts/verify-templates.sh` was running when this opened; its result follows as a comment. The generator source could not be validated against Hardened.Amz locally, as Amz main does not yet build against Framework main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
