### PR TITLE
Stream a Smithy @streaming union as server-sent events

### DIFF
--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/PetEventsTests.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/PetEventsTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Serializer;
+
+namespace Hardened.IntegrationTests.Smithy.SUT.Tests;
+
+/// <summary>
+/// An event stream declared with Smithy's own spelling, a union under <c>@streaming</c>, end to
+/// end: the wire, the refusal before the first event, and the document.
+/// </summary>
+/// <remarks>
+/// The union is the item. The generated <c>PetEventStream</c> implements <c>ISseEvent</c>, so the
+/// framing writes the member's name as the <c>event:</c> field and the member's own JSON as
+/// <c>data:</c>, which is what a browser's <c>EventSource</c> dispatches on.
+/// </remarks>
+public class PetEventsTests {
+
+    [HardenedTest]
+    public async Task EachMemberIsAnEventNamedForIt(ITestWebApp app) {
+        var response = await app.Get("/pets/1/events");
+
+        response.Assert.Ok();
+
+        Assert.Equal(
+            KnownContentType.EventStream, response.Headers[KnownHeaders.ContentType].ToString());
+
+        Assert.Equal(
+            """
+            event: adopted
+            data: {"petId":"1","by":"pia"}
+
+            event: weighed
+            data: {"petId":"1","grams":4200}
+
+
+            """.ReplaceLineEndings("\n"),
+            await BodyOf(response));
+    }
+
+    [HardenedTest]
+    public async Task ARefusalBeforeTheFirstEventIsANotFound(ITestWebApp app) {
+        var response = await app.Get("/pets/missing/events");
+
+        Assert.Equal(404, response.StatusCode);
+        Assert.StartsWith("application/json", response.Headers[KnownHeaders.ContentType].ToString());
+        Assert.Contains("No pet has id missing.", await BodyOf(response));
+    }
+
+    /// <summary>
+    /// The document says what the wire does: the item is the union, published as the choice of
+    /// its members, under <c>itemSchema</c> and as an array under <c>schema</c>.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheDocumentDescribesTheStreamAsTheChoiceOfItsMembers(ITestWebApp app) {
+        var response = await app.Get("/openapi.json");
+
+        response.Assert.Ok();
+
+        using var document = JsonDocument.Parse(await response.ReadTextAsync());
+
+        var media = document.RootElement.GetProperty("paths").GetProperty("/pets/{petId}/events")
+            .GetProperty("get").GetProperty("responses").GetProperty("200")
+            .GetProperty("content").GetProperty("text/event-stream");
+
+        var item = media.GetProperty("itemSchema");
+        var whole = media.GetProperty("schema");
+
+        Assert.Equal("#/components/schemas/PetEventStream", item.GetProperty("$ref").GetString());
+        Assert.Equal("array", whole.GetProperty("type").GetString());
+        Assert.Equal(item.GetRawText(), whole.GetProperty("items").GetRawText());
+
+        var union = document.RootElement.GetProperty("components").GetProperty("schemas")
+            .GetProperty("PetEventStream").GetProperty("oneOf");
+
+        Assert.Equal(
+            ["#/components/schemas/PetAdopted", "#/components/schemas/PetWeighed"],
+            union.EnumerateArray().Select(branch => branch.GetProperty("$ref").GetString()));
+    }
+
+    private static async Task<string> BodyOf(TestWebResponse response) {
+        response.Body.Position = 0;
+
+        using var reader = new StreamReader(response.Body, leaveOpen: true);
+
+        return await reader.ReadToEndAsync();
+    }
+}

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/PetStoreServiceImpl.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/PetStoreServiceImpl.cs
@@ -1,6 +1,7 @@
 using Hardened.IntegrationTests.Smithy.SUT.Models;
 using Hardened.IntegrationTests.Smithy.SUT.Services;
 using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Abstract.Responses;
 
 namespace Hardened.IntegrationTests.Smithy.SUT;
 
@@ -81,4 +82,19 @@ public class PetStoreServiceImpl : IPetStoreService {
     /// </summary>
     public Task<GetSecuredPetOutput> GetSecuredPet() =>
         Task.FromResult(new GetSecuredPetOutput(Pets[0]));
+
+    /// <summary>
+    /// The one streamed operation: an event stream declared with a @streaming union. The refusal
+    /// is thrown before the first event, which is the only place a stream can refuse.
+    /// </summary>
+    public async IAsyncEnumerable<PetEventStream> PetEvents(string petId) {
+        if (petId == "missing") {
+            throw new NotFound("pet", $"No pet has id {petId}.").AsException();
+        }
+
+        await Task.Yield();
+
+        yield return new PetAdopted(petId, "pia");
+        yield return new PetWeighed(petId, 4200);
+    }
 }

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/Specs/petstore.smithy
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/Specs/petstore.smithy
@@ -14,7 +14,7 @@ use hardened.api#timeout
 @httpBearerAuth
 service PetStore {
     version: "2024-01-01"
-    operations: [GetPet, ListPets, CreatePet, GetSecuredPet]
+    operations: [GetPet, ListPets, CreatePet, GetSecuredPet, PetEvents]
 }
 
 @documentation("Requires an authenticated caller.")
@@ -158,4 +158,48 @@ structure Throttled {
 
     @range(min: 0)
     retryAfterSeconds: Integer
+}
+
+/// One event in a pet's history: it was adopted.
+structure PetAdopted {
+    @required
+    petId: String
+
+    @required
+    by: String
+}
+
+/// One event in a pet's history: it was weighed.
+structure PetWeighed {
+    @required
+    petId: String
+
+    @required
+    grams: Integer
+}
+
+/// Smithy's own spelling for an event stream: a union under @streaming, one member per kind of
+/// event. The generated interface returns IAsyncEnumerable<PetEventStream>, the response is framed
+/// as server-sent events, and the member name is written as the event: field beside each item.
+@streaming
+union PetEventStream {
+    adopted: PetAdopted
+    weighed: PetWeighed
+}
+
+@documentation("The pet's history, one event at a time.")
+@http(method: "GET", uri: "/pets/{petId}/events", code: 200)
+@readonly
+@auth([])
+operation PetEvents {
+    input := {
+        @httpLabel
+        @required
+        petId: String
+    }
+    output := {
+        @required
+        @httpPayload
+        events: PetEventStream
+    }
 }

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
@@ -324,6 +324,53 @@
         },
         "x-hardened-timeout": 2000
       }
+    },
+    "/pets/{petId}/events": {
+      "get": {
+        "tags": [
+          "PetStore"
+        ],
+        "operationId": "PetEvents",
+        "description": "The pet's history, one event at a time.",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PetEventStream"
+                  }
+                },
+                "itemSchema": {
+                  "$ref": "#/components/schemas/PetEventStream"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -345,7 +392,15 @@
         ]
       },
       "Attribute": {
-        "type": "object"
+        "oneOf": [
+          {
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "type": "string"
+          }
+        ]
       },
       "CreatePetInput": {
         "type": "object",
@@ -526,6 +581,33 @@
           "name"
         ]
       },
+      "PetAdopted": {
+        "type": "object",
+        "description": "One event in a pet's history: it was adopted.",
+        "properties": {
+          "petId": {
+            "type": "string"
+          },
+          "by": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petId",
+          "by"
+        ]
+      },
+      "PetEventStream": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PetAdopted"
+          },
+          {
+            "$ref": "#/components/schemas/PetWeighed"
+          }
+        ],
+        "description": "Smithy's own spelling for an event stream: a union under @streaming, one member per kind of\nevent. The generated interface returns IAsyncEnumerable<PetEventStream>, the response is framed\nas server-sent events, and the member name is written as the event: field beside each item."
+      },
       "PetKind": {
         "type": "string",
         "enum": [
@@ -543,6 +625,22 @@
         },
         "required": [
           "message"
+        ]
+      },
+      "PetWeighed": {
+        "type": "object",
+        "description": "One event in a pet's history: it was weighed.",
+        "properties": {
+          "petId": {
+            "type": "string"
+          },
+          "grams": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "petId",
+          "grams"
         ]
       },
       "RequestValidationError": {

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ChoiceBranchModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ChoiceBranchModel.cs
@@ -1,64 +1,63 @@
 namespace Hardened.Generation.Models;
 
 /// <summary>
-/// One of the things a <c>oneOf</c> permits.
+/// One branch of a <see cref="SchemaKind.OneOf"/> schema or of a property that offers a choice.
 /// </summary>
-/// <remarks>
-/// <para>
-/// A branch is a named schema or an inline type, and it has to be both because published
-/// descriptions are mostly the second kind: of 338 undiscriminated choices across the corpus, 200
-/// name nothing at all - <c>oneOf: [string, boolean]</c> and its variations - and another 45 mix a
-/// reference with an inline type. Modelling a branch as a reference covers 28% of them and silently
-/// drops the rest, which reads as a <c>oneOf</c> with one branch and produces no type.
-/// </para>
-/// <para>
-/// The two are exclusive: <see cref="Ref"/> names a schema the document declares, and
-/// <see cref="Type"/> is a type written in place. Nothing carries both.
-/// </para>
-/// </remarks>
 internal class ChoiceBranchModel : IEquatable<ChoiceBranchModel> {
 
-    /// <summary>The schema this branch names, or null for an inline one.</summary>
     public string? Ref { get; set; }
 
-    /// <summary>The spec type written in place, or null for a reference.</summary>
     public string? Type { get; set; }
 
-    /// <summary>The inline type's format, which decides what it maps to.</summary>
     public string? Format { get; set; }
 
     /// <summary>
-    /// The branch as one string, for the model file.
+    /// The name the description gives this branch, or null where it gives none.
     /// </summary>
     /// <remarks>
-    /// A reference is written as itself; an inline type is prefixed with <c>=</c>, which a
-    /// reference cannot start with because one always begins <c>#/</c>. That keeps the whole list
-    /// on the existing string-list encoding rather than adding a record type and the ordering
-    /// machinery that goes with it.
+    /// A Smithy union names every member, and a streamed union writes that name as the
+    /// <c>event:</c> field beside each item, which is what tells a client which member arrived. An
+    /// OpenAPI <c>oneOf</c> lists bare schemas and has nothing to put here.
     /// </remarks>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The branch as one string, for the intermediate file: a reference, or <c>=type:format</c>,
+    /// with <c>|name</c> after either when the branch is named.
+    /// </summary>
     public string Encoded =>
-        Ref ?? "=" + Type + (Format == null ? "" : ":" + Format);
+        (Ref ?? "=" + Type + (Format == null ? "" : ":" + Format)) + (Name == null ? "" : "|" + Name);
 
     public static ChoiceBranchModel Decode(string encoded) {
+        string? name = null;
+        var bar = encoded.LastIndexOf('|');
+
+        if (bar >= 0) {
+            name = Empty(encoded.Substring(bar + 1));
+            encoded = encoded.Substring(0, bar);
+        }
+
         if (!encoded.StartsWith("=", StringComparison.Ordinal)) {
-            return new ChoiceBranchModel { Ref = encoded };
+            return new ChoiceBranchModel { Ref = encoded, Name = name };
         }
 
         var body = encoded.Substring(1);
         var colon = body.IndexOf(':');
 
         return colon < 0
-            ? new ChoiceBranchModel { Type = Empty(body) }
+            ? new ChoiceBranchModel { Type = Empty(body), Name = name }
             : new ChoiceBranchModel {
                 Type = Empty(body.Substring(0, colon)),
-                Format = Empty(body.Substring(colon + 1))
+                Format = Empty(body.Substring(colon + 1)),
+                Name = name
             };
     }
 
     private static string? Empty(string value) => value.Length == 0 ? null : value;
 
     public bool Equals(ChoiceBranchModel? other) =>
-        other is not null && Ref == other.Ref && Type == other.Type && Format == other.Format;
+        other is not null && Ref == other.Ref && Type == other.Type && Format == other.Format &&
+        Name == other.Name;
 
     public override bool Equals(object? obj) => Equals(obj as ChoiceBranchModel);
 
@@ -66,7 +65,8 @@ internal class ChoiceBranchModel : IEquatable<ChoiceBranchModel> {
         unchecked {
             var hash = Ref?.GetHashCode() ?? 0;
             hash = (hash * 397) ^ (Type?.GetHashCode() ?? 0);
-            return (hash * 397) ^ (Format?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ (Format?.GetHashCode() ?? 0);
+            return (hash * 397) ^ (Name?.GetHashCode() ?? 0);
         }
     }
 }

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -350,6 +350,11 @@ internal static class SpecModelSerializer {
         record.Add("DictionaryValueType", schema.DictionaryValueType);
         record.Add("DictionaryValueRef", schema.DictionaryValueRef);
         record.Add("DictionaryValueFormat", schema.DictionaryValueFormat);
+
+        // A union's branches, which did not cross this file: the emitter writes the union on the
+        // task side and never missed them, but the document is written on the generator side, and
+        // a union it could not see was published as a bare object.
+        record.Add("OneOf", Encode(schema.OneOf));
         record.WriteTo(builder);
 
         for (var i = 0; i < schema.EnumValues.Count; i++) {
@@ -404,6 +409,9 @@ internal static class SpecModelSerializer {
             case nameof(SchemaKind.Array): return SchemaKind.Array;
             case nameof(SchemaKind.Primitive): return SchemaKind.Primitive;
             case nameof(SchemaKind.Dictionary): return SchemaKind.Dictionary;
+            // Read as an object before, which is what a union's branches not crossing the file
+            // looked like from this side: a kind with nothing to hold.
+            case nameof(SchemaKind.OneOf): return SchemaKind.OneOf;
             default: return SchemaKind.Object;
         }
     }
@@ -430,6 +438,7 @@ internal static class SpecModelSerializer {
         IsErrorShape = record.Bool("IsErrorShape"),
         EnumMemberNamesAreDeclared = record.Bool("EnumMemberNamesAreDeclared"),
         DiscriminatorPropertyName = record.String("DiscriminatorPropertyName"),
+        OneOf = Decode(record.Strings("OneOf")),
         BaseRef = record.String("BaseRef"),
         Type = record.String("Type"),
         Format = record.String("Format"),

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/OneOfEmitter.cs
@@ -65,7 +65,7 @@ internal static class OneOfEmitter {
         NamingHelper.ToPascalCase(schemaName) + "Converter";
 
     public static ClassDefinition Emit(
-        IConstructContainer container, SchemaModel schema, string modelsNamespace) {
+        IConstructContainer container, SchemaModel schema, string modelsNamespace, bool streamed = false) {
         var name = NamingHelper.ToPascalCase(schema.Name);
         var branches = Branches(schema, modelsNamespace);
         var readable = Readable(branches);
@@ -84,7 +84,96 @@ internal static class OneOfEmitter {
         EmitConversions(type, name, branches);
         EmitToString(type);
 
+        if (streamed) {
+            EmitSseEvent(type, NamedBranches(schema, modelsNamespace));
+        }
+
         return type;
+    }
+
+    /// <summary>
+    /// A union that is the item of a streamed response is an event: the member it holds is the
+    /// payload, and the member's name is the <c>event:</c> field beside it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The SSE framing already reads <c>ISseEvent</c> off whatever a handler yields and writes the
+    /// event name beside the payload rather than inside it, so implementing the interface here is
+    /// the whole of the runtime side: the handler yields the union, the framing writes
+    /// <c>event: adopted</c> and then <c>data:</c> with the member's own JSON.
+    /// </para>
+    /// <para>
+    /// Explicit implementations, so the four members do not appear on the union's own surface -
+    /// <c>Value</c> is its surface, and a handler that reads <c>Data</c> off it would be reading
+    /// the same thing under a name that belongs to the framing.
+    /// </para>
+    /// </remarks>
+    private static void EmitSseEvent(ClassDefinition type, List<KeyValuePair<string, string?>> branches) {
+        type.AddBaseType(TypeDefinition.Get(SseEventNamespace, "ISseEvent"));
+
+        var sseEvent = "global::" + SseEventNamespace + ".ISseEvent";
+
+        type.AddComponent(
+            new CodeOutputComponent($"object? {sseEvent}.Data => Value;") { Indented = true });
+        type.AddComponent(
+            new CodeOutputComponent($"string? {sseEvent}.Id => null;") { Indented = true });
+        type.AddComponent(
+            new CodeOutputComponent($"int? {sseEvent}.Retry => null;") { Indented = true });
+
+        var arms = new List<string>();
+
+        foreach (var branch in branches) {
+            if (branch.Value != null) {
+                arms.Add($"{branch.Key} _ => \"{branch.Value}\"");
+            }
+        }
+
+        arms.Add("_ => null");
+
+        type.AddComponent(
+            new CodeOutputComponent(
+                $"string? {sseEvent}.Event => Value switch {{ {string.Join(", ", arms)} }};") {
+                Indented = true
+            });
+    }
+
+    private const string SseEventNamespace = "Hardened.Requests.Abstract.Serializer";
+
+    /// <summary>
+    /// The branch types with the names the description gave them, one entry per type.
+    /// </summary>
+    /// <remarks>
+    /// The same walk as <see cref="Branches"/>, keeping the name. Two members of one type cannot be
+    /// told apart by the value alone, and the wrapper already cannot hold them - the implicit
+    /// conversions would collide - so the first name a type was given is the one written.
+    /// </remarks>
+    public static List<KeyValuePair<string, string?>> NamedBranches(SchemaModel schema, string modelsNamespace) {
+        var branches = new List<KeyValuePair<string, string?>>();
+
+        foreach (var described in schema.OneOf) {
+            var branch = TypeMapper.QualifiedName(
+                modelsNamespace, ChoiceResolution.CSharpType(described), false);
+
+            if (branch.EndsWith("JsonElement", System.StringComparison.Ordinal)) {
+                continue;
+            }
+
+            var known = false;
+
+            foreach (var existing in branches) {
+                if (existing.Key == branch) {
+                    known = true;
+
+                    break;
+                }
+            }
+
+            if (!known) {
+                branches.Add(new KeyValuePair<string, string?>(branch, described.Name));
+            }
+        }
+
+        return branches;
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
@@ -25,11 +25,13 @@ internal static class SchemaEmitter {
     /// </summary>
     public static IOutputComponent? Emit(
         IConstructContainer container, SchemaModel schema, string modelsNamespace, PatternRegistry patterns,
-        IReadOnlyList<SchemaModel>? allSchemas = null) =>
+        IReadOnlyList<SchemaModel>? allSchemas = null, ICollection<string>? streamedItems = null) =>
         schema.Kind switch {
             SchemaKind.Object => EmitRecord(container, schema, modelsNamespace, patterns, allSchemas),
             SchemaKind.Enum => EmitEnumWithConverter(container, schema, modelsNamespace),
-            SchemaKind.OneOf => EmitOneOf(container, schema, modelsNamespace, allSchemas),
+            SchemaKind.OneOf => EmitOneOf(
+                container, schema, modelsNamespace, allSchemas,
+                streamedItems != null && streamedItems.Contains(NamingHelper.ToPascalCase(schema.Name))),
             _ => null,
         };
 
@@ -50,8 +52,8 @@ internal static class SchemaEmitter {
     /// </summary>
     private static IOutputComponent EmitOneOf(
         IConstructContainer container, SchemaModel schema, string modelsNamespace,
-        IReadOnlyList<SchemaModel>? allSchemas) {
-        var type = OneOfEmitter.Emit(container, schema, modelsNamespace);
+        IReadOnlyList<SchemaModel>? allSchemas, bool streamed) {
+        var type = OneOfEmitter.Emit(container, schema, modelsNamespace, streamed);
 
         OneOfConverterEmitter.Emit(
             container, schema, modelsNamespace,

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
@@ -56,9 +56,21 @@ internal static class SpecFileEmitter {
         // it uses and the [GeneratedRegex] members are written from what was registered.
         var patterns = new PatternRegistry(rootNamespace + "." + ValidationNamespace, model.FileName);
 
+        // The schemas that are the item of a streamed response. A union among them is an event
+        // stream, and is emitted as an event as well as a union.
+        var streamedItems = new HashSet<string>(System.StringComparer.Ordinal);
+
+        foreach (var service in model.Services) {
+            foreach (var operation in service.Operations) {
+                if (operation.ItemSchemaRef != null) {
+                    streamedItems.Add(NamingHelper.ToPascalCase(TypeMapper.GetRefName(operation.ItemSchemaRef)));
+                }
+            }
+        }
+
         foreach (var schema in model.Schemas) {
             Coverage.Apply(
-                SchemaEmitter.Emit(models, schema, modelsNamespace, patterns, model.Schemas),
+                SchemaEmitter.Emit(models, schema, modelsNamespace, patterns, model.Schemas, streamedItems),
                 excludeFromCoverage);
         }
 

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
@@ -251,6 +251,12 @@ public class SpecModelSerializerTests {
     /// </summary>
     private static ServiceSpecModel FullyPopulated() {
         var property = new PropertyModel {
+            // A named branch and a bare one, because the name is optional and rides on the same
+            // encoded string as the reference.
+            OneOf = {
+                new ChoiceBranchModel { Ref = "#/components/schemas/Tag", Name = "tag" },
+                new ChoiceBranchModel { Type = "string", Format = "uuid" },
+            },
             Name = "prop",
             Description = "What the property means.",
             Type = "string",
@@ -388,6 +394,16 @@ public class SpecModelSerializerTests {
                     Format = "custom",
                 },
                 new SchemaModel { Name = "PetStatus", Kind = SchemaKind.Enum, EnumValues = { "available", "sold" } },
+                // A union, whose branches did not cross the file at all before: every member is
+                // named, as a Smithy union names them.
+                new SchemaModel {
+                    Name = "PetEvent",
+                    Kind = SchemaKind.OneOf,
+                    OneOf = {
+                        new ChoiceBranchModel { Ref = "#/components/schemas/Adopted", Name = "adopted" },
+                        new ChoiceBranchModel { Type = "string", Name = "note" },
+                    },
+                },
             },
             Services = { new ServiceModel { Tag = "Pet", TagDescription = "Everything about pets.", Operations = { operation } } },
             FilterTypes = {

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/StreamedUnionTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/StreamedUnionTests.cs
@@ -1,0 +1,127 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Hardened.SourceGeneration.Testing;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// A stream whose item is a choice of schemas, which is what a Smithy <c>@streaming</c> union
+/// arrives as and what an OpenAPI <c>oneOf</c> under <c>itemSchema</c> spells directly.
+/// </summary>
+/// <remarks>
+/// The union is emitted as an event as well as a union: it implements <c>ISseEvent</c> so the
+/// framing writes the member it holds as <c>data:</c> and, where the description named the
+/// member, that name as <c>event:</c>. An OpenAPI <c>oneOf</c> names nothing, so the event field
+/// stays empty here; the Smithy fixture in the integration suite carries the named case.
+/// </remarks>
+public class StreamedUnionTests {
+
+    private const string Spec =
+        """
+        openapi: "3.2.0"
+        info: { title: Pets, version: "1.0" }
+        paths:
+          /pets/{petId}/events:
+            get:
+              tags: [Pet]
+              operationId: petEvents
+              parameters:
+                - name: petId
+                  in: path
+                  required: true
+                  schema: { type: string }
+              responses:
+                '200':
+                  description: The pet's history, one event at a time.
+                  content:
+                    text/event-stream:
+                      itemSchema:
+                        $ref: '#/components/schemas/PetEvent'
+        components:
+          schemas:
+            PetEvent:
+              oneOf:
+                - $ref: '#/components/schemas/PetAdopted'
+                - $ref: '#/components/schemas/PetWeighed'
+            PetAdopted:
+              type: object
+              required: [by]
+              properties:
+                by: { type: string }
+            PetWeighed:
+              type: object
+              required: [grams]
+              properties:
+                grams: { type: integer }
+        """;
+
+    private const string Implementation =
+        """
+        [Handler]
+        public class PetServiceImpl : IPetService {
+            public async IAsyncEnumerable<PetEvent> PetEvents(string petId) {
+                await Task.Yield();
+
+                yield return new PetAdopted("pia");
+                yield return new PetWeighed(4200);
+            }
+        }
+        """;
+
+    [Fact]
+    public void TheStreamedUnionIsAnEvent() {
+        var generated = OpenApiGenerator.Run(Spec).AssertNoErrors().SourceContaining("petstore.g.cs");
+
+        Assert.Contains("partial struct PetEvent : global::Hardened.Requests.Abstract.Serializer.ISseEvent", generated);
+        Assert.Contains("ISseEvent.Data => Value;", generated);
+        Assert.Contains("ISseEvent.Event => Value switch { _ => null };", generated);
+    }
+
+    [Fact]
+    public void AStreamingImplementationCompiles() {
+        OpenApiGenerator.Run(Spec, OpenApiGenerator.EntryPointWithHandler(Implementation)).AssertNoErrors();
+    }
+
+    /// <summary>
+    /// The union is published as the choice it is. Before, a union crossed to the document writer
+    /// as a bare object, because its branches never crossed the intermediate file.
+    /// </summary>
+    [Fact]
+    public void TheDocumentPublishesTheUnionAsAChoice() {
+        var result = OpenApiGenerator.Run(Spec, OpenApiGenerator.EntryPointWithHandler(Implementation))
+            .AssertNoErrors();
+
+        using var document = JsonDocument.Parse(ServedDocument(result));
+
+        var union = document.RootElement.GetProperty("components").GetProperty("schemas")
+            .GetProperty("PetEvent").GetProperty("oneOf");
+
+        Assert.Equal(
+            ["#/components/schemas/PetAdopted", "#/components/schemas/PetWeighed"],
+            union.EnumerateArray().Select(branch => branch.GetProperty("$ref").GetString()));
+    }
+
+    private static string ServedDocument(GeneratorResult result) {
+        var source = result.SourceContaining("OpenApiDocument");
+
+        var match = Regex.Match(source, @"new byte\[\]\s*\{(.*?)\}\s*;", RegexOptions.Singleline);
+
+        Assert.True(match.Success, "No document byte array in the generated source.");
+
+        var bytes = match.Groups[1].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(byte.Parse)
+            .ToArray();
+
+        using var compressed = new MemoryStream(bytes, writable: false);
+        using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
+        using var inflated = new MemoryStream();
+
+        gzip.CopyTo(inflated);
+
+        return Encoding.UTF8.GetString(inflated.ToArray());
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/Hardened.OpenApiDocument.BuildTask.Tests.csproj
+++ b/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/Hardened.OpenApiDocument.BuildTask.Tests.csproj
@@ -19,6 +19,7 @@
         <ProjectReference Include="..\..\IntegrationTests\Web\Hardened.IntegrationTests.WebApp.SUT\Hardened.IntegrationTests.WebApp.SUT.csproj"/>
         <ProjectReference Include="..\..\IntegrationTests\OpenApi\Hardened.IntegrationTests.OpenApi.SUT\Hardened.IntegrationTests.OpenApi.SUT.csproj"/>
         <ProjectReference Include="..\..\IntegrationTests\Smithy\Hardened.IntegrationTests.Smithy.SUT\Hardened.IntegrationTests.Smithy.SUT.csproj"/>
+                <ProjectReference Include="..\..\IntegrationTests\OpenApi\Hardened.IntegrationTests.OpenApi.ResponseModel.SUT\Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/TaskHarness.cs
+++ b/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/TaskHarness.cs
@@ -31,6 +31,12 @@ internal sealed class TaskHarness : IDisposable {
 
     public const string SmithyApp = "Hardened.IntegrationTests.Smithy.SUT";
 
+    /// <summary>
+    /// The one application that streams nothing. The other three each declare a streamed
+    /// response, so a test about the absence of one has to run over this.
+    /// </summary>
+    public const string LabelsApp = "Hardened.IntegrationTests.OpenApi.ResponseModel.SUT";
+
     public Result Run(string assembly, string output, string version = "", string prefix = "HRDOA") {
         var engine = new RecordingBuildEngine();
 

--- a/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/WriteOpenApiDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApiDocument.BuildTask.Tests/WriteOpenApiDocumentTests.cs
@@ -227,12 +227,12 @@ public class WriteOpenApiDocumentTests : IDisposable {
     }
 
     /// <remarks>
-    /// Nothing about <em>lowering</em>, which is what this measures. The Smithy application also
-    /// repeats an operation key, and 031 says so on every export of it whatever the version.
+    /// The labels application, because it is the one with no streamed response: the web, OpenAPI
+    /// and Smithy applications each declare one now, and lowering any of them names it.
     /// </remarks>
     [Fact]
     public void LoweringAnApplicationWithNoStreamingWarnsNothing() {
-        var result = _harness.Run(TaskHarness.Fixture(TaskHarness.SmithyApp), "lowered.json", version: "3.0.0");
+        var result = _harness.Run(TaskHarness.Fixture(TaskHarness.LabelsApp), "lowered.json", version: "3.0.0");
 
         Assert.True(result.Succeeded, result.ErrorText);
         Assert.DoesNotContain(WriteOpenApiDocument.StreamLostItemSchemaCode, result.WarningText);

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/Fixtures/event-stream.json
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/Fixtures/event-stream.json
@@ -1,0 +1,146 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.example.events#Events": {
+            "type": "service",
+            "version": "2024-01-01",
+            "operations": [
+                {
+                    "target": "com.example.events#GetPet"
+                },
+                {
+                    "target": "com.example.events#PetEvents"
+                }
+            ]
+        },
+        "com.example.events#GetPet": {
+            "type": "operation",
+            "input": {
+                "target": "com.example.events#GetPetInput"
+            },
+            "output": {
+                "target": "com.example.events#Pet"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/pets/{petId}",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.example.events#GetPetInput": {
+            "type": "structure",
+            "members": {
+                "petId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.example.events#Pet": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.example.events#PetAdopted": {
+            "type": "structure",
+            "members": {
+                "petId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.example.events#PetEventStream": {
+            "type": "union",
+            "members": {
+                "adopted": {
+                    "target": "com.example.events#PetAdopted"
+                },
+                "weighed": {
+                    "target": "com.example.events#PetWeighed",
+                    "traits": {
+                        "smithy.api#jsonName": "weighed-in"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#streaming": {}
+            }
+        },
+        "com.example.events#PetEvents": {
+            "type": "operation",
+            "input": {
+                "target": "com.example.events#PetEventsInput"
+            },
+            "output": {
+                "target": "com.example.events#PetEventsOutput"
+            },
+            "traits": {
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/pets/{petId}/events",
+                    "code": 200
+                },
+                "smithy.api#readonly": {}
+            }
+        },
+        "com.example.events#PetEventsInput": {
+            "type": "structure",
+            "members": {
+                "petId": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.example.events#PetEventsOutput": {
+            "type": "structure",
+            "members": {
+                "events": {
+                    "target": "com.example.events#PetEventStream",
+                    "traits": {
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.example.events#PetWeighed": {
+            "type": "structure",
+            "members": {
+                "grams": {
+                    "target": "smithy.api#Integer",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/Fixtures/event-stream.smithy
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/Fixtures/event-stream.smithy
@@ -1,0 +1,58 @@
+$version: "2"
+
+namespace com.example.events
+
+// A service with one streamed operation, for the parser tests: the payload is a union under
+// @streaming, which is Smithy's own spelling for an event stream.
+service Events {
+    version: "2024-01-01"
+    operations: [GetPet, PetEvents]
+}
+
+structure Pet {
+    @required
+    id: String
+}
+
+structure PetAdopted {
+    @required
+    petId: String
+}
+
+structure PetWeighed {
+    @required
+    grams: Integer
+}
+
+@streaming
+union PetEventStream {
+    adopted: PetAdopted
+    @jsonName("weighed-in")
+    weighed: PetWeighed
+}
+
+@http(method: "GET", uri: "/pets/{petId}", code: 200)
+@readonly
+operation GetPet {
+    input := {
+        @httpLabel
+        @required
+        petId: String
+    }
+    output: Pet
+}
+
+@http(method: "GET", uri: "/pets/{petId}/events", code: 200)
+@readonly
+operation PetEvents {
+    input := {
+        @httpLabel
+        @required
+        petId: String
+    }
+    output := {
+        @required
+        @httpPayload
+        events: PetEventStream
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyEventStreamTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyEventStreamTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Hardened.Generation.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// A union under <c>@streaming</c>, which is Smithy's own spelling for an event stream, read as
+/// the streamed response it is: the union is the item, framed as server-sent events.
+/// </summary>
+/// <remarks>
+/// Before this the trait was in no table, so it was reported as one this generator does not
+/// model and the payload was read as a single JSON object: a <c>Task&lt;PetEventStream&gt;</c>
+/// on the interface and one document where the model promised many.
+/// </remarks>
+public class SmithyEventStreamTests {
+
+    private static string Fixture() =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "event-stream.json"));
+
+    private static ServiceSpecModel Model(List<string> diagnostics) {
+        var model = SmithySpecParser.Parse(Fixture(), "event-stream", diagnostics);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private static OperationModel Operation(string operationId) =>
+        Model(new List<string>()).Services
+            .SelectMany(service => service.Operations)
+            .Single(operation => operation.OperationId == operationId);
+
+    [Fact]
+    public void AStreamingUnionPayloadIsTheItemOfAStream() {
+        var operation = Operation("PetEvents");
+
+        Assert.Equal("#/components/schemas/PetEventStream", operation.ItemSchemaRef);
+        Assert.Equal("text/event-stream", operation.ResponseContentType);
+
+        // The item schema is what a stream has instead of a response schema, not as well as.
+        Assert.Null(operation.ResponseRef);
+        Assert.False(operation.ResponseIsArray);
+    }
+
+    [Fact]
+    public void AnUnstreamedOperationIsUntouched() {
+        var operation = Operation("GetPet");
+
+        Assert.Null(operation.ItemSchemaRef);
+        Assert.Equal("#/components/schemas/Pet", operation.ResponseRef);
+    }
+
+    /// <summary>
+    /// Each member's wire name rides with its branch, which is what becomes the <c>event:</c>
+    /// field; <c>@jsonName</c> renames it the way it renames a property.
+    /// </summary>
+    [Fact]
+    public void TheUnionsMembersKeepTheirNames() {
+        var union = Model(new List<string>()).Schemas.Single(schema => schema.Name == "PetEventStream");
+
+        Assert.Equal(SchemaKind.OneOf, union.Kind);
+        Assert.Equal(
+            new[] { "#/components/schemas/PetAdopted as adopted", "#/components/schemas/PetWeighed as weighed-in" },
+            union.OneOf.Select(branch => branch.Ref + " as " + branch.Name));
+    }
+
+    [Fact]
+    public void StreamingIsAModelledTrait() {
+        var diagnostics = new List<string>();
+
+        Model(diagnostics);
+
+        Assert.DoesNotContain(diagnostics, line => line.Contains("smithy.api#streaming"));
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -751,6 +751,21 @@ internal static class SmithySpecParser {
                 // serialized {} with no diagnostic at all.
                 Describe(context, target, out var type, out var format, out var reference, out var facts);
 
+                // A @streaming union is Smithy's event stream: the payload is many of the union's
+                // members, one after another, each named by the member it came in as. That is a
+                // streamed response whose item is the union, framed as server-sent events with the
+                // member name as the event field - the same thing OpenAPI 3.2 spells as itemSchema
+                // under text/event-stream, so it goes on the model the same way.
+                if (reference != null &&
+                    context.Ast.TryGetShape(target, out var streamedShape) &&
+                    SmithyAst.HasTrait(streamedShape, SmithyTraits.Streaming) &&
+                    SmithyAst.Kind(streamedShape) == "union") {
+                    model.ItemSchemaRef = reference;
+                    model.ResponseContentType = "text/event-stream";
+
+                    return headers;
+                }
+
                 if (reference != null) {
                     model.ResponseRef = reference;
                 } else if (facts.IsArray) {
@@ -1306,9 +1321,14 @@ internal static class SmithySpecParser {
 
                     Describe(context, target, out var type, out var format, out var reference, out _);
 
+                    // The member's wire name rides with the branch. A streamed union writes it as
+                    // the event: field beside each item, which is what tells a client which
+                    // member arrived; nothing else about a union reads it.
+                    var branchName = JsonName(member.Value) ?? member.Key;
+
                     schema.OneOf.Add(reference != null
-                        ? new ChoiceBranchModel { Ref = reference }
-                        : new ChoiceBranchModel { Type = type, Format = format });
+                        ? new ChoiceBranchModel { Ref = reference, Name = branchName }
+                        : new ChoiceBranchModel { Type = type, Format = format, Name = branchName });
                 }
 
                 break;

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
@@ -114,7 +114,8 @@ internal static class SmithyTraits {
         "smithy.api#httpBearerAuth", "smithy.api#httpDigestAuth",
         Readonly, Idempotent, Input, Output, Private, Internal, Mixin,
         Trait,
-        Timeout
+        Timeout,
+        Streaming
     };
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecSchemaWriter.cs
@@ -170,6 +170,29 @@ internal static class SpecSchemaWriter {
 
                 break;
 
+            case SchemaKind.OneOf:
+                // A union, as the choice it is. Published as a bare object before, because the
+                // branches never reached this side of the build; a streamed union's items are
+                // exactly one of these each, so the document has to say which.
+                builder.Append("{\"oneOf\":[");
+
+                for (var i = 0; i < schema.OneOf.Count; i++) {
+                    if (i > 0) {
+                        builder.Append(',');
+                    }
+
+                    var branch = schema.OneOf[i];
+
+                    builder.Append(
+                        Inline(branch.Ref, branch.Type, branch.Format, null, null, false, schemas, components, seen));
+                }
+
+                builder.Append(']');
+                Describe(builder, schema.Description);
+                builder.Append('}');
+
+                break;
+
             default:
                 builder.Append("{\"type\":\"object\"");
                 Describe(builder, schema.Description);


### PR DESCRIPTION
Closes the Smithy half of the 0.21.0-rc1000 trial's H-01, on top of #289. A union under `@streaming` is Smithy's own event stream: the payload is many of the union's members, one after another, each named by the member it came in as. The trait sat in no table, so it was reported as one this generator does not model and the payload was read as one JSON object: `Task<PetEventStream>` on the interface, a single document on the wire, and `{"type":"object"}` in the published document.

## The mapping

`IAsyncEnumerable<TUnion>` framed as server-sent events, with the member name as the `event:` field, as agreed.

- **Parser.** A `@streaming` union bound as an `@httpPayload` output is the item of a streamed response under `text/event-stream`, which is what OpenAPI 3.2 spells as `itemSchema` and what the bridge from #289 already turns into an `IAsyncEnumerable<T>` handler on the streaming filter. `@streaming` is a mapped trait now. Each member's wire name rides on its branch (`ChoiceBranchModel.Name`, honouring `@jsonName`).
- **Emitter.** A union that is the item of a stream implements `ISseEvent`: `Data` is the member it holds, `Event` is that member's name, `Id` and `Retry` are null. The SSE framing already reads `ISseEvent` off whatever a handler yields and writes the event name beside the payload, so nothing in the runtime changed. The handler yields `new PetAdopted(...)` through the union's implicit conversion and the wire is:

  ```
  event: adopted
  data: {"petId":"1","by":"pia"}

  event: weighed
  data: {"petId":"1","grams":4200}
  ```

- **Document.** A union's branches now cross the intermediate file (they never did, which is why the document writer had nothing to publish), `SchemaKind.OneOf` reads back as itself, and `SpecSchemaWriter` publishes a union as the `oneOf` it is. That is what lets the streamed item's document say what each event can be, and it corrects every union the Smithy front end published as a bare object before; the tracked Smithy export shows one existing union changing that way.

## Fixtures and tests

- `Hardened.IntegrationTests.Smithy.SUT` gains `PetEvents` over a two-member union (`adopted`, `weighed`), public with `@auth([])` like its neighbours, and `PetEventsTests`: the exact framing above, a `NotFound` thrown before the first event, and the document's `itemSchema`, `schema` and `oneOf`.
- `SmithyEventStreamTests` in the parser tests, over a new `event-stream.smithy` fixture and its AST built with the pinned CLI: the item and content type, an unstreamed neighbour untouched, member names including a `@jsonName`, and no unmodelled-trait report for `@streaming`.
- `StreamedUnionTests` in the OpenAPI generator tests: an OpenAPI `oneOf` under `itemSchema` gets the same `ISseEvent` union with an empty event name, and the document publishes the `oneOf`.
- The serializer's round-trip model gains a union with named branches and a named property branch; `ChoiceBranchModel` encodes the name after a `|` and reads a nameless branch as before.
- `WriteOpenApiDocumentTests.LoweringAnApplicationWithNoStreamingWarnsNothing` moves to the labels application, since the web, OpenAPI and Smithy applications all stream now.

## What Refitter makes of it

From the fixture's export, Refitter `main` declares `IAsyncEnumerable<PetAdopted> PetEvents(string petId)`: it takes the first branch of a `oneOf`, which is Refitter's reading of `oneOf` rather than anything the document can change. Kiota returns a `Stream` as it does for every stream.

## Verification

- CI-parity build (`Release`, `ContinuousIntegrationBuild=true`, Smithy CLI 1.73.0 on PATH): 0 errors; the one warning is the standing `HSMT031`.
- Full suite against that build: 7288 tests, the only failure being the lowering test above before it was moved; green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)