### PR TITLE
Let a described handler see its budget: a bound CancellationToken and IRequestDeadline

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/BoundCancellationTokenTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/BoundCancellationTokenTests.cs
@@ -1,0 +1,54 @@
+using Hardened.Shared.Testing.Attributes;
+using Hardened.Web.Testing;
+
+namespace Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests;
+
+/// <summary>
+/// The described half of <c>$(HardenedBindCancellationToken)</c>, driven through a real request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A described handler implements a signature it did not write, so this parameter is the only way
+/// the request's token reaches one. This project sets the property; the sibling SUT leaves it off,
+/// so the two together build and dispatch against both shapes of the generated interface.
+/// </para>
+/// <para>
+/// That the project compiles at all is most of the assertion: the interface is written by the build
+/// task and the call that fills it by the source generator, and a flag reaching one and not the
+/// other is a call whose arguments do not match the method it calls. What compiling cannot say is
+/// which token arrived, which is what the test below is for.
+/// </para>
+/// </remarks>
+public class BoundCancellationTokenTests {
+
+    /// <summary>
+    /// The operation carries a <c>[Timeout]</c>, so the token bound to it is the budget's rather
+    /// than <c>CancellationToken.None</c> - which compiles just as well and never fires.
+    /// </summary>
+    [HardenedTest]
+    public async Task ABoundedHandlerIsHandedATokenThatCanFire(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/labels/abc");
+
+        response.Assert.Ok();
+
+        Assert.True(LabelServiceImpl.LastTokenCanBeCanceled);
+    }
+
+    /// <summary>
+    /// The other half, in the same handler: what the token cannot say is how long there was.
+    /// </summary>
+    /// <remarks>
+    /// Taken through the constructor, which is the only way into a described handler, and resolved
+    /// from a singleton registration so the handler's own lifetime does not decide whether it can
+    /// ask.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ABoundedHandlerCanReadItsDeadline(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/labels/abc");
+
+        response.Assert.Ok();
+
+        Assert.NotNull(LabelServiceImpl.LastDeadlineRemainingMs);
+        Assert.InRange(LabelServiceImpl.LastDeadlineRemainingMs!.Value, 0, 30_000);
+    }
+}

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/BoundCancellationTokenTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Tests/BoundCancellationTokenTests.cs
@@ -51,4 +51,18 @@ public class BoundCancellationTokenTests {
         Assert.NotNull(LabelServiceImpl.LastDeadlineRemainingMs);
         Assert.InRange(LabelServiceImpl.LastDeadlineRemainingMs!.Value, 0, 30_000);
     }
+
+    /// <summary>
+    /// The two routes into a described handler agree. The parameter is bound off the context by the
+    /// generated dispatch and the accessor is published by the filter, and both are meant to be the
+    /// token the budget cancels.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheAccessorCarriesTheSameTokenThatWasBound(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/labels/abc");
+
+        response.Assert.Ok();
+
+        Assert.True(LabelServiceImpl.AccessorTokenMatchedTheBoundOne);
+    }
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.csproj
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.csproj
@@ -14,7 +14,12 @@
             the branch that decided a scalar success was bodyless, never executed there.
         -->
         <HardenedResponseModel>Response</HardenedResponseModel>
-    </PropertyGroup>
+    
+        <!-- The described half of the token binding, end to end. The sibling SUT keeps the flag
+             off, so between them both shapes of the generated interface are built and dispatched
+             against. -->
+        <HardenedBindCancellationToken>true</HardenedBindCancellationToken>
+</PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
@@ -49,6 +49,16 @@ public class LabelServiceImpl : ILabelService {
     public static double? LastDeadlineRemainingMs { get; private set; }
 
     /// <summary>
+    /// Whether the token the accessor carried is the one the bound parameter got.
+    /// </summary>
+    /// <remarks>
+    /// The two reach the handler by different routes - one bound onto the signature, one published
+    /// into an AsyncLocal - and both are meant to be the budget's. A handler that took one and
+    /// passed the other would bound nothing.
+    /// </remarks>
+    public static bool AccessorTokenMatchedTheBoundOne { get; private set; }
+
+    /// <summary>
     /// The 404 is the framework's own record. The build wrote the conversion into the case the
     /// contract declares, NotFound&lt;Problem&gt;, with the Problem's title and status filled from
     /// the record and the detail from here.
@@ -57,6 +67,7 @@ public class LabelServiceImpl : ILabelService {
     public Task<GetLabelResponse> GetLabel(string labelId, CancellationToken cancellationToken) {
         LastTokenCanBeCanceled = cancellationToken.CanBeCanceled;
         LastDeadlineRemainingMs = _deadline.Deadline?.GetRemainingMilliseconds();
+        AccessorTokenMatchedTheBoundOne = _deadline.CancellationToken == cancellationToken;
 
         if (labelId == "missing") {
             return Task.FromResult<GetLabelResponse>(new NotFound("label", "No such label"));

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.ResponseModel.SUT/LabelServiceImpl.cs
@@ -1,4 +1,7 @@
+using System.Threading;
 using Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Models;
+using Hardened.Requests.Abstract.Timeouts;
+using Hardened.Requests.Runtime.Filters;
 using Hardened.IntegrationTests.OpenApi.ResponseModel.SUT.Services;
 using Hardened.Requests.Abstract.Attributes;
 using Hardened.Requests.Abstract.Responses;
@@ -18,13 +21,43 @@ namespace Hardened.IntegrationTests.OpenApi.ResponseModel.SUT;
 /// </remarks>
 [Handler]
 public class LabelServiceImpl : ILabelService {
+    private readonly IRequestDeadline _deadline;
+
+    /// <summary>
+    /// The deadline arrives through the constructor, which is the only way into a handler whose
+    /// signature belongs to the contract. Registered as a singleton for that reason, so this class's
+    /// own lifetime does not decide whether it can ask.
+    /// </summary>
+    public LabelServiceImpl(IRequestDeadline deadline) {
+        _deadline = deadline;
+    }
+
+    /// <summary>
+    /// Whether the last bound token was one that can actually fire.
+    /// </summary>
+    /// <remarks>
+    /// The described interface declares the parameter and the generated dispatch fills it, and a
+    /// signature that compiles says nothing about which token arrived: <c>default</c> is a
+    /// perfectly good <c>CancellationToken</c> that never fires. This records the one fact that
+    /// separates the two.
+    /// </remarks>
+    public static bool LastTokenCanBeCanceled { get; private set; }
+
+    /// <summary>
+    /// How long the last bounded request had left, or null when nothing bounded it.
+    /// </summary>
+    public static double? LastDeadlineRemainingMs { get; private set; }
 
     /// <summary>
     /// The 404 is the framework's own record. The build wrote the conversion into the case the
     /// contract declares, NotFound&lt;Problem&gt;, with the Problem's title and status filled from
     /// the record and the detail from here.
     /// </summary>
-    public Task<GetLabelResponse> GetLabel(string labelId) {
+    [Timeout(Milliseconds = 30_000)]
+    public Task<GetLabelResponse> GetLabel(string labelId, CancellationToken cancellationToken) {
+        LastTokenCanBeCanceled = cancellationToken.CanBeCanceled;
+        LastDeadlineRemainingMs = _deadline.Deadline?.GetRemainingMilliseconds();
+
         if (labelId == "missing") {
             return Task.FromResult<GetLabelResponse>(new NotFound("label", "No such label"));
         }
@@ -32,12 +65,14 @@ public class LabelServiceImpl : ILabelService {
         return Task.FromResult<GetLabelResponse>(new GetLabelOk($"Label {labelId}"));
     }
 
-    public Task<CreateLabelResponse> CreateLabel(LabelRequest body) {
+    public Task<CreateLabelResponse> CreateLabel(
+        LabelRequest body, CancellationToken cancellationToken) {
         return Task.FromResult<CreateLabelResponse>(body);
     }
 
     /// <summary>The shared instance, for a handler with nothing to add: no allocation for the 404.</summary>
-    public Task<ArchiveLabelResponse> ArchiveLabel(string labelId) {
+    public Task<ArchiveLabelResponse> ArchiveLabel(
+        string labelId, CancellationToken cancellationToken) {
         if (labelId == "missing") {
             return Task.FromResult<ArchiveLabelResponse>(NotFound.Default);
         }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -1848,7 +1848,7 @@ namespace Hardened.Requests.Abstract.Timeouts
     }
     public interface IRequestDeadline
     {
-        System.Threading.CancellationToken CancellationToken { get; }
+        System.Threading.CancellationToken? CancellationToken { get; }
         Hardened.Shared.Runtime.Diagnostics.MachineTimestamp? Deadline { get; }
     }
     public interface IRequestTimeoutConvention

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -1846,6 +1846,10 @@ namespace Hardened.Requests.Abstract.Timeouts
     {
         Hardened.Requests.Abstract.Timeouts.TimeoutPolicy Timeout { get; }
     }
+    public interface IRequestDeadline
+    {
+        Hardened.Shared.Runtime.Diagnostics.MachineTimestamp? Deadline { get; }
+    }
     public interface IRequestTimeoutConvention
     {
         Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? Apply(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo);
@@ -1854,7 +1858,8 @@ namespace Hardened.Requests.Abstract.Timeouts
     {
         public const int DefaultMilliseconds = 30000;
         public const int DefaultStatus = 504;
-        public TimeoutPolicy(int Milliseconds, int Status = 504, int RetryAfterSeconds = 0) { }
+        public TimeoutPolicy(int Milliseconds, int Status = 504, int RetryAfterSeconds = 0, bool Deadline = true) { }
+        public bool Deadline { get; init; }
         public int Milliseconds { get; init; }
         public int RetryAfterSeconds { get; init; }
         public int Status { get; init; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -1848,6 +1848,7 @@ namespace Hardened.Requests.Abstract.Timeouts
     }
     public interface IRequestDeadline
     {
+        System.Threading.CancellationToken CancellationToken { get; }
         Hardened.Shared.Runtime.Diagnostics.MachineTimestamp? Deadline { get; }
     }
     public interface IRequestTimeoutConvention

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -1,3 +1,4 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Hardened.Requests.Runtime.Tests")]
 namespace Hardened.Requests.Runtime
 {
     public class AotSerializerModule : DependencyModules.Runtime.Interfaces.IDependencyModule
@@ -521,6 +522,7 @@ namespace Hardened.Requests.Runtime.Filters
     public sealed class TimeoutAttribute : System.Attribute, Hardened.Requests.Abstract.Timeouts.IDeclaresTimeout
     {
         public TimeoutAttribute() { }
+        public bool Deadline { get; set; }
         public int Milliseconds { get; set; }
         public int RetryAfterSeconds { get; set; }
         public int Status { get; set; }
@@ -528,7 +530,7 @@ namespace Hardened.Requests.Runtime.Filters
     }
     public class TimeoutFilter : Hardened.Requests.Abstract.Execution.IExecutionFilter
     {
-        public TimeoutFilter(int milliseconds) { }
+        public TimeoutFilter(int milliseconds, bool publishDeadline = true) { }
         public System.Threading.Tasks.Task Execute(Hardened.Requests.Abstract.Execution.IExecutionChain chain) { }
     }
 }

--- a/src/Requests/Hardened.Requests.Abstract/Timeouts/IRequestDeadline.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Timeouts/IRequestDeadline.cs
@@ -1,0 +1,49 @@
+using Hardened.Shared.Runtime.Diagnostics;
+
+namespace Hardened.Requests.Abstract.Timeouts;
+
+/// <summary>
+/// When the request being handled runs out of time.
+///
+/// <code>
+/// public Task&lt;Quote&gt; Quote(Job job, IRequestDeadline deadline, CancellationToken cancellationToken) {
+///     if (deadline.Deadline is { } at &amp;&amp; at.GetRemainingMilliseconds() &lt; 250) {
+///         return Task.FromResult(Quote.Estimated(job));
+///     }
+///
+///     return _pricing.Quote(job, cancellationToken);
+/// }
+/// </code>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The token says stop; this says how long there is.</b> A handler that only needs to abandon
+/// its work when the budget runs out binds a <see cref="System.Threading.CancellationToken"/> and
+/// passes it down. This is for the handler that has to decide something before starting: whether
+/// there is time for a retry, for a second upstream call, or for the slow path rather than the
+/// cached one.
+/// </para>
+/// <para>
+/// <b>Registered as a singleton, so a handler of any lifetime can take it.</b> A described handler
+/// implements a generated interface and cannot add a parameter to its own signature, so the
+/// constructor is the only way in and a scoped registration would be captured by a singleton that
+/// took one. The per-request value therefore lives in an <c>AsyncLocal</c> rather than on the
+/// instance, which is the cost <c>[Timeout(Deadline = false)]</c> exists to decline.
+/// </para>
+/// <para>
+/// <b>Null means nothing bounds this request.</b> Only <c>TimeoutFilter</c> publishes a deadline,
+/// so a handler no budget applies to reads null here however it was called. Null is also what a
+/// handler reads outside a request entirely.
+/// </para>
+/// <para>
+/// Monotonic, from <see cref="MachineTimestamp"/>, so a deadline is not moved by a clock
+/// adjustment while a request is in flight. It is meaningful only on the machine that issued it.
+/// </para>
+/// </remarks>
+public interface IRequestDeadline {
+
+    /// <summary>
+    /// When this request's budget runs out, or null when nothing bounds it.
+    /// </summary>
+    MachineTimestamp? Deadline { get; }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Timeouts/IRequestDeadline.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Timeouts/IRequestDeadline.cs
@@ -6,12 +6,12 @@ namespace Hardened.Requests.Abstract.Timeouts;
 /// When the request being handled runs out of time.
 ///
 /// <code>
-/// public Task&lt;Quote&gt; Quote(Job job) {
+/// public Task&lt;Quote&gt; Quote(Job job, CancellationToken cancellationToken) {
 ///     if (_deadline.Deadline is { } at &amp;&amp; at.GetRemainingMilliseconds() &lt; 250) {
 ///         return Task.FromResult(Quote.Estimated(job));
 ///     }
 ///
-///     return _pricing.Quote(job, _deadline.CancellationToken);
+///     return _pricing.Quote(job, _deadline.CancellationToken ?? cancellationToken);
 /// }
 /// </code>
 /// </summary>
@@ -31,17 +31,18 @@ namespace Hardened.Requests.Abstract.Timeouts;
 /// </para>
 /// <para>
 /// <b>Nothing bounds every request.</b> Only <c>TimeoutFilter</c> publishes, so a handler no budget
-/// applies to reads <see cref="Deadline"/> null and <see cref="CancellationToken"/>
-/// <see cref="System.Threading.CancellationToken.None"/>, which is also what a handler reads
-/// outside a request entirely. The two say the same thing and are never one without the other.
+/// applies to reads null from both, which is also what a handler reads outside a request entirely.
+/// Both are nullable rather than one of them carrying a sentinel: they record the same publication
+/// and are never one without the other, so one pattern reads both and neither absence has to be
+/// recognised as a special value.
 /// </para>
 /// <para>
 /// <b>This is not the way to get the request's token.</b> A handler that wants cancellation whether
 /// or not a budget was declared - a client hanging up cancels either way - takes a
 /// <see cref="System.Threading.CancellationToken"/> parameter, which a code-first handler writes on
 /// its own signature and a described one gets from
-/// <c>$(HardenedBindCancellationToken)</c>. The token here is the budget's, and it is
-/// <see cref="System.Threading.CancellationToken.None"/> when there is no budget.
+/// <c>$(HardenedBindCancellationToken)</c>. The token here is the budget's, and it is null when
+/// there is no budget, which is why the example above falls back to the bound one.
 /// </para>
 /// <para>
 /// Monotonic, from <see cref="MachineTimestamp"/>, so a deadline is not moved by a clock
@@ -56,8 +57,7 @@ public interface IRequestDeadline {
     MachineTimestamp? Deadline { get; }
 
     /// <summary>
-    /// The token that fires at <see cref="Deadline"/>, or
-    /// <see cref="System.Threading.CancellationToken.None"/> when nothing bounds this request.
+    /// The token that fires at <see cref="Deadline"/>, or null when nothing bounds this request.
     /// </summary>
     /// <remarks>
     /// The same token the budget's own filter installed, so passing it to an upstream call is what
@@ -65,5 +65,5 @@ public interface IRequestDeadline {
     /// find, because a handler that has just decided it has time to start something needs the token
     /// to start it with.
     /// </remarks>
-    CancellationToken CancellationToken { get; }
+    CancellationToken? CancellationToken { get; }
 }

--- a/src/Requests/Hardened.Requests.Abstract/Timeouts/IRequestDeadline.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Timeouts/IRequestDeadline.cs
@@ -6,22 +6,21 @@ namespace Hardened.Requests.Abstract.Timeouts;
 /// When the request being handled runs out of time.
 ///
 /// <code>
-/// public Task&lt;Quote&gt; Quote(Job job, IRequestDeadline deadline, CancellationToken cancellationToken) {
-///     if (deadline.Deadline is { } at &amp;&amp; at.GetRemainingMilliseconds() &lt; 250) {
+/// public Task&lt;Quote&gt; Quote(Job job) {
+///     if (_deadline.Deadline is { } at &amp;&amp; at.GetRemainingMilliseconds() &lt; 250) {
 ///         return Task.FromResult(Quote.Estimated(job));
 ///     }
 ///
-///     return _pricing.Quote(job, cancellationToken);
+///     return _pricing.Quote(job, _deadline.CancellationToken);
 /// }
 /// </code>
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>The token says stop; this says how long there is.</b> A handler that only needs to abandon
-/// its work when the budget runs out binds a <see cref="System.Threading.CancellationToken"/> and
-/// passes it down. This is for the handler that has to decide something before starting: whether
-/// there is time for a retry, for a second upstream call, or for the slow path rather than the
-/// cached one.
+/// <b>What the token cannot say is how long there is.</b> Cancellation tells a handler to stop; the
+/// deadline is what lets it decide something before starting, such as whether there is time for a
+/// retry, for a second upstream call, or for the slow path rather than the cached one. Both
+/// readings come from the same publication, so they cannot describe different budgets.
 /// </para>
 /// <para>
 /// <b>Registered as a singleton, so a handler of any lifetime can take it.</b> A described handler
@@ -31,9 +30,18 @@ namespace Hardened.Requests.Abstract.Timeouts;
 /// instance, which is the cost <c>[Timeout(Deadline = false)]</c> exists to decline.
 /// </para>
 /// <para>
-/// <b>Null means nothing bounds this request.</b> Only <c>TimeoutFilter</c> publishes a deadline,
-/// so a handler no budget applies to reads null here however it was called. Null is also what a
-/// handler reads outside a request entirely.
+/// <b>Nothing bounds every request.</b> Only <c>TimeoutFilter</c> publishes, so a handler no budget
+/// applies to reads <see cref="Deadline"/> null and <see cref="CancellationToken"/>
+/// <see cref="System.Threading.CancellationToken.None"/>, which is also what a handler reads
+/// outside a request entirely. The two say the same thing and are never one without the other.
+/// </para>
+/// <para>
+/// <b>This is not the way to get the request's token.</b> A handler that wants cancellation whether
+/// or not a budget was declared - a client hanging up cancels either way - takes a
+/// <see cref="System.Threading.CancellationToken"/> parameter, which a code-first handler writes on
+/// its own signature and a described one gets from
+/// <c>$(HardenedBindCancellationToken)</c>. The token here is the budget's, and it is
+/// <see cref="System.Threading.CancellationToken.None"/> when there is no budget.
 /// </para>
 /// <para>
 /// Monotonic, from <see cref="MachineTimestamp"/>, so a deadline is not moved by a clock
@@ -46,4 +54,16 @@ public interface IRequestDeadline {
     /// When this request's budget runs out, or null when nothing bounds it.
     /// </summary>
     MachineTimestamp? Deadline { get; }
+
+    /// <summary>
+    /// The token that fires at <see cref="Deadline"/>, or
+    /// <see cref="System.Threading.CancellationToken.None"/> when nothing bounds this request.
+    /// </summary>
+    /// <remarks>
+    /// The same token the budget's own filter installed, so passing it to an upstream call is what
+    /// makes the deadline reach that call. Beside the reading rather than left to the caller to
+    /// find, because a handler that has just decided it has time to start something needs the token
+    /// to start it with.
+    /// </remarks>
+    CancellationToken CancellationToken { get; }
 }

--- a/src/Requests/Hardened.Requests.Abstract/Timeouts/TimeoutPolicy.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Timeouts/TimeoutPolicy.cs
@@ -30,10 +30,17 @@ namespace Hardened.Requests.Abstract.Timeouts;
 /// <see cref="Status"/> 503: a deadline out at a dependency knows nothing about when that
 /// dependency recovers.
 /// </param>
+/// <param name="Deadline">
+/// Whether the budget is published as an <see cref="IRequestDeadline"/> the handler can read. On,
+/// because a declared budget the handler cannot see is the gap this closes. Off for a handler that
+/// will not read it and would rather not pay for the publication, which is an <c>AsyncLocal</c>
+/// write and therefore an execution-context copy on every continuation after it.
+/// </param>
 public sealed record TimeoutPolicy(
     int Milliseconds,
     int Status = TimeoutPolicy.DefaultStatus,
-    int RetryAfterSeconds = 0) {
+    int RetryAfterSeconds = 0,
+    bool Deadline = true) {
 
     /// <summary>
     /// The budget an application-wide default takes when nothing states one. A bound rather than a
@@ -52,6 +59,11 @@ public sealed record TimeoutPolicy(
     /// <c>IAuthorizationConvention</c> follows, for the same reason: a convention standing between
     /// an unannotated handler and the world must not be defeatable by the handler, and must not
     /// quietly undo what the handler asked for either.
+    /// </remarks>
+    /// <remarks>
+    /// One whole policy wins, <see cref="Deadline"/> included, on the same terms as
+    /// <see cref="Status"/> and <see cref="RetryAfterSeconds"/>: a convention that shortens a budget
+    /// states all four, and a flag picked from the loser would be a pairing nothing declared.
     /// </remarks>
     public static TimeoutPolicy? Tighter(TimeoutPolicy? left, TimeoutPolicy? right) {
         if (left == null) {

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RequestDeadlineTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RequestDeadlineTests.cs
@@ -90,7 +90,7 @@ public class RequestDeadlineTests {
         Assert.Null(observed);
 
         // Both readings say the same thing, and neither is a token that looks live.
-        Assert.False(Accessor.CancellationToken.CanBeCanceled);
+        Assert.Null(Accessor.CancellationToken);
 
         // The budget still applies; only the reading of it was declined.
         Assert.True(bounded.CanBeCanceled);
@@ -99,7 +99,7 @@ public class RequestDeadlineTests {
     [Fact]
     public void AHandlerNoBudgetAppliesToReadsNothing() {
         Assert.Null(Accessor.Deadline);
-        Assert.Equal(CancellationToken.None, Accessor.CancellationToken);
+        Assert.Null(Accessor.CancellationToken);
     }
 
     /// <summary>
@@ -113,7 +113,7 @@ public class RequestDeadlineTests {
 
         var context = Pipeline.Cancellable(transport.Token);
 
-        CancellationToken published = default;
+        CancellationToken? published = null;
         CancellationToken installed = default;
 
         await Pipeline.Chain(
@@ -141,7 +141,7 @@ public class RequestDeadlineTests {
         var chain = Pipeline.Chain(
             context,
             new TimeoutFilter(ShortBudget),
-            new Pipeline.Inline(_ => Task.Delay(Timeout.Infinite, Accessor.CancellationToken)));
+            new Pipeline.Inline(_ => Task.Delay(Timeout.Infinite, Accessor.CancellationToken!.Value)));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => chain.Next());
     }
@@ -157,7 +157,7 @@ public class RequestDeadlineTests {
         await Pipeline.Chain(context, new TimeoutFilter(LongBudget)).Next();
 
         Assert.Null(Accessor.Deadline);
-        Assert.Equal(CancellationToken.None, Accessor.CancellationToken);
+        Assert.Null(Accessor.CancellationToken);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RequestDeadlineTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RequestDeadlineTests.cs
@@ -19,6 +19,9 @@ public class RequestDeadlineTests {
     /// <summary>Longer than any test here takes, so nothing expires on its own.</summary>
     private const int LongBudget = 60_000;
 
+    /// <summary>Short enough to expire during a test, but not so short it races.</summary>
+    private const int ShortBudget = 30;
+
     private static readonly IRequestDeadline Accessor = new RequestDeadline();
 
     [Fact]
@@ -86,6 +89,9 @@ public class RequestDeadlineTests {
 
         Assert.Null(observed);
 
+        // Both readings say the same thing, and neither is a token that looks live.
+        Assert.False(Accessor.CancellationToken.CanBeCanceled);
+
         // The budget still applies; only the reading of it was declined.
         Assert.True(bounded.CanBeCanceled);
     }
@@ -93,6 +99,51 @@ public class RequestDeadlineTests {
     [Fact]
     public void AHandlerNoBudgetAppliesToReadsNothing() {
         Assert.Null(Accessor.Deadline);
+        Assert.Equal(CancellationToken.None, Accessor.CancellationToken);
+    }
+
+    /// <summary>
+    /// The published token is the one enforcing the budget, not a copy of the transport's. Passing
+    /// it to an upstream call is what makes the deadline reach that call, so a token that merely
+    /// looks cancellable would be the wrong one.
+    /// </summary>
+    [Fact]
+    public async Task ThePublishedTokenIsTheOneTheBudgetCancels() {
+        using var transport = new CancellationTokenSource();
+
+        var context = Pipeline.Cancellable(transport.Token);
+
+        CancellationToken published = default;
+        CancellationToken installed = default;
+
+        await Pipeline.Chain(
+            context,
+            new TimeoutFilter(LongBudget),
+            new Pipeline.Inline(chain => {
+                published = Accessor.CancellationToken;
+                installed = chain.Context.CancellationToken;
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Equal(installed, published);
+        Assert.NotEqual(transport.Token, published);
+    }
+
+    /// <summary>
+    /// The whole point of carrying the token: work started on it is abandoned when the budget runs
+    /// out, for a handler that reached it through the accessor rather than a parameter.
+    /// </summary>
+    [Fact]
+    public async Task WorkStartedOnThePublishedTokenIsCancelledByTheBudget() {
+        var context = Pipeline.Context();
+
+        var chain = Pipeline.Chain(
+            context,
+            new TimeoutFilter(ShortBudget),
+            new Pipeline.Inline(_ => Task.Delay(Timeout.Infinite, Accessor.CancellationToken)));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => chain.Next());
     }
 
     /// <summary>
@@ -106,6 +157,7 @@ public class RequestDeadlineTests {
         await Pipeline.Chain(context, new TimeoutFilter(LongBudget)).Next();
 
         Assert.Null(Accessor.Deadline);
+        Assert.Equal(CancellationToken.None, Accessor.CancellationToken);
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RequestDeadlineTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Filters/RequestDeadlineTests.cs
@@ -1,0 +1,141 @@
+using Hardened.Requests.Abstract.Timeouts;
+using Hardened.Shared.Runtime.Diagnostics;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Tests.Support;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Filters;
+
+/// <summary>
+/// What a handler can learn about its budget, and what it costs when it does not ask.
+/// </summary>
+/// <remarks>
+/// Read through <see cref="IRequestDeadline"/> rather than the <c>AsyncLocal</c> behind it, because
+/// the accessor is the whole contract: a handler takes this in its constructor whatever its
+/// lifetime, which is the reason the value is not on a scoped holder.
+/// </remarks>
+public class RequestDeadlineTests {
+
+    /// <summary>Longer than any test here takes, so nothing expires on its own.</summary>
+    private const int LongBudget = 60_000;
+
+    private static readonly IRequestDeadline Accessor = new RequestDeadline();
+
+    [Fact]
+    public async Task ABoundedHandlerReadsWhenItsBudgetRunsOut() {
+        var context = Pipeline.Context();
+
+        double remaining = 0;
+
+        await Pipeline.Chain(
+            context,
+            new TimeoutFilter(LongBudget),
+            new Pipeline.Inline(_ => {
+                remaining = Accessor.Deadline!.Value.GetRemainingMilliseconds();
+
+                return Task.CompletedTask;
+            })).Next();
+
+        // Bounded rather than exact: the deadline is taken as the filter starts the budget, so the
+        // reading is a whole budget less however long the chain took to reach the handler.
+        Assert.InRange(remaining, LongBudget - 5_000, LongBudget);
+    }
+
+    /// <summary>
+    /// The budget is what the handler reads, not the request's whole elapsed time. A deadline
+    /// measured from anywhere but the <c>CancelAfter</c> would disagree with the token enforcing it.
+    /// </summary>
+    [Fact]
+    public async Task TheDeadlineIsAheadWhileTheBudgetHolds() {
+        var context = Pipeline.Context();
+
+        var future = false;
+
+        await Pipeline.Chain(
+            context,
+            new TimeoutFilter(LongBudget),
+            new Pipeline.Inline(_ => {
+                future = Accessor.Deadline!.Value.Future;
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.True(future);
+    }
+
+    /// <summary>
+    /// The opt-out. Nothing else about the budget changes; only the publication is skipped, which
+    /// is the <c>AsyncLocal</c> write and the execution-context copies after it.
+    /// </summary>
+    [Fact]
+    public async Task DeadlineFalsePublishesNothing() {
+        var context = Pipeline.Context();
+
+        MachineTimestamp? observed = null;
+        CancellationToken bounded = default;
+
+        await Pipeline.Chain(
+            context,
+            new TimeoutFilter(LongBudget, publishDeadline: false),
+            new Pipeline.Inline(chain => {
+                observed = Accessor.Deadline;
+                bounded = chain.Context.CancellationToken;
+
+                return Task.CompletedTask;
+            })).Next();
+
+        Assert.Null(observed);
+
+        // The budget still applies; only the reading of it was declined.
+        Assert.True(bounded.CanBeCanceled);
+    }
+
+    [Fact]
+    public void AHandlerNoBudgetAppliesToReadsNothing() {
+        Assert.Null(Accessor.Deadline);
+    }
+
+    /// <summary>
+    /// The restore, for the same reason <c>CancellationScope</c> has one: whatever runs after the
+    /// filter must not read a deadline from a request that has finished.
+    /// </summary>
+    [Fact]
+    public async Task TheDeadlineIsGoneWhenTheFilterReturns() {
+        var context = Pipeline.Context();
+
+        await Pipeline.Chain(context, new TimeoutFilter(LongBudget)).Next();
+
+        Assert.Null(Accessor.Deadline);
+    }
+
+    /// <summary>
+    /// Nested budgets nest. An inner <c>[Timeout]</c> is what the handler inside it reads, and the
+    /// outer one is what is visible again afterwards.
+    /// </summary>
+    [Fact]
+    public async Task AnInnerBudgetIsWhatTheHandlerReadsAndTheOuterComesBack() {
+        var context = Pipeline.Context();
+
+        double inner = 0;
+        double afterInner = 0;
+
+        await Pipeline.Chain(
+            context,
+            new TimeoutFilter(LongBudget),
+            new Pipeline.Inline(async chain => {
+                await Pipeline.Chain(
+                    chain.Context,
+                    new TimeoutFilter(1_000),
+                    new Pipeline.Inline(_ => {
+                        inner = Accessor.Deadline!.Value.GetRemainingMilliseconds();
+
+                        return Task.CompletedTask;
+                    })).Next();
+
+                afterInner = Accessor.Deadline!.Value.GetRemainingMilliseconds();
+            })).Next();
+
+        Assert.InRange(inner, 0, 1_000);
+        Assert.InRange(afterInner, LongBudget - 5_000, LongBudget);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -12,6 +12,8 @@ using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Runtime.Configuration;
 using Hardened.Shared.Runtime.DependencyInjection;
 using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Abstract.Timeouts;
+using Hardened.Requests.Runtime.Filters;
 using Hardened.Requests.Runtime.Serializer;
 using Hardened.Requests.Runtime.Streaming;
 using Microsoft.Extensions.DependencyInjection;
@@ -65,6 +67,14 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
         // else reads the interface, which is what keeps the setter off the contract.
         services.AddScoped<CurrentCaller>();
         services.AddScoped<ICurrentCaller>(provider => provider.GetRequiredService<CurrentCaller>());
+
+        // The deadline, as a service a handler can take. Singleton rather than scoped, because a
+        // described handler can only reach this through its constructor - its signature is the
+        // contract's - and may itself be a singleton, which a scoped registration would let it
+        // capture. One registration rather than the two above: the per-request value lives in a
+        // static AsyncLocal that TimeoutFilter writes, so nothing needs a second registration to
+        // fill an instance with.
+        services.AddSingleton<IRequestDeadline, RequestDeadline>();
 
         // Always installed. It costs one call per handler at startup and returns null for a handler
         // that carries no authorization attribute, so an application that has not opted in to

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
@@ -340,7 +340,7 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
             return;
         }
 
-        var filter = new TimeoutFilter(timeout.Milliseconds);
+        var filter = new TimeoutFilter(timeout.Milliseconds, timeout.Deadline);
 
         filterList.Add(new RequestFilterInfo(
             _ => filter,

--- a/src/Requests/Hardened.Requests.Runtime/Filters/RequestDeadline.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/RequestDeadline.cs
@@ -32,8 +32,7 @@ internal sealed class RequestDeadline : IRequestDeadline {
     public MachineTimestamp? Deadline => Current.Value?.Deadline;
 
     /// <inheritdoc />
-    public CancellationToken CancellationToken =>
-        Current.Value?.CancellationToken ?? CancellationToken.None;
+    public CancellationToken? CancellationToken => Current.Value?.CancellationToken;
 
     /// <summary>
     /// Publishes a budget until the scope is disposed, or nothing when <paramref name="deadline"/>

--- a/src/Requests/Hardened.Requests.Runtime/Filters/RequestDeadline.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/RequestDeadline.cs
@@ -19,29 +19,41 @@ namespace Hardened.Requests.Runtime.Filters;
 /// nothing writes this unless a budget was declared, and why <c>[Timeout(Deadline = false)]</c>
 /// exists for a bounded handler that would rather not pay it.
 /// </para>
+/// <para>
+/// One <c>AsyncLocal</c> holding both readings rather than two. They describe one fact and are
+/// published together, and two cells could be read a continuation apart and disagree.
+/// </para>
 /// </remarks>
 internal sealed class RequestDeadline : IRequestDeadline {
 
-    private static readonly AsyncLocal<MachineTimestamp?> Current = new();
+    private static readonly AsyncLocal<Bound?> Current = new();
 
     /// <inheritdoc />
-    public MachineTimestamp? Deadline => Current.Value;
+    public MachineTimestamp? Deadline => Current.Value?.Deadline;
+
+    /// <inheritdoc />
+    public CancellationToken CancellationToken =>
+        Current.Value?.CancellationToken ?? CancellationToken.None;
 
     /// <summary>
-    /// Publishes <paramref name="deadline"/> until the scope is disposed, or nothing when it is
-    /// null.
+    /// Publishes a budget until the scope is disposed, or nothing when <paramref name="deadline"/>
+    /// is null.
     /// </summary>
-    internal static DeadlineScope Until(MachineTimestamp? deadline) => new(deadline);
+    internal static DeadlineScope Until(MachineTimestamp? deadline, CancellationToken token) =>
+        new(deadline, token);
 
-    /// <summary>The value the scope reads and restores. Not part of the contract.</summary>
-    internal static MachineTimestamp? Value {
+    /// <summary>The cell the scope reads and restores. Not part of the contract.</summary>
+    internal static Bound? Value {
         get => Current.Value;
         set => Current.Value = value;
     }
+
+    /// <summary>What a bounded request has: when it runs out, and the token that fires then.</summary>
+    internal sealed record Bound(MachineTimestamp Deadline, CancellationToken CancellationToken);
 }
 
 /// <summary>
-/// Publishes a deadline for a span of the pipeline, and puts the previous one back.
+/// Publishes a budget for a span of the pipeline, and puts the previous one back.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -51,16 +63,16 @@ internal sealed class RequestDeadline : IRequestDeadline {
 /// written the same way.
 /// </para>
 /// <para>
-/// A struct, so a bounded request allocates nothing for this. Constructing one with null writes
-/// nothing and disposing it restores nothing, which is how a handler that declined the deadline
-/// pays for none of it.
+/// A struct, so the scope itself allocates nothing. Constructing one with a null deadline writes
+/// nothing and disposing it restores nothing, which is how a handler that declined the budget pays
+/// for none of it.
 /// </para>
 /// </remarks>
 internal readonly struct DeadlineScope : IDisposable {
-    private readonly MachineTimestamp? _previous;
+    private readonly RequestDeadline.Bound? _previous;
     private readonly bool _published;
 
-    internal DeadlineScope(MachineTimestamp? deadline) {
+    internal DeadlineScope(MachineTimestamp? deadline, CancellationToken token) {
         if (deadline is not { } until) {
             _previous = null;
             _published = false;
@@ -70,7 +82,7 @@ internal readonly struct DeadlineScope : IDisposable {
 
         _previous = RequestDeadline.Value;
         _published = true;
-        RequestDeadline.Value = until;
+        RequestDeadline.Value = new RequestDeadline.Bound(until, token);
     }
 
     public void Dispose() {

--- a/src/Requests/Hardened.Requests.Runtime/Filters/RequestDeadline.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/RequestDeadline.cs
@@ -1,0 +1,81 @@
+using Hardened.Requests.Abstract.Timeouts;
+using Hardened.Shared.Runtime.Diagnostics;
+
+namespace Hardened.Requests.Runtime.Filters;
+
+/// <summary>
+/// The singleton <see cref="IRequestDeadline"/> resolves to, reading the request it is asked on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written by <see cref="TimeoutFilter"/> for the span of the chain it bounds, and read by whatever
+/// the handler was resolved with. A static <c>AsyncLocal</c> rather than a scoped holder, because a
+/// described handler can only take this through its constructor and may be a singleton, which a
+/// scoped registration would let it capture.
+/// </para>
+/// <para>
+/// <b>The write is the cost.</b> Setting an <c>AsyncLocal</c> makes the execution context
+/// non-default for the rest of the request, so every continuation after it copies one. That is why
+/// nothing writes this unless a budget was declared, and why <c>[Timeout(Deadline = false)]</c>
+/// exists for a bounded handler that would rather not pay it.
+/// </para>
+/// </remarks>
+internal sealed class RequestDeadline : IRequestDeadline {
+
+    private static readonly AsyncLocal<MachineTimestamp?> Current = new();
+
+    /// <inheritdoc />
+    public MachineTimestamp? Deadline => Current.Value;
+
+    /// <summary>
+    /// Publishes <paramref name="deadline"/> until the scope is disposed, or nothing when it is
+    /// null.
+    /// </summary>
+    internal static DeadlineScope Until(MachineTimestamp? deadline) => new(deadline);
+
+    /// <summary>The value the scope reads and restores. Not part of the contract.</summary>
+    internal static MachineTimestamp? Value {
+        get => Current.Value;
+        set => Current.Value = value;
+    }
+}
+
+/// <summary>
+/// Publishes a deadline for a span of the pipeline, and puts the previous one back.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The restore is what makes nested budgets nest: an inner <c>[Timeout]</c> is what a handler
+/// inside it reads, and the outer one is what is visible again afterwards. It matters for the same
+/// reason <see cref="Hardened.Requests.Abstract.Execution.CancellationScope"/>'s does, and is
+/// written the same way.
+/// </para>
+/// <para>
+/// A struct, so a bounded request allocates nothing for this. Constructing one with null writes
+/// nothing and disposing it restores nothing, which is how a handler that declined the deadline
+/// pays for none of it.
+/// </para>
+/// </remarks>
+internal readonly struct DeadlineScope : IDisposable {
+    private readonly MachineTimestamp? _previous;
+    private readonly bool _published;
+
+    internal DeadlineScope(MachineTimestamp? deadline) {
+        if (deadline is not { } until) {
+            _previous = null;
+            _published = false;
+
+            return;
+        }
+
+        _previous = RequestDeadline.Value;
+        _published = true;
+        RequestDeadline.Value = until;
+    }
+
+    public void Dispose() {
+        if (_published) {
+            RequestDeadline.Value = _previous;
+        }
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Filters/TimeoutAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/TimeoutAttribute.cs
@@ -64,6 +64,16 @@ public sealed class TimeoutAttribute : Attribute, IDeclaresTimeout {
     /// </summary>
     public int RetryAfterSeconds { get; set; }
 
+    /// <summary>
+    /// Whether the handler can read this budget as an <see cref="IRequestDeadline"/>. On.
+    /// </summary>
+    /// <remarks>
+    /// Worth turning off for a bounded handler known not to read it. Publishing the deadline sets
+    /// an <c>AsyncLocal</c>, so every continuation for the rest of the request copies an execution
+    /// context. Nothing else changes: the budget still fires and the token still carries it.
+    /// </remarks>
+    public bool Deadline { get; set; } = true;
+
     /// <inheritdoc />
-    public TimeoutPolicy Timeout => new(Milliseconds, Status, RetryAfterSeconds);
+    public TimeoutPolicy Timeout => new(Milliseconds, Status, RetryAfterSeconds, Deadline);
 }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/TimeoutFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/TimeoutFilter.cs
@@ -25,11 +25,12 @@ namespace Hardened.Requests.Runtime.Filters;
 /// a thread runs to completion and the request answers late; nothing here can take a thread back.
 /// </para>
 /// <para>
-/// <b>It also publishes the deadline, for the handler that has to decide before it starts.</b>
+/// <b>It also publishes the budget, for the handler that has to decide before it starts.</b>
 /// The token says stop and says nothing about how long there was;
-/// <see cref="IRequestDeadline"/> answers the second question. Publishing it writes an
-/// <c>AsyncLocal</c>, which every continuation after it copies, so
-/// <c>[Timeout(Deadline = false)]</c> turns it off for a handler that will not read it.
+/// <see cref="IRequestDeadline"/> carries both readings, published together from here so they
+/// cannot describe different budgets. Publishing writes an <c>AsyncLocal</c>, which every
+/// continuation after it copies, so <c>[Timeout(Deadline = false)]</c> turns it off for a handler
+/// that will not read it.
 /// </para>
 /// <para>
 /// See <see cref="CancellationScope"/> for why the token is put back rather than left swapped, and
@@ -57,7 +58,7 @@ public class TimeoutFilter : IExecutionFilter {
 
         try {
             using (context.WithCancellation(deadline.Token))
-            using (RequestDeadline.Until(Published())) {
+            using (RequestDeadline.Until(Published(), deadline.Token)) {
                 await chain.Next();
             }
         }

--- a/src/Requests/Hardened.Requests.Runtime/Filters/TimeoutFilter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Filters/TimeoutFilter.cs
@@ -1,5 +1,7 @@
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Metrics;
+using Hardened.Requests.Abstract.Timeouts;
+using Hardened.Shared.Runtime.Diagnostics;
 
 namespace Hardened.Requests.Runtime.Filters;
 
@@ -23,14 +25,24 @@ namespace Hardened.Requests.Runtime.Filters;
 /// a thread runs to completion and the request answers late; nothing here can take a thread back.
 /// </para>
 /// <para>
-/// See <see cref="CancellationScope"/> for why the token is put back rather than left swapped.
+/// <b>It also publishes the deadline, for the handler that has to decide before it starts.</b>
+/// The token says stop and says nothing about how long there was;
+/// <see cref="IRequestDeadline"/> answers the second question. Publishing it writes an
+/// <c>AsyncLocal</c>, which every continuation after it copies, so
+/// <c>[Timeout(Deadline = false)]</c> turns it off for a handler that will not read it.
+/// </para>
+/// <para>
+/// See <see cref="CancellationScope"/> for why the token is put back rather than left swapped, and
+/// <see cref="DeadlineScope"/> for the deadline's own restore.
 /// </para>
 /// </remarks>
 public class TimeoutFilter : IExecutionFilter {
     private readonly int _milliseconds;
+    private readonly bool _publishDeadline;
 
-    public TimeoutFilter(int milliseconds) {
+    public TimeoutFilter(int milliseconds, bool publishDeadline = true) {
         _milliseconds = milliseconds;
+        _publishDeadline = publishDeadline;
     }
 
     public async Task Execute(IExecutionChain chain) {
@@ -44,7 +56,8 @@ public class TimeoutFilter : IExecutionFilter {
         deadline.CancelAfter(_milliseconds);
 
         try {
-            using (context.WithCancellation(deadline.Token)) {
+            using (context.WithCancellation(deadline.Token))
+            using (RequestDeadline.Until(Published())) {
                 await chain.Next();
             }
         }
@@ -63,4 +76,13 @@ public class TimeoutFilter : IExecutionFilter {
             }
         }
     }
+
+    /// <summary>The deadline to publish, or null when this handler declined it.</summary>
+    /// <remarks>
+    /// Taken now rather than from the request's start, because now is when the budget starts
+    /// running: <c>CancelAfter</c> is called on the same pass, and a deadline measured from
+    /// anywhere else would disagree with the token enforcing it.
+    /// </remarks>
+    private MachineTimestamp? Published() =>
+        _publishDeadline ? MachineTimestamp.Now.AddMs(_milliseconds) : null;
 }

--- a/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
+++ b/src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj
@@ -53,4 +53,10 @@
         <PackageReference Condition="'$(UseLocalValidationModules)' != 'true'" Include="ValidationModules.Runtime" Version="$(ValidationModulesVersion)"/>
     </ItemGroup>
 
+    <!-- RequestDeadline reads a static AsyncLocal that TimeoutFilter writes, and the tests for
+         what the filter publishes and restores have to read it back through the same accessor. -->
+    <ItemGroup>
+        <InternalsVisibleTo Include="Hardened.Requests.Runtime.Tests"/>
+    </ItemGroup>
+
 </Project>

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
@@ -106,6 +106,31 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     public SpecResponseModel ResponseModel { get; set; } = SpecResponseModel.Throws;
 
     /// <summary>
+    /// Whether every generated service method takes a <c>CancellationToken</c>, and the dispatch
+    /// binds one to it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// From <c>$(HardenedBindCancellationToken)</c>, and stamped here for the reason
+    /// <see cref="ResponseModel"/> is: the interface signature and the dispatch that calls it are
+    /// written by two halves of the build, and the second reads only this model. A flag that
+    /// reached one and not the other would emit a call whose argument list does not match the
+    /// interface it calls through.
+    /// </para>
+    /// <para>
+    /// Off, because turning it on adds a parameter to every method of every generated interface and
+    /// so stops an existing implementation compiling. That break is the point of the flag: it is
+    /// taken deliberately, once, with the compiler naming every method to change.
+    /// </para>
+    /// <para>
+    /// A whole-spec answer rather than a per-operation one. One interface with some methods taking
+    /// a token and some not is worse to read and worse to migrate than one that is consistent, and
+    /// a token costs nothing where it is not used.
+    /// </para>
+    /// </remarks>
+    public bool BindCancellationToken { get; set; }
+
+    /// <summary>
     /// Keywords the description declared that the parser did not map, in the order they were met.
     /// </summary>
     /// <remarks>
@@ -132,6 +157,7 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     public bool Equals(ServiceSpecModel? other) {
         if (other is not null && ContentNegotiation != other.ContentNegotiation) return false;
         if (other is not null && ResponseModel != other.ResponseModel) return false;
+        if (other is not null && BindCancellationToken != other.BindCancellationToken) return false;
 
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -68,6 +68,7 @@ internal static class SpecModelSerializer {
         spec.Add("JsonTypeInfoResolverName", model.JsonTypeInfoResolverName);
         spec.Add("ContentNegotiation", model.ContentNegotiation);
         spec.Add("ResponseModel", model.ResponseModel.ToString());
+        spec.Add("BindCancellationToken", model.BindCancellationToken);
         spec.Add("PublishUrl", model.PublishUrl);
         spec.Add("SourceUrl", model.SourceUrl);
         spec.Add("UiUrl", model.UiUrl);
@@ -146,6 +147,7 @@ internal static class SpecModelSerializer {
                     model.JsonTypeInfoResolverName = record.String("JsonTypeInfoResolverName") ?? "";
                     model.ContentNegotiation = record.String("ContentNegotiation") ?? "";
                     model.ResponseModel = ParseResponseModel(record.String("ResponseModel"));
+                    model.BindCancellationToken = record.Bool("BindCancellationToken");
                     model.PublishUrl = record.String("PublishUrl") ?? "";
                     model.SourceUrl = record.String("SourceUrl") ?? "";
                     model.UiUrl = record.String("UiUrl") ?? "";

--- a/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
+++ b/src/SourceGenerators/Hardened.Idl.BuildTask/ExtractSpecTask.cs
@@ -119,6 +119,25 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
     /// </remarks>
     public bool EmitUnreferencedSchemas { get; set; }
 
+    /// <summary>
+    /// Whether every generated service method takes a <c>CancellationToken</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Off. A described handler implements a signature it did not write, so the only way it can
+    /// take the request's token is for the generated interface to declare one - and declaring one
+    /// unconditionally would stop every existing implementation compiling. From
+    /// <c>$(HardenedBindCancellationToken)</c>, so the break is taken deliberately and once, with
+    /// the compiler naming every method that has to change.
+    /// </para>
+    /// <para>
+    /// Stamped onto the model rather than only handed to the emitters, for the reason
+    /// <c>ResponseModel</c> is: the generator that writes the dispatch never sees an MSBuild
+    /// property.
+    /// </para>
+    /// </remarks>
+    public bool BindCancellationToken { get; set; }
+
     /// <summary>The written models, for the caller to add to <c>@(AdditionalFiles)</c>.</summary>
     [Output]
     public ITaskItem[] ModelFiles { get; set; } = System.Array.Empty<ITaskItem>();
@@ -456,6 +475,7 @@ public abstract class ExtractSpecTask : Microsoft.Build.Utilities.Task {
             // property - so a mode that reached one and not the other produced a handler assigning a
             // response set as though it were a single value.
             model.ResponseModel = SelectedResponseModel();
+            model.BindCancellationToken = BindCancellationToken;
 
             if (!Published(spec, path, model)) {
                 continue;

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
@@ -13,7 +13,8 @@ internal static class ServiceInterfaceEmitter {
 
     public static InterfaceDefinition Emit(
         IConstructContainer container, ServiceModel service, string modelsNamespace,
-        SpecResponseModel responseModel = SpecResponseModel.Throws) {
+        SpecResponseModel responseModel = SpecResponseModel.Throws,
+        bool bindCancellationToken = false) {
         var interfaceDefinition = container.AddInterface(NamingHelper.ToInterfaceName(service.TypeBaseName));
 
         interfaceDefinition.Modifiers |= ComponentModifier.Public | ComponentModifier.Partial;
@@ -48,7 +49,7 @@ internal static class ServiceInterfaceEmitter {
 
             method.SetReturnType(GetReturnType(operation, modelsNamespace, responseModel));
 
-            AddParameters(method, operation, modelsNamespace);
+            AddParameters(method, operation, modelsNamespace, bindCancellationToken);
         }
 
         return interfaceDefinition;
@@ -213,8 +214,26 @@ internal static class ServiceInterfaceEmitter {
         return TypeDefinition.Get("System.Threading.Tasks", "Task");
     }
 
+    /// <summary>
+    /// The operation's own parameters, its body, and the request's token where the build asked for
+    /// one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The token goes last, after the body, which is where a C# author writes one and where the
+    /// binder's own ordering leaves it: a description names its parameters and its body separately,
+    /// so nothing else in the list is interleaved either.
+    /// </para>
+    /// <para>
+    /// No default value on it. An interface method may declare one, but the implementation is then
+    /// free to omit or contradict it, and a described handler is called by generated code that
+    /// always passes the argument - so a default would only be a second place for the two to
+    /// disagree.
+    /// </para>
+    /// </remarks>
     private static void AddParameters(
-        MethodDefinition method, OperationModel operation, string modelsNamespace) {
+        MethodDefinition method, OperationModel operation, string modelsNamespace,
+        bool bindCancellationToken = false) {
         foreach (var parameter in operation.Parameters) {
             var csType = TypeMapper.MapParameterToCSharpType(parameter);
 
@@ -230,6 +249,17 @@ internal static class ServiceInterfaceEmitter {
         } else if (operation.RequestBodyType != null) {
             var csType = TypeMapper.MapToCSharpType(operation.RequestBodyType, null);
             method.AddParameter(TypeMapper.GetTypeDefinition(modelsNamespace, csType, false), "body");
+        }
+
+        if (bindCancellationToken) {
+            // By name rather than typeof(CancellationToken), for the reason IAsyncEnumerable above
+            // is named that way: this assembly targets netstandard2.0 and declares no package
+            // references, and naming the type keeps it that way.
+            var token = method.AddParameter(
+                TypeDefinition.Get("System.Threading", "CancellationToken"), "cancellationToken");
+
+            token.Comment = DocComment.Format(
+                "Cancelled when the request's budget runs out or its caller hangs up.");
         }
     }
 

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
@@ -81,7 +81,9 @@ internal static class SpecFileEmitter {
 
             foreach (var service in model.Services) {
                 Coverage.Apply(
-                    ServiceInterfaceEmitter.Emit(services, service, modelsNamespace, responseModel),
+                    ServiceInterfaceEmitter.Emit(
+                        services, service, modelsNamespace, responseModel,
+                        model.BindCancellationToken),
                     excludeFromCoverage);
 
                 // In the models namespace, beside the payloads they carry, rather than beside the

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/BindCancellationTokenTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/BindCancellationTokenTests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using Hardened.Generation.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// What <c>$(HardenedBindCancellationToken)</c> puts on a generated interface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A described handler implements a signature it did not write, so a parameter the description does
+/// not name can only reach it this way. The flag exists rather than the parameter being
+/// unconditional because adding one stops every existing implementation compiling, which is a break
+/// worth taking deliberately and once.
+/// </para>
+/// <para>
+/// The other half of the pair is <c>SpecHandlerModelBuilder</c>, which binds the argument the
+/// dispatch passes. The two are written by different halves of the build and read the same flag off
+/// the model, which is what keeps the call and the signature agreeing.
+/// </para>
+/// </remarks>
+public class BindCancellationTokenTests {
+
+    private static ServiceModel Service() =>
+        new() {
+            Tag = "Job",
+            Operations = new List<OperationModel> {
+                new() {
+                    OperationId = "getJob",
+                    Path = "/jobs/{jobId}",
+                    HttpMethod = "GET",
+                    Tag = "Job",
+                    SuccessStatusCode = 200,
+                    ResponseRef = "#/components/schemas/Job",
+                    Parameters = new List<ParameterModel> {
+                        new() { Name = "jobId", In = "path", IsRequired = true, Type = "integer", Format = "int32" }
+                    }
+                },
+                new() {
+                    OperationId = "createJob",
+                    Path = "/jobs",
+                    HttpMethod = "POST",
+                    Tag = "Job",
+                    SuccessStatusCode = 201,
+                    RequestBodyRef = "#/components/schemas/NewJob",
+                    ResponseRef = "#/components/schemas/Job"
+                }
+            }
+        };
+
+    [Fact]
+    public void OffByDefault() {
+        var result = EmitterHarness.ServiceInterface(Service());
+
+        Assert.Contains("Task<Job> GetJob(int jobId);", result);
+        Assert.DoesNotContain("CancellationToken", result);
+    }
+
+    [Fact]
+    public void OnPutsTheTokenLastOnEveryMethod() {
+        var result = EmitterHarness.ServiceInterface(Service(), bindCancellationToken: true);
+
+        // The short name, under a using the emitter registered. Generated code a person opens reads
+        // the way they would have written it.
+        Assert.Contains("using System.Threading;", result);
+        Assert.Contains(
+            "Task<Job> GetJob(int jobId, CancellationToken cancellationToken);",
+            result);
+    }
+
+    /// <summary>
+    /// After the body, which is where a C# author writes one. A description names its parameters
+    /// and its body separately, so nothing else in the list is interleaved either.
+    /// </summary>
+    [Fact]
+    public void TheTokenGoesAfterTheBody() {
+        var result = EmitterHarness.ServiceInterface(Service(), bindCancellationToken: true);
+
+        Assert.Contains(
+            "Task<Job> CreateJob(NewJob body, CancellationToken cancellationToken);",
+            result);
+    }
+
+    /// <summary>
+    /// An operation taking nothing still takes the token, because the flag is a whole-spec answer.
+    /// One interface with some methods bound and some not is worse to read and worse to migrate.
+    /// </summary>
+    [Fact]
+    public void AnOperationWithNoParametersTakesItToo() {
+        var service = new ServiceModel {
+            Tag = "Job",
+            Operations = new List<OperationModel> {
+                new() {
+                    OperationId = "listJobs",
+                    Path = "/jobs",
+                    HttpMethod = "GET",
+                    Tag = "Job",
+                    SuccessStatusCode = 200,
+                    ResponseRef = "#/components/schemas/JobList"
+                }
+            }
+        };
+
+        var result = EmitterHarness.ServiceInterface(service, bindCancellationToken: true);
+
+        Assert.Contains(
+            "Task<JobList> ListJobs(CancellationToken cancellationToken);",
+            result);
+    }
+
+    /// <summary>
+    /// A streamed operation takes it too, after the parameters and before nothing else. Its return
+    /// type is an <c>IAsyncEnumerable</c> rather than a <c>Task</c>, which is the shape where a C#
+    /// author writes <c>[EnumeratorCancellation]</c> on the implementation's own parameter.
+    /// </summary>
+    [Fact]
+    public void AStreamedOperationTakesItAfterItsParameters() {
+        var service = new ServiceModel {
+            Tag = "Job",
+            Operations = new List<OperationModel> {
+                new() {
+                    OperationId = "jobEvents",
+                    Path = "/jobs/{jobId}/events",
+                    HttpMethod = "GET",
+                    Tag = "Job",
+                    SuccessStatusCode = 200,
+                    ItemSchemaRef = "#/components/schemas/JobEvent",
+                    Parameters = new List<ParameterModel> {
+                        new() { Name = "jobId", In = "path", IsRequired = true, Type = "integer", Format = "int32" }
+                    }
+                }
+            }
+        };
+
+        var result = EmitterHarness.ServiceInterface(service, bindCancellationToken: true);
+
+        Assert.Contains(
+            "IAsyncEnumerable<JobEvent> JobEvents(int jobId, CancellationToken cancellationToken);",
+            result);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/EmitterHarness.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/EmitterHarness.cs
@@ -56,8 +56,10 @@ internal static class EmitterHarness {
             ns, schema, ModelsNamespace,
             new PatternRegistry(RootNamespace + ".Validation", "petstore"), allSchemas));
 
-    internal static string ServiceInterface(ServiceModel service) =>
-        Write(ns => ServiceInterfaceEmitter.Emit(ns, service, ModelsNamespace),
+    internal static string ServiceInterface(
+        ServiceModel service, bool bindCancellationToken = false) =>
+        Write(ns => ServiceInterfaceEmitter.Emit(
+                ns, service, ModelsNamespace, SpecResponseModel.Throws, bindCancellationToken),
             RootNamespace + ".Services");
 
     internal static string JsonTypeInfo(

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
@@ -368,6 +368,7 @@ public class SpecModelSerializerTests {
 
         return new ServiceSpecModel {
             FileName = "petstore",
+            BindCancellationToken = true,
             Schemas = {
                 new SchemaModel {
                     Name = "Pet",

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/RequestModelBuilderTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/RequestModelBuilderTests.cs
@@ -427,4 +427,93 @@ public class RequestModelBuilderTests {
 
         Assert.Equal(ParameterBindType.Header, authParam.BindingType);
     }
+
+    /// <summary>
+    /// The dispatch half of <c>$(HardenedBindCancellationToken)</c>: the argument the generated
+    /// call passes, matching the parameter <c>ServiceInterfaceEmitter</c> put on the interface it
+    /// calls through.
+    /// </summary>
+    /// <remarks>
+    /// Bound the way a code-first handler's own <c>CancellationToken</c> parameter is, which is off
+    /// the context at <c>FilterOrder.Serialization</c> - inside <c>TimeoutFilter</c>'s span, and so
+    /// the budget's token rather than the transport's.
+    /// </remarks>
+    [Fact]
+    public void BuildModels_BindCancellationToken_AddsABoundTokenLast() {
+        var spec = CreatePetstoreSpec();
+        spec.BindCancellationToken = true;
+
+        var models = RequestModelBuilder.BuildModels(
+            spec, "Test.Api.Models", "Test.Api.Services", "Test.Api.Generated", "Test.Api.Validation");
+
+        var createPet = models.First(m => m.HandlerMethod == "CreatePet");
+        var parameters = createPet.RequestParameterInformationList;
+        var token = parameters[parameters.Count - 1];
+
+        Assert.Equal(ParameterBindType.CancellationToken, token.BindingType);
+        Assert.Equal("cancellationToken", token.Name);
+        Assert.Equal("CancellationToken", token.ParameterType.Name);
+
+        // After the body, matching the signature. A transposed argument list still compiles when the
+        // types happen to line up, so the position is what this pins.
+        Assert.Equal(ParameterBindType.Body, parameters[parameters.Count - 2].BindingType);
+    }
+
+    [Fact]
+    public void BuildModels_WithoutTheFlag_BindsNoToken() {
+        var spec = CreatePetstoreSpec();
+
+        var models = RequestModelBuilder.BuildModels(
+            spec, "Test.Api.Models", "Test.Api.Services", "Test.Api.Generated", "Test.Api.Validation");
+
+        Assert.DoesNotContain(
+            models.SelectMany(m => m.RequestParameterInformationList),
+            p => p.BindingType == ParameterBindType.CancellationToken);
+    }
+
+    /// <summary>
+    /// Every operation, because the flag is a whole-spec answer and the interface it has to match
+    /// puts the parameter on every method.
+    /// </summary>
+    [Fact]
+    public void BuildModels_BindCancellationToken_ReachesEveryOperation() {
+        var spec = CreatePetstoreSpec();
+        spec.BindCancellationToken = true;
+
+        var models = RequestModelBuilder.BuildModels(
+            spec, "Test.Api.Models", "Test.Api.Services", "Test.Api.Generated", "Test.Api.Validation");
+
+        Assert.All(models, model => Assert.Contains(
+            model.RequestParameterInformationList,
+            p => p.BindingType == ParameterBindType.CancellationToken));
+    }
+
+    /// <summary>
+    /// A streamed operation binds it the same way. Its dispatch is wired to the async-enumerable
+    /// filters rather than the standard ones, so the argument list is worth pinning separately.
+    /// </summary>
+    [Fact]
+    public void BuildModels_BindCancellationToken_ReachesAStreamedOperation() {
+        var spec = CreatePetstoreSpec();
+        spec.BindCancellationToken = true;
+        spec.Schemas.Add(new SchemaModel { Name = "PetEvent", Kind = SchemaKind.Object });
+        spec.Services[0].Operations.Add(new OperationModel {
+            OperationId = "petEvents",
+            Path = "/pets/{petId}/events",
+            HttpMethod = "GET",
+            ItemSchemaRef = "#/components/schemas/PetEvent",
+            Parameters = new List<ParameterModel> {
+                new() { Name = "petId", In = "path", IsRequired = true, Type = "string" }
+            }
+        });
+
+        var models = RequestModelBuilder.BuildModels(
+            spec, "Test.Api.Models", "Test.Api.Services", "Test.Api.Generated", "Test.Api.Validation");
+
+        var events = models.First(m => m.HandlerMethod == "PetEvents");
+        var parameters = events.RequestParameterInformationList;
+
+        Assert.Equal(
+            ParameterBindType.CancellationToken, parameters[parameters.Count - 1].BindingType);
+    }
 }

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator/Package/Hardened.OpenApi.SourceGenerator.targets
@@ -196,7 +196,7 @@
 
         <WriteLinesToFile
             File="$(HardenedOpenApiModelDir)filters.stamp"
-            Lines="@(HardenedOpenApiSpec->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)|%(SourceUrl)');$(HardenedResponseModel);@(_HardenedOpenApiTaskIdentity->'%(FullPath)|%(ModifiedTime)')"
+            Lines="@(HardenedOpenApiSpec->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)|%(SourceUrl)');$(HardenedResponseModel);$(HardenedBindCancellationToken);@(_HardenedOpenApiTaskIdentity->'%(FullPath)|%(ModifiedTime)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
     </Target>
@@ -214,6 +214,7 @@
                             Namespace="$(HardenedOpenApiNamespace)"
                             ExcludeFromCoverage="$(ExcludeGeneratedCodeFromCoverage)"
                             ResponseModel="$(HardenedResponseModel)"
+                            BindCancellationToken="$(HardenedBindCancellationToken)"
                             ApplyServerBasePath="$(HardenedOpenApiApplyServerBasePath)"
                             EmbedDocument="$(HardenedOpenApiEmbedDocument)"
                             GroupUntaggedByPath="$(HardenedOpenApiGroupUntaggedByPath)"

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/Hardened.Smithy.SourceGenerator.targets
@@ -311,7 +311,7 @@
 
         <WriteLinesToFile
             File="$(HardenedSmithyModelDir)filters.stamp"
-            Lines="@(HardenedSmithyAst->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)|%(SourceUrl)');$(HardenedSmithyServiceShapeId);$(HardenedResponseModel);@(_HardenedSmithyTaskIdentity->'%(FullPath)|%(ModifiedTime)')"
+            Lines="@(HardenedSmithyAst->'%(Identity)|%(Slice)|%(IncludePaths)|%(ExcludePaths)|%(Tags)|%(PublishUrl)|%(UiUrl)|%(UiEnvironments)|%(EmbedDocument)|%(SourceUrl)');$(HardenedSmithyServiceShapeId);$(HardenedResponseModel);$(HardenedBindCancellationToken);@(_HardenedSmithyTaskIdentity->'%(FullPath)|%(ModifiedTime)')"
             Overwrite="true"
             WriteOnlyWhenDifferent="true"/>
     </Target>
@@ -339,6 +339,7 @@
                            Namespace="$(HardenedSmithyNamespace)"
                            ExcludeFromCoverage="$(ExcludeGeneratedCodeFromCoverage)"
                            ResponseModel="$(HardenedResponseModel)"
+                           BindCancellationToken="$(HardenedBindCancellationToken)"
                            EmbedDocument="$(HardenedSmithyEmbedDocument)"
                            EmitUnreferencedSchemas="$(HardenedSmithyEmitUnreferencedSchemas)"
                            ServiceShapeId="$(HardenedSmithyServiceShapeId)">

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -49,7 +49,7 @@ internal static class SpecHandlerModelBuilder {
                     spec.ResponseModel,
                     spec.ValidatedOperations, filterTypeLookup, spec.Schemas,
                     service.DispatchHeader, Symbols(symbols, operation),
-                    service.TagDescription);
+                    service.TagDescription, spec.BindCancellationToken);
                 models.Add(model);
             }
         }
@@ -93,7 +93,8 @@ internal static class SpecHandlerModelBuilder {
         IReadOnlyList<SchemaModel> schemas,
         string? dispatchHeader = null,
         OperationSymbols? symbols = null,
-        string? tagDescription = null) {
+        string? tagDescription = null,
+        bool bindCancellationToken = false) {
         var methodName = operation.MethodName;
 
         // Derived by convention from the service's name for a described application, because a
@@ -111,7 +112,8 @@ internal static class SpecHandlerModelBuilder {
         var nameModel = new RequestHandlerNameModel(
             ConstrainedPath(operation), operation.HttpMethod, dispatchHeader, operation.DispatchKey);
 
-        var parameters = BuildParameters(operation, modelsNamespace, schemas, symbols);
+        var parameters = BuildParameters(
+            operation, modelsNamespace, schemas, symbols, bindCancellationToken);
         var responseInfo = symbols?.ResponseInformation
                            ?? BuildResponseInfo(operation, schemas, modelsNamespace, responseModel);
 
@@ -263,7 +265,7 @@ internal static class SpecHandlerModelBuilder {
 
     private static IReadOnlyList<RequestParameterInformation> BuildParameters(
         OperationModel operation, string modelsNamespace, IReadOnlyList<SchemaModel> schemas,
-        OperationSymbols? symbols = null) {
+        OperationSymbols? symbols = null, bool bindCancellationToken = false) {
         var parameters = new List<RequestParameterInformation>();
         var index = 0;
 
@@ -369,6 +371,25 @@ internal static class SpecHandlerModelBuilder {
                 true,
                 null,
                 ParameterBindType.Body,
+                "",
+                index++));
+        }
+
+        // Last, matching the parameter ServiceInterfaceEmitter puts at the end of the same
+        // signature. Bound the way a code-first handler's own CancellationToken parameter is, so
+        // the value read is whatever the context holds at FilterOrder.Serialization - which is
+        // inside TimeoutFilter's span, and therefore the budget's token rather than the transport's.
+        //
+        // Only where the signature came from a description. A hand-written handler declares its own
+        // parameters and the front end has already read them, so adding one here would be a second
+        // token the method never asked for.
+        if (bindCancellationToken && symbols == null) {
+            parameters.Add(new RequestParameterInformation(
+                TypeDefinition.Get("System.Threading", "CancellationToken"),
+                "cancellationToken",
+                true,
+                null,
+                ParameterBindType.CancellationToken,
                 "",
                 index++));
         }


### PR DESCRIPTION
A contract-first handler implements a signature it did not write, so neither the request's token nor its deadline could reach one. The timeout filter fired, the caller got its 504 on time, and the handler kept running against an upstream that never answered.

Two ways in, because they answer different questions.

## `$(HardenedBindCancellationToken)`

Puts a `CancellationToken` last on every method of every generated interface, and the dispatch binds it the way a code-first handler's own token parameter is bound. Read off the context at `FilterOrder.Serialization`, which is inside `TimeoutFilter`'s span, so it is the budget's token rather than the transport's.

Off by default. Turning it on adds a parameter to every method and stops an existing implementation compiling, which is a break worth taking deliberately and once, with the compiler naming every method to change.

The flag is stamped on the spec model rather than only handed to the emitters, for the reason `ResponseModel` is: the interface and the call that fills it are written by two halves of the build, and only one of them sees an MSBuild property. A flag reaching one and not the other is a call whose arguments do not match the method it calls.

## `IRequestDeadline`

Answers how long there is, which the token cannot. For the handler that has to decide before it starts whether there is time for a retry, a second upstream call, or the slow path.

`TimeoutFilter` publishes it for the span it bounds and restores it after, so nested budgets nest. It carries a `MachineTimestamp?`, monotonic and null when nothing bounds the request.

Registered as a singleton over an `AsyncLocal` rather than a scoped holder. A described handler reaches this through its constructor and may itself be a singleton, which a scoped registration would let it capture. That write makes the execution context non-default for the rest of the request, so `[Timeout(Deadline = false)]` declines it for a bounded handler that will not read it.

## Coverage

The ResponseModel SUT turns the flag on and its handler takes `IRequestDeadline` through its constructor under a `[Timeout]`, so both halves are built and dispatched end to end and the test asserts the token can actually fire rather than being `default`. The sibling SUT keeps the flag off, which keeps the default path covered the same way.

Unit tests pin the interface signature, the bound argument list and the round trip through `SpecModelSerializer`, including a streamed operation now that a described `itemSchema` generates one.

Full solution builds clean under `--configuration Release -p:ContinuousIntegrationBuild=true`, 39 test assemblies pass.

## Not in scope

A contract has no way to decline the deadline. `x-hardened-timeout` and `@timeout` are a number, and opting out would mean changing the extension's shape. The default is on, so a described operation gets the deadline; turning it off is code-first only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)