### PR TITLE
Stream a described operation that declares itemSchema

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/PetEventsTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/PetEventsTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Serializer;
+
+namespace Hardened.IntegrationTests.OpenApi.SUT.Tests;
+
+/// <summary>
+/// A streamed operation declared in a contract with <c>itemSchema</c>, end to end: the wire, the
+/// refusal before the first event, and the document the application serves for it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this the interface said <c>IAsyncEnumerable&lt;PetEvent&gt;</c> and nothing behind it
+/// agreed: the generated handler awaited the enumerable and did not compile, and the served
+/// document described the 200 with no content. The contract is <c>events.yaml</c>, a second
+/// contract in the same project so it can carry the 3.2 banner <c>itemSchema</c> needs.
+/// </para>
+/// </remarks>
+public class PetEventsTests {
+
+    /// <summary>
+    /// Each event is <c>data:</c> and a blank line under <c>text/event-stream</c>, exactly as a
+    /// code-first <c>[ServerSentEvents]</c> handler answers.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheStreamIsFramedAsServerSentEvents(ITestWebApp app) {
+        var response = await app.Get("/pets/1/events");
+
+        response.Assert.Ok();
+
+        Assert.Equal(
+            KnownContentType.EventStream, response.Headers[KnownHeaders.ContentType].ToString());
+
+        Assert.Equal(
+            """
+            data: {"petId":"1","kind":"adopted"}
+
+            data: {"petId":"1","kind":"weighed"}
+
+
+            """.ReplaceLineEndings("\n"),
+            await BodyOf(response));
+    }
+
+    /// <summary>
+    /// A refusal thrown before the first event is a 404 with its JSON body, not a stream that
+    /// starts and breaks. The contract does not declare it; <c>events.yaml</c> says why.
+    /// </summary>
+    [HardenedTest]
+    public async Task ARefusalBeforeTheFirstEventIsANotFound(ITestWebApp app) {
+        var response = await app.Get("/pets/missing/events");
+
+        Assert.Equal(404, response.StatusCode);
+        Assert.StartsWith("application/json", response.Headers[KnownHeaders.ContentType].ToString());
+        Assert.Contains("No pet has id missing.", await BodyOf(response));
+    }
+
+    /// <summary>
+    /// The served document describes the stream the way the code-first writer does: the item under
+    /// <c>itemSchema</c>, the complete content as an array of it under <c>schema</c>, the
+    /// contract's own description.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheDocumentDescribesTheStream(ITestWebApp app) {
+        var response = await app.Get("/openapi.json");
+
+        response.Assert.Ok();
+
+        using var document = JsonDocument.Parse(await response.ReadTextAsync());
+
+        var responses = document.RootElement.GetProperty("paths").GetProperty("/pets/{petId}/events")
+            .GetProperty("get").GetProperty("responses");
+
+        var ok = responses.GetProperty("200");
+        var media = ok.GetProperty("content").GetProperty("text/event-stream");
+        var item = media.GetProperty("itemSchema");
+        var whole = media.GetProperty("schema");
+
+        Assert.Equal("The pet's history, one event at a time.", ok.GetProperty("description").GetString());
+        Assert.Equal("#/components/schemas/PetEvent", item.GetProperty("$ref").GetString());
+        Assert.Equal("array", whole.GetProperty("type").GetString());
+        Assert.Equal(item.GetRawText(), whole.GetProperty("items").GetRawText());
+
+        var components = document.RootElement.GetProperty("components").GetProperty("schemas");
+
+        Assert.True(components.TryGetProperty("PetEvent", out _), "the item's schema survives the slicer");
+    }
+
+    private static async Task<string> BodyOf(TestWebResponse response) {
+        response.Body.Position = 0;
+
+        using var reader = new StreamReader(response.Body, leaveOpen: true);
+
+        return await reader.ReadToEndAsync();
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Hardened.IntegrationTests.OpenApi.SUT.csproj
@@ -68,6 +68,12 @@
             <SourceUrl>/openapi.yaml</SourceUrl>
             <UiUrl>/docs</UiUrl>
         </HardenedOpenApiSpec>
+
+        <!--
+            The streamed operation, on its own 3.2 contract; the file says why. No URLs: the
+            application serves one document for every contract it composes, from the item above.
+        -->
+        <HardenedOpenApiSpec Include="Specs\events.yaml" />
     </ItemGroup>
 
     <!--

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/PetHistoryServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/PetHistoryServiceImpl.cs
@@ -1,0 +1,31 @@
+using Hardened.IntegrationTests.OpenApi.SUT.Models;
+using Hardened.IntegrationTests.OpenApi.SUT.Services;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Abstract.Responses;
+
+namespace Hardened.IntegrationTests.OpenApi.SUT;
+
+/// <summary>
+/// Implements the interface <c>events.yaml</c> generates: an operation whose success is a stream,
+/// declared with <c>itemSchema</c>, which the generated signature turns into
+/// <c>IAsyncEnumerable&lt;PetEvent&gt;</c>.
+/// </summary>
+/// <remarks>
+/// The refusal is thrown before the first event, which is the only place a stream can refuse:
+/// once an event has been written the status is gone. That is the same shape a code-first
+/// <c>[ServerSentEvents]</c> handler takes with <c>[Throws&lt;NotFound&gt;]</c>.
+/// </remarks>
+[Handler]
+public class PetHistoryServiceImpl : IPetHistoryService {
+
+    public async IAsyncEnumerable<PetEvent> PetEvents(string petId) {
+        if (petId == "missing") {
+            throw new NotFound("pet", $"No pet has id {petId}.").AsException();
+        }
+
+        await Task.Yield();
+
+        yield return new PetEvent(petId, "adopted");
+        yield return new PetEvent(petId, "weighed");
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/events.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/events.yaml
@@ -1,0 +1,47 @@
+# A second contract in the same project, on the 3.2 banner: itemSchema is a 3.2 keyword, and the
+# reader surfaces it only under that banner. petstore.yaml stays at 3.0.0 because its nullable
+# spelling is the 3.0 one, and a banner change would silently change what that property means.
+#
+# No declared error response. The handler still refuses an unknown pet with a thrown NotFound
+# before the first event, as a code-first stream does; the refusal is not declared here because a
+# second contract declaring an error body emits a second DefaultErrorBodies holder into the one
+# Models namespace, which does not compile beside petstore's. A declared 404 beside a stream is
+# covered by StreamedOperationTests in Hardened.OpenApi.SourceGenerator.Tests.
+openapi: "3.2.0"
+info:
+  title: Pet history
+  version: "1.0.0"
+paths:
+  /pets/{petId}/events:
+    get:
+      tags:
+        - PetHistory
+      operationId: petEvents
+      summary: The pet's history, one event at a time.
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The pet's history, one event at a time.
+          content:
+            text/event-stream:
+              itemSchema:
+                $ref: '#/components/schemas/PetEvent'
+
+components:
+  schemas:
+    # Referenced from the itemSchema alone, which is what proves the slicer keeps it.
+    PetEvent:
+      type: object
+      required:
+        - petId
+        - kind
+      properties:
+        petId:
+          type: string
+        kind:
+          type: string

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
@@ -23,6 +23,9 @@
     },
     {
       "name": "Store"
+    },
+    {
+      "name": "PetHistory"
     }
   ],
   "paths": {
@@ -586,6 +589,53 @@
         }
       }
     },
+    "/pets/{petId}/events": {
+      "get": {
+        "tags": [
+          "PetHistory"
+        ],
+        "operationId": "petEvents",
+        "summary": "The pet's history, one event at a time.",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The pet's history, one event at a time.",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PetEvent"
+                  }
+                },
+                "itemSchema": {
+                  "$ref": "#/components/schemas/PetEvent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/pets/{petId}/label": {
       "get": {
         "tags": [
@@ -972,6 +1022,21 @@
         "required": [
           "id",
           "name"
+        ]
+      },
+      "PetEvent": {
+        "type": "object",
+        "properties": {
+          "petId": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petId",
+          "kind"
         ]
       },
       "PetSize": {

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -566,6 +566,12 @@ internal static class SpecModelSerializer {
         record.Add("RequestBodyRef", operation.RequestBodyRef);
         record.Add("RequestBodyType", operation.RequestBodyType);
         record.Add("ResponseContentType", operation.ResponseContentType);
+
+        // The item of a streamed response. Every field an operation carries has to cross this
+        // file or the generator never sees it: this one did not, so the build task emitted an
+        // interface returning IAsyncEnumerable<T> and the generator described the handler that
+        // implements it as an ordinary awaited body.
+        record.Add("ItemSchemaRef", operation.ItemSchemaRef);
         record.Add("RawBytesResponse", operation.RawBytesResponse);
 
         // Three flat members rather than a nested record, because the format is flat and a
@@ -676,6 +682,7 @@ internal static class SpecModelSerializer {
         RequestBodyRef = record.String("RequestBodyRef"),
         RequestBodyType = record.String("RequestBodyType"),
         ResponseContentType = record.String("ResponseContentType"),
+        ItemSchemaRef = record.String("ItemSchemaRef"),
         RawBytesResponse = record.Bool("RawBytesResponse"),
         ResponseRef = record.String("ResponseRef"),
         ResponseType = record.String("ResponseType"),

--- a/src/SourceGenerators/Hardened.Idl.Emit/Filtering/SpecSlicer.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Filtering/SpecSlicer.cs
@@ -143,6 +143,11 @@ internal static class SpecSlicer {
                 Reach(operation.ResponseRef);
                 Reach(operation.ResponseArrayItemsRef);
 
+                // The item of a streamed response, the only reference such an operation holds to
+                // its payload: without it the schema was pruned while the service interface
+                // still named it. ModelRefs.All carries the same handle for the passes that use it.
+                Reach(operation.ItemSchemaRef);
+
                 // Every declared success, not only the primary one the flat fields above name. A
                 // schema reachable solely through a second 2xx - the 202's body on a poll endpoint -
                 // is otherwise pruned as unreferenced, and the case type that carries it names a
@@ -265,6 +270,7 @@ internal static class SpecSlicer {
                 Check(operation.RequestBodyRef, from);
                 Check(operation.ResponseRef, from);
                 Check(operation.ResponseArrayItemsRef, from);
+                Check(operation.ItemSchemaRef, from);
 
                 foreach (var success in operation.SuccessResponses) {
                     Check(success.Ref, from);

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/ModelRefs.cs
@@ -128,6 +128,14 @@ internal static class ModelRefs {
                     operation.ResponseArrayItemsRef, primary + " items",
                     value => captured.ResponseArrayItemsRef = value);
 
+                // One item of a streamed response. It is the only reference a streamed operation
+                // holds to its payload - the success carries no schema of its own - and a walk
+                // without it pruned the item's schema as unreferenced while the service interface
+                // still named it: CS0234 in generated code, from a contract that was right.
+                yield return new Handle(
+                    operation.ItemSchemaRef, primary + " item",
+                    value => captured.ItemSchemaRef = value);
+
                 foreach (var error in operation.ErrorResponses) {
                     var errorCaptured = error;
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
@@ -322,6 +322,9 @@ public class SpecModelSerializerTests {
             RequestBodyRef = "#/components/schemas/CreatePetRequest",
             RequestBodyType = "object",
             ResponseContentType = "text/plain",
+            // The one field that was not here, and so the one the file silently dropped: a
+            // streamed operation's item, which the generator needs to describe the handler.
+            ItemSchemaRef = "#/components/schemas/PetEvent",
             ResponseRef = "#/components/schemas/Pet",
             ResponseType = "object",
             ResponseFormat = "json",

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecSlicerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecSlicerTests.cs
@@ -120,6 +120,55 @@ public class SpecSlicerTests {
     /// trace of <c>Dog</c> is its own <c>allOf</c> pointing back. Dropping it would compile and
     /// then fail to deserialize the response it was told to expect.
     /// </remarks>
+    /// <summary>
+    /// A schema a streamed operation reaches only through <c>itemSchema</c> is kept.
+    /// </summary>
+    /// <remarks>
+    /// The item is the only reference a streamed operation holds to its payload - the success
+    /// carries no schema of its own - and the walk did not include it, so the schema was pruned as
+    /// unreferenced while the generated service interface still named it: CS0234 in generated
+    /// code, from a contract that was right.
+    /// </remarks>
+    [Fact]
+    public void ASchemaReachedOnlyThroughAnItemSchemaIsKept() {
+        var model = OpenApiSpecParser.Parse(Streamed, "spec", CancellationToken.None)!;
+
+        var result = SpecSlicer.Apply(model, new SpecSlicer.Filter());
+
+        Assert.Equal(1, result.SchemasDropped);
+
+        var names = model.Schemas.ConvertAll(schema => schema.Name);
+
+        Assert.Contains("Reading", names);
+        Assert.DoesNotContain("Unreferenced", names);
+    }
+
+    private const string Streamed = """
+        openapi: "3.2.0"
+        info: { title: T, version: "1.0" }
+        paths:
+          /readings:
+            get:
+              tags: [Readings]
+              operationId: readings
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    text/event-stream:
+                      itemSchema: { $ref: '#/components/schemas/Reading' }
+        components:
+          schemas:
+            Reading:
+              type: object
+              properties:
+                value: { type: number }
+            Unreferenced:
+              type: object
+              properties:
+                nothing: { type: string }
+        """;
+
     [Fact]
     public void ASubtypeOfADiscriminatedBaseIsReachedThroughTheBase() {
         var model = OpenApiSpecParser.Parse(Polymorphic, "spec", CancellationToken.None)!;

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/StreamedOperationTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/StreamedOperationTests.cs
@@ -1,0 +1,202 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Hardened.SourceGeneration.Testing;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// An operation whose success is a stream, declared with OpenAPI 3.2's <c>itemSchema</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The interface half of this worked from the start: <c>ServiceInterfaceEmitter</c> read
+/// <c>ItemSchemaRef</c> and returned <c>IAsyncEnumerable&lt;T&gt;</c>. The handler half did not,
+/// because the field never crossed the intermediate file the build task hands the generator, so
+/// the bridge described the operation as an ordinary awaited body: the generated invoke method
+/// awaited the enumerable (CS9353 in generated code), the handler sat on the buffered filter, and
+/// the published document had a 200 with no content. Every test here drives the same
+/// parse-emit-serialise-generate path a build does, which is what makes them able to see that.
+/// </para>
+/// </remarks>
+public class StreamedOperationTests {
+
+    private const string Spec =
+        """
+        openapi: "3.2.0"
+        info: { title: Pets, version: "1.0" }
+        paths:
+          /pets/{petId}/events:
+            get:
+              tags: [Pet]
+              operationId: petEvents
+              parameters:
+                - name: petId
+                  in: path
+                  required: true
+                  schema: { type: string }
+              responses:
+                '200':
+                  description: The pet's history, one event at a time.
+                  content:
+                    text/event-stream:
+                      itemSchema:
+                        $ref: '#/components/schemas/PetEvent'
+                '404':
+                  description: No pet with that id.
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Problem'
+          /pets/{petId}/readings:
+            get:
+              tags: [Pet]
+              operationId: petReadings
+              parameters:
+                - name: petId
+                  in: path
+                  required: true
+                  schema: { type: string }
+              responses:
+                '200':
+                  description: One reading per line.
+                  content:
+                    application/x-ndjson:
+                      itemSchema:
+                        $ref: '#/components/schemas/PetEvent'
+        components:
+          schemas:
+            PetEvent:
+              type: object
+              required: [petId, kind]
+              properties:
+                petId: { type: string }
+                kind: { type: string }
+            Problem:
+              type: object
+              properties:
+                detail: { type: string }
+        """;
+
+    private const string Implementation =
+        """
+        [Handler]
+        public class PetServiceImpl : IPetService {
+            public async IAsyncEnumerable<PetEvent> PetEvents(string petId) {
+                await Task.Yield();
+
+                yield return new PetEvent(petId, "adopted");
+            }
+
+            public async IAsyncEnumerable<PetEvent> PetReadings(string petId) {
+                await Task.Yield();
+
+                yield return new PetEvent(petId, "weighed");
+            }
+        }
+        """;
+
+    [Fact]
+    public void TheInterfaceReturnsAStream() {
+        var generated = OpenApiGenerator.Run(Spec).AssertNoErrors().SourceContaining("petstore.g.cs");
+
+        Assert.Contains("IAsyncEnumerable<global::TestNamespace.Models.PetEvent> PetEvents(string petId)", generated);
+    }
+
+    /// <summary>
+    /// The handler hands the enumerable to the streaming filter rather than awaiting it.
+    /// </summary>
+    [Fact]
+    public void TheHandlerStreamsWithTheFramingTheContractNames() {
+        var result = OpenApiGenerator.Run(Spec).AssertNoErrors();
+
+        var events = result.SourceContaining("PetController_PetEvents");
+        var readings = result.SourceContaining("PetController_PetReadings");
+
+        Assert.Contains("AsyncEnumerableFilterWithParameters", events);
+        Assert.Contains("SseFraming.Instance", events);
+        Assert.Contains("context.Response.ResponseValue = controller.PetEvents(", events);
+        Assert.DoesNotContain("await controller.PetEvents(", events);
+
+        // Newline-delimited JSON is the filter's own default, so the code-first emitter names no
+        // framing for it and this path emits exactly the same call.
+        Assert.Contains("AsyncEnumerableFilterWithParameters", readings);
+        Assert.DoesNotContain("SseFraming", readings);
+    }
+
+    /// <summary>
+    /// The handler info says the operation streams, which is what the conditional-GET stage reads
+    /// to stand down rather than buffer an event stream.
+    /// </summary>
+    [Fact]
+    public void TheHandlerInfoSaysItStreams() {
+        var events = OpenApiGenerator.Run(Spec).AssertNoErrors().SourceContaining("PetController_PetEvents");
+
+        Assert.Contains("streamsResponse: true", events);
+    }
+
+    /// <summary>
+    /// An implementation returning <c>IAsyncEnumerable&lt;T&gt;</c> compiles against what was
+    /// generated - which is the assertion that failed before, in the generated invoke method.
+    /// </summary>
+    [Fact]
+    public void AStreamingImplementationCompiles() {
+        OpenApiGenerator.Run(Spec, OpenApiGenerator.EntryPointWithHandler(Implementation)).AssertNoErrors();
+    }
+
+    /// <summary>
+    /// The served document describes the stream the way the code-first writer does: the item under
+    /// <c>itemSchema</c>, the complete content as an array of it under <c>schema</c>, with the
+    /// contract's own description, beside the 404 the contract declares.
+    /// </summary>
+    [Fact]
+    public void TheDocumentDescribesTheStream() {
+        var result = OpenApiGenerator.Run(Spec, OpenApiGenerator.EntryPointWithHandler(Implementation))
+            .AssertNoErrors();
+
+        using var document = JsonDocument.Parse(ServedDocument(result));
+
+        var events = document.RootElement.GetProperty("paths").GetProperty("/pets/{petId}/events")
+            .GetProperty("get").GetProperty("responses");
+
+        var ok = events.GetProperty("200");
+        var media = ok.GetProperty("content").GetProperty("text/event-stream");
+        var item = media.GetProperty("itemSchema");
+        var whole = media.GetProperty("schema");
+
+        Assert.Equal("The pet's history, one event at a time.", ok.GetProperty("description").GetString());
+        Assert.Equal("#/components/schemas/PetEvent", item.GetProperty("$ref").GetString());
+        Assert.Equal("array", whole.GetProperty("type").GetString());
+        Assert.Equal(item.GetRawText(), whole.GetProperty("items").GetRawText());
+        Assert.True(events.TryGetProperty("404", out _), "the declared 404 is written beside the stream");
+
+        var readings = document.RootElement.GetProperty("paths").GetProperty("/pets/{petId}/readings")
+            .GetProperty("get").GetProperty("responses").GetProperty("200").GetProperty("content");
+
+        Assert.True(readings.TryGetProperty("application/x-ndjson", out _), "the framing is the contract's media type");
+    }
+
+    /// <summary>The document the generator embeds, inflated the way CI's extractor does it.</summary>
+    private static string ServedDocument(GeneratorResult result) {
+        var source = result.SourceContaining("OpenApiDocument");
+
+        var match = Regex.Match(source, @"new byte\[\]\s*\{(.*?)\}\s*;", RegexOptions.Singleline);
+
+        Assert.True(match.Success, "No document byte array in the generated source.");
+
+        var bytes = match.Groups[1].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(byte.Parse)
+            .ToArray();
+
+        using var compressed = new MemoryStream(bytes, writable: false);
+        using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
+        using var inflated = new MemoryStream();
+
+        gzip.CopyTo(inflated);
+
+        return Encoding.UTF8.GetString(inflated.ToArray());
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -478,12 +478,12 @@ public static class OpenApiDocumentGenerator {
             WriteSingleResponse(builder, handler, components, version, successStatus);
         }
         else if (returnTypeDeclaredThem) {
-            WriteDeclaredResponses(builder, handler, components);
+            WriteDeclaredResponses(builder, handler, components, version);
         }
         else {
             WriteSingleResponse(builder, handler, components, version, successStatus);
             builder.Append(',');
-            WriteDeclaredResponses(builder, handler, components);
+            WriteDeclaredResponses(builder, handler, components, version);
         }
 
         WriteValidationResponse(builder, handler, components);
@@ -576,7 +576,12 @@ public static class OpenApiDocumentGenerator {
     /// </para>
     /// </remarks>
     private static void WriteDeclaredResponses(
-        StringBuilder builder, RequestHandlerModel handler, SortedDictionary<string, string> components) {
+        StringBuilder builder, RequestHandlerModel handler, SortedDictionary<string, string> components,
+        OpenApiVersion version) {
+        var streamedStatus = handler.ResponseInformation.IsAsyncEnumerable
+            ? handler.ResponseInformation.DefaultStatusCode ?? 200
+            : (int?)null;
+
         var byStatus = handler.ResponseSchemas
             .GroupBy(response => response.Status)
             .OrderBy(group => group.Key);
@@ -602,7 +607,13 @@ public static class OpenApiDocumentGenerator {
 
             var bodies = group.Where(response => response.Schema != null).ToList();
 
-            if (bodies.Count > 0) {
+            // A described operation's streamed success sits in the declared set for its
+            // description and headers, and carries no schema of its own: the item is on
+            // ResponseSchema, and the streamed path writes it the way it does code-first.
+            if (group.Key == streamedStatus) {
+                WriteStreamedResponse(builder, handler, components, version);
+            }
+            else if (bodies.Count > 0) {
                 builder.Append(",\"content\":{\"").Append(JsonSchemaWriter.Escape(contentType))
                     .Append("\":{\"schema\":");
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -215,6 +215,11 @@ internal static class SpecHandlerModelBuilder {
             RequestSchema = SpecSchemaWriter.ForRef(operation.RequestBodyRef, schemas),
             ResponseSchemas = BuildResponseSchemas(operation, schemas),
 
+            // One item of a streamed response, which the document writer publishes as itemSchema
+            // and as the array of it under schema, beside the description and headers the
+            // success declares in ResponseSchemas. Null for every operation that streams nothing.
+            ResponseSchema = SpecSchemaWriter.ForRef(operation.ItemSchemaRef, schemas),
+
             // What the operation says about itself. Carried here rather than left to each caller,
             // because a handler model that has lost its summary cannot be told from one whose
             // operation never had a summary - and the document written from it is silently poorer.
@@ -375,6 +380,36 @@ internal static class SpecHandlerModelBuilder {
         OperationModel operation, IReadOnlyList<SchemaModel> schemas, string modelsNamespace,
         SpecResponseModel responseModel) {
         ITypeDefinition? returnType = null;
+
+        // A stream, ahead of everything else, exactly as ServiceInterfaceEmitter.GetReturnType
+        // decides it: itemSchema means the body is many of the item one after another, so the
+        // interface says IAsyncEnumerable<T> and this has to describe the handler that fills it the
+        // way a code-first IAsyncEnumerable<T> handler is described. IsAsync stays false because
+        // the enumerable is handed to the pipeline rather than awaited - the invoke method awaited
+        // it before, which is CS9353 in generated code - and there is no response set, because a
+        // stream's refusals are thrown before the first item, as they are code-first.
+        if (operation.ItemSchemaRef != null) {
+            var itemType = TypeDefinition.Get(
+                modelsNamespace, NamingHelper.ToPascalCase(TypeMapper.GetRefName(operation.ItemSchemaRef)));
+
+            return new ResponseInformationModel {
+                IsAsync = false,
+                IsAsyncEnumerable = true,
+                AsyncEnumerableItemType = itemType,
+                ReturnType = new GenericTypeDefinition(
+                    TypeDefinitionEnum.InterfaceDefinition,
+                    "System.Collections.Generic",
+                    "IAsyncEnumerable",
+                    new[] { itemType }),
+                StreamFraming = StreamFramingFor(operation.ResponseContentType),
+                DeclaredContentType = operation.ResponseContentType,
+                RendersAModel = true,
+                ProducedContentTypes = operation.ProducedContentTypes.Count > 0
+                    ? string.Join(",", operation.ProducedContentTypes)
+                    : null,
+                ValidationErrorStatus = DeclaredValidationStatus(operation)
+            };
+        }
 
         // The declared set, ahead of everything below, exactly as ServiceInterfaceEmitter.GetReturnType
         // decides it - because that emitter writes the signature this dispatch has to fill.
@@ -845,6 +880,21 @@ internal static class SpecHandlerModelBuilder {
     /// generated client with no branch for the 404 the contract promised. The response's own
     /// description wins over the status's standard wording.
     /// </remarks>
+    /// <summary>
+    /// The framing a described stream is sent with, from the media type the contract declares.
+    /// </summary>
+    /// <remarks>
+    /// The runtime frames a stream two ways, and a code-first handler names one with
+    /// <c>[ServerSentEvents]</c> or takes newline-delimited JSON by naming nothing. A contract names
+    /// the media type instead, so this is the same choice read from the other end:
+    /// <c>text/event-stream</c> is the event framing, and anything else is one JSON document per
+    /// line, which is what the document then declares.
+    /// </remarks>
+    private static string? StreamFramingFor(string? contentType) =>
+        string.Equals(contentType, "text/event-stream", StringComparison.OrdinalIgnoreCase)
+            ? StreamFramingNames.ServerSentEvents
+            : null;
+
     private static IReadOnlyList<ResponseSchemaModel> BuildResponseSchemas(
         OperationModel operation, IReadOnlyList<SchemaModel> schemas) {
         var result = new List<ResponseSchemaModel>();


### PR DESCRIPTION
Closes the blocker the 0.21.0-rc1000 trial filed as H-01 for the OpenAPI front end: a contract-first operation whose success is a `text/event-stream` (or `application/x-ndjson`) response with an `itemSchema` generated a service interface returning `IAsyncEnumerable<T>` and nothing behind it agreed. The generated invoke method awaited the enumerable (`CS9353` in generated code), the handler sat on the buffered filter, a schema referenced only from `itemSchema` was pruned as unreferenced (`CS0234`), and the served document described the 200 with no content. The streaming guide said a specification-first application "streams by writing the spec".

## Cause

`SpecModelSerializer` wrote every operation field but `ItemSchemaRef`, so the build task emitted the interface from a model that knew about the stream and the generator described the handler from a copy that did not. The two slicer walks and the shared `ModelRefs.All` had the same gap.

## Change

- `SpecModelSerializer` carries `ItemSchemaRef`; the round-trip test's fully populated model now populates it, and fails without the change.
- `SpecHandlerModelBuilder.BuildResponseInfo` describes a streamed operation ahead of everything else, the way the code-first transform describes an `IAsyncEnumerable<T>` handler: `IsAsyncEnumerable`, the item type, `IAsyncEnumerable<T>` as the return type, the framing read from the contract's media type (`text/event-stream` is the event framing, anything else is newline-delimited JSON, the filter's default), and no response set, since a stream's refusals are thrown before the first item. `ResponseSchema` carries the item for the document writer.
- `OpenApiDocumentGenerator.WriteDeclaredResponses` writes a streamed success from inside the declared set, so a described operation keeps its own description and headers while the content is `schema` (the array, from #287) and `itemSchema`.
- `SpecSlicer`'s two reference walks and `ModelRefs.All` reach the item schema.
- Fixture: `Hardened.IntegrationTests.OpenApi.SUT` gains `Specs/events.yaml`, a second contract on the 3.2 banner (`petstore.yaml` stays at 3.0.0 because its `nullable` spelling is the 3.0 one), `PetHistoryServiceImpl` returning `IAsyncEnumerable<PetEvent>` with a thrown `NotFound` before the first event, and `PetEventsTests`: exact SSE framing, the 404 before the first event, and the served document's `schema`/`itemSchema` with the contract's description. The tracked `openapi/OpenApiTestApp.json` gains the operation.

## What the readers now get

From the fixture's exported document: Refitter `main` declares `IAsyncEnumerable<PetEvent> PetEvents(string petId)`; Refitter 2.1.3 declares `Task<IApiResponse<ICollection<PetEvent>>>`; Kiota returns a `Stream` as it does for a code-first stream.

## Found on the way, not fixed here

A second contract in one project that declares an error body emits a second `DefaultErrorBodies` holder into the one `Models` namespace, which does not compile beside the first's (`CS0101`). The fixture's second contract therefore declares no 404; `StreamedOperationTests.TheDocumentDescribesTheStream` covers a declared 404 beside a stream through the generator harness instead.

Smithy is untouched: the model has no spelling for a stream, so `@streaming` on a union still generates a union struct and the document a single JSON object. That needs a decision on the spelling first.

## Verification

- CI-parity build (`Release`, `ContinuousIntegrationBuild=true`, Smithy CLI 1.73.0 on PATH): 0 errors; the one warning is the standing `HSMT031` from the AWS JSON fixture.
- Full suite against that build: 39 projects, 7279 tests, 0 failures.
- New tests: `StreamedOperationTests` (5) in `Hardened.OpenApi.SourceGenerator.Tests`, driving the same parse, emit, serialise, generate path a build does; `SpecSlicerTests.ASchemaReachedOnlyThroughAnItemSchemaIsKept`; `PetEventsTests` (3) in the OpenApi fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)