### PR TITLE
Release 0.22.0-rc1000 and open the 0.23.0 line

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -328,8 +328,8 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           # The open line, which is the one previews belong under - not the last one released.
-          # The line has released through v0.21.0-rc1000; there was no 0.7.0.
-          RELEASE_LINE: 0.22.0
+          # The line has released through v0.22.0-rc1000; there was no 0.7.0.
+          RELEASE_LINE: 0.23.0
         run: |
           BUILD=$(printf '%06d' "$GITHUB_RUN_NUMBER")
           echo "Packing $RELEASE_LINE-preview$BUILD"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ unmeasured rather than untested.
 ## Releasing
 
 A `v*` tag drives `release.yaml`, and the tag is the source of truth for the version. The current
-line is `0.21.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
+line is `0.22.0-rc1000`; there was no 0.7.0. Do not describe versions as `1.0.0-*`.
 
 **The pack list in `release.yaml` is hand-maintained and has drifted four times.** A new packable
 project has to be added to it *and* to `EXPECTED`, which is a literal on purpose. Adding it to the


### PR DESCRIPTION
Moves `RELEASE_LINE` to 0.23.0 and the current-line sentence in AGENTS.md to 0.22.0-rc1000. Tag `v0.22.0-rc1000` on the merge commit to publish.

Dry run against a local folder feed at 0.22.0-rc1000, with the package cache redirected:

- The solution builds with the CI flags and all 29 listed projects pack; the pack list covers every packable project and matches `EXPECTED`.
- Projects generated from the packed template restore, build and test against the feed: kestrel, aws-lambda and the SQS function. The Hardened generators reach the compiler.
- Hardened.Amz with its pins moved to 0.22.0-rc1000 restores, builds with the CI flags and passes its tests against the feed. That bump is ready to open once these packages are on nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)