### PR TITLE
Serialize enum-keyed dictionaries with the enum's wire vocabulary

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/EnumVocabularyTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/EnumVocabularyTests.cs
@@ -49,6 +49,34 @@ public class EnumVocabularyTests {
     }
 
     /// <summary>
+    /// A dictionary keyed by the enum writes its keys in the vocabulary, and reads them back. It
+    /// answered 500 with an empty body once the converter was registered, because the converter
+    /// read and wrote values and System.Text.Json wants the property-name pair for a key.
+    /// </summary>
+    [HardenedTest]
+    public async Task ADictionaryKeyIsWrittenInTheVocabulary(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/enum-vocabulary/by-priority/counts");
+
+        Assert.Equal(200, response.StatusCode);
+
+        var body = await response.ReadTextAsync();
+
+        Assert.Contains("\"low\":1", body);
+        Assert.Contains("\"inProgress\":2", body);
+    }
+
+    [HardenedTest]
+    public async Task ADictionaryKeyIsReadInTheVocabulary(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            "{\"onHold\":3}",
+            "/enum-vocabulary/by-priority/counts",
+            request => request.Headers["Content-Type"] = "application/json");
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Equal("3", await response.ReadTextAsync());
+    }
+
+    /// <summary>
     /// A value the application does not declare is refused rather than guessed at.
     /// </summary>
     [HardenedTest]

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/EnumVocabularyController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/EnumVocabularyController.cs
@@ -56,4 +56,15 @@ public class EnumVocabularyController {
     [Get("/by-shipping")]
     public string DeclaredNamingFromQuery([FromQueryString] Shipping shipping) =>
         shipping.ToString();
+
+    /// <summary>
+    /// The enum as a dictionary key, which System.Text.Json refuses unless the converter reads
+    /// and writes property names. Priority is bound above, so its converter is registered here.
+    /// </summary>
+    [Get("/by-priority/counts")]
+    public Dictionary<Priority, int> Counts() =>
+        new() { [Priority.Low] = 1, [Priority.InProgress] = 2 };
+
+    [Post("/by-priority/counts")]
+    public int ReadCounts(Dictionary<Priority, int> counts) => counts[Priority.OnHold];
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -2400,6 +2400,86 @@
         "x-hardened-timeout": 300000
       }
     },
+    "/enum-vocabulary/by-priority/counts": {
+      "get": {
+        "tags": [
+          "EnumVocabulary"
+        ],
+        "operationId": "counts",
+        "summary": "The enum as a dictionary key, which System.Text.Json refuses unless the converter reads and writes property names. Priority is bound above, so its converter is registered here.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      },
+      "post": {
+        "tags": [
+          "EnumVocabulary"
+        ],
+        "operationId": "readCounts",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
     "/enum-vocabulary/by-shipping": {
       "get": {
         "tags": [

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/EnumWireConverterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/EnumWireConverterTests.cs
@@ -61,6 +61,22 @@ public class EnumWireConverterTests {
     }
 
     /// <summary>
+    /// The dictionary-key half. System.Text.Json reads and writes a key through the property-name
+    /// overrides and refuses the type as a key when a converter has none, so a converter that only
+    /// read and wrote values broke every enum-keyed dictionary the moment it was registered.
+    /// </summary>
+    [Fact]
+    public void AnEnumOnTheWireGetsAConverterForDictionaryKeys() {
+        var routing = RequestGeneratorHarness.Generate(Application(PriorityController))
+            .AssertNoErrors()
+            .SourceContaining("Application.Routing");
+
+        Assert.Contains("ReadAsPropertyName", routing);
+        Assert.Contains("WriteAsPropertyName", routing);
+        Assert.Contains("writer.WritePropertyName(wire);", routing);
+    }
+
+    /// <summary>
     /// The binder's half. A path or query value is text and never reaches a JSON converter, so the
     /// same vocabulary has to be registered for it separately.
     /// </summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/EnumWireConverterEmitter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/EnumWireConverterEmitter.cs
@@ -88,14 +88,21 @@ internal static class EnumWireConverterEmitter {
             ComponentModifier.Public | ComponentModifier.Static | ComponentModifier.Readonly;
         instance.InitializeValue = new CodeOutputComponent("new()") { Indented = false };
 
-        EmitRead(converter, vocabulary, enumType);
-        EmitWrite(converter, vocabulary, enumType);
+        EmitRead(converter, vocabulary, enumType, "Read");
+        EmitWrite(converter, vocabulary, enumType, "Write", "writer.WriteStringValue(wire);");
+
+        // The same vocabulary as a dictionary key. System.Text.Json reads and writes a key through
+        // these two rather than Read and Write, and refuses the type as a key when a converter
+        // does not override them: an enum-keyed dictionary serialized until any handler bound the
+        // enum and this converter was registered, and then answered 500 with an empty body.
+        EmitRead(converter, vocabulary, enumType, "ReadAsPropertyName");
+        EmitWrite(converter, vocabulary, enumType, "WriteAsPropertyName", "writer.WritePropertyName(wire);");
         EmitTryParseWire(converter, vocabulary, enumType);
     }
 
     private static void EmitRead(
-        ClassDefinition converter, EnumVocabulary vocabulary, ITypeDefinition enumType) {
-        var method = converter.AddMethod("Read");
+        ClassDefinition converter, EnumVocabulary vocabulary, ITypeDefinition enumType, string name) {
+        var method = converter.AddMethod(name);
 
         method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
         method.SetReturnType(enumType);
@@ -128,8 +135,9 @@ internal static class EnumWireConverterEmitter {
     }
 
     private static void EmitWrite(
-        ClassDefinition converter, EnumVocabulary vocabulary, ITypeDefinition enumType) {
-        var method = converter.AddMethod("Write");
+        ClassDefinition converter, EnumVocabulary vocabulary, ITypeDefinition enumType,
+        string name, string write) {
+        var method = converter.AddMethod(name);
 
         method.Modifiers |= ComponentModifier.Public | ComponentModifier.Override;
         method.AddParameter(TypeDefinition.Get("System.Text.Json", "Utf8JsonWriter"), "writer");
@@ -149,7 +157,7 @@ internal static class EnumWireConverterEmitter {
         lines.Add($"        \"The value is not one {Escape(vocabulary.Name)} declares.\")");
         lines.Add("};");
         lines.Add("");
-        lines.Add("writer.WriteStringValue(wire);");
+        lines.Add(write);
 
         Write(method, lines);
     }


### PR DESCRIPTION
From the 0.21 Dispatch trial: H-03. Independent of #294.

`Dictionary<JobStatus, int>` serialized with member-name keys while no handler bound the enum. Once one did, the generated `JobStatusWireConverter` was registered and System.Text.Json refused the enum as a dictionary key: `NotSupportedException: The type 'JobStatus' is not a supported dictionary key`, a 500 with an empty body, and the metric line recorded 200.

The generated converter now overrides `ReadAsPropertyName` and `WriteAsPropertyName` beside `Read` and `Write`, with the same vocabulary. That pair is what System.Text.Json reads and writes a key through.

## What was checked

An emitter test asserts the two overrides are written. In the WebApp SUT, `EnumVocabularyController` answers and reads a `Dictionary<Priority, int>`, with `Priority` bound by a query parameter on the same controller so the converter is registered, and two end-to-end tests assert the keys are the camelCase vocabulary on the wire in both directions. The full solution under `--configuration Release -p:ContinuousIntegrationBuild=true`: 39 test assemblies pass.

H-16 is untouched: a serializer exception still escapes `ITestWebApp.Get` as a raw exception rather than a 500 with `Failure` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
