### PR TITLE
Run the Lambda templates' local-run probe again, now that Hardened.Amz 0.22.0 is out

### DIFF
--- a/scripts/verify-templates.sh
+++ b/scripts/verify-templates.sh
@@ -692,42 +692,38 @@ for AMZ in "hardened-function --trigger invoke|default|default" \
         run_tests "$AMZ_OUT" "$MOCK_TEST"
         echo "   $AMZ_TEMPLATE $*: builds and tests"
 
-        # Commented out until Hardened.Amz 0.22.0 is on nuget.org. The probe below needs the
-        # LambdaEmulator that Hardened.Amz #89 added to the generated Main, and the float still
-        # resolves 0.21.0, which has no such thing - so the host exits on a UriFormatException and
-        # every Lambda row fails. Uncomment when 0.22.0 ships for both repositories.
-#        # The generated Main starts the AWS Lambda Test Tool when nothing else is running the
-#        # function, which is the whole local story and the reason there is no Harness project any
-#        # more. Proved over a socket: the web host answers through the tool's API Gateway emulator
-#        # on PORT, and a function brings the tool's page up on the emulator port. Random ports, so
-#        # a row never talks to a tool an earlier row left behind, and the tool is restored by the
-#        # generated project's own build from the manifest the template pins it in.
-#        EMULATOR_PORT=$((5600 + RANDOM % 200))
-#        if [ "$AMZ_TEMPLATE" = hardened-web ]; then
-#            LAMBDA_PORT=$((5800 + RANDOM % 200))
-#            ( cd "$AMZ_OUT/src/Sample.Host" && PORT="$LAMBDA_PORT" HARDENED_LAMBDA_EMULATOR_PORT="$EMULATOR_PORT" \
-#                dotnet run --no-build >"$AMZ_OUT/serve.log" 2>&1 & )
-#            PROBE="http://localhost:$LAMBDA_PORT/todos/1"
-#        else
-#            ( cd "$AMZ_OUT/src/Sample" && HARDENED_LAMBDA_EMULATOR_PORT="$EMULATOR_PORT" \
-#                dotnet run --no-build >"$AMZ_OUT/serve.log" 2>&1 & )
-#            PROBE="http://localhost:$EMULATOR_PORT/"
-#        fi
-#        CODE=000
-#        for _ in $(seq 1 100); do
-#            CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE" || true)
-#            [ "$CODE" = "200" ] && break
-#            sleep 0.5
-#        done
-#        # SIGTERM to the application takes the tool it started down with it.
-#        pkill -f "$AMZ_OUT/src/Sample" 2>/dev/null || true
-#        if [ "$CODE" = "200" ]; then
-#            echo "   $AMZ_TEMPLATE $*: runs locally against the AWS Lambda Test Tool"
-#        else
-#            echo "   FAILED: $AMZ_TEMPLATE $*: $PROBE answered $CODE"
-#            tail -20 "$AMZ_OUT/serve.log"
-#            FAILED=1
-#        fi
+        # The generated Main starts the AWS Lambda Test Tool when nothing else is running the
+        # function, which is the whole local story and the reason there is no Harness project any
+        # more. Proved over a socket: the web host answers through the tool's API Gateway emulator
+        # on PORT, and a function brings the tool's page up on the emulator port. Random ports, so
+        # a row never talks to a tool an earlier row left behind, and the tool is restored by the
+        # generated project's own build from the manifest the template pins it in.
+        EMULATOR_PORT=$((5600 + RANDOM % 200))
+        if [ "$AMZ_TEMPLATE" = hardened-web ]; then
+            LAMBDA_PORT=$((5800 + RANDOM % 200))
+            ( cd "$AMZ_OUT/src/Sample.Host" && PORT="$LAMBDA_PORT" HARDENED_LAMBDA_EMULATOR_PORT="$EMULATOR_PORT" \
+                dotnet run --no-build >"$AMZ_OUT/serve.log" 2>&1 & )
+            PROBE="http://localhost:$LAMBDA_PORT/todos/1"
+        else
+            ( cd "$AMZ_OUT/src/Sample" && HARDENED_LAMBDA_EMULATOR_PORT="$EMULATOR_PORT" \
+                dotnet run --no-build >"$AMZ_OUT/serve.log" 2>&1 & )
+            PROBE="http://localhost:$EMULATOR_PORT/"
+        fi
+        CODE=000
+        for _ in $(seq 1 100); do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE" || true)
+            [ "$CODE" = "200" ] && break
+            sleep 0.5
+        done
+        # SIGTERM to the application takes the tool it started down with it.
+        pkill -f "$AMZ_OUT/src/Sample" 2>/dev/null || true
+        if [ "$CODE" = "200" ]; then
+            echo "   $AMZ_TEMPLATE $*: runs locally against the AWS Lambda Test Tool"
+        else
+            echo "   FAILED: $AMZ_TEMPLATE $*: $PROBE answered $CODE"
+            tail -20 "$AMZ_OUT/serve.log"
+            FAILED=1
+        fi
         # Worth printing: a float that silently stopped resolving would otherwise look identical
         # to one that resolved to the right thing.
         grep -hoE '"Hardened\.Amz\.[A-Za-z.]+/[^"]+"' "$AMZ_OUT"/src/*/obj/project.assets.json 2>/dev/null \


### PR DESCRIPTION
Undoes #295. The templates float to Hardened.Amz 0.22.0-rc1000, now on nuget.org, whose generated `Main` starts the AWS Lambda Test Tool. The Lambda rows of `verify-templates.sh` are probed over a socket again: `/todos/1` through the gateway emulator for the web row, the tool's page for the function rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)