### PR TITLE
Fix the template's README, one-build Kiota regeneration and the throws sample's declarations

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -117,6 +117,13 @@ check_generated() {
             echo "   FAILED: $out/README.md does not end where the template's does"
             FAILED=1
         fi
+        # A directive written inline on a fence line is swallowed to the next #endif with everything
+        # between, so the fence never closes and the README still ends where it should. The 0.17
+        # and 0.21 trials both shipped that; fences pair up, so an odd count is the tell.
+        if [ $(( $(grep -c '^```' "$out/README.md") % 2 )) -ne 0 ]; then
+            echo "   FAILED: $out/README.md has an unclosed code fence"
+            FAILED=1
+        fi
     fi
 }
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/AGENTS.md
@@ -20,8 +20,12 @@ is wrong. Run `dotnet build` first.
 
 ```
 src/Hardened1/obj/<configuration>/<tfm>/generated/     one directory per generator
-#if (specFirst)
+#if (openapi)
 src/Hardened1/obj/<configuration>/<tfm>/openapi/       the normalised contract and the code built from it
+#endif
+#if (smithy)
+src/Hardened1/obj/<configuration>/<tfm>/smithy/ast/    the model's AST, written by the Smithy CLI
+src/Hardened1/obj/<configuration>/<tfm>/smithy/generated/  the normalised contract and the code built from it
 #endif
 ```
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -54,7 +54,7 @@ Four routes. `GET /todos` has one answer; the other three each declare more than
 
 ```bash
 curl -i -X POST localhost:5080/todos -H 'Content-Type: application/json' \
-     -d '{"title":"Add an endpoint"}'
+     -d '{"title":"Write a test"}'
 ```
 
 #if (OpenApiUi)
@@ -78,7 +78,11 @@ from a terminal browse to the page yourself.
 | | |
 |---|---|
 | `src/Hardened1` | Everything the application does — routes, services, models. Knows nothing about where it runs. |
+#if (lambda)
+| `src/Hardened1.Host` | Which runtime hosts it. `Main` is generated, so there is no `Program.cs`. The only host-specific project. |
+#else
 | `src/Hardened1.Host` | Which runtime hosts it, and `Program.cs`. The only host-specific project. |
+#endif
 #if (kiotaClient)
 | `src/Hardened1.Client` | The generated client. No hand-written code; Kiota writes it from the document the library's build wrote. |
 #endif
@@ -98,10 +102,25 @@ would be tied to a deployment target for no reason.
 A route is an attribute on a method of a plain class - no base type, no interface, no registration.
 `src/Hardened1/TodoController.cs` is the whole pattern:
 
+#if (throwsMode)
 ```csharp
 [Get("/{id}")]
-public async Task<#if (throwsMode)Todo#endif#if (responseMode)Response<Todo, NotFound>#endif#if (unionMode)TodoResult#endif> ById(ITodoStore store, int id)
+[Throws<NotFound>]
+public async Task<Todo> ById(ITodoStore store, int id)
 ```
+#endif
+#if (responseMode)
+```csharp
+[Get("/{id}")]
+public async Task<Response<Todo, NotFound>> ById(ITodoStore store, int id)
+```
+#endif
+#if (unionMode)
+```csharp
+[Get("/{id}")]
+public async Task<TodoResult> ById(ITodoStore store, int id)
+```
+#endif
 
 `[BasePath]` on `TemplateModuleNameLibrary` prefixes every route in the assembly, so that one is
 served at `/todos/{id}`. `[Get]`, `[Post]`, `[Put]`, `[Delete]` and `[Patch]` all behave the same
@@ -120,6 +139,7 @@ that test until its `Expected` table names the new operation and the statuses a 
 is the point: a status the document declares and nothing answers is the defect a reference page
 cannot show.
 #if (specFirst)
+
 #if (openapi)
 The contract is `src/Hardened1/contracts/todos.yaml`.
 #endif

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Client/Hardened1.Client.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Client/Hardened1.Client.csproj
@@ -44,16 +44,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-      The generated client, so it is visible in the IDE and compiled on every build after the
-      first. obj/ is outside the SDK's default glob, so nothing here is a duplicate of it.
-
-      On a clean tree this matches nothing, because item globs are evaluated before any target
-      runs and the files do not exist yet - IncludeClient below covers that one build, adding only
-      what this missed.
-    -->
-    <Compile Include="$(KiotaOutput)**/*.cs" />
-
     <!-- Version from Directory.Packages.props, where it is pinned beside the tool's. -->
     <PackageReference Include="Microsoft.Kiota.Bundle" />
 
@@ -136,15 +126,15 @@
   </Target>
 
   <!--
-    The first build only. The item glob above runs before any target, so on a clean tree it sees
-    nothing and this is what compiles the freshly generated client; on every build after that the
-    glob has already matched and Exclude keeps the same file from being compiled twice, which is
-    CS2002 and an error in a warning-free build.
+    Inside a target, after the client is generated, and never as a static item. A static glob is
+    evaluated before any target runs: on a clean tree it matches nothing, and after a contract
+    change it still names the files kiota's clean-output has just deleted, which is CS2001 on the
+    first build and a pass on the second. Evaluated here, the list is the client as it is now, so
+    a contract change builds in one go.
   -->
   <Target Name="IncludeClient" AfterTargets="GenerateClient" BeforeTargets="CoreCompile">
     <ItemGroup>
-      <_KiotaGenerated Include="$(KiotaOutput)**/*.cs" />
-      <Compile Include="@(_KiotaGenerated)" Exclude="@(Compile)" />
+      <Compile Include="$(KiotaOutput)**/*.cs" />
     </ItemGroup>
   </Target>
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Client/Hardened1.Client.refit.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Client/Hardened1.Client.refit.csproj
@@ -50,15 +50,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-      The generated client, so it is visible in the IDE and compiled on every build after the
-      first. obj/ is outside the SDK's default glob, so nothing here is a duplicate of it.
-
-      On a clean tree this matches nothing, because item globs are evaluated before any target
-      runs and the file does not exist yet - IncludeClient below covers that one build, adding only
-      what this missed.
-    -->
-    <Compile Include="$(RefitterOutput)**/*.cs" />
 
     <!-- Version from Directory.Packages.props, beside the tool's pin. -->
     <PackageReference Include="Refit" />
@@ -116,15 +107,13 @@
   </Target>
 
   <!--
-    The first build only. The item glob above runs before any target, so on a clean tree it sees
-    nothing and this is what compiles the freshly generated client; on every build after that the
-    glob has already matched and Exclude keeps the same file from being compiled twice, which is
-    CS2002 and an error in a warning-free build.
+    Inside a target, after the client is generated, and never as a static item. A static glob is
+    evaluated before any target runs, so on a clean tree it matches nothing; evaluated here, the
+    list is the client as it is now, the same way the Kiota project includes its output.
   -->
   <Target Name="IncludeClient" AfterTargets="GenerateClient" BeforeTargets="CoreCompile">
     <ItemGroup>
-      <_RefitterGenerated Include="$(RefitterOutput)**/*.cs" />
-      <Compile Include="@(_RefitterGenerated)" Exclude="@(Compile)" />
+      <Compile Include="$(RefitterOutput)**/*.cs" />
     </ItemGroup>
   </Target>
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/Hardened1.csproj
@@ -78,6 +78,7 @@
       later would otherwise compile and silently never run.
     -->
     <PackageReference Include="Hardened.Validation.SourceGenerator" />
+<!--#if (specFirst) -->
     <!--
       PrivateAssets="all" so the generators stay in this project.
       
@@ -91,6 +92,7 @@
       One attribute stops the whole subtree at this project's boundary, which is where a build-time
       generator belongs anyway.
     -->
+<!--#endif -->
 <!--#if (openapi) -->
     <PackageReference Include="Hardened.OpenApi.SourceGenerator" PrivateAssets="all" />
 <!--#endif -->

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TemplateModuleNameLibrary.cs
@@ -22,6 +22,9 @@ namespace Hardened1;
 #if (codeFirst)
 // This assembly's URL space. Every route below it is relative to this.
 [BasePath("/todos")]
+// The address the document lists under servers, which is where a client generated from it sends
+// by default and what keeps Kiota from warning that there is none. A deployment adds its own.
+[Server("http://localhost:5080", "Local")]
 // Embeds the document the build wrote from this assembly's routes, and serves it at
 // /openapi.json.
 //

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1/TodoController.cs
@@ -55,10 +55,12 @@ public class TodoController {
     /// <remarks>
     /// Throws mode: the signature names the success type, and every other status is thrown. The
     /// thrown value is the same NotFound record the declared modes return, so the 404 body is
-    /// identical either way - what differs is whether the compiler knows the route can answer it.
+    /// identical either way. [Throws&lt;NotFound&gt;] is what puts the 404 in the document; nothing
+    /// checks that the method throws it, which is the difference from the declared modes.
     /// </remarks>
     [Operation("getTodo")]
     [Get("/{id}")]
+    [Throws<NotFound>]
     public async Task<Todo> ById(ITodoStore store, [Range(Min = 1)] int id) {
         var todo = await store.Find(id);
 
@@ -78,6 +80,7 @@ public class TodoController {
     /// </remarks>
     [Operation("createTodo")]
     [Post("/")]
+    [Throws<Conflict>]
     public async Task<Todo> Create(ITodoStore store, NewTodo request) {
         if (await store.TitleExists(request.Title)) {
             throw new Conflict($"A todo titled '{request.Title}' already exists.").AsException();
@@ -89,6 +92,7 @@ public class TodoController {
     /// <summary>Removes one, or 404. Answers 200 with the removed todo, for the reason above.</summary>
     [Operation("removeTodo")]
     [Delete("/{id}")]
+    [Throws<NotFound>]
     public async Task<Todo> Remove(ITodoStore store, [Range(Min = 1)] int id) {
         var todo = await store.Find(id);
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
@@ -19,13 +19,13 @@ public class DocumentStatusTests {
 
     private static readonly Dictionary<string, string[]> Expected = new() {
 #if (codeFirst && throwsMode)
-        // Throws mode documents what the signature declares. The thrown NotFound and Conflict
-        // answer at runtime and are invisible here - the declared models close exactly that gap.
-        // The 400s stay: the id and the title are constrained, so binding either can refuse.
+        // Throws mode documents what the signature declares plus what [Throws<T>] adds: the 404
+        // and the 409 are thrown, and the attribute is what puts them in the document. The 400s
+        // stay: the id and the title are constrained, so binding either can refuse.
         ["GET /todos"] = ["200"],
-        ["GET /todos/{id}"] = ["200", "400"],
-        ["POST /todos"] = ["200", "400"],
-        ["DELETE /todos/{id}"] = ["200", "400"],
+        ["GET /todos/{id}"] = ["200", "400", "404"],
+        ["POST /todos"] = ["200", "400", "409"],
+        ["DELETE /todos/{id}"] = ["200", "400", "404"],
 #else
         // The declared statuses, plus the 400 the generated validation answers: the id and the
         // title are constrained, so every operation binding either can refuse.

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoStoreMockTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoStoreMockTests.cs
@@ -25,20 +25,41 @@ namespace Hardened1.Tests;
 /// [Mock] on a parameter registers the double over the application's own registration and hands
 /// the test the same instance, so what the test configures is what the handler was built against.
 #endif
-/// ITestWebApp sends the request through the pipeline, so this reads the same whichever client the
-/// project generates.
+#if (hasClient)
+/// The request goes through the generated client, like every request the client can make.
+#else
+/// ITestWebApp sends the request through the pipeline.
+#endif
 /// </remarks>
 public class TodoStoreMockTests {
+#if (!hasClient)
 
     /// <summary>The response shape as a client sees it, asserted on the wire rather than on an internal type.</summary>
     private record TodoResponse(int Id, string Title, bool Done);
+#endif
 
     [HardenedTest]
 #if (moq)
+#if (kiotaClient)
+    public async Task GetTodo_ReadsTheMockedStore(TemplateModuleNameClient client, Mock<ITodoStore> store) {
+#endif
+#if (refitClient)
+    public async Task GetTodo_ReadsTheMockedStore(ITemplateModuleNameClient client, Mock<ITodoStore> store) {
+#endif
+#if (!hasClient)
     public async Task GetTodo_ReadsTheMockedStore(ITestWebApp app, Mock<ITodoStore> store) {
+#endif
         store.Setup(s => s.Find(1)).ReturnsAsync(new Todo(1, "from the mock", false));
 #else
+#if (kiotaClient)
+    public async Task GetTodo_ReadsTheMockedStore(TemplateModuleNameClient client, [Mock] ITodoStore store) {
+#endif
+#if (refitClient)
+    public async Task GetTodo_ReadsTheMockedStore(ITemplateModuleNameClient client, [Mock] ITodoStore store) {
+#endif
+#if (!hasClient)
     public async Task GetTodo_ReadsTheMockedStore(ITestWebApp app, [Mock] ITodoStore store) {
+#endif
 #if (nsubstitute)
         store.Find(1).Returns(new Todo(1, "from the mock", false));
 #endif
@@ -47,6 +68,25 @@ public class TodoStoreMockTests {
 #endif
 #endif
 
+#if (kiotaClient)
+        var todo = await client.Todos[1].GetAsync().Returns<Ok<ClientModels.Todo>>();
+
+#if (xunit)
+        Assert.Equal("from the mock", todo.Value.Title);
+#else
+        Assert.That(todo.Value.Title, Is.EqualTo("from the mock"));
+#endif
+#endif
+#if (refitClient)
+        var todo = await client.GetTodo(1).Returns<Ok<ClientModels.Todo>>();
+
+#if (xunit)
+        Assert.Equal("from the mock", todo.Value.Title);
+#else
+        Assert.That(todo.Value.Title, Is.EqualTo("from the mock"));
+#endif
+#endif
+#if (!hasClient)
         var response = await app.Get("/todos/1");
 
         response.Assert.Ok();
@@ -54,6 +94,7 @@ public class TodoStoreMockTests {
         Assert.Equal("from the mock", response.Deserialize<TodoResponse>().Title);
 #else
         Assert.That(response.Deserialize<TodoResponse>().Title, Is.EqualTo("from the mock"));
+#endif
 #endif
     }
 }

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.cs
@@ -7,10 +7,10 @@ namespace Hardened1.Tests;
 /// The client is a test parameter; [assembly: KiotaTesting] in Bootstrap.cs is what builds it, over
 /// the same in-process chain ITestWebApp drives - routing, filters, binding, the handler and
 /// serialisation. A call is asserted with Returns&lt;T&gt;(), naming the response type the contract
-/// declares - Created&lt;Todo&gt;, NotFound&lt;Problem&gt;, NoContent - which is the status, the
-/// body type and the headers that status carries in one word, for a success the client returns and
-/// a refusal it throws alike. ReturnsStatus&lt;T&gt;() asserts the status alone, for one the
-/// document declares no body for.
+/// declares - Created&lt;Todo&gt;, a NotFound carrying the 404 body the contract declares,
+/// NoContent - which is the status, the body type and the headers that status carries in one word,
+/// for a success the client returns and a refusal it throws alike. ReturnsStatus&lt;T&gt;() asserts
+/// the status alone, for one the document declares no body for.
 ///
 /// Every declared status is asserted, not only the happy one. A response model that is only ever
 /// exercised at 200 is indistinguishable from one that has no declared set at all, which is the
@@ -40,35 +40,19 @@ public class TodoTests {
 #endif
     }
 
-#if (codeFirst && throwsMode)
+#if (codeFirst)
+#if (throwsMode)
     /// <summary>
-    /// Throws mode documents only the 200, so the generated client has no 404 branch: the same
-    /// request that answers a typed NotFound under the response model is a bare ApiException here,
-    /// with no body type to name. The status is what is asserted, and the declared models close
-    /// exactly that gap.
+    /// [Throws&lt;NotFound&gt;] on the handler puts the 404 in the document, so Kiota generated a
+    /// typed exception for it - named after the case, NotFound, and carrying the body the server
+    /// answered. Without the attribute the same request is a bare ApiException with no body type.
     /// </summary>
-    [HardenedTest]
-    public async Task GetTodo_UnknownId_IsAnUntypedNotFound(TemplateModuleNameClient client) {
-        await client.Todos[9999].GetAsync().ReturnsStatus<NotFound>();
-    }
-
-    [HardenedTest]
-    public async Task RemoveTodo_UnknownId_IsAnUntypedNotFound(TemplateModuleNameClient client) {
-        await client.Todos[9999].DeleteAsync().ReturnsStatus<NotFound>();
-    }
-
-    /// <summary>Titles are unique, which is what gives the sample a real 409 - thrown and undocumented, like the 404.</summary>
-    [HardenedTest]
-    public async Task CreateTodo_DuplicateTitle_IsAnUntypedConflict(TemplateModuleNameClient client) {
-        await client.Todos.PostAsync(new ClientModels.NewTodo { Title = "Add an endpoint" })
-            .ReturnsStatus<Conflict>();
-    }
-#endif
-#if (codeFirst && declaredMode)
+#else
     /// <summary>
     /// The 404 is in the signature, so it is in the document, so Kiota generated a typed exception
     /// for it - named after the case, NotFound, and carrying the body the server answered.
     /// </summary>
+#endif
     [HardenedTest]
     public async Task GetTodo_UnknownId_IsATypedNotFound(TemplateModuleNameClient client) {
         var missing = await client.Todos[9999].GetAsync().Returns<NotFound<ClientModels.NotFound>>();

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.refit.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/TodoTests.refit.cs
@@ -39,33 +39,20 @@ public class TodoTests {
 #endif
     }
 
-#if (codeFirst && throwsMode)
+#if (codeFirst)
+#if (throwsMode)
     /// <summary>
-    /// Throws mode documents only the 200, so the document declares no body for the 404 and there
-    /// is no type to name: the status is what is asserted. The declared models close exactly that gap.
+    /// [Throws&lt;NotFound&gt;] on the handler puts the 404 in the document, so Refitter generated a
+    /// model for its body - named after the case, NotFound - and the refusal is read as it, through
+    /// the client's own serializer. Without the attribute the status is all the client can see.
     /// </summary>
-    [HardenedTest]
-    public async Task GetTodo_UnknownId_IsAnUntypedNotFound(ITemplateModuleNameClient client) {
-        await client.GetTodo(9999).ReturnsStatus<NotFound>();
-    }
-
-    [HardenedTest]
-    public async Task RemoveTodo_UnknownId_IsAnUntypedNotFound(ITemplateModuleNameClient client) {
-        await client.RemoveTodo(9999).ReturnsStatus<NotFound>();
-    }
-
-    /// <summary>Titles are unique, which is what gives the sample a real 409 - thrown and undocumented, like the 404.</summary>
-    [HardenedTest]
-    public async Task CreateTodo_DuplicateTitle_IsAnUntypedConflict(ITemplateModuleNameClient client) {
-        await client.CreateTodo(new ClientModels.NewTodo { Title = "Add an endpoint" }).ReturnsStatus<Conflict>();
-    }
-#endif
-#if (codeFirst && declaredMode)
+#else
     /// <summary>
     /// The 404 is in the signature, so it is in the document, so Refitter generated a model for its
     /// body - named after the case, NotFound - and the refusal is read as it, through the client's
     /// own serializer.
     /// </summary>
+#endif
     [HardenedTest]
     public async Task GetTodo_UnknownId_IsATypedNotFound(ITemplateModuleNameClient client) {
         var missing = await client.GetTodo(9999).Returns<NotFound<ClientModels.NotFound>>();


### PR DESCRIPTION
From the 0.21 Dispatch trial: S-01, S-02, S-09, S-11, S-15, H-08, H-24, H-26, H-35, and H-30 checked.

## What changes

- **The README's handler sample renders in every response model.** `README.md` put three `#if ... #endif` pairs inline on one fence line, and the engine honours a directive only on its own line: in response and union modes the fence never closed and the `[BasePath]` and services paragraphs were gone, and in throws mode the signature line was missing. One fence per mode now. `verify-templates.sh` fails an odd fence count, because the 0.17 trial reported the same trigger and it came back.
- **The throws sample declares what it throws.** `[Throws<NotFound>]` and `[Throws<Conflict>]` on the three handlers, so the document carries the 404 and 409 the host answers, `DocumentStatusTests` expects them, and the client tests assert the typed refusal the way the declared modes do. The README's own snippet shows the attribute.
- **A contract change builds in one go.** Both client projects included the generated files as a static `Compile` glob, evaluated before `GenerateClient` runs `--clean-output`, so removing a model failed the first build with CS2001 on a file Kiota had just deleted and passed the second. The files are included inside `IncludeClient` only.
- **The rest.** `[Server("http://localhost:5080", "Local")]` on the library module, so the document has a `servers` entry and Kiota stops warning on every build; the mock test sends through the generated client where there is one; the POST example uses a title the seed does not have; the projects table says `Main` is generated on Lambda; the `PrivateAssets` comment is written only where the references it explains are; AGENTS names the Smithy `obj` layout; two wording slips.

H-30 needed no change: singleton, scoped and transient classes all resolve by their own type from a generated project, checked with a throwaway test.

## What was checked

`scripts/verify-templates.sh` with the default rows: every Kestrel and ASP.NET Core row, the Smithy rows, the library rows and the dotted-name rows build and test green, and the new fence check passes on every rendered README. On the generated throws row: a second build has no CS2002; removing the Create route and building the client once passes, with the two deleted model files gone from the output; a simulated design-time build (`Compile` with `DesignTimeBuild=true` and `SkipCompilerExecution=true`) still lists the generated files on both the Kiota and the Refit rows.

The five Lambda rows fail their socket probe, as #292 says they do until an Amz release carrying Hardened.Amz #89 is on nuget.org: the released 0.21 `Main` runs the bootstrap against an unset `AWS_LAMBDA_RUNTIME_API`. Their build and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
