### PR TITLE
Open the 0.22.0 preview line

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -328,8 +328,8 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           # The open line, which is the one previews belong under - not the last one released.
-          # The line has released through v0.18.0-rc1000; there was no 0.7.0.
-          RELEASE_LINE: 0.19.0
+          # The line has released through v0.21.0-rc1000; there was no 0.7.0.
+          RELEASE_LINE: 0.22.0
         run: |
           BUILD=$(printf '%06d' "$GITHUB_RUN_NUMBER")
           echo "Packing $RELEASE_LINE-preview$BUILD"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ unmeasured rather than untested.
 ## Releasing
 
 A `v*` tag drives `release.yaml`, and the tag is the source of truth for the version. The current
-line is `0.20.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
+line is `0.21.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
 
 **The pack list in `release.yaml` is hand-maintained and has drifted four times.** A new packable
 project has to be added to it *and* to `EXPECTED`, which is a literal on purpose. Adding it to the


### PR DESCRIPTION
`RELEASE_LINE` sat at 0.19.0 while 0.19.0 and 0.20.0 both released. Previews have been stamped under a line that closed two releases ago. The workflow's own comment requires the bump when a line opens.

Bumped to 0.22.0 ahead of the `v0.21.0-rc1000` tag, so the line previews claim is the one that is open once this release is cut. `AGENTS.md` moves with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)