### PR TITLE
Publish maps, guard refusals and a dropped nullable in a described document

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -431,6 +431,7 @@ the other.
 | `026` | Warning. `$(HardenedResponseModel)` is `Standard`, the throws mode's name before 0.19.0. The mode selected is unchanged; write `Throws`. Reported once per project. |
 | `027` | The description references something it does not declare. Part of the model-diagnostics pass; see below. |
 | `018`, `019`, `028`–`031` | The document export, which the three generator packages share. See below. |
+| `032` | Warning. `nullable` declared under a banner that removed the keyword. Part of the model-diagnostics pass; see below. |
 
 ### The Smithy CLI task (HSMT010–HSMT014)
 
@@ -511,7 +512,7 @@ The `hardened-web` template's project files carry three checks of their own, in 
 | `HTPL003` | The Kiota tool and `Microsoft.Kiota.Bundle` disagree. The tool version in `.config/dotnet-tools.json` and `KiotaBundleVersion` in `Directory.Packages.props` move together; the message names both versions and both files. |
 | `HTPL004` | The Refitter tool could not be restored, so the client cannot be generated (`--client refit`). The pin is in `.config/dotnet-tools.json`; a fresh machine needs network for the first restore. There is no counterpart to `HTPL003` for the Refit pair, because Refitter does not report the Refit version it writes for. |
 
-### The model-diagnostics pass (020–027)
+### The model-diagnostics pass (020–027, 032)
 
 Problems any description can state that would generate C# which does not compile, found before
 anything is emitted so they are reported against the document rather than as compiler errors in a
@@ -526,6 +527,10 @@ generated file.
 | `024` | Warning. A declared keyword or trait the generator does not enforce, named with a representative location. Remove it, or enforce the rule in the handler. |
 | `026` | Warning. A path template names a token the operation declares no path parameter for. The route matches and the value is discarded. |
 | `027` | A reference to something the description does not declare. |
+| `032` | Warning. `nullable` written under a 3.1 or later banner, which removed the keyword. The reader does not read it, so the member generates non-null and a null the service sends fails to deserialize. Write `type: [<type>, "null"]`. |
+
+`028`–`031` were taken by the document export before this pass needed another number, which is
+why the newest finder is `032`.
 
 `025` is retired. It rejected two error responses at one status on one operation, and a valid
 Smithy model says that routinely — two `@error("client")` shapes both default to 400. The reason it

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/GeneratedDocumentTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/GeneratedDocumentTests.cs
@@ -251,4 +251,51 @@ public class GeneratedDocumentTests {
     }
 
     #endregion
+
+    private static JsonElement Responses(JsonElement document, string path) =>
+        document.GetProperty("paths").GetProperty(path).GetProperty("get").GetProperty("responses");
+
+    /// <summary>
+    /// The 403 an <c>[AuthorizeGrants]</c> on the implementation produces, over the operation the
+    /// contract declares public.
+    /// </summary>
+    /// <remarks>
+    /// <c>AttributeAuthorizationTests</c> holds the other half: the route is guarded. It was
+    /// guarded and undocumented, so a generated client had no branch for the refusal it would
+    /// meet.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnAttributeGuardedOperationDeclaresItsRefusal(ITestWebApp app) =>
+        Assert.Contains(
+            "does not hold",
+            Responses(await Document(app), "/guarded/by-attribute")
+                .GetProperty("403").GetProperty("description").GetString());
+
+    /// <summary>
+    /// The 403 a described scope produces, beside the 401 that was already there.
+    /// </summary>
+    [HardenedTest]
+    public async Task AScopedRequirementDeclaresBothRefusals(ITestWebApp app) {
+        var responses = Responses(await Document(app), "/secured/scoped");
+
+        Assert.True(responses.TryGetProperty("401", out _));
+        Assert.True(responses.TryGetProperty("403", out _));
+    }
+
+    /// <summary>
+    /// An OR with one unscoped alternative declares no 403, because nobody past the 401 can be
+    /// refused by it.
+    /// </summary>
+    /// <remarks>
+    /// The control on the rule above. Publishing the 403 wherever any entry names a scope would
+    /// put a status here that the operation cannot answer, which is the defect this closes with
+    /// the sign flipped.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnUnscopedAlternativeDeclaresNoForbidden(ITestWebApp app) {
+        var responses = Responses(await Document(app), "/secured/either");
+
+        Assert.True(responses.TryGetProperty("401", out _));
+        Assert.False(responses.TryGetProperty("403", out _));
+    }
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
@@ -85,6 +85,16 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "The caller does not hold what this operation requires.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
           }
         }
       }
@@ -845,6 +855,16 @@
                 }
               }
             },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller does not hold what this operation requires.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyServedDocumentTests.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyServedDocumentTests.cs
@@ -200,4 +200,27 @@ public class SmithyServedDocumentTests {
 
         Assert.Fail("No limit parameter in the served document.");
     }
+
+    /// <summary>
+    /// A Smithy <c>map</c> member is published as the map it is.
+    /// </summary>
+    /// <remarks>
+    /// The described schema writer had no dictionary branch, so <c>TagMap</c> reached the scalar
+    /// writer with no type and took its <c>string</c> default: the document said the member was a
+    /// string while the generated record was a <c>Dictionary</c> and the wire carried an object.
+    /// Refitter generated a string and threw reading it; Kiota generated one and read null.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AMapMemberIsPublishedAsAMap(ITestWebApp app) {
+        var tags = (await Document(app))
+            .GetProperty("components").GetProperty("schemas").GetProperty("CreatePetInput")
+            .GetProperty("properties").GetProperty("tags");
+
+        Assert.Contains(
+            "object",
+            tags.GetProperty("type").EnumerateArray().Select(entry => entry.GetString()));
+
+        Assert.Equal(
+            "string", tags.GetProperty("additionalProperties").GetProperty("type").GetString());
+    }
 }

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyTimeoutTraitTests.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT.Tests/SmithyTimeoutTraitTests.cs
@@ -73,4 +73,30 @@ public class SmithyTimeoutTraitTests {
         Assert.True(operation.TryGetProperty("x-hardened-timeout", out var published));
         Assert.True(published.GetInt32() > 0);
     }
+
+    /// <summary>
+    /// The status the deadline answers, beside the budget it bounds.
+    /// </summary>
+    /// <remarks>
+    /// <c>x-hardened-timeout</c> says how long the operation may take and nothing about what the
+    /// caller is told, so the document published the budget and left the 504 unmentioned while the
+    /// runtime answered it. A code-first handler had this from <c>TimeoutAttribute</c>'s
+    /// <c>[AnswersStatus]</c> all along.
+    /// </remarks>
+    [HardenedTest]
+    public void ThePublishedDeadlineDeclaresTheStatusItAnswers(ITestWebApp app) {
+        var responses = Operation(app, "/pets/{petId}", "get").GetProperty("responses");
+
+        Assert.Contains("budget", responses.GetProperty("504").GetProperty("description").GetString());
+        Assert.Equal(
+            "#/components/schemas/ErrorModel",
+            responses.GetProperty("504").GetProperty("content").GetProperty("application/json")
+                .GetProperty("schema").GetProperty("$ref").GetString());
+    }
+
+    /// <summary>An unbounded operation declares no gateway timeout either.</summary>
+    [HardenedTest]
+    public void AnOperationDeclaringNoDeadlineDeclaresNoGatewayTimeout(ITestWebApp app) =>
+        Assert.False(
+            Operation(app, "/pets", "get").GetProperty("responses").TryGetProperty("504", out _));
 }

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
@@ -320,6 +320,16 @@
                 }
               }
             }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
           }
         },
         "x-hardened-timeout": 2000
@@ -415,9 +425,12 @@
           },
           "tags": {
             "type": [
-              "string",
+              "object",
               "null"
-            ]
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "birthday": {
             "type": [

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/SpecDiagnostics.cs
@@ -24,7 +24,10 @@ namespace Hardened.Idl;
 /// left with it.
 /// </para>
 /// <para>
-/// Codes are the front end's prefix plus 020-024 and 027, one number per finder. The prefix is a
+/// Codes are the front end's prefix plus 020-024, 027 and 032, one number per finder. 032 rather
+/// than the retired 025, because a project still carrying a NoWarn for what 025 used to be would
+/// silence a diagnostic about something else; 028-031 belong to the document export. The prefix
+/// is a
 /// parameter because this pass runs for every front end and a finding belongs to the document
 /// that caused it: a Smithy model's mixed enum reported as HOAT anything sends its author to the
 /// OpenAPI documentation. 020 up is this pass's block; everything below it belongs to the task
@@ -159,6 +162,21 @@ internal static class SpecDiagnostics {
                 : $"at {locations[0]} and {locations.Count - 1} other " +
                   (locations.Count == 2 ? "place" : "places");
 
+            // A keyword the version removed is a different thing from a rule that is not
+            // enforced, and takes different advice: nothing was promised and left unapplied, the
+            // reader never saw the keyword at all. See NullableKeyword.
+            if (keyword == NullableKeyword) {
+                problems.Add(new Problem(
+                    prefix + "032",
+                    $"'nullable' is declared {where} and was not read. OpenAPI 3.1 removed the " +
+                    "keyword, so a reader on this document's version ignores it: the member " +
+                    "generates as non-null and a null the service sends fails to deserialize. " +
+                    "Write the null in the type instead, as type: [<type>, \"null\"].",
+                    fatal: false));
+
+                continue;
+            }
+
             problems.Add(new Problem(
                 prefix + "024",
                 $"'{keyword}' is declared {where} and is not enforced. The description promises it " +
@@ -171,6 +189,16 @@ internal static class SpecDiagnostics {
                 fatal: false));
         }
     }
+
+    /// <summary>
+    /// The keyword <c>OpenApiSpecParser.NoteUnmappedNullable</c> records, which earns its own code.
+    /// </summary>
+    /// <remarks>
+    /// Its own code so it can be silenced on its own. A document carrying <c>nullable</c> under a
+    /// 3.1 banner is usually one converted from 3.0 in bulk, which is exactly the case where the
+    /// warning fires on every member at once and the author wants to keep the rest of 024.
+    /// </remarks>
+    private const string NullableKeyword = "nullable";
 
     /// <summary>
     /// An <c>enum</c> declaring both strings and numbers, which is not a C# enum in either form.

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerInfo.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerInfo.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
 using Hardened.SourceGenerator.Shared;
 using Microsoft.CodeAnalysis;
 
@@ -115,15 +117,31 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
     public HandlerMethodFilterInfo(
         string methodName,
         IReadOnlyList<AttributeModel> filters,
-        ITypeDefinition? outputType = null) {
+        ITypeDefinition? outputType = null,
+        IReadOnlyList<ResponseSchemaModel>? refusals = null) {
         MethodName = methodName;
         Filters = filters;
         OutputType = outputType;
+        Refusals = refusals ?? Array.Empty<ResponseSchemaModel>();
     }
 
     public string MethodName { get; }
 
     public IReadOnlyList<AttributeModel> Filters { get; }
+
+    /// <summary>
+    /// The statuses the declarations covering this method can answer, from their
+    /// <c>[AnswersStatus]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Read here rather than in the bridge for the reason <see cref="OutputType"/> is: a described
+    /// operation's signature is generated, so the implementation is the only place an author can
+    /// write <c>[AuthorizeGrants]</c> or <c>[RateLimit]</c> - and this pass is the only one holding
+    /// both that syntax and a semantic model to resolve the attribute's declared body type against.
+    /// The filters themselves already travelled, which is why the runtime answered a 403 and a 429
+    /// the document did not mention.
+    /// </remarks>
+    public IReadOnlyList<ResponseSchemaModel> Refusals { get; }
 
     /// <summary>
     /// What writes this operation's response, named by <c>[Output&lt;T&gt;]</c>, or null.
@@ -142,7 +160,8 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
         if (ReferenceEquals(this, other)) return true;
         return MethodName == other.MethodName &&
                Equals(OutputType, other.OutputType) &&
-               Filters.DeepEquals(other.Filters);
+               Filters.DeepEquals(other.Filters) &&
+               Refusals.SequenceEqual(other.Refusals);
     }
 
     public override bool Equals(object? obj) => Equals(obj as HandlerMethodFilterInfo);
@@ -153,6 +172,7 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
 
             hash = (hash * 397) ^ Filters.GetHashCodeAggregation();
             hash = (hash * 397) ^ (OutputType?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ Refusals.GetHashCodeAggregation();
 
             return hash;
         }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerSelector.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerSelector.cs
@@ -77,11 +77,17 @@ internal static class HandlerSelector {
 
             var outputType = OutputAttributeSelector.Read(context, methodDeclaration);
 
-            if (methodAttrs.Count > 0 || outputType != null) {
+            // The same reading the attribute-routed path makes on its own handler method, over the
+            // method, its class and the assembly. A described operation's guards can only be
+            // written here, so this is the only place they can be read from.
+            var refusals = FilterResponseSelector.Read(context, methodDeclaration, cancellationToken);
+
+            if (methodAttrs.Count > 0 || outputType != null || refusals.Count > 0) {
                 methodFilters.Add(new HandlerMethodFilterInfo(
                     methodDeclaration.Identifier.Text,
                     methodAttrs,
-                    outputType));
+                    outputType,
+                    refusals));
             }
         }
 

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
@@ -46,6 +46,7 @@ internal static class RequestModelBuilder {
 
                 // Find method-level filters matching this handler's method
                 var responseInformation = model.ResponseInformation;
+                var responseSchemas = model.ResponseSchemas;
 
                 foreach (var methodFilter in handlerInfo.MethodFilters) {
                     if (string.Equals(methodFilter.MethodName, model.HandlerMethod,
@@ -60,6 +61,8 @@ internal static class RequestModelBuilder {
                                 responseInformation with { OutputType = methodFilter.OutputType };
                         }
 
+                        responseSchemas = WithRefusals(responseSchemas, methodFilter.Refusals);
+
                         break;
                     }
                 }
@@ -68,7 +71,7 @@ internal static class RequestModelBuilder {
                 // hand-rolled copy. This used to restate the members one by one, and each field
                 // added to the model was silently dropped here until someone noticed - the tag's
                 // description was the latest. One copy site is the fix, not a longer list.
-                result.Add(model.WithFilters(filters, responseInformation));
+                result.Add(model.WithFilters(filters, responseInformation, responseSchemas));
             } else {
                 result.Add(model);
             }
@@ -76,6 +79,56 @@ internal static class RequestModelBuilder {
 
         return result;
     }
+
+    /// <summary>
+    /// The contract's responses plus the ones the implementation's guards can answer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The contract wins on a status both name. A described 429 carries the author's wording and
+    /// the body their document declared; the attribute's is the framework's fallback for a
+    /// contract that said nothing, and replacing one with the other would make writing the
+    /// response down cost its description.
+    /// </para>
+    /// <para>
+    /// Which is the whole of the difference from the attribute-routed path, where nothing else
+    /// declares these and <c>FilterResponseSelector</c>'s answer stands alone.
+    /// </para>
+    /// <para>
+    /// Appended rather than merged into status order, because the declared order is the
+    /// document's and reordering it here would rewrite every described operation's responses to
+    /// fix three that were missing. <c>FilterResponseSelector</c> hands these over in status
+    /// order already.
+    /// </para>
+    /// </remarks>
+    private static IReadOnlyList<ResponseSchemaModel> WithRefusals(
+        IReadOnlyList<ResponseSchemaModel> declared,
+        IReadOnlyList<ResponseSchemaModel> refusals) {
+        if (refusals.Count == 0) {
+            return declared;
+        }
+
+        var merged = new List<ResponseSchemaModel>(declared);
+
+        foreach (var refusal in refusals) {
+            var already = false;
+
+            foreach (var response in declared) {
+                if (response.Status == refusal.Status) {
+                    already = true;
+
+                    break;
+                }
+            }
+
+            if (!already) {
+                merged.Add(refusal);
+            }
+        }
+
+        return merged;
+    }
+
     /// <summary>
     /// The handler implementing this operation's service, wherever it sits in the base list.
     /// </summary>

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnmappedKeywordTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/UnmappedKeywordTests.cs
@@ -247,4 +247,70 @@ public class UnmappedKeywordTests {
         Assert.Equal(withKeyword.Schemas.Count, withoutKeyword.Schemas.Count);
         Assert.Equal(withKeyword, withoutKeyword);
     }
+
+    /// <summary>
+    /// <c>nullable</c> under a 3.1 banner, which the version removed and the reader parks
+    /// unread.
+    /// </summary>
+    /// <remarks>
+    /// The member generated as non-null, the service sent null through it and a generated client's
+    /// <c>int</c> failed to deserialize the response, with nothing between the document and that.
+    /// </remarks>
+    [Fact]
+    public void NullableUnderThreeOneIsRecordedAsUnmapped() {
+        var model = Parse(Nullable.Replace("openapi: 3.0.0", "openapi: 3.1.0"));
+
+        Assert.Contains(model.UnmappedKeywords, u => u.Keyword == "nullable");
+        Assert.Contains(
+            "courierId", model.UnmappedKeywords.Single(u => u.Keyword == "nullable").Location);
+    }
+
+    /// <summary>
+    /// The same keyword under 3.0, where the reader folds it into the type and the member does
+    /// generate nullable. Warning there would fire on every correct 3.0 document there is.
+    /// </summary>
+    [Fact]
+    public void NullableUnderThreeZeroIsRead() {
+        var model = Parse(Nullable);
+        var courierId = model.Schemas.Single(s => s.Name == "Job").Properties
+            .Single(p => p.Name == "courierId");
+
+        Assert.True(courierId.IsNullable);
+        Assert.DoesNotContain(model.UnmappedKeywords, u => u.Keyword == "nullable");
+    }
+
+    /// <summary>Its own code, so a bulk-converted document can silence it and keep 024.</summary>
+    [Fact]
+    public void TheDroppedNullableDiagnosticIsItsOwnWarning() {
+        var problem = SpecDiagnostics
+            .Find(Parse(Nullable.Replace("openapi: 3.0.0", "openapi: 3.1.0")), "HOAT")
+            .Single(p => p.Code == "HOAT032");
+
+        Assert.False(problem.Fatal);
+        Assert.Contains("courierId", problem.Message);
+        Assert.Contains("type: [<type>, \"null\"]", problem.Message);
+    }
+
+    private const string Nullable = """
+        openapi: 3.0.0
+        info: { title: Depot, version: '1.0' }
+        paths:
+          /jobs:
+            get:
+              operationId: listJobs
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Job' }
+        components:
+          schemas:
+            Job:
+              type: object
+              properties:
+                courierId:
+                  type: integer
+                  nullable: true
+        """;
 }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -1300,7 +1300,35 @@ internal static class OpenApiSpecParser {
             unmapped.Add(new UnmappedKeywordModel("not", location));
         }
 
+        NoteUnmappedNullable(schema, location, unmapped);
         NoteUnmappedItemConstraints(schema, location, unmapped);
+    }
+
+    /// <summary>
+    /// <c>nullable</c> written under a banner that removed it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// OpenAPI 3.1 dropped the keyword in favour of <c>"null"</c> in the type, and the reader
+    /// honours that: under a 3.0 banner <c>nullable: true</c> arrives folded into
+    /// <see cref="JsonSchemaType.Null"/> and <see cref="IsNullable"/> reads it; under 3.1 or 3.2
+    /// it is not a keyword at all, so the reader parks it here and nothing looked. The member
+    /// generated as non-null, the service sent null through it, and a generated client's
+    /// <c>int</c> failed to read the response - with no build output between the document and
+    /// that.
+    /// </para>
+    /// <para>
+    /// Reported rather than honoured. The document is what the author asked for, and a parser
+    /// that quietly restores a keyword the version removed makes the file mean something no other
+    /// reader would agree with. <c>type: [integer, "null"]</c> is the spelling, and the message
+    /// says so.
+    /// </para>
+    /// </remarks>
+    private static void NoteUnmappedNullable(
+        IOpenApiSchema schema, string location, ICollection<UnmappedKeywordModel> unmapped) {
+        if (schema.UnrecognizedKeywords is { } keywords && keywords.ContainsKey("nullable")) {
+            unmapped.Add(new UnmappedKeywordModel("nullable", location));
+        }
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
@@ -406,4 +406,145 @@ public class SpecFirstDocumentTests {
     }
 
     #endregion
+
+    #region What the runtime answers
+
+    /// <summary>
+    /// A guarded, rate-limited, bounded operation the contract describes as none of those things.
+    /// </summary>
+    /// <remarks>
+    /// The three guards a described service can carry. The deadline is in the contract, because
+    /// that is where a described one is written; the other two are on the implementation, because
+    /// a generated signature has nowhere to put them.
+    /// </remarks>
+    private const string GuardedOperation =
+        """
+        openapi: "3.0.0"
+        info: { title: Dispatch, version: "1.0" }
+        paths:
+          /quotes:
+            get:
+              tags: [Quote]
+              operationId: getQuote
+              x-hardened-timeout: 2000
+              security:
+                - dispatchOAuth: ["quotes:read"]
+              responses:
+                '200':
+                  description: A quote
+                  content:
+                    application/json:
+                      schema: { type: string }
+        components:
+          securitySchemes:
+            dispatchOAuth:
+              type: oauth2
+              flows:
+                clientCredentials:
+                  tokenUrl: https://example.test/token
+                  scopes: { "quotes:read": Read quotes }
+        """;
+
+    private static readonly string GuardedHandler = OpenApiGenerator.EntryPointWithHandler(
+        """
+        [Handler]
+        public class QuoteServiceImpl : IQuoteService {
+            [Hardened.Requests.Runtime.RateLimiting.RateLimit(PermitLimit = 2)]
+            [Hardened.Requests.Runtime.Authorization.AuthorizeGrants("quotes:read")]
+            public Task<string> GetQuote() => Task.FromResult("40.00");
+        }
+        """);
+
+    private static JsonElement GuardedResponses() {
+        var result = OpenApiGenerator.Run(GuardedOperation, GuardedHandler);
+
+        Assert.Empty(result.Errors);
+
+        return PublishedDocumentFrom(result)
+            .GetProperty("paths").GetProperty("/quotes").GetProperty("get")
+            .GetProperty("responses");
+    }
+
+    /// <summary>
+    /// A rate limit written on the implementation reaches the document, as it does code-first.
+    /// </summary>
+    /// <remarks>
+    /// The filter always travelled - <c>RequestModelBuilder.EnrichWithHandlerFilters</c> appends
+    /// it - so the runtime refused the third call with a 429 that the document did not mention,
+    /// and a generated client had no branch for it.
+    /// </remarks>
+    [Fact]
+    public void ARateLimitOnTheImplementationPublishesItsRefusal() {
+        var refusal = GuardedResponses().GetProperty("429");
+
+        Assert.Contains("allowance", refusal.GetProperty("description").GetString());
+        Assert.Equal(
+            "#/components/schemas/ErrorModel",
+            refusal.GetProperty("content").GetProperty("application/json")
+                .GetProperty("schema").GetProperty("$ref").GetString());
+    }
+
+    /// <summary>An authorization attribute on the implementation, on the same terms.</summary>
+    [Fact]
+    public void AnAuthorizationAttributeOnTheImplementationPublishesItsRefusal() =>
+        Assert.Contains(
+            "does not hold",
+            GuardedResponses().GetProperty("403").GetProperty("description").GetString());
+
+    /// <summary>
+    /// The contract's own deadline, whose status nothing published while
+    /// <c>x-hardened-timeout</c> published the budget beside it.
+    /// </summary>
+    [Fact]
+    public void ADescribedDeadlinePublishesTheStatusItAnswers() {
+        var responses = GuardedResponses();
+
+        Assert.Contains("budget", responses.GetProperty("504").GetProperty("description").GetString());
+        Assert.Equal(
+            "#/components/schemas/ErrorModel",
+            responses.GetProperty("504").GetProperty("content").GetProperty("application/json")
+                .GetProperty("schema").GetProperty("$ref").GetString());
+    }
+
+    /// <summary>
+    /// A map, which the described schema writer had no branch for at all: the member took the
+    /// scalar writer's <c>string</c> default while the wire carried an object.
+    /// </summary>
+    [Fact]
+    public void AMapInTheContractIsPublishedAsAMap() {
+        var byStatus = PublishedDocument(MappedBody)
+            .GetProperty("components").GetProperty("schemas").GetProperty("Report")
+            .GetProperty("properties").GetProperty("byStatus");
+
+        Assert.Equal("object", byStatus.GetProperty("type").GetString());
+        Assert.Equal(
+            "integer",
+            byStatus.GetProperty("additionalProperties").GetProperty("type").GetString());
+    }
+
+    private const string MappedBody =
+        """
+        openapi: "3.0.0"
+        info: { title: Dispatch, version: "1.0" }
+        paths:
+          /reports:
+            get:
+              operationId: getReport
+              responses:
+                '200':
+                  description: A report
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Report' }
+        components:
+          schemas:
+            Report:
+              type: object
+              properties:
+                byStatus:
+                  type: object
+                  additionalProperties: { type: integer }
+        """;
+
+    #endregion
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/SpecBridge/SpecSchemaWriterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/SpecBridge/SpecSchemaWriterTests.cs
@@ -200,4 +200,106 @@ public class SpecSchemaWriterTests {
         Assert.Equal("Created", SpecSchemaWriter.DescriptionFor("", 201));
         Assert.Equal("Pet created", SpecSchemaWriter.DescriptionFor("Pet created", 201));
     }
+
+    /// <summary>
+    /// A map property, as the object it is rather than as the string it fell back to.
+    /// </summary>
+    /// <remarks>
+    /// The writer had no dictionary branch at either level, so a member the model typed
+    /// <c>Dictionary&lt;string,int&gt;</c> reached the scalar writer with no type and took its
+    /// <c>string</c> default. Refitter generated a string and threw reading the object; Kiota
+    /// generated one and read null.
+    /// </remarks>
+    [Fact]
+    public void AMapPropertyIsPublishedAsAnObjectWithAdditionalProperties() {
+        var schemas = new List<SchemaModel> {
+            Object("Report", new PropertyModel {
+                Name = "byStatus", IsDictionary = true, DictionaryValueType = "integer",
+                DictionaryValueFormat = "int32"
+            })
+        };
+
+        var byStatus = Component(SpecSchemaWriter.ForRef("#/components/schemas/Report", schemas)!, "Report")
+            .GetProperty("properties").GetProperty("byStatus");
+
+        Assert.Equal("object", byStatus.GetProperty("type").GetString());
+        Assert.Equal("integer", byStatus.GetProperty("additionalProperties").GetProperty("type").GetString());
+        Assert.Equal("int32", byStatus.GetProperty("additionalProperties").GetProperty("format").GetString());
+    }
+
+    /// <summary>A map whose values name a component references it rather than inlining it.</summary>
+    [Fact]
+    public void AMapOfReferencesReferencesTheValueSchema() {
+        var schemas = new List<SchemaModel> {
+            Object("Store", new PropertyModel {
+                Name = "pets", IsDictionary = true,
+                DictionaryValueRef = "#/components/schemas/Pet"
+            }),
+            Object("Pet", Property("id"))
+        };
+
+        var written = SpecSchemaWriter.ForRef("#/components/schemas/Store", schemas)!;
+
+        Assert.Equal(
+            "#/components/schemas/Pet",
+            Component(written, "Store").GetProperty("properties").GetProperty("pets")
+                .GetProperty("additionalProperties").GetProperty("$ref").GetString());
+
+        Assert.Equal("object", Component(written, "Pet").GetProperty("type").GetString());
+    }
+
+    /// <summary>
+    /// A nullable map keeps both facts. <c>Nullable</c> rewrites the type it finds first, which is
+    /// the map's own and not its value's.
+    /// </summary>
+    [Fact]
+    public void ANullableMapIsAnObjectOrNull() {
+        var schemas = new List<SchemaModel> {
+            Object("Pet", new PropertyModel {
+                Name = "tags", IsDictionary = true, DictionaryValueType = "string", IsNullable = true
+            })
+        };
+
+        var tags = Component(SpecSchemaWriter.ForRef("#/components/schemas/Pet", schemas)!, "Pet")
+            .GetProperty("properties").GetProperty("tags");
+        var type = tags.GetProperty("type");
+
+        Assert.Equal(2, type.GetArrayLength());
+        Assert.Equal("object", type[0].GetString());
+        Assert.Equal("null", type[1].GetString());
+        Assert.Equal("string", tags.GetProperty("additionalProperties").GetProperty("type").GetString());
+    }
+
+    /// <summary>A schema that is itself a map, which the object branch published members-less.</summary>
+    [Fact]
+    public void ANamedMapSchemaIsPublishedAsAMap() {
+        var schemas = new List<SchemaModel> {
+            new() {
+                Name = "Counts", Kind = SchemaKind.Dictionary, DictionaryValueType = "integer",
+                Description = "How many of each."
+            }
+        };
+
+        var counts = Component(SpecSchemaWriter.ForRef("#/components/schemas/Counts", schemas)!, "Counts");
+
+        Assert.Equal("object", counts.GetProperty("type").GetString());
+        Assert.Equal("How many of each.", counts.GetProperty("description").GetString());
+        Assert.Equal("integer", counts.GetProperty("additionalProperties").GetProperty("type").GetString());
+    }
+
+    /// <summary>
+    /// A schema the contract names for a scalar, which the same missing branch published as an
+    /// object.
+    /// </summary>
+    [Fact]
+    public void ANamedPrimitiveSchemaKeepsItsTypeAndFormat() {
+        var schemas = new List<SchemaModel> {
+            new() { Name = "Sku", Kind = SchemaKind.Primitive, Type = "string", Format = "uuid" }
+        };
+
+        var sku = Component(SpecSchemaWriter.ForRef("#/components/schemas/Sku", schemas)!, "Sku");
+
+        Assert.Equal("string", sku.GetProperty("type").GetString());
+        Assert.Equal("uuid", sku.GetProperty("format").GetString());
+    }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -42,7 +42,8 @@ public class RequestHandlerModel {
     /// </remarks>
     public RequestHandlerModel WithFilters(
         IReadOnlyList<AttributeModel> filters,
-        ResponseInformationModel? responseInformation = null) =>
+        ResponseInformationModel? responseInformation = null,
+        IReadOnlyList<ResponseSchemaModel>? responseSchemas = null) =>
         new(Name,
             ControllerType,
             HandlerMethod,
@@ -53,7 +54,7 @@ public class RequestHandlerModel {
             ParametersInterface = ParametersInterface,
             ParametersValidator = ParametersValidator,
             ResponseSchema = ResponseSchema,
-            ResponseSchemas = ResponseSchemas,
+            ResponseSchemas = responseSchemas ?? ResponseSchemas,
             DeclaredResponsesAreComplete = DeclaredResponsesAreComplete,
             DeclaredTimeout = DeclaredTimeout,
             RequestSchema = RequestSchema,

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -496,9 +496,126 @@ public static class OpenApiDocumentGenerator {
 
         WriteValidationResponse(builder, handler, components);
         WriteAuthenticationResponse(builder, handler, components);
+        WriteAuthorizationResponse(builder, handler, components);
+        WriteTimeoutResponse(builder, handler, components);
         WriteConstrainedPathResponse(builder, handler);
 
         builder.Append('}');
+    }
+
+    /// <summary>
+    /// The 403 an operation whose security requires a scope can answer, declared rather than
+    /// implied.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A scoped entry becomes <c>Requirement.Grant</c>, which refuses an authenticated caller who
+    /// does not hold it - so the status is a fact about the operation the way the 401 beside it
+    /// is. An entry with no scopes becomes <c>Requirement.Authenticated</c> and can refuse nobody
+    /// who got past the 401, which is why this is keyed on the scopes rather than on there being a
+    /// requirement at all. <c>docs/described-authorization.md</c> is the table both readings come
+    /// from.
+    /// </para>
+    /// <para>
+    /// Every alternative, because the array is an OR. One unscoped entry beside a scoped one is
+    /// satisfied by anybody who got past the 401, so the 403 is unreachable and publishing it
+    /// would be the second half of the same defect this closes.
+    /// </para>
+    /// <para>
+    /// Only a described operation reaches this. An attribute-routed one gets the same 403 from
+    /// <c>IAuthorizeAttribute</c>'s <c>[AnswersStatus]</c>, which lands in <c>ResponseSchemas</c>
+    /// and takes <see cref="DeclaresStatus"/>'s branch out.
+    /// </para>
+    /// </remarks>
+    private static void WriteAuthorizationResponse(
+        StringBuilder builder, RequestHandlerModel handler,
+        SortedDictionary<string, string> components) {
+        if (!EveryAlternativeRequiresAScope(handler) || DeclaresStatus(handler, 403)) {
+            return;
+        }
+
+        components["ErrorModel"] = ErrorModelSchema;
+
+        builder.Append(",\"403\":{\"description\":\"The caller does not hold what this operation requires.\"," +
+                       "\"content\":{\"application/json\":{\"schema\":" +
+                       "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}");
+    }
+
+    /// <summary>
+    /// Whether the operation declares security and every alternative names at least one scope.
+    /// </summary>
+    /// <remarks>
+    /// The entries are written as OpenAPI requirement objects - <c>{"oauth2":["pets:read"]}</c> -
+    /// so a scope is a non-empty array under some scheme. Read as text rather than reparsed,
+    /// because this generator writes the same strings a few lines further down and holds no JSON
+    /// reader; a bracket pair with something between it is the whole of the question.
+    /// </remarks>
+    private static bool EveryAlternativeRequiresAScope(RequestHandlerModel handler) {
+        if (handler.SecurityRequirements.Count == 0) {
+            return false;
+        }
+
+        foreach (var requirement in handler.SecurityRequirements) {
+            if (!NamesAScope(requirement)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Whether one requirement object carries a non-empty scope array.</summary>
+    private static bool NamesAScope(string requirement) {
+        var open = requirement.IndexOf('[');
+
+        while (open >= 0) {
+            var close = requirement.IndexOf(']', open);
+
+            if (close < 0) {
+                return false;
+            }
+
+            if (requirement.Substring(open + 1, close - open - 1).Trim().Length > 0) {
+                return true;
+            }
+
+            open = requirement.IndexOf('[', close);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The status a bounded operation answers when its budget runs out, declared rather than
+    /// implied.
+    /// </summary>
+    /// <remarks>
+    /// <c>x-hardened-timeout</c> says how long the operation may take and nothing about what the
+    /// caller is told, so a described contract that declared a deadline published a budget and no
+    /// status while the runtime answered 504 all along. An attribute-routed handler already has
+    /// this from <c>TimeoutAttribute</c>'s <c>[AnswersStatus]</c>, which is where the wording is
+    /// taken from so the two paths publish one sentence.
+    /// </remarks>
+    private static void WriteTimeoutResponse(
+        StringBuilder builder, RequestHandlerModel handler,
+        SortedDictionary<string, string> components) {
+        if (handler.DeclaredTimeout is not { } timeout || DeclaresStatus(handler, timeout.Status)) {
+            return;
+        }
+
+        components["ErrorModel"] = ErrorModelSchema;
+
+        builder.Append(",\"").Append(timeout.Status)
+            .Append("\":{\"description\":\"The operation did not finish inside its budget.\"");
+
+        if (timeout.RetryAfterSeconds > 0) {
+            builder.Append(",\"headers\":{\"Retry-After\":{" +
+                           "\"description\":\"How long to wait before trying again, in seconds.\"," +
+                           "\"schema\":{\"type\":\"integer\"}}}");
+        }
+
+        builder.Append(",\"content\":{\"application/json\":{\"schema\":" +
+                       "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}");
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecSchemaWriter.cs
@@ -193,6 +193,18 @@ internal static class SpecSchemaWriter {
 
                 break;
 
+            case SchemaKind.Dictionary:
+                builder.Append(Map(schema.DictionaryValueRef, schema.DictionaryValueType,
+                    schema.DictionaryValueFormat, schema.Description, schemas, components, seen));
+
+                break;
+
+            case SchemaKind.Primitive:
+                builder.Append(Inline(null, schema.Type, schema.Format, schema.Description,
+                    null, false, schemas, components, seen));
+
+                break;
+
             default:
                 builder.Append("{\"type\":\"object\"");
                 Describe(builder, schema.Description);
@@ -203,6 +215,28 @@ internal static class SpecSchemaWriter {
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// A map, as the <c>additionalProperties</c> object it is.
+    /// </summary>
+    /// <remarks>
+    /// Both spellings landed in <c>default</c>: a named map schema was published as an object with
+    /// no members, and a map property fell through to <see cref="Inline"/>, whose type defaults to
+    /// string when the model names none - so <c>Dictionary&lt;string,int&gt;</c> was published as
+    /// <c>{"type":"string"}</c>. Refitter generated a string and failed to read the object; Kiota
+    /// generated one and read null. The model carried the value type the whole time.
+    /// </remarks>
+    private static string Map(
+        string? valueRef, string? valueType, string? valueFormat, string? description,
+        IReadOnlyList<SchemaModel> schemas, Dictionary<string, string> components,
+        HashSet<string> seen) {
+        var builder = new StringBuilder("{\"type\":\"object\",\"additionalProperties\":")
+            .Append(Inline(valueRef, valueType, valueFormat, null, null, false, schemas, components, seen));
+
+        Describe(builder, description);
+
+        return builder.Append('}').ToString();
     }
 
     private static void WriteProperties(
@@ -239,6 +273,12 @@ internal static class SpecSchemaWriter {
                 Describe(array, property.Description);
 
                 builder.Append(Nullable(array.Append('}').ToString(), property.IsNullable));
+            }
+            else if (property.IsDictionary) {
+                builder.Append(Nullable(
+                    Map(property.DictionaryValueRef, property.DictionaryValueType,
+                        property.DictionaryValueFormat, property.Description, schemas, components, seen),
+                    property.IsNullable));
             }
             else {
                 builder.Append(Inline(property.Ref, property.Type, property.Format,


### PR DESCRIPTION
Closes H-05, H-06 and H-18 from the [0.21 Dispatch trial](https://claude.ai/code/artifact/7b01d3d1-4b28-4a6c-ad1e-1ff6a3b88ae3). Three ways the document a contract-first application serves said less than the application does.

## A map was published as a string (H-05)

`SpecSchemaWriter` had no dictionary branch at either level. A member the model typed `Dictionary<string,int>` reached the scalar writer with no type and took its `string` default; a named map schema was published as an object with no members, and a named primitive schema as an object too. Refitter generated a `string` and threw reading the object; Kiota generated one and read null. The value type was in the model the whole time.

The Smithy SUT's `tags` moves from `{"type":["string","null"]}` to `{"type":["object","null"],"additionalProperties":{"type":"string"}}`.

## A guard on the implementation published nothing (H-06)

`[AuthorizeGrants]` and `[RateLimit]` written on a `[Handler]` class reached the pipeline — `EnrichWithHandlerFilters` appended them — so the runtime refused with a 403 or a 429 the document never mentioned, and a generated client had no branch for it.

`HandlerSelector` now makes the same `[AnswersStatus]` reading the attribute-routed path makes, over the method, its class and the assembly. Enrichment appends what the contract did not already declare; the contract wins on a status both name, because a described 429 carries the author's wording and the attribute's is the framework's fallback.

The other two halves are written beside the synthesized 401, from the wording `TimeoutAttribute` and `IAuthorizeAttribute` already carry:

- a described deadline published `x-hardened-timeout` and no status, while the runtime answered 504
- a scoped security requirement published its 401 and no 403

The 403 needs **every** alternative to name a scope. `security` is an OR, so one unscoped entry beside a scoped one is satisfied by anybody past the 401 and the 403 would be unreachable — publishing it there is the same defect with the sign flipped. `/secured/either` keeps its 401 and gets no 403; there is a test for that.

## `nullable` was dropped in silence (H-18)

OpenAPI 3.1 removed the keyword, so under a 3.1 or later banner the reader parks it in `UnrecognizedKeywords` and nothing looked. The member generated non-null, the service sent null through it, and a generated client's `int` failed to read the response — with no build output in between. Under 3.0 the reader folds it into the type and nothing changes.

Reported rather than honoured: quietly restoring a keyword the version removed makes the file mean something no other reader agrees with. `HOAT032`/`HSMT032` names the member and the spelling that works.

`032` rather than the free-looking `025`. `025` was retired in 0.18 and may still be in somebody's `NoWarn`; `028`–`031` belong to the document export.

## Verified

CI-shaped build and full suite green. The two exported SUT documents are regenerated and committed, and the new statuses are asserted end to end: `/guarded/by-attribute` declares its 403, `/secured/scoped` declares both refusals, `/secured/either` declares neither, `GET /pets/{petId}` on the Smithy SUT declares its 504, and `CreatePetInput.tags` is a map. Coverage gate passes at 26 assemblies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)