### PR TITLE
Write a streamed response's array schema beside itemSchema

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -399,7 +399,7 @@ error, with no `NoWarn`: there is no reading of zero that means anything else.
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
 | `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. The ones with an entry have a section above. |
 | `HRDOA001` | `<HardenedOpenApiVersion>` is not 3.0.0, 3.1.0 or 3.2.0. |
-| `HRDOA002` | Warning. A streamed response under a document version with no `itemSchema`; the operation is described without a schema. |
+| `HRDOA002` | Warning. A streamed response under a document version with no `itemSchema`; the operation is described as an array of the item under `schema`, so a client generated from the document reads a list rather than a stream. |
 | `HRDOA003` | Warning. `[Enable<OpenApiDocumentPublishing>]` sits on a module declaring no routes, so the document is empty. |
 | `HRDOA004` | Two handlers declare the same `[Operation]` id. An operationId names one operation, so give each handler its own. |
 | `HRDOA018`, `019`, `028`–`030` | The document export, reported under the code-first prefix. The numbers mean the same under `HOAT` and `HSMT`; see below. |
@@ -457,7 +457,7 @@ onward follows the model-diagnostics pass, since `025` is retired and stays so.
 | `019` | The project declares more than one served document - two modules enabling publishing in one compilation - and one output path cannot express both. Keep one, or move the other to a project of its own. |
 | `028` | The output path's extension names no format. Use `.json` for indented JSON, or `.yaml` or `.yml` for YAML. |
 | `029` | `<HardenedOpenApiOutputVersion>` is not `3.0.0` or `3.1.0`. Remove it to write the version the application serves. |
-| `030` | Warning. The file was lowered to a version with no `itemSchema`, and the named operation streams its response; the file describes it with its media type and no schema. Remove `<HardenedOpenApiOutputVersion>` to export the 3.2 document the application serves. Once per operation. |
+| `030` | Warning. The file was lowered to a version with no `itemSchema`, and the named operation streams its response; the file keeps the item type as an array under `schema`, so a client generated from it reads a list rather than a stream. Remove `<HardenedOpenApiOutputVersion>` to export the 3.2 document the application serves. Once per operation. |
 | `031` | Warning. The served document puts more than one operation at the named path under the same method, so the file repeats a key OpenAPI cannot tell apart: readers refuse it and no client can be generated from it. Once per path. |
 
 ```

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -3911,6 +3911,12 @@
             "description": "OK",
             "content": {
               "application/x-ndjson": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -3944,6 +3950,12 @@
             "description": "OK",
             "content": {
               "application/x-ndjson": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -3976,6 +3988,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4008,6 +4026,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4040,6 +4064,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4072,6 +4102,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4104,6 +4140,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4157,6 +4199,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4189,6 +4237,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4222,6 +4276,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4254,6 +4314,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4287,6 +4353,12 @@
             "description": "OK",
             "content": {
               "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4319,6 +4391,12 @@
             "description": "OK",
             "content": {
               "application/x-ndjson": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4351,6 +4429,12 @@
             "description": "OK",
             "content": {
               "application/x-ndjson": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Measurement"
+                  }
+                },
                 "itemSchema": {
                   "$ref": "#/components/schemas/Measurement"
                 }
@@ -4393,6 +4477,12 @@
             "description": "OK",
             "content": {
               "application/x-ndjson": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "itemSchema": {
                   "type": "string"
                 }

--- a/src/SourceGenerators/Hardened.Generation.Shared/Document/OpenApiDocumentLowering.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Document/OpenApiDocumentLowering.cs
@@ -19,7 +19,10 @@ namespace Hardened.Generation.Document;
 /// <para>
 /// What changes, and only when the target version needs it. The <c>openapi</c> banner. Every
 /// <c>itemSchema</c>, which arrived in 3.2 and is what <c>scripts/extract-openapi.py</c> removed
-/// for the same reason; each operation that loses one is returned so the caller can name it. And,
+/// for the same reason; each operation that loses one is returned so the caller can name it. The
+/// array of the item the generator writes beside it under <c>schema</c> stays, so the lowered file
+/// still names the item type and says there are many; what it can no longer say is that they
+/// arrive one after another. And,
 /// for 3.0.0 only, the two spellings the generator itself writes differently under a 3.0 banner:
 /// a numeric <c>exclusiveMinimum</c> or <c>exclusiveMaximum</c> becomes the bound plus a boolean,
 /// and a <c>type</c> array of one type and <c>"null"</c> becomes the type with

--- a/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask/WriteOpenApiDocument.cs
+++ b/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask/WriteOpenApiDocument.cs
@@ -178,10 +178,10 @@ public sealed class WriteOpenApiDocument : Microsoft.Build.Utilities.Task {
         if (version != null) {
             foreach (var operation in OpenApiDocumentLowering.Lower(document, version)) {
                 Log.LogWarning(null, prefix + StreamLostItemSchemaCode, null, ProjectFile(), 0, 0, 0, 0,
-                    $"'{operation}' streams its response, and OpenAPI {version} has no way to describe one - " +
-                    "itemSchema arrived in 3.2. The exported file describes the operation with its media type " +
-                    "and no schema. Remove <HardenedOpenApiOutputVersion> to export the 3.2 document the " +
-                    "application serves.");
+                    $"'{operation}' streams its response, and OpenAPI {version} has no itemSchema - it arrived " +
+                    "in 3.2. The exported file keeps the item type as an array under schema, so a client " +
+                    "generated from it reads a list rather than a stream. Remove <HardenedOpenApiOutputVersion> " +
+                    "to export the 3.2 document the application serves.");
             }
         }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -867,20 +867,28 @@ public static class OpenApiDocumentGenerator {
                 : "application/json";
 
     /// <summary>
-    /// A streamed response: the media type it is framed as, and the shape of one item.
+    /// A streamed response: the media type it is framed as, the shape of one item, and the whole
+    /// body as an array of them.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <c>itemSchema</c> rather than <c>schema</c>, which is the distinction OpenAPI 3.2 added for
-    /// exactly this: <c>schema</c> describes the whole body, and the body here is many documents one
-    /// after another. Putting the item under <c>schema</c> - which is what this emitted before -
-    /// tells a client the response is a single one of them, and a generator built from that document
-    /// produces a client that reads one and stops.
+    /// Two keys, because they answer different questions and OpenAPI 3.2 says both may be written.
+    /// <c>itemSchema</c> describes each item as it is read off the stream, and is the only spelling
+    /// that says the items arrive one after another. <c>schema</c> describes the complete content,
+    /// which the specification defines for a sequential media type as the items treated as an
+    /// array in the order they were sent - so it is written as exactly that, an array of the item.
+    /// The item alone under <c>schema</c>, which is what this emitted before <c>itemSchema</c>
+    /// existed, claims the response is a single one of them, and a generator built from that
+    /// document produces a client that reads one and stops.
     /// </para>
     /// <para>
-    /// Below 3.2 the media type is written and the schema is not. That says "a body of this type,
-    /// contents unspecified", which is true where the alternative is false; the handler is named in
-    /// a build warning by <c>RoutingTableGenerator</c> so the omission is not silent.
+    /// <c>schema</c> is written at every version and is what a reader without 3.2 sees. Refitter
+    /// takes a stream's element type from it and reads nothing from <c>itemSchema</c>, and a 3.0 or
+    /// 3.1 reader that would otherwise be told nothing is told the item type and that there are
+    /// many. What such a reader cannot be told is that they stream, so a client generated below 3.2
+    /// reads a list; the handler is named in a build warning by <c>RoutingTableGenerator</c> so the
+    /// trade is not silent. Kiota ignores both keys for a streaming media type and hands back the
+    /// raw stream either way.
     /// </para>
     /// </remarks>
     private static void WriteStreamedResponse(
@@ -890,10 +898,16 @@ public static class OpenApiDocumentGenerator {
 
         builder.Append(",\"content\":{\"").Append(JsonSchemaWriter.Escape(contentType)).Append("\":{");
 
-        if (handler.ResponseSchema != null && OpenApiVersionFacts.SupportsItemSchema(version)) {
+        if (handler.ResponseSchema != null) {
             Merge(components, handler.ResponseSchema);
 
-            builder.Append("\"itemSchema\":").Append(handler.ResponseSchema.Schema);
+            builder.Append("\"schema\":{\"type\":\"array\",\"items\":")
+                .Append(handler.ResponseSchema.Schema)
+                .Append('}');
+
+            if (OpenApiVersionFacts.SupportsItemSchema(version)) {
+                builder.Append(",\"itemSchema\":").Append(handler.ResponseSchema.Schema);
+            }
         }
 
         builder.Append("}}");

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiVersion.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiVersion.cs
@@ -34,8 +34,8 @@ public enum OpenApiVersion {
     V3_1,
 
     /// <summary>
-    /// Adds <c>itemSchema</c>, the only spelling in any version that can describe a streamed
-    /// response. The default.
+    /// Adds <c>itemSchema</c>, the only spelling in any version that says a response's items arrive
+    /// one after another. The default.
     /// </summary>
     V3_2
 }
@@ -108,12 +108,13 @@ public static class OpenApiVersionFacts {
         version != OpenApiVersion.V3_0;
 
     /// <summary>
-    /// Whether the version can describe a streamed response at all.
+    /// Whether the version can say that a response streams.
     /// </summary>
     /// <remarks>
-    /// <c>itemSchema</c> arrived in 3.2. Before it there is no way to say "many of these, one after
-    /// another" - putting the item's schema under <c>schema</c> claims the response is one of them,
-    /// which is what the document said before any of this and is a lie rather than an omission.
+    /// <c>itemSchema</c> arrived in 3.2. Below it the document can still say "many of these", as an
+    /// array of the item under <c>schema</c>, but not "one after another". Putting the item's schema
+    /// alone under <c>schema</c> claims the response is one of them, which is what the document said
+    /// before any of this and is a lie rather than an omission.
     /// </remarks>
     public static bool SupportsItemSchema(OpenApiVersion version) =>
         version == OpenApiVersion.V3_2;

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiVersionDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiVersionDiagnostics.cs
@@ -37,12 +37,12 @@ public static class OpenApiVersionDiagnostics {
 
     internal static DiagnosticDescriptor StreamNeedsItemSchemaDescriptor() => new(
         id: StreamNeedsItemSchemaId,
-        title: "Streamed response cannot be described at this document version",
+        title: "Streamed response is described as an array at this document version",
         messageFormat:
-        "'{0}' streams its response, and OpenAPI {1} has no way to describe one - itemSchema " +
-        "arrived in 3.2. The operation is emitted with its media type and no schema, so the " +
-        "document says a body of that type without saying what is in it. Set " +
-        "<{2}>3.2.0</{2}> to describe it.",
+        "'{0}' streams its response, and OpenAPI {1} has no itemSchema - it arrived in 3.2. The " +
+        "operation is emitted with its media type and the item type as an array under schema, so " +
+        "a client generated from the document reads a list rather than a stream. Set " +
+        "<{2}>3.2.0</{2}> to describe the stream.",
         category: "Hardened.OpenApi",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -140,8 +140,9 @@ public static class RoutingTableGenerator {
                     context, models.Left.EntryPointType.Name, documentPath);
             }
 
-            // A streamed response has no spelling before 3.2, so the document is emitted without one
-            // and the handler is named rather than the omission being silent.
+            // Before 3.2 the document can say a streamed response is many of the item, as an array
+            // under schema, but not that they arrive one after another. The handler is named so the
+            // trade is not silent.
             if (!OpenApiVersionFacts.SupportsItemSchema(documentVersion)) {
                 foreach (var handler in routable) {
                     if (handler.ResponseInformation.IsAsyncEnumerable) {

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OpenApiVersionGeneratorTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/OpenApiVersionGeneratorTests.cs
@@ -90,6 +90,57 @@ public class OpenApiVersionGeneratorTests {
     private static Diagnostic? Reported(GeneratorResult result, string id) =>
         result.GeneratorDiagnostics.FirstOrDefault(diagnostic => diagnostic.Id == id);
 
+    /// <summary>The media type object under the streamed operation's 200, whatever it is framed as.</summary>
+    private static JsonElement StreamedMediaType(GeneratorResult result) {
+        var source = result.GeneratedSources
+            .First(pair => pair.Key.Contains("OpenApiDocument")).Value;
+
+        using var document = JsonDocument.Parse(GeneratedOpenApiDocument.Extract(source));
+
+        var content = document.RootElement
+            .GetProperty("paths").GetProperty("/feed").GetProperty("get")
+            .GetProperty("responses").GetProperty("200").GetProperty("content");
+
+        return content.EnumerateObject().Single().Value.Clone();
+    }
+
+    /// <summary>
+    /// At 3.2 a streamed response is written twice over: the item under <c>itemSchema</c>, and the
+    /// complete content as an array of it under <c>schema</c>.
+    /// </summary>
+    /// <remarks>
+    /// Both, because OpenAPI 3.2 says both may be written and they answer different questions, and
+    /// because they have different readers. Refitter takes a stream's element type from
+    /// <c>schema</c> and never reads <c>itemSchema</c>; the specification-first reader in this
+    /// repository does the opposite. A document carrying only <c>itemSchema</c> gave Refitter
+    /// <c>IAsyncEnumerable&lt;object&gt;</c>.
+    /// </remarks>
+    [Fact]
+    public void AStreamedResponseCarriesTheItemAndTheArrayAtThreeTwo() {
+        var media = StreamedMediaType(Generate(StreamingHandler, "3.2.0"));
+
+        var item = media.GetProperty("itemSchema");
+        var whole = media.GetProperty("schema");
+
+        Assert.Equal("array", whole.GetProperty("type").GetString());
+        Assert.Equal(item.GetRawText(), whole.GetProperty("items").GetRawText());
+    }
+
+    /// <summary>
+    /// Below 3.2 the array stays and <c>itemSchema</c> goes, so a reader is told the item type and
+    /// that there are many, which is everything the version can say.
+    /// </summary>
+    [Theory]
+    [InlineData("3.0.0")]
+    [InlineData("3.1.0")]
+    public void AStreamedResponseKeepsTheArrayBelowThreeTwo(string version) {
+        var media = StreamedMediaType(Generate(StreamingHandler, version));
+
+        Assert.False(media.TryGetProperty("itemSchema", out _));
+        Assert.Equal("array", media.GetProperty("schema").GetProperty("type").GetString());
+        Assert.True(media.GetProperty("schema").TryGetProperty("items", out _));
+    }
+
     /// <summary>
     /// Unset emits the default, and the default is 3.2.0.
     /// </summary>


### PR DESCRIPTION
The code-first document described a streamed response with `itemSchema` alone. That is the OpenAPI 3.2 spelling and the right one, but a reader without 3.2 was told nothing about the item. Refitter takes a stream's element type from `schema` and never reads `itemSchema`, so its `main` branch (PR christianhelle/refitter#1221, merged 2026-08-12, unreleased) generated `IAsyncEnumerable<object>` from the exported file, and a `HardenedOpenApiOutputVersion` of 3.0 or 3.1 dropped the item type altogether.

OpenAPI 3.2 says `schema` and `itemSchema` may both be written, and that `schema` on a sequential media type describes the complete content as the items treated as an array. The writer now emits exactly that beside `itemSchema` at 3.2, and the array alone below it:

```json
"text/event-stream": {
  "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Measurement" } },
  "itemSchema": { "$ref": "#/components/schemas/Measurement" }
}
```

The item alone under `schema`, which is what the generator emitted before `itemSchema` existed, is still not written: it claims the response is one item, and a client generated from it reads one and stops. The lowering leaves the array in place and still removes `itemSchema`.

## What each reader now gets

Run against the regenerated `openapi/Application.json` of the WebApp fixture:

- Refitter `main`: `IAsyncEnumerable<Measurement>` for all five streamed operations (was `IAsyncEnumerable<object>`). Refit 14.0.0 and later consume it; the template still pins Refit 8.0.0 and Refitter 2.1.3, which is a separate bump once Refitter releases.
- Refitter 2.1.3 (the newest release): `Task<IApiResponse<ICollection<Measurement>>>` (was a bodiless `Task<IApiResponse>`). A list is what a reader without 3.2 can be told; the array says "many of these" but not "one after another".
- Kiota 1.34.1: byte-for-byte the same client. It hands back a raw `Stream` for these media types whatever the schema says.
- The specification-first reader in this repository reads `itemSchema` first and is unchanged; `OpenApiReverseRoundTripTests` still produces `IAsyncEnumerable<T>`.

## Warnings

`HRDOA002` (served document below 3.2) and `030` (lowered export) keep firing, because the array cannot say the items stream. Their text now says what the document does say: the item type as an array under `schema`, so a generated client reads a list rather than a stream. `docs/generator-diagnostics.md` has the new wording.

## Verification

- CI-parity build (`Release`, `ContinuousIntegrationBuild=true`, Smithy CLI 1.73.0 on PATH): clean.
- Full suite against that build: 39 projects, 7270 tests, 0 failures. `Hardened.IntegrationTests.WebApp.SUT.Tests` (381) and the NUnit variant (16) include `ExportedDocumentTests` and `GeneratedClientTests` over the Kiota client regenerated from the tracked document.
- Two new tests in `OpenApiVersionGeneratorTests`: at 3.2 both keys, with `schema.items` equal to `itemSchema`; at 3.0 and 3.1 the array alone.
- The tracked `Application.json` is regenerated in this commit (15 streamed media types gain the array).

Found by the 0.21.0-rc1000 trial while checking how the generated clients handle a stream. The companion Docs change updates streaming.md, openapi-document.md and clients.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)