### PR TITLE
Add deadlines, comparison and subtraction to MachineTimestamp

### DIFF
--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Runtime.approved.txt
@@ -224,14 +224,31 @@ namespace Hardened.Shared.Runtime.DependencyInjection
 }
 namespace Hardened.Shared.Runtime.Diagnostics
 {
-    public readonly struct MachineTimestamp
+    public readonly struct MachineTimestamp : System.IComparable<Hardened.Shared.Runtime.Diagnostics.MachineTimestamp>, System.IEquatable<Hardened.Shared.Runtime.Diagnostics.MachineTimestamp>
     {
         public static readonly double MillisecondsToTicksRatio;
         public static readonly double SecondsToTicksRatio;
+        public bool Future { get; }
+        public bool Past { get; }
+        public bool Present { get; }
         public static Hardened.Shared.Runtime.Diagnostics.MachineTimestamp Now { get; }
+        public Hardened.Shared.Runtime.Diagnostics.MachineTimestamp AddMs(double milliseconds) { }
+        public int CompareTo(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp other) { }
+        public bool Equals(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp other) { }
+        public override bool Equals(object? obj) { }
         public double GetElapsedMilliseconds() { }
         public System.TimeSpan GetElapsedTime() { }
+        public override int GetHashCode() { }
+        public double GetRemainingMilliseconds() { }
+        public double GetRemainingSeconds() { }
         public static Hardened.Shared.Runtime.Diagnostics.MachineTimestamp FromTicks(long ticks) { }
+        public static bool operator !=(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp left, Hardened.Shared.Runtime.Diagnostics.MachineTimestamp right) { }
+        public static System.TimeSpan operator -(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp left, Hardened.Shared.Runtime.Diagnostics.MachineTimestamp right) { }
+        public static bool operator <(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp left, Hardened.Shared.Runtime.Diagnostics.MachineTimestamp right) { }
+        public static bool operator <=(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp left, Hardened.Shared.Runtime.Diagnostics.MachineTimestamp right) { }
+        public static bool operator ==(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp left, Hardened.Shared.Runtime.Diagnostics.MachineTimestamp right) { }
+        public static bool operator >(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp left, Hardened.Shared.Runtime.Diagnostics.MachineTimestamp right) { }
+        public static bool operator >=(Hardened.Shared.Runtime.Diagnostics.MachineTimestamp left, Hardened.Shared.Runtime.Diagnostics.MachineTimestamp right) { }
     }
 }
 namespace Hardened.Shared.Runtime.Json

--- a/src/Shared/Hardened.Shared.Runtime.Tests/Diagnostic/MachineTimestampTests.cs
+++ b/src/Shared/Hardened.Shared.Runtime.Tests/Diagnostic/MachineTimestampTests.cs
@@ -36,6 +36,13 @@ public class MachineTimestampTests {
     private const int SleepMilliseconds = 200;
 
     /// <summary>
+    /// The span the deadline tests add to a timestamp. Long enough that no plausible pause between
+    /// two adjacent statements is a measurable part of it, so a deadline built from it is still in
+    /// the future when it is read back on the next line.
+    /// </summary>
+    private const int DeadlineMilliseconds = 60_000;
+
+    /// <summary>
     /// How far the two clocks may disagree. Generous, because it absorbs each clock's resolution and
     /// the ordinary execution between the two pairs of readings; far too tight to hide a unit error,
     /// which is what this is here to catch and which would be out by a factor of a thousand.
@@ -119,6 +126,12 @@ public class MachineTimestampTests {
     public void ADefaultTimestampRefusesToBeRead() {
         Assert.Throws<Exception>(() => default(MachineTimestamp).GetElapsedMilliseconds());
         Assert.Throws<Exception>(() => default(MachineTimestamp).GetElapsedTime());
+        Assert.Throws<Exception>(() => default(MachineTimestamp).GetRemainingMilliseconds());
+        Assert.Throws<Exception>(() => default(MachineTimestamp).GetRemainingSeconds());
+        Assert.Throws<Exception>(() => default(MachineTimestamp).Past);
+        Assert.Throws<Exception>(() => default(MachineTimestamp).Present);
+        Assert.Throws<Exception>(() => default(MachineTimestamp).Future);
+        Assert.Throws<Exception>(() => default(MachineTimestamp).AddMs(1000));
     }
 
     /// <summary>
@@ -148,5 +161,223 @@ public class MachineTimestampTests {
 
         Assert.Equal(MachineTimestamp.FromTicks(ticks), MachineTimestamp.FromTicks(ticks));
         Assert.NotEqual(MachineTimestamp.FromTicks(ticks), MachineTimestamp.FromTicks(ticks + 1));
+        Assert.True(MachineTimestamp.FromTicks(ticks) == MachineTimestamp.FromTicks(ticks));
+        Assert.True(MachineTimestamp.FromTicks(ticks) != MachineTimestamp.FromTicks(ticks + 1));
+        Assert.Equal(
+            MachineTimestamp.FromTicks(ticks).GetHashCode(),
+            MachineTimestamp.FromTicks(ticks).GetHashCode());
+
+        // The boxed overload is the one a non-generic collection reaches, and it is reached by
+        // nothing else in this file.
+        Assert.True(MachineTimestamp.FromTicks(ticks).Equals((object)MachineTimestamp.FromTicks(ticks)));
+        Assert.False(MachineTimestamp.FromTicks(ticks).Equals((object)MachineTimestamp.FromTicks(ticks + 1)));
+        Assert.False(MachineTimestamp.FromTicks(ticks).Equals("not a timestamp"));
+        Assert.False(MachineTimestamp.FromTicks(ticks).Equals(null));
+    }
+    /// <summary>
+    /// Adding milliseconds puts the timestamp that far ahead of where it was. The conversion runs
+    /// the other way from the elapsed readings above, milliseconds into machine ticks, so it is its
+    /// own chance at a unit error and gets its own wall clock check.
+    /// </summary>
+    /// <remarks>
+    /// The reading is corrected by the wall clock rather than compared to the added value directly.
+    /// Time passes between taking the timestamp and reading the deadline back, and on a loaded
+    /// machine it can be a lot of time. That shows up in both clocks, so the sum of the two is what
+    /// stays put.
+    /// </remarks>
+    [Fact]
+    public void AddMsPutsTheTimestampThatFarAhead() {
+        var wallStart = DateTime.UtcNow;
+        var deadline = MachineTimestamp.Now.AddMs(DeadlineMilliseconds);
+
+        var remaining = deadline.GetRemainingMilliseconds();
+        var wallElapsed = (DateTime.UtcNow - wallStart).TotalMilliseconds;
+
+        Assert.InRange(
+            remaining + wallElapsed,
+            DeadlineMilliseconds - ToleranceMilliseconds,
+            DeadlineMilliseconds + ToleranceMilliseconds);
+    }
+
+    /// <summary>
+    /// A negative value moves the timestamp back, and the reading it produces carries the sign that
+    /// says so.
+    /// </summary>
+    [Fact]
+    public void AddingNegativeMillisecondsPutsTheTimestampBehind() {
+        var wallStart = DateTime.UtcNow;
+        var passed = MachineTimestamp.Now.AddMs(-DeadlineMilliseconds);
+
+        var remaining = passed.GetRemainingMilliseconds();
+        var wallElapsed = (DateTime.UtcNow - wallStart).TotalMilliseconds;
+
+        Assert.InRange(
+            remaining + wallElapsed,
+            -DeadlineMilliseconds - ToleranceMilliseconds,
+            -DeadlineMilliseconds + ToleranceMilliseconds);
+    }
+
+    /// <summary>
+    /// A deadline is in the future until its span has passed and in the past afterwards. Waiting it
+    /// out is the only assertion here that needs the clock to advance, and a machine that stalls
+    /// only makes it more true.
+    /// </summary>
+    [Fact]
+    public void ADeadlineIsPastOnceItsSpanHasElapsed() {
+        var deadline = MachineTimestamp.Now.AddMs(SleepMilliseconds);
+
+        Assert.True(deadline.Future, "A deadline is in the future before its span elapses.");
+
+        Thread.Sleep(SleepMilliseconds * 2);
+
+        Assert.True(deadline.Past, "A deadline is in the past once its span has elapsed.");
+        Assert.True(
+            deadline.GetRemainingMilliseconds() < 0,
+            $"{deadline.GetRemainingMilliseconds()} was not negative for an elapsed deadline.");
+    }
+
+    /// <summary>
+    /// Exactly one of the three holds, whatever the timestamp. Anything else and a caller that tests
+    /// them in turn either takes two branches or takes none.
+    /// </summary>
+    [Fact]
+    public void ATimestampIsPastPresentOrFutureAndOnlyOne() {
+        foreach (var timestamp in new[] {
+                     MachineTimestamp.Now.AddMs(DeadlineMilliseconds),
+                     MachineTimestamp.Now.AddMs(-DeadlineMilliseconds),
+                     MachineTimestamp.Now
+                 }) {
+            var held = new[] { timestamp.Past, timestamp.Present, timestamp.Future }.Count(x => x);
+
+            Assert.True(held == 1, $"{held} of Past, Present and Future held at once.");
+        }
+    }
+
+    /// <summary>
+    /// One reading in two units, the same pairing the elapsed accessors have, and the same factor of
+    /// a thousand between a right answer and a wrong one.
+    /// </summary>
+    [Fact]
+    public void TheTwoRemainingAccessorsReportTheSameTime() {
+        var deadline = MachineTimestamp.Now.AddMs(DeadlineMilliseconds);
+
+        var milliseconds = deadline.GetRemainingMilliseconds();
+        var seconds = deadline.GetRemainingSeconds();
+
+        Assert.InRange(
+            seconds * 1000,
+            milliseconds - ToleranceMilliseconds,
+            milliseconds + ToleranceMilliseconds);
+    }
+
+    /// <summary>
+    /// Time remaining and time elapsed are the same distance measured from opposite ends, so on a
+    /// timestamp that has gone by they differ only in sign.
+    /// </summary>
+    [Fact]
+    public void RemainingIsElapsedNegated() {
+        var timestamp = MachineTimestamp.Now;
+
+        Thread.Sleep(20);
+
+        var elapsed = timestamp.GetElapsedMilliseconds();
+        var remaining = timestamp.GetRemainingMilliseconds();
+
+        Assert.InRange(
+            remaining,
+            -elapsed - ToleranceMilliseconds,
+            -elapsed + ToleranceMilliseconds);
+    }
+    /// <summary>
+    /// Timestamps order by the moment they were taken, which is what lets a caller hold several and
+    /// ask which came first without reading elapsed time off each one at some later moment.
+    /// </summary>
+    [Fact]
+    public void TimestampsOrderByWhenTheyWereTaken() {
+        var ticks = Stopwatch.GetTimestamp();
+        var earlier = MachineTimestamp.FromTicks(ticks);
+        var later = MachineTimestamp.FromTicks(ticks + 1);
+
+        Assert.True(earlier < later);
+        Assert.True(later > earlier);
+        Assert.True(earlier <= later);
+        Assert.True(later >= earlier);
+        Assert.True(earlier <= MachineTimestamp.FromTicks(ticks));
+        Assert.True(earlier >= MachineTimestamp.FromTicks(ticks));
+        Assert.False(later < earlier);
+        Assert.False(earlier > later);
+
+        Assert.True(earlier.CompareTo(later) < 0);
+        Assert.True(later.CompareTo(earlier) > 0);
+        Assert.Equal(0, earlier.CompareTo(MachineTimestamp.FromTicks(ticks)));
+    }
+
+    /// <summary>
+    /// Subtracting one timestamp from another gives the time between them. The wall clock brackets
+    /// the same pair, so it is what says the machine ticks were converted to a time span correctly.
+    /// </summary>
+    [Fact]
+    public void SubtractingTwoTimestampsGivesTheTimeBetweenThem() {
+        var wallStart = DateTime.UtcNow;
+        var earlier = MachineTimestamp.Now;
+
+        Thread.Sleep(SleepMilliseconds);
+
+        var later = MachineTimestamp.Now;
+        var wallElapsed = DateTime.UtcNow - wallStart;
+
+        Assert.InRange(
+            (later - earlier).TotalMilliseconds,
+            wallElapsed.TotalMilliseconds - ToleranceMilliseconds,
+            wallElapsed.TotalMilliseconds + ToleranceMilliseconds);
+    }
+
+    /// <summary>
+    /// The difference runs negative the other way round, so a caller subtracting in the wrong order
+    /// is told rather than handed a plausible positive number.
+    /// </summary>
+    [Fact]
+    public void SubtractingInTheOtherOrderIsNegated() {
+        var ticks = Stopwatch.GetTimestamp();
+        var earlier = MachineTimestamp.FromTicks(ticks);
+        var later = earlier.AddMs(DeadlineMilliseconds);
+
+        Assert.Equal(-(later - earlier), earlier - later);
+        Assert.True((earlier - later).Ticks < 0);
+    }
+
+    /// <summary>
+    /// Subtracting <c>Now</c> from a timestamp is the reading <see cref="MachineTimestamp.GetElapsedTime"/>
+    /// gives, negated. Two ways to the same measurement, so they must not disagree about it.
+    /// </summary>
+    [Fact]
+    public void TheDifferenceFromNowIsTheElapsedTime() {
+        var timestamp = MachineTimestamp.Now;
+
+        Thread.Sleep(20);
+
+        var elapsed = timestamp.GetElapsedTime();
+        var difference = MachineTimestamp.Now - timestamp;
+
+        Assert.InRange(
+            difference.TotalMilliseconds,
+            elapsed.TotalMilliseconds - ToleranceMilliseconds,
+            elapsed.TotalMilliseconds + ToleranceMilliseconds);
+    }
+
+    /// <summary>
+    /// Subtraction is a reading like the others, so an uninitialized timestamp is refused on either
+    /// side of it rather than measured from the moment the machine started. Ordering and equality
+    /// are deliberately not guarded this way, because a sort or a dictionary must not throw.
+    /// </summary>
+    [Fact]
+    public void SubtractingADefaultTimestampThrows() {
+        var timestamp = MachineTimestamp.Now;
+
+        Assert.Throws<Exception>(() => timestamp - default(MachineTimestamp));
+        Assert.Throws<Exception>(() => default(MachineTimestamp) - timestamp);
+
+        Assert.False(default(MachineTimestamp) == timestamp);
+        Assert.True(default(MachineTimestamp) < timestamp);
     }
 }

--- a/src/Shared/Hardened.Shared.Runtime/Diagnostics/MachineTimestamp.cs
+++ b/src/Shared/Hardened.Shared.Runtime/Diagnostics/MachineTimestamp.cs
@@ -5,7 +5,7 @@ namespace Hardened.Shared.Runtime.Diagnostics;
 /// <summary>
 /// Timestamp that uses the machine ticks, it is only valid on the local machine.
 /// </summary>
-public readonly struct MachineTimestamp {
+public readonly struct MachineTimestamp : IEquatable<MachineTimestamp>, IComparable<MachineTimestamp> {
     public static readonly double SecondsToTicksRatio = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
     public static readonly double MillisecondsToTicksRatio = 1 / (double)TimeSpan.TicksPerMillisecond;
     private readonly long _timestamp;
@@ -33,13 +33,8 @@ public readonly struct MachineTimestamp {
     /// </summary>
     /// <returns></returns>
     public double GetElapsedMilliseconds() {
-        if (_timestamp == 0) {
-            throw new Exception("MachineTimestamp was not initialized, can't be used here");
-        }
+        var totalElapsedTime = Stopwatch.GetTimestamp() - TimestampOrThrow();
 
-
-        var currentTime = Stopwatch.GetTimestamp();
-        var totalElapsedTime = currentTime - _timestamp;
         return (totalElapsedTime * SecondsToTicksRatio) * MillisecondsToTicksRatio;
     }
 
@@ -49,12 +44,136 @@ public readonly struct MachineTimestamp {
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
     public TimeSpan GetElapsedTime() {
+        var totalElapsedTime = Stopwatch.GetTimestamp() - TimestampOrThrow();
+
+        return new TimeSpan((long)(totalElapsedTime * SecondsToTicksRatio));
+    }
+
+    /// <summary>
+    /// Move the timestamp forward by a number of milliseconds, giving a deadline that far from it.
+    /// A negative value moves it back.
+    /// </summary>
+    /// <param name="milliseconds"></param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public MachineTimestamp AddMs(double milliseconds) {
+        var machineTicks = (milliseconds / 1000) * Stopwatch.Frequency;
+
+        return new MachineTimestamp(TimestampOrThrow() + (long)machineTicks);
+    }
+
+    /// <summary>
+    /// The timestamp has gone by
+    /// </summary>
+    /// <exception cref="Exception"></exception>
+    public bool Past => GetRemainingTicks() < 0;
+
+    /// <summary>
+    /// The clock reads the timestamp's own tick. True for at most one tick, so a deadline is
+    /// tested with <see cref="Past"/> or <see cref="Future"/> rather than with this.
+    /// </summary>
+    /// <exception cref="Exception"></exception>
+    public bool Present => GetRemainingTicks() == 0;
+
+    /// <summary>
+    /// The timestamp is still ahead
+    /// </summary>
+    /// <exception cref="Exception"></exception>
+    public bool Future => GetRemainingTicks() > 0;
+
+    /// <summary>
+    /// Get the milliseconds from now to the timestamp, negative once the timestamp is in the past
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public double GetRemainingMilliseconds() {
+        return (GetRemainingTicks() * SecondsToTicksRatio) * MillisecondsToTicksRatio;
+    }
+
+    /// <summary>
+    /// Get the seconds from now to the timestamp, negative once the timestamp is in the past
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public double GetRemainingSeconds() {
+        return (GetRemainingTicks() * SecondsToTicksRatio) / TimeSpan.TicksPerSecond;
+    }
+
+    /// <summary>
+    /// Get the time from one timestamp to another, negative when the right one is the later
+    /// </summary>
+    /// <param name="left"></param>
+    /// <param name="right"></param>
+    /// <returns></returns>
+    /// <exception cref="Exception"></exception>
+    public static TimeSpan operator -(MachineTimestamp left, MachineTimestamp right) {
+        var totalTime = left.TimestampOrThrow() - right.TimestampOrThrow();
+
+        return new TimeSpan((long)(totalTime * SecondsToTicksRatio));
+    }
+
+    /// <summary>
+    /// Order two timestamps by the machine ticks they hold. Unlike the readings above this does not
+    /// reject an uninitialized timestamp, because sorting and equality must not throw.
+    /// </summary>
+    /// <param name="other"></param>
+    /// <returns></returns>
+    public int CompareTo(MachineTimestamp other) {
+        return _timestamp.CompareTo(other._timestamp);
+    }
+
+    /// <summary>
+    /// Two timestamps of the same machine ticks are the same timestamp
+    /// </summary>
+    /// <param name="other"></param>
+    /// <returns></returns>
+    public bool Equals(MachineTimestamp other) {
+        return _timestamp == other._timestamp;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) {
+        return obj is MachineTimestamp other && Equals(other);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode() {
+        return _timestamp.GetHashCode();
+    }
+
+    public static bool operator ==(MachineTimestamp left, MachineTimestamp right) {
+        return left._timestamp == right._timestamp;
+    }
+
+    public static bool operator !=(MachineTimestamp left, MachineTimestamp right) {
+        return left._timestamp != right._timestamp;
+    }
+
+    public static bool operator <(MachineTimestamp left, MachineTimestamp right) {
+        return left._timestamp < right._timestamp;
+    }
+
+    public static bool operator >(MachineTimestamp left, MachineTimestamp right) {
+        return left._timestamp > right._timestamp;
+    }
+
+    public static bool operator <=(MachineTimestamp left, MachineTimestamp right) {
+        return left._timestamp <= right._timestamp;
+    }
+
+    public static bool operator >=(MachineTimestamp left, MachineTimestamp right) {
+        return left._timestamp >= right._timestamp;
+    }
+
+    private long GetRemainingTicks() {
+        return TimestampOrThrow() - Stopwatch.GetTimestamp();
+    }
+
+    private long TimestampOrThrow() {
         if (_timestamp == 0) {
             throw new Exception("MachineTimestamp was not initialized, can't be used here");
         }
 
-        var currentTime = Stopwatch.GetTimestamp();
-        var totalElapsedTime = currentTime - _timestamp;
-        return new TimeSpan((long)(totalElapsedTime * SecondsToTicksRatio));
+        return _timestamp;
     }
 }


### PR DESCRIPTION
`MachineTimestamp` could only say how long ago it was taken. This adds the other direction, so a timestamp can be used as a deadline, and gives the type the comparison it never had.

`AddMs(double)` moves a timestamp forward, or back on a negative value. `Past`, `Present` and `Future` say where it sits relative to now. `GetRemainingMilliseconds()` and `GetRemainingSeconds()` report the distance to it, positive while it is ahead and negative once it has gone by.

Two timestamps now compare. The struct implements `IEquatable<MachineTimestamp>` and `IComparable<MachineTimestamp>` and carries `==`, `!=`, `<`, `>`, `<=` and `>=`, so a caller can hold several and ask which came first. Subtracting one from another gives the `TimeSpan` between them, negative when the right one is the later. `MachineTimestamp.Now - timestamp` is `timestamp.GetElapsedTime()`.

Subtraction rejects an uninitialized timestamp the way the elapsed readings do, since the alternative is a plausible looking measurement taken from the moment the machine started. Ordering and equality do not reject it, because a sort or a dictionary must not throw.

`Present` is true only while the clock reads the timestamp's own tick. On macOS that tick is a nanosecond, so it will effectively never be true. On Windows it is 100ns and it will be true occasionally. It is there so exactly one of the three always holds. The XML doc points a deadline test at `Past` or `Future`.

The uninitialized check moved into a private `TimestampOrThrow()` instead of being copied into each member that needs it. It throws the same exception with the same message, so nothing about `default(MachineTimestamp)` changed.

## Tests

Ten new tests, in the style the file already uses. The readings are corrected by the wall clock rather than compared to the added value directly, so a stalled machine does not fail them.

- `AddMs` puts the timestamp that far ahead, and a negative value puts it behind.
- A deadline is in the future until its milliseconds elapse and in the past after.
- Exactly one of `Past`, `Present` and `Future` holds, for a future, a past and a current timestamp.
- The two remaining accessors are one reading in two units.
- Remaining is elapsed negated.
- Timestamps order by when they were taken, through the operators and through `CompareTo`.
- Subtracting two timestamps gives the time between them, negated in the other order.
- The difference from `Now` is the elapsed time.
- `default` refuses every reading, and is subtracted from neither side, but still orders and compares.

Mutating `AddMs` to multiply by 1000 instead of dividing fails three of them.

The full solution builds and tests green with `--configuration Release -p:ContinuousIntegrationBuild=true`. The public API approved file is regenerated, and its diff is the new members and the two interfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
