### PR TITLE
Publish each enum once as a component schema

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/EnumVocabularyTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/EnumVocabularyTests.cs
@@ -152,12 +152,21 @@ public class EnumVocabularyTests {
         Assert.Equal(new[] { "next-day", "two-day" }, Values(schemas, "Order", "shipping"));
     }
 
-    private static string[] Values(JsonElement schemas, string schema, string property) =>
-        schemas.GetProperty(schema)
+    /// <summary>
+    /// Through the reference: an enum is one component, and the member refers to it, so a client
+    /// generator produces one type per server enum rather than one per property.
+    /// </summary>
+    private static string[] Values(JsonElement schemas, string schema, string property) {
+        var reference = schemas.GetProperty(schema)
             .GetProperty("properties")
             .GetProperty(property)
+            .GetProperty("$ref")
+            .GetString()!;
+
+        return schemas.GetProperty(reference.Substring("#/components/schemas/".Length))
             .GetProperty("enum")
             .EnumerateArray()
             .Select(value => value.GetString()!)
             .ToArray();
+    }
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/GeneratedClientTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/GeneratedClientTests.cs
@@ -72,7 +72,7 @@ public class GeneratedClientTests {
         var ticket = await client.EnumVocabulary.Ticket.GetAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal("Ship it", ticket!.Title);
-        Assert.Equal(ClientModels.Ticket_priority.InProgress, ticket.Priority);
+        Assert.Equal(ClientModels.Priority.InProgress, ticket.Priority);
     }
 
     /// <summary>

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -2356,12 +2356,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "low",
-                "inProgress",
-                "onHold"
-              ]
+              "$ref": "#/components/schemas/Priority"
             }
           }
         ],
@@ -2492,11 +2487,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "next-day",
-                "two-day"
-              ]
+              "$ref": "#/components/schemas/Shipping"
             }
           }
         ],
@@ -2617,12 +2608,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string",
-                  "enum": [
-                    "low",
-                    "inProgress",
-                    "onHold"
-                  ]
+                  "$ref": "#/components/schemas/Priority"
                 }
               }
             }
@@ -5306,6 +5292,13 @@
           }
         }
       },
+      "LegacyCode": {
+        "type": "string",
+        "enum": [
+          "AB12",
+          "CD34"
+        ]
+      },
       "MathAddModel": {
         "type": "object",
         "properties": {
@@ -5349,20 +5342,20 @@
         ],
         "properties": {
           "code": {
-            "type": "string",
-            "enum": [
-              "AB12",
-              "CD34"
-            ]
+            "$ref": "#/components/schemas/LegacyCode"
           },
           "shipping": {
-            "type": "string",
-            "enum": [
-              "next-day",
-              "two-day"
-            ]
+            "$ref": "#/components/schemas/Shipping"
           }
         }
+      },
+      "Priority": {
+        "type": "string",
+        "enum": [
+          "low",
+          "inProgress",
+          "onHold"
+        ]
       },
       "Reading": {
         "type": "object",
@@ -5463,6 +5456,13 @@
           }
         }
       },
+      "Shipping": {
+        "type": "string",
+        "enum": [
+          "next-day",
+          "two-day"
+        ]
+      },
       "Ticket": {
         "type": "object",
         "required": [
@@ -5474,12 +5474,7 @@
             "type": "string"
           },
           "priority": {
-            "type": "string",
-            "enum": [
-              "low",
-              "inProgress",
-              "onHold"
-            ]
+            "$ref": "#/components/schemas/Priority"
           }
         }
       }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
@@ -407,12 +407,19 @@ public class OpenApiDocumentEmissionTests {
     /// </summary>
     [Fact]
     public void AnEnumParameterCarriesItsVocabulary() {
-        var schema = ListParameter(FidelityDocument(), "carrier").GetProperty("schema");
+        var document = FidelityDocument();
+        var schema = ListParameter(document, "carrier").GetProperty("schema");
 
-        Assert.Equal("string", schema.GetProperty("type").GetString());
+        // One component per enum, referenced from the parameter as from a member, so a client
+        // generator produces one type per server enum rather than one per use.
+        Assert.Equal("#/components/schemas/Carrier", schema.GetProperty("$ref").GetString());
+
+        var carrier = document.GetProperty("components").GetProperty("schemas").GetProperty("Carrier");
+
+        Assert.Equal("string", carrier.GetProperty("type").GetString());
         Assert.Equal(
             new[] { "dhl", "fedex", "royalMail" },
-            schema.GetProperty("enum").EnumerateArray().Select(value => value.GetString()));
+            carrier.GetProperty("enum").EnumerateArray().Select(value => value.GetString()));
     }
 
     /// <summary>
@@ -423,13 +430,17 @@ public class OpenApiDocumentEmissionTests {
     /// </summary>
     [Fact]
     public void AParameterOnlyEnumCarriesItsVocabulary() {
-        var schema = Parameter(FidelityDocument(), "/shipments/urgent", "priority")
-            .GetProperty("schema");
+        var document = FidelityDocument();
+        var schema = Parameter(document, "/shipments/urgent", "priority").GetProperty("schema");
 
-        Assert.Equal("string", schema.GetProperty("type").GetString());
+        Assert.Equal("#/components/schemas/Priority", schema.GetProperty("$ref").GetString());
+
+        var priority = document.GetProperty("components").GetProperty("schemas").GetProperty("Priority");
+
+        Assert.Equal("string", priority.GetProperty("type").GetString());
         Assert.Equal(
             new[] { "low", "high" },
-            schema.GetProperty("enum").EnumerateArray().Select(value => value.GetString()));
+            priority.GetProperty("enum").EnumerateArray().Select(value => value.GetString()));
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
@@ -118,7 +118,7 @@ public static class JsonSchemaWriter {
             }
 
             if (named.TypeKind == TypeKind.Enum) {
-                return EnumSchema(named, enums, compilationAssembly);
+                return EnumRef(named, components, enums, compilationAssembly);
             }
 
             if (named.TypeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Interface) {
@@ -151,6 +151,27 @@ public static class JsonSchemaWriter {
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// An enum as one component, referenced from every member typed with it.
+    /// </summary>
+    /// <remarks>
+    /// The values were written inline at every use, so a document with three enums carried
+    /// thirteen copies and a client generator produced one type per property: Refitter's
+    /// <c>JobStatus</c>, <c>JobSummaryStatus</c>, <c>JobEventStatus</c> and <c>Status</c> were one
+    /// server enum, and every test that moved a value between models converted by hand. One
+    /// component under the enum's name is one generated type. The parameter writer in
+    /// <c>OpenApiDocumentGenerator</c> refers to the same component from the vocabulary it holds.
+    /// </remarks>
+    private static string EnumRef(
+        INamedTypeSymbol named, Dictionary<string, string> components,
+        Dictionary<string, EnumVocabulary> enums, IAssemblySymbol? compilationAssembly) {
+        var name = SchemaName(named);
+
+        components[name] = EnumSchema(named, enums, compilationAssembly);
+
+        return "{\"$ref\":\"#/components/schemas/" + Escape(name) + "\"}";
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -81,6 +81,14 @@ public static class OpenApiDocumentGenerator {
             enums[vocabulary.QualifiedName] = vocabulary;
         }
 
+        // Every vocabulary is a component, whether a body reached it or only a parameter did. A
+        // parameter's schema refers to the component by name, and a parameter-only enum has no
+        // body schema to carry it in. A body schema that reaches the same enum writes the same
+        // component again, byte for byte.
+        foreach (var vocabulary in enums.Values) {
+            components[vocabulary.Name] = EnumComponent(vocabulary);
+        }
+
         // Grouped by path, because a document keys operations under one path entry rather than
         // repeating the path per verb.
         // Grouped by the template, which is what the document keys on - not by the route, which is
@@ -1113,6 +1121,10 @@ public static class OpenApiDocumentGenerator {
     /// Consulting it is what keeps a parameter's <c>enum</c> array agreeing with what the binder
     /// accepts - the fourth of the four places <c>EnumWireNaming</c>'s remarks require to agree.
     /// </remarks>
+    /// <summary>
+    /// A reference to the component an enum parameter's vocabulary is written as, or null for a
+    /// type that is not one of the application's enums.
+    /// </summary>
     private static string? EnumSchema(
         ITypeDefinition type, IReadOnlyDictionary<string, EnumVocabulary> enums) {
         var qualified = "global::" + type.Namespace + "." + type.Name.TrimEnd('?');
@@ -1121,6 +1133,11 @@ public static class OpenApiDocumentGenerator {
             return null;
         }
 
+        return "{\"$ref\":\"#/components/schemas/" + JsonSchemaWriter.Escape(vocabulary.Name) + "\"}";
+    }
+
+    /// <summary>The component an enum is written as: its values, in the vocabulary the wire carries.</summary>
+    private static string EnumComponent(EnumVocabulary vocabulary) {
         var builder = new StringBuilder("{\"type\":\"string\",\"enum\":[");
 
         for (var i = 0; i < vocabulary.Values.Count; i++) {

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/EnumWireVocabularyTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/EnumWireVocabularyTests.cs
@@ -105,10 +105,16 @@ public class EnumWireVocabularyTests {
 
         using var document = JsonDocument.Parse(GeneratedOpenApiDocument.Extract(source));
 
-        var values = document.RootElement
-            .GetProperty("components").GetProperty("schemas")
-            .GetProperty("Ticket").GetProperty("properties").GetProperty("priority")
-            .GetProperty("enum")
+        var schemas = document.RootElement.GetProperty("components").GetProperty("schemas");
+
+        // One component per enum, referenced from the member, so a client generator produces one
+        // type per server enum rather than one per property.
+        Assert.Equal(
+            "#/components/schemas/Priority",
+            schemas.GetProperty("Ticket").GetProperty("properties").GetProperty("priority")
+                .GetProperty("$ref").GetString());
+
+        var values = schemas.GetProperty("Priority").GetProperty("enum")
             .EnumerateArray().Select(value => value.GetString()).ToArray();
 
         Assert.Equal(new[] { "low", "inProgress" }, values);


### PR DESCRIPTION
From the 0.21 Dispatch trial: H-12. On top of #296.

An enum's values were written inline at every use, so a document with three enums carried thirteen copies and a client generator produced one type per property: Refitter's `JobStatus`, `JobSummaryStatus`, `JobEventStatus`, `StatusChangeStatus` and `Status` were three server enums, and every test that moved a value between models converted by hand.

## What changes

Each enum is one component under its name, `{"type":"string","enum":[...]}` in the wire's vocabulary, and every member and parameter typed with it is a `$ref` to that component. `JsonSchemaWriter` registers the component where it used to inline the values; `OpenApiDocumentGenerator` writes a component for every vocabulary it collected, so a parameter-only enum has one to refer to, and writes the parameter's schema as the reference. A body that reaches the same enum writes the same component again, byte for byte.

This changes the type names generated clients produce, which is why it is its own PR: a Kiota client's `Ticket_priority` becomes `Priority`, and `GeneratedClientTests` in the WebApp SUT says so. A nullable enum member is a bare `$ref` now, the way a nullable record member already is; the type array is not written beside a reference.

## What was checked

The four tests that read enum values follow the reference now, in the generator suite, the Web generator suite and the WebApp SUT. On a Kiota row and a Refit row generated from this branch's packages, with `Priority` added to `Todo` and as a query parameter: Kiota generates `Priority.cs` and no per-property enum, Refitter generates one `public enum Priority`, and the document carries one `Priority` component referenced from the member and the parameter. The full solution under `--configuration Release -p:ContinuousIntegrationBuild=true`: 39 test assemblies pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
