### PR TITLE
Declare the headers an operation writes and reads, and sort every response by status

### DIFF
--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
@@ -194,6 +194,16 @@
               }
             }
           },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
           "429": {
             "description": "The caller is being throttled.",
             "headers": {
@@ -208,16 +218,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
                 }
               }
             }
@@ -470,6 +470,16 @@
               }
             }
           },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "No pet with that id",
             "content": {
@@ -486,16 +496,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
                 }
               }
             }
@@ -682,22 +682,22 @@
               }
             }
           },
-          "404": {
-            "description": "No pet with that id",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No pet with that id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }
@@ -787,9 +787,6 @@
               }
             }
           },
-          "403": {
-            "description": "The caller is not the owner."
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
@@ -817,6 +814,9 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "The caller is not the owner."
           }
         }
       }

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
@@ -179,22 +179,22 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PetNotFound"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetNotFound"
                 }
               }
             }
@@ -291,6 +291,16 @@
               }
             }
           },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -307,16 +317,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Throttled"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
                 }
               }
             }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/DeclaredHeaderDocumentTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/DeclaredHeaderDocumentTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// What a declaration says the operation writes and reads, in the document it generates.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three things the document could not say. A handler that writes a header itself had no way to
+/// declare it, so a throws-mode 201 published no <c>Location</c> and a generated client had
+/// nothing to read the new resource's address from. <c>[ConditionalGet]</c> published nothing at
+/// all - no 304, no <c>ETag</c>, no <c>If-None-Match</c> - so no client generated from the
+/// document could make the request the filter exists to answer. And the statuses a guard
+/// synthesized were appended after the declared ones, so one <c>responses</c> object was sorted
+/// in its first half and arbitrary in its second.
+/// </para>
+/// <para>
+/// Over the served document rather than the exported file, because the served one is what a client
+/// generator is pointed at. <c>ExportedDocumentTests</c> holds the two to each other.
+/// </para>
+/// </remarks>
+public class DeclaredHeaderDocumentTests {
+
+    private static async Task<JsonElement> Operation(
+        ITestWebApp app, string path, string method) {
+        var response = await app.Get("/openapi.json");
+
+        response.Assert.Ok();
+
+        using var document = JsonDocument.Parse(await response.ReadTextAsync());
+
+        return document.RootElement
+            .GetProperty("paths").GetProperty(path).GetProperty(method).Clone();
+    }
+
+    private static IEnumerable<string> ParameterNames(JsonElement operation) {
+        if (!operation.TryGetProperty("parameters", out var parameters)) {
+            yield break;
+        }
+
+        foreach (var parameter in parameters.EnumerateArray()) {
+            yield return parameter.GetProperty("name").GetString()!;
+        }
+    }
+
+    /// <summary>
+    /// A header the handler writes on the context, declared with <c>[AnswersHeader]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The response-mode <c>Created&lt;T&gt;</c> has always published this, because the type
+    /// carries the header. A handler returning a plain value carries nothing, and the trial's
+    /// throws-mode arm found no way to say it.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AHandlerDeclaresTheHeaderItWrites(ITestWebApp app) {
+        var created = (await Operation(app, "/declared-header/notes", "post"))
+            .GetProperty("responses").GetProperty("201");
+
+        Assert.Equal(
+            "Where the note was created.",
+            created.GetProperty("headers").GetProperty("Location")
+                .GetProperty("description").GetString());
+
+        Assert.Equal(
+            "string",
+            created.GetProperty("headers").GetProperty("Location")
+                .GetProperty("schema").GetProperty("type").GetString());
+    }
+
+    /// <summary>And the value reaches the wire, so the document is describing something real.</summary>
+    [HardenedTest]
+    public async Task TheDeclaredHeaderIsTheOneTheHandlerSends(ITestWebApp app) {
+        var response = await app.Post(new { }, "/declared-header/notes");
+
+        Assert.Equal(201, response.StatusCode);
+        Assert.Equal(
+            DeclaredHeaderController.CreatedAt, response.Headers["Location"].ToString());
+    }
+
+    /// <summary>
+    /// <c>[ConditionalGet]</c> publishes the 304 it answers, the <c>ETag</c> it writes and the
+    /// conditional headers it reads.
+    /// </summary>
+    [HardenedTest]
+    public async Task AConditionalGetPublishesWhatItAnswersAndReads(ITestWebApp app) {
+        var read = await Operation(app, "/declared-header/notes", "get");
+        var responses = read.GetProperty("responses");
+
+        Assert.Contains("current", responses.GetProperty("304").GetProperty("description").GetString());
+
+        // The tag on both, because a client needs it from the 200 to send back and gets it again
+        // on the 304.
+        Assert.True(responses.GetProperty("200").GetProperty("headers").TryGetProperty("ETag", out _));
+        Assert.True(responses.GetProperty("304").GetProperty("headers").TryGetProperty("ETag", out _));
+
+        // And no body on the 304, which is what stops a generated client waiting for one.
+        Assert.False(responses.GetProperty("304").TryGetProperty("content", out _));
+
+        Assert.Contains("If-None-Match", ParameterNames(read));
+        Assert.Contains("If-Modified-Since", ParameterNames(read));
+    }
+
+    /// <summary>
+    /// The write beside it publishes none of that, because the filter installs on neither of them.
+    /// </summary>
+    /// <remarks>
+    /// The declaration is on the class. Without the reach it states, every operation under a
+    /// class-level <c>[ConditionalGet]</c> would publish a 304 it cannot answer and a header
+    /// nothing reads - which is the same defect as publishing nothing, with the sign flipped.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AWriteUnderTheSameClassPublishesNoConditionalRequest(ITestWebApp app) {
+        var write = await Operation(app, "/declared-header/notes", "post");
+
+        Assert.False(write.GetProperty("responses").TryGetProperty("304", out _));
+        Assert.DoesNotContain("If-None-Match", ParameterNames(write));
+        Assert.DoesNotContain("If-Modified-Since", ParameterNames(write));
+    }
+
+    /// <summary>
+    /// Every status in one <c>responses</c> object is in status order, declared and synthesized
+    /// alike.
+    /// </summary>
+    /// <remarks>
+    /// The synthesized ones were appended after the declared block, so a bounded read answering
+    /// 200, 304 and 504 published <c>200, 504, 304</c>. The declared half has always been sorted;
+    /// this is the other half agreeing with it.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ResponsesAreInStatusOrder(ITestWebApp app) {
+        var response = await app.Get("/openapi.json");
+
+        response.Assert.Ok();
+
+        using var document = JsonDocument.Parse(await response.ReadTextAsync());
+        var checkedAny = false;
+
+        foreach (var path in document.RootElement.GetProperty("paths").EnumerateObject()) {
+            foreach (var operation in path.Value.EnumerateObject()) {
+                if (operation.Value.ValueKind != JsonValueKind.Object ||
+                    !operation.Value.TryGetProperty("responses", out var responses)) {
+                    continue;
+                }
+
+                var statuses = responses.EnumerateObject()
+                    .Select(status => int.Parse(status.Name)).ToList();
+
+                Assert.Equal(statuses.OrderBy(status => status).ToList(), statuses);
+
+                checkedAny |= statuses.Count > 1;
+            }
+        }
+
+        Assert.True(checkedAny, "No operation declared more than one status.");
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/DeclaredHeaderController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/DeclaredHeaderController.cs
@@ -1,0 +1,45 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Responses;
+using Hardened.Web.Runtime.Attributes;
+using Hardened.Web.Runtime.Conditional;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// A header a handler writes itself, declared so the document carries it, and a class-level
+/// <c>[ConditionalGet]</c> over a read and a write.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both halves of what a declaration can say about a document. <see cref="Create"/> writes
+/// <c>Location</c> on the context, which is the only way to send one from a handler returning a
+/// plain value - and the document described the response as bare, so a generated client had
+/// nothing to read the new resource's address from. <c>[AnswersHeader]</c> is the handler saying
+/// what it sends.
+/// </para>
+/// <para>
+/// And the reach. <c>[ConditionalGet]</c> is on the class, so it installs on <see cref="Read"/>
+/// and stands down on <see cref="Create"/>. The document has to do the same: a 304 on the POST
+/// would be a status the operation cannot answer, and an <c>If-None-Match</c> parameter on it
+/// would be a header nothing reads.
+/// </para>
+/// </remarks>
+[BasePath("/declared-header")]
+[ConditionalGet]
+public class DeclaredHeaderController {
+
+    /// <summary>Where <see cref="Create"/> says it put the note.</summary>
+    public const string CreatedAt = "/declared-header/notes/1";
+
+    [Get("/notes")]
+    public string[] Read() => ["first"];
+
+    [Post("/notes", SuccessStatus = 201)]
+    [AnswersHeader(201, KnownHeaders.Location, Description = "Where the note was created.")]
+    public string Create(IExecutionContext context) {
+        context.Response.Headers[KnownHeaders.Location] = CreatedAt;
+
+        return "created";
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -30,6 +30,9 @@
       "name": "Constraints"
     },
     {
+      "name": "DeclaredHeader"
+    },
+    {
       "name": "EnumVocabulary"
     },
     {
@@ -582,22 +585,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -834,6 +837,9 @@
               }
             }
           },
+          "404": {
+            "description": "The path did not name a resource: a token failed its route constraint."
+          },
           "504": {
             "description": "The operation did not finish inside its budget.",
             "content": {
@@ -843,9 +849,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "The path did not name a resource: a token failed its route constraint."
           }
         },
         "x-hardened-timeout": 300000
@@ -881,16 +884,6 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
@@ -903,6 +896,16 @@
           },
           "404": {
             "description": "The path did not name a resource: a token failed its route constraint."
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
           }
         },
         "x-hardened-timeout": 300000
@@ -937,22 +940,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -1171,22 +1174,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -1226,22 +1229,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -1283,22 +1286,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -1377,22 +1380,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -1652,7 +1655,7 @@
         "tags": [
           "CollectionRoot"
         ],
-        "operationId": "create",
+        "operationId": "collectionRootCreate",
         "responses": {
           "200": {
             "description": "OK",
@@ -1931,22 +1934,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -1991,14 +1994,53 @@
         "tags": [
           "Conditional"
         ],
-        "operationId": "read",
+        "operationId": "conditionalRead",
+        "parameters": [
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "A tag a previous response carried. Matching it is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Modified-Since",
+            "in": "header",
+            "required": false,
+            "description": "When the caller last read this. Unchanged since then is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
+            "headers": {
+              "ETag": {
+                "description": "A tag for this response, to send back in If-None-Match.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The caller's copy is current; nothing is sent.",
+            "headers": {
+              "ETag": {
+                "description": "The tag the caller already holds, repeated.",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -2032,13 +2074,50 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "A tag a previous response carried. Matching it is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Modified-Since",
+            "in": "header",
+            "required": false,
+            "description": "When the caller last read this. Unchanged since then is answered 304.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "OK",
+            "headers": {
+              "ETag": {
+                "description": "A tag for this response, to send back in If-None-Match.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The caller's copy is current; nothing is sent.",
+            "headers": {
+              "ETag": {
+                "description": "The tag the caller already holds, repeated.",
                 "schema": {
                   "type": "string"
                 }
@@ -2091,16 +2170,6 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
@@ -2113,6 +2182,16 @@
           },
           "404": {
             "description": "The path did not name a resource: a token failed its route constraint."
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
           }
         },
         "x-hardened-timeout": 300000
@@ -2150,22 +2229,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -2204,22 +2283,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -2257,22 +2336,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -2343,6 +2422,116 @@
         "x-hardened-timeout": 300000
       }
     },
+    "/declared-header/notes": {
+      "get": {
+        "tags": [
+          "DeclaredHeader"
+        ],
+        "operationId": "declaredHeaderRead",
+        "parameters": [
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "A tag a previous response carried. Matching it is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Modified-Since",
+            "in": "header",
+            "required": false,
+            "description": "When the caller last read this. Unchanged since then is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "ETag": {
+                "description": "A tag for this response, to send back in If-None-Match.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The caller's copy is current; nothing is sent.",
+            "headers": {
+              "ETag": {
+                "description": "The tag the caller already holds, repeated.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      },
+      "post": {
+        "tags": [
+          "DeclaredHeader"
+        ],
+        "operationId": "declaredHeaderCreate",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "description": "Where the note was created.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
     "/enum-vocabulary/by-priority": {
       "get": {
         "tags": [
@@ -2371,22 +2560,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -2502,22 +2691,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -3033,22 +3222,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -3382,22 +3571,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -3580,22 +3769,22 @@
               }
             }
           },
-          "504": {
-            "description": "The operation did not finish inside its budget.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
-                }
-              }
-            }
-          },
           "400": {
             "description": "The request failed validation.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -3618,13 +3807,50 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "A tag a previous response carried. Matching it is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Modified-Since",
+            "in": "header",
+            "required": false,
+            "description": "When the caller last read this. Unchanged since then is answered 304.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "OK",
+            "headers": {
+              "ETag": {
+                "description": "A tag for this response, to send back in If-None-Match.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The caller's copy is current; nothing is sent.",
+            "headers": {
+              "ETag": {
+                "description": "The tag the caller already holds, repeated.",
                 "schema": {
                   "type": "string"
                 }
@@ -3695,11 +3921,50 @@
         "operationId": "granted",
         "summary": "Guarded by grants alone, which settle before serialization and so ahead of the cache, and the case the resource-scoped rule must not also refuse.",
         "description": "This comment used to say \"safe to cache behind\" and stopped there, which is how the authorization bypass shipped. Settling ahead of the cache is not by itself what makes it safe: a refusal ahead of serialization is recorded and travels on, so the cache has to read it. AWarmCacheStillRefusesTheGrantlessCaller is the test that says so.",
+        "parameters": [
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "A tag a previous response carried. Matching it is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-Modified-Since",
+            "in": "header",
+            "required": false,
+            "description": "When the caller last read this. Unchanged since then is answered 304.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
+            "headers": {
+              "ETag": {
+                "description": "A tag for this response, to send back in If-None-Match.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The caller's copy is current; nothing is sent.",
+            "headers": {
+              "ETag": {
+                "description": "The tag the caller already holds, repeated.",
                 "schema": {
                   "type": "string"
                 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -791,12 +791,25 @@ namespace Hardened.Requests.Abstract.Responses
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
         public static Hardened.Requests.Abstract.Responses.Accepted FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
+    public sealed class AnswersHeaderAttribute : System.Attribute
+    {
+        public AnswersHeaderAttribute(int status, string name) { }
+        public string? Description { get; set; }
+        public string? Methods { get; set; }
+        public string Name { get; }
+        public bool NotWhenStreaming { get; set; }
+        public int Status { get; }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
     public sealed class AnswersStatusAttribute : System.Attribute
     {
+        public AnswersStatusAttribute(int status) { }
         public AnswersStatusAttribute(int status, System.Type body) { }
-        public System.Type Body { get; }
+        public System.Type? Body { get; }
         public string? Description { get; set; }
+        public string? Methods { get; set; }
+        public bool NotWhenStreaming { get; set; }
         public int Status { get; }
         public string? StatusFrom { get; set; }
     }
@@ -1403,6 +1416,15 @@ namespace Hardened.Requests.Abstract.Responses
         public static int StatusCode { get; }
         public void ApplyHeaders(System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues> headers) { }
         public static Hardened.Requests.Abstract.Responses.RateLimited<T> FromResponse(object? body, System.Collections.Generic.IReadOnlyDictionary<string, string> headers) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
+    public sealed class ReadsHeaderAttribute : System.Attribute
+    {
+        public ReadsHeaderAttribute(string name) { }
+        public string? Description { get; set; }
+        public string? Methods { get; set; }
+        public string Name { get; }
+        public bool NotWhenStreaming { get; set; }
     }
     [Hardened.Requests.Abstract.Responses.HttpStatus(408)]
     public sealed class RequestTimeout : Hardened.Requests.Abstract.Responses.IDeclaresStatus, Hardened.Requests.Abstract.Responses.IHttpStatusResponse, System.IEquatable<Hardened.Requests.Abstract.Responses.RequestTimeout>

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -736,6 +736,7 @@ namespace Hardened.Requests.Runtime.RateLimiting
         public System.Threading.Tasks.ValueTask<Hardened.Requests.Runtime.RateLimiting.RateLimitDecision> Acquire(string partition, Hardened.Requests.Runtime.RateLimiting.RateLimitPolicy policy, System.Threading.CancellationToken cancellationToken) { }
         public void Dispose() { }
     }
+    [Hardened.Requests.Abstract.Responses.AnswersHeader(429, "Retry-After", Description="How long to wait before the allowance returns, in seconds.")]
     [Hardened.Requests.Abstract.Responses.AnswersStatus(429, typeof(Hardened.Requests.Abstract.Errors.ErrorModel), Description="The caller has spent this operation\'s allowance. Retry-After says when it returns" +
         ".")]
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
@@ -204,6 +204,11 @@ namespace Hardened.Web.Runtime.Conditional
         public override int GetHashCode() { }
         public void PopulateServiceCollection(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
     }
+    [Hardened.Requests.Abstract.Responses.AnswersHeader(200, "ETag", Description="A tag for this response, to send back in If-None-Match.", Methods="GET,HEAD", NotWhenStreaming=true)]
+    [Hardened.Requests.Abstract.Responses.AnswersHeader(304, "ETag", Description="The tag the caller already holds, repeated.", Methods="GET,HEAD", NotWhenStreaming=true)]
+    [Hardened.Requests.Abstract.Responses.AnswersStatus(304, Description="The caller\'s copy is current; nothing is sent.", Methods="GET,HEAD", NotWhenStreaming=true)]
+    [Hardened.Requests.Abstract.Responses.ReadsHeader("If-Modified-Since", Description="When the caller last read this. Unchanged since then is answered 304.", Methods="GET,HEAD", NotWhenStreaming=true)]
+    [Hardened.Requests.Abstract.Responses.ReadsHeader("If-None-Match", Description="A tag a previous response carried. Matching it is answered 304.", Methods="GET,HEAD", NotWhenStreaming=true)]
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method)]
     public sealed class ConditionalGetAttribute : System.Attribute, Hardened.Requests.Abstract.RequestFilter.IRequestFilterProvider
     {

--- a/src/Requests/Hardened.Requests.Abstract/Responses/AnswersHeaderAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/AnswersHeaderAttribute.cs
@@ -1,0 +1,68 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// States that a response carries a header, so the published document says so.
+///
+/// <code>
+/// [Post("/jobs")]
+/// [AnswersHeader(201, "Location", Description = "Where the job was created.")]
+/// public Job Create(NewJob job) { ... }
+/// </code>
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The declaration, not the value.</b> A document says <em>201 carries a Location</em>; it
+/// cannot say what that Location is, because the value comes from the resource the handler just
+/// made. The same division <c>Created&lt;T&gt;</c> makes, where the type carries the header and the
+/// caller carries its value - and this is how a handler that is not returning a
+/// <c>Created&lt;T&gt;</c> says the same thing. In throws mode there was no way to say it at all:
+/// the handler set the header on the context and the document described the response as bare.
+/// </para>
+/// <para>
+/// <b>On a handler, or on a declaration's type.</b> Written on a method or its class it describes
+/// that operation. Written on an attribute's own type - the way <c>[AnswersStatus]</c> is - it
+/// describes every operation carrying that attribute, which is how <c>[ConditionalGet]</c>
+/// publishes the <c>ETag</c> it writes without the document generator knowing what the filter does.
+/// </para>
+/// <para>
+/// The status need not be one the handler declares. A header on a status nothing else publishes is
+/// dropped rather than inventing the response, because a header is a fact about a response and not
+/// a response.
+/// </para>
+/// <para>
+/// No schema type, for the reason a response header never has one here: a header is a string on the
+/// wire whatever it carries, and a quoted ETag is the header that settled it.
+/// </para>
+/// </remarks>
+/// <param name="status">The status whose response carries the header.</param>
+/// <param name="name">The header's name, as it goes on the wire.</param>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Method,
+    AllowMultiple = true, Inherited = true)]
+public sealed class AnswersHeaderAttribute(int status, string name) : Attribute {
+
+    /// <summary>The status whose response carries the header.</summary>
+    public int Status { get; } = status;
+
+    /// <summary>The header's name, as it goes on the wire.</summary>
+    public string Name { get; } = name;
+
+    /// <summary>The header's <c>description</c>, or null to publish it unexplained.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The HTTP methods this reaches, comma-separated, or null for every method.
+    /// </summary>
+    /// <remarks>
+    /// For a declaration written on a class, where it covers operations a filter stands down on.
+    /// <c>[ConditionalGet]</c> on a controller installs on the reads and on nothing else, so
+    /// without this the document claimed a 304 on the writes beside them.
+    /// </remarks>
+    public string? Methods { get; set; }
+
+    /// <summary>
+    /// Whether a handler that streams its response is left out, for the reason
+    /// <see cref="Methods"/> exists.
+    /// </summary>
+    public bool NotWhenStreaming { get; set; }
+}

--- a/src/Requests/Hardened.Requests.Abstract/Responses/AnswersStatusAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/AnswersStatusAttribute.cs
@@ -31,21 +31,56 @@ namespace Hardened.Requests.Abstract.Responses;
 /// into the same list.
 /// </para>
 /// </remarks>
-/// <param name="status">The status an operation carrying this declaration may be answered with.</param>
-/// <param name="body">
-/// The envelope that status carries. Every refusal the framework raises is serialized through
-/// <c>ExceptionToModelConverter</c>, so that is <c>ErrorModel</c> for all of them; a declaration
-/// answering something else names it here.
-/// </param>
 [AttributeUsage(
     AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = true)]
-public sealed class AnswersStatusAttribute(int status, Type body) : Attribute {
+public sealed class AnswersStatusAttribute : Attribute {
+
+    /// <summary>A status carrying a body.</summary>
+    /// <param name="status">The status an operation carrying this declaration may be answered with.</param>
+    /// <param name="body">
+    /// The envelope that status carries. Every refusal the framework raises is serialized through
+    /// <c>ExceptionToModelConverter</c>, so that is <c>ErrorModel</c> for all of them; a declaration
+    /// answering something else names it here.
+    /// </param>
+    public AnswersStatusAttribute(int status, Type body) {
+        Status = status;
+        Body = body;
+    }
+
+    /// <summary>
+    /// A status carrying nothing.
+    /// </summary>
+    /// <remarks>
+    /// A 304 has no body by definition, and neither does a 204. Naming an envelope for one would
+    /// describe a payload the runtime never sends, and the alternative before this existed was to
+    /// publish nothing at all - which is what <c>[ConditionalGet]</c> did.
+    /// </remarks>
+    /// <param name="status">The status an operation carrying this declaration may be answered with.</param>
+    public AnswersStatusAttribute(int status) {
+        Status = status;
+    }
 
     /// <summary>The status, unless <see cref="StatusFrom"/> names a property that overrode it.</summary>
-    public int Status { get; } = status;
+    public int Status { get; }
 
-    /// <summary>The envelope the status carries.</summary>
-    public Type Body { get; } = body;
+    /// <summary>The envelope the status carries, or null where it carries none.</summary>
+    public Type? Body { get; }
+
+    /// <summary>
+    /// The HTTP methods this reaches, comma-separated, or null for every method.
+    /// </summary>
+    /// <remarks>
+    /// For a declaration written on a class, where it covers operations a filter stands down on.
+    /// <c>[ConditionalGet]</c> on a controller installs on the reads and on nothing else, so
+    /// without this the document claimed a 304 on the writes beside them.
+    /// </remarks>
+    public string? Methods { get; set; }
+
+    /// <summary>
+    /// Whether a handler that streams its response is left out, for the reason
+    /// <see cref="Methods"/> exists.
+    /// </summary>
+    public bool NotWhenStreaming { get; set; }
 
     /// <summary>
     /// The response's <c>description</c>, or null for the status's standard reason phrase.

--- a/src/Requests/Hardened.Requests.Abstract/Responses/ReadsHeaderAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Responses/ReadsHeaderAttribute.cs
@@ -1,0 +1,57 @@
+namespace Hardened.Requests.Abstract.Responses;
+
+/// <summary>
+/// States that an operation reads a request header its handler does not bind, so the published
+/// document declares the parameter.
+///
+/// <code>
+/// [ReadsHeader("If-None-Match", Description = "A tag a previous response carried.")]
+/// public sealed class ConditionalGetAttribute : Attribute, IRequestFilterProvider { }
+/// </code>
+/// </summary>
+/// <remarks>
+/// <para>
+/// A filter that reads a header reads it before the handler runs, so nothing in the handler's
+/// signature mentions it and the document published no parameter for it. A generated client
+/// therefore had no way to send it: <c>[ConditionalGet]</c> answers a conditional request and no
+/// client generated from the document could make one.
+/// </para>
+/// <para>
+/// The counterpart of <see cref="AnswersHeaderAttribute"/>, read the same two ways - on a handler
+/// or its class, and on a declaration's own type - and dropped where the operation already binds a
+/// parameter of that name, because the handler's own is the more specific description.
+/// </para>
+/// <para>
+/// Always optional. A header a filter reads is one the caller may send; a header the operation
+/// requires is one the handler binds, and binding it is how the 400 for its absence gets declared
+/// too.
+/// </para>
+/// </remarks>
+/// <param name="name">The header's name, as it goes on the wire.</param>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Method,
+    AllowMultiple = true, Inherited = true)]
+public sealed class ReadsHeaderAttribute(string name) : Attribute {
+
+    /// <summary>The header's name, as it goes on the wire.</summary>
+    public string Name { get; } = name;
+
+    /// <summary>The parameter's <c>description</c>, or null to publish it unexplained.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The HTTP methods this reaches, comma-separated, or null for every method.
+    /// </summary>
+    /// <remarks>
+    /// For a declaration written on a class, where it covers operations a filter stands down on.
+    /// <c>[ConditionalGet]</c> on a controller installs on the reads and on nothing else, so
+    /// without this the document claimed a 304 on the writes beside them.
+    /// </remarks>
+    public string? Methods { get; set; }
+
+    /// <summary>
+    /// Whether a handler that streams its response is left out, for the reason
+    /// <see cref="Methods"/> exists.
+    /// </summary>
+    public bool NotWhenStreaming { get; set; }
+}

--- a/src/Requests/Hardened.Requests.Runtime/RateLimiting/RateLimitAttribute.cs
+++ b/src/Requests/Hardened.Requests.Runtime/RateLimiting/RateLimitAttribute.cs
@@ -1,6 +1,7 @@
 using Hardened.Requests.Abstract.Errors;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Responses;
 
 namespace Hardened.Requests.Runtime.RateLimiting;
@@ -41,6 +42,10 @@ public enum RateLimitScope {
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
 [AnswersStatus(429, typeof(ErrorModel),
     Description = "The caller has spent this operation's allowance. Retry-After says when it returns.")]
+// The headers the limiter writes on every refusal, which the description above already names and
+// the document did not carry.
+[AnswersHeader(429, KnownHeaders.RetryAfter,
+    Description = "How long to wait before the allowance returns, in seconds.")]
 public class RateLimitAttribute : Attribute, IRequestFilterProvider {
 
     /// <summary>Requests allowed per <see cref="WindowSeconds"/>.</summary>

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerInfo.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerInfo.cs
@@ -1,6 +1,5 @@
-using System.Linq;
 using CSharpAuthor;
-using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Requests;
 using Hardened.SourceGenerator.Shared;
 using Microsoft.CodeAnalysis;
 
@@ -118,11 +117,11 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
         string methodName,
         IReadOnlyList<AttributeModel> filters,
         ITypeDefinition? outputType = null,
-        IReadOnlyList<ResponseSchemaModel>? refusals = null) {
+        DeclaredOperationFacts? declared = null) {
         MethodName = methodName;
         Filters = filters;
         OutputType = outputType;
-        Refusals = refusals ?? Array.Empty<ResponseSchemaModel>();
+        Declared = declared ?? DeclaredOperationFacts.Empty;
     }
 
     public string MethodName { get; }
@@ -130,8 +129,8 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
     public IReadOnlyList<AttributeModel> Filters { get; }
 
     /// <summary>
-    /// The statuses the declarations covering this method can answer, from their
-    /// <c>[AnswersStatus]</c>.
+    /// What the declarations covering this method say the operation answers with and reads, from
+    /// their <c>[AnswersStatus]</c>, <c>[AnswersHeader]</c> and <c>[ReadsHeader]</c>.
     /// </summary>
     /// <remarks>
     /// Read here rather than in the bridge for the reason <see cref="OutputType"/> is: a described
@@ -140,8 +139,13 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
     /// both that syntax and a semantic model to resolve the attribute's declared body type against.
     /// The filters themselves already travelled, which is why the runtime answered a 403 and a 429
     /// the document did not mention.
+    ///
+    /// <para>
+    /// Unnarrowed, because the operation's verb comes from the contract and this pass has not seen
+    /// it. <c>RequestModelBuilder</c> narrows.
+    /// </para>
     /// </remarks>
-    public IReadOnlyList<ResponseSchemaModel> Refusals { get; }
+    public DeclaredOperationFacts Declared { get; }
 
     /// <summary>
     /// What writes this operation's response, named by <c>[Output&lt;T&gt;]</c>, or null.
@@ -161,7 +165,7 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
         return MethodName == other.MethodName &&
                Equals(OutputType, other.OutputType) &&
                Filters.DeepEquals(other.Filters) &&
-               Refusals.SequenceEqual(other.Refusals);
+               Declared.Equals(other.Declared);
     }
 
     public override bool Equals(object? obj) => Equals(obj as HandlerMethodFilterInfo);
@@ -172,7 +176,7 @@ internal class HandlerMethodFilterInfo : IEquatable<HandlerMethodFilterInfo> {
 
             hash = (hash * 397) ^ Filters.GetHashCodeAggregation();
             hash = (hash * 397) ^ (OutputType?.GetHashCode() ?? 0);
-            hash = (hash * 397) ^ Refusals.GetHashCodeAggregation();
+            hash = (hash * 397) ^ Declared.GetHashCode();
 
             return hash;
         }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerSelector.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerSelector.cs
@@ -80,14 +80,14 @@ internal static class HandlerSelector {
             // The same reading the attribute-routed path makes on its own handler method, over the
             // method, its class and the assembly. A described operation's guards can only be
             // written here, so this is the only place they can be read from.
-            var refusals = FilterResponseSelector.Read(context, methodDeclaration, cancellationToken);
+            var declared = FilterResponseSelector.Read(context, methodDeclaration, cancellationToken);
 
-            if (methodAttrs.Count > 0 || outputType != null || refusals.Count > 0) {
+            if (methodAttrs.Count > 0 || outputType != null || !declared.IsEmpty) {
                 methodFilters.Add(new HandlerMethodFilterInfo(
                     methodDeclaration.Identifier.Text,
                     methodAttrs,
                     outputType,
-                    refusals));
+                    declared));
             }
         }
 

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/RequestModelBuilder.cs
@@ -47,6 +47,7 @@ internal static class RequestModelBuilder {
                 // Find method-level filters matching this handler's method
                 var responseInformation = model.ResponseInformation;
                 var responseSchemas = model.ResponseSchemas;
+                OperationDeclarations? declared = null;
 
                 foreach (var methodFilter in handlerInfo.MethodFilters) {
                     if (string.Equals(methodFilter.MethodName, model.HandlerMethod,
@@ -61,7 +62,13 @@ internal static class RequestModelBuilder {
                                 responseInformation with { OutputType = methodFilter.OutputType };
                         }
 
-                        responseSchemas = WithRefusals(responseSchemas, methodFilter.Refusals);
+                        // Narrowed here, where the operation's verb and response shape are known.
+                        // HandlerSelector read the implementation's syntax and had neither.
+                        declared = methodFilter.Declared.For(
+                            model.Name.Method, responseInformation.IsAsyncEnumerable);
+
+                        responseSchemas =
+                            declared.WithHeaders(WithRefusals(responseSchemas, declared.Refusals));
 
                         break;
                     }
@@ -71,7 +78,21 @@ internal static class RequestModelBuilder {
                 // hand-rolled copy. This used to restate the members one by one, and each field
                 // added to the model was silently dropped here until someone noticed - the tag's
                 // description was the latest. One copy site is the fix, not a longer list.
-                result.Add(model.WithFilters(filters, responseInformation, responseSchemas));
+                var enriched = model.WithFilters(filters, responseInformation, responseSchemas);
+
+                if (declared != null) {
+                    enriched.DeclaredHeaderParameters = declared.HeaderParameters();
+
+                    // For the same reason the attribute-routed path sets it: a success the
+                    // document writes from the return type has no ResponseSchemas entry to carry
+                    // a header on. Every described operation declares its responses, so this is
+                    // usually empty - and symmetry is cheaper than working out when it is not.
+                    enriched.SingleResponseHeaders = declared.Headers(
+                        enriched.ResponseInformation.DefaultStatusCode ?? 200,
+                        System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>());
+                }
+
+                result.Add(enriched);
             } else {
                 result.Add(model);
             }

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
@@ -451,9 +451,20 @@ public class SpecFirstDocumentTests {
         public class QuoteServiceImpl : IQuoteService {
             [Hardened.Requests.Runtime.RateLimiting.RateLimit(PermitLimit = 2)]
             [Hardened.Requests.Runtime.Authorization.AuthorizeGrants("quotes:read")]
+            [AnswersHeader(200, "X-Quote-Source", Description = "Which book priced it.")]
+            [ReadsHeader("X-Quote-Currency", Description = "The currency to price in.")]
             public Task<string> GetQuote() => Task.FromResult("40.00");
         }
         """);
+
+    private static JsonElement GuardedOperationElement() {
+        var result = OpenApiGenerator.Run(GuardedOperation, GuardedHandler);
+
+        Assert.Empty(result.Errors);
+
+        return PublishedDocumentFrom(result)
+            .GetProperty("paths").GetProperty("/quotes").GetProperty("get");
+    }
 
     private static JsonElement GuardedResponses() {
         var result = OpenApiGenerator.Run(GuardedOperation, GuardedHandler);
@@ -545,6 +556,56 @@ public class SpecFirstDocumentTests {
                   type: object
                   additionalProperties: { type: integer }
         """;
+
+    /// <summary>
+    /// A header written on a described handler reaches its document, the way one written on an
+    /// attribute-routed handler does.
+    /// </summary>
+    /// <remarks>
+    /// The implementation is the only place an author can write anything about a described
+    /// operation - its signature is generated - so a header the handler sends had nowhere to be
+    /// declared and the document described the response as bare.
+    /// </remarks>
+    [Fact]
+    public void AHeaderDeclaredOnADescribedHandlerReachesItsDocument() =>
+        Assert.Equal(
+            "Which book priced it.",
+            GuardedOperationElement().GetProperty("responses").GetProperty("200")
+                .GetProperty("headers").GetProperty("X-Quote-Source")
+                .GetProperty("description").GetString());
+
+    /// <summary>And a header it says it reads becomes a parameter a generated client can send.</summary>
+    [Fact]
+    public void AHeaderADescribedHandlerReadsBecomesAParameter() {
+        var parameters = GuardedOperationElement().GetProperty("parameters");
+
+        var declared = parameters.EnumerateArray()
+            .Single(parameter => parameter.GetProperty("name").GetString() == "X-Quote-Currency");
+
+        Assert.Equal("header", declared.GetProperty("in").GetString());
+        Assert.False(declared.GetProperty("required").GetBoolean());
+        Assert.Equal("The currency to price in.", declared.GetProperty("description").GetString());
+    }
+
+    /// <summary>
+    /// The rate limiter's <c>Retry-After</c>, which travels on the attribute rather than being
+    /// written by hand.
+    /// </summary>
+    [Fact]
+    public void ARateLimitPublishesTheHeaderItWrites() =>
+        Assert.True(
+            GuardedOperationElement().GetProperty("responses").GetProperty("429")
+                .GetProperty("headers").TryGetProperty("Retry-After", out _));
+
+    /// <summary>Described responses are in status order too, synthesized ones included.</summary>
+    [Fact]
+    public void DescribedResponsesAreInStatusOrder() {
+        var statuses = GuardedOperationElement().GetProperty("responses").EnumerateObject()
+            .Select(status => int.Parse(status.Name)).ToList();
+
+        Assert.True(statuses.Count > 2);
+        Assert.Equal(statuses.OrderBy(status => status).ToList(), statuses);
+    }
 
     #endregion
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/DeclaredScopeTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Requests/DeclaredScopeTests.cs
@@ -1,0 +1,69 @@
+using Hardened.SourceGenerator.Requests;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Requests;
+
+/// <summary>
+/// Which operations a declaration written on a class reaches.
+/// </summary>
+/// <remarks>
+/// A filter that stands down on some of the operations under it leaves the document claiming a
+/// status or a header those operations cannot produce. <c>[ConditionalGet]</c> on a controller
+/// installs on the reads, so a 304 on the writes beside them is a lie a generated client would
+/// write a branch for. The declaration states its reach and this applies it, which keeps the rule
+/// that nothing in the selector knows what any filter does.
+/// </remarks>
+public class DeclaredScopeTests {
+
+    [Fact]
+    public void AnUnrestrictedDeclarationReachesEveryOperation() {
+        var scope = new DeclaredScope(methods: null, notWhenStreaming: false);
+
+        Assert.True(scope.Reaches("GET", streams: false));
+        Assert.True(scope.Reaches("POST", streams: false));
+        Assert.True(scope.Reaches("GET", streams: true));
+    }
+
+    [Fact]
+    public void AMethodRestrictionReachesOnlyThose() {
+        var scope = new DeclaredScope("GET,HEAD", notWhenStreaming: false);
+
+        Assert.True(scope.Reaches("GET", streams: false));
+        Assert.True(scope.Reaches("HEAD", streams: false));
+        Assert.False(scope.Reaches("POST", streams: false));
+        Assert.False(scope.Reaches("DELETE", streams: false));
+    }
+
+    /// <summary>Written the way somebody writes it.</summary>
+    [Fact]
+    public void SpacingAndCaseDoNotDecideIt() {
+        var scope = new DeclaredScope(" get , Head ", notWhenStreaming: false);
+
+        Assert.True(scope.Reaches("GET", streams: false));
+        Assert.True(scope.Reaches("head", streams: false));
+    }
+
+    [Fact]
+    public void AStreamingHandlerIsLeftOutWhereTheDeclarationSaysSo() {
+        var restricted = new DeclaredScope("GET", notWhenStreaming: true);
+
+        Assert.True(restricted.Reaches("GET", streams: false));
+        Assert.False(restricted.Reaches("GET", streams: true));
+
+        var unrestricted = new DeclaredScope("GET", notWhenStreaming: false);
+
+        Assert.True(unrestricted.Reaches("GET", streams: true));
+    }
+
+    /// <summary>
+    /// An operation whose verb is unknown keeps the declaration rather than losing it.
+    /// </summary>
+    /// <remarks>
+    /// The narrowing exists to stop a document claiming what an operation cannot answer. Dropping
+    /// a declaration because the verb was not carried would lose what it can answer, which is the
+    /// worse of the two.
+    /// </remarks>
+    [Fact]
+    public void AnUnknownVerbKeepsTheDeclaration() =>
+        Assert.True(new DeclaredScope("GET", notWhenStreaming: false).Reaches(null, streams: false));
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/DeclaredHeaderParameterModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/DeclaredHeaderParameterModel.cs
@@ -1,0 +1,37 @@
+namespace Hardened.SourceGenerator.Models.Request;
+
+/// <summary>
+/// A request header the operation reads that no handler parameter binds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Separate from <c>RequestParameterInformation</c>, which describes a value the generated binder
+/// passes to the handler. Nothing binds this one: a filter reads it before the handler runs, and
+/// the only thing to say about it is that a caller may send it. Putting it in the binder's list
+/// would generate an argument for a parameter that does not exist.
+/// </para>
+/// <para>
+/// Always optional and always a string, for the reasons <c>[ReadsHeader]</c> gives.
+/// </para>
+/// </remarks>
+public sealed class DeclaredHeaderParameterModel : System.IEquatable<DeclaredHeaderParameterModel> {
+
+    public DeclaredHeaderParameterModel(string name, string? description) {
+        Name = name;
+        Description = description;
+    }
+
+    /// <summary>The header's name, as it goes on the wire.</summary>
+    public string Name { get; }
+
+    /// <summary>The parameter's <c>description</c>, or null.</summary>
+    public string? Description { get; }
+
+    public bool Equals(DeclaredHeaderParameterModel? other) =>
+        other is not null && Name == other.Name && Description == other.Description;
+
+    public override bool Equals(object? obj) => Equals(obj as DeclaredHeaderParameterModel);
+
+    public override int GetHashCode() =>
+        unchecked((Name.GetHashCode() * 397) ^ (Description?.GetHashCode() ?? 0));
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -55,6 +55,8 @@ public class RequestHandlerModel {
             ParametersValidator = ParametersValidator,
             ResponseSchema = ResponseSchema,
             ResponseSchemas = responseSchemas ?? ResponseSchemas,
+            DeclaredHeaderParameters = DeclaredHeaderParameters,
+            SingleResponseHeaders = SingleResponseHeaders,
             DeclaredResponsesAreComplete = DeclaredResponsesAreComplete,
             DeclaredTimeout = DeclaredTimeout,
             RequestSchema = RequestSchema,
@@ -169,6 +171,28 @@ public class RequestHandlerModel {
 
     public IReadOnlyList<ResponseSchemaModel> ResponseSchemas { get; set; } =
         Array.Empty<ResponseSchemaModel>();
+
+    /// <summary>
+    /// Header parameters a declaration contributes that no handler parameter binds.
+    /// </summary>
+    /// <remarks>
+    /// A filter reading <c>If-None-Match</c> reads it before the handler runs, so the signature
+    /// says nothing about it and the document published no parameter for it - which left a
+    /// generated client unable to make the conditional request the operation answers.
+    /// </remarks>
+    public IReadOnlyList<DeclaredHeaderParameterModel> DeclaredHeaderParameters { get; set; } =
+        Array.Empty<DeclaredHeaderParameterModel>();
+
+    /// <summary>
+    /// Headers declared on the success of a handler whose return type declares no response set.
+    /// </summary>
+    /// <remarks>
+    /// Beside <see cref="ResponseSchemas"/> rather than in it, because a handler returning a plain
+    /// value has no entry there at all - the document writer describes its success from the return
+    /// type. Empty for every handler whose responses are declared, where the headers travel on the
+    /// entry they belong to.
+    /// </remarks>
+    internal IReadOnlyList<Generation.Models.ResponseHeaderModel>? SingleResponseHeaders { get; set; }
 
     /// <summary>The request body's JSON Schema, on the same terms.</summary>
     public HandlerSchema? RequestSchema { get; set; }

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -393,7 +393,16 @@ public static class OpenApiDocumentGenerator {
             .Where(p => Location(p.BindingType) != null)
             .ToList();
 
-        if (bound.Count == 0) {
+        // A header a filter reads is dropped where the handler binds one of that name: the
+        // handler's carries a type, a constraint and a description of its own, and two entries
+        // under one name is a document no generator can read.
+        var declared = handler.DeclaredHeaderParameters
+            .Where(header => !bound.Any(parameter => string.Equals(
+                string.IsNullOrEmpty(parameter.BindingName) ? parameter.Name : parameter.BindingName,
+                header.Name, System.StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        if (bound.Count == 0 && declared.Count == 0) {
             return;
         }
 
@@ -429,6 +438,19 @@ public static class OpenApiDocumentGenerator {
             builder.Append("")
                 .Append(",\"schema\":").Append(ParameterSchema(parameter, version, enums))
                 .Append('}');
+        }
+
+        for (var i = 0; i < declared.Count; i++) {
+            if (bound.Count > 0 || i > 0) {
+                builder.Append(',');
+            }
+
+            builder.Append("{\"name\":\"").Append(JsonSchemaWriter.Escape(declared[i].Name))
+                .Append("\",\"in\":\"header\",\"required\":false");
+
+            WriteText(builder, "description", declared[i].Description);
+
+            builder.Append(",\"schema\":{\"type\":\"string\"}}");
         }
 
         builder.Append(']');
@@ -482,23 +504,41 @@ public static class OpenApiDocumentGenerator {
         // of them.
         var returnTypeDeclaredThem = handler.DeclaredResponsesAreComplete;
 
+        // Keyed and sorted rather than appended in the order the writers run. A synthesized 400 or
+        // 401 used to land after every declared response, so an operation answering 200, 404 and
+        // 401 published them in that order - which reads as arbitrary next to the declared block,
+        // which has always been sorted, and made the two halves of one responses object disagree
+        // about what order means.
+        var responses = new SortedDictionary<int, string>();
+
         if (handler.ResponseSchemas.Count == 0) {
-            WriteSingleResponse(builder, handler, components, version, successStatus);
+            WriteSingleResponse(responses, handler, components, version, successStatus);
         }
         else if (returnTypeDeclaredThem) {
-            WriteDeclaredResponses(builder, handler, components, version);
+            WriteDeclaredResponses(responses, handler, components, version);
         }
         else {
-            WriteSingleResponse(builder, handler, components, version, successStatus);
-            builder.Append(',');
-            WriteDeclaredResponses(builder, handler, components, version);
+            WriteSingleResponse(responses, handler, components, version, successStatus);
+            WriteDeclaredResponses(responses, handler, components, version);
         }
 
-        WriteValidationResponse(builder, handler, components);
-        WriteAuthenticationResponse(builder, handler, components);
-        WriteAuthorizationResponse(builder, handler, components);
-        WriteTimeoutResponse(builder, handler, components);
-        WriteConstrainedPathResponse(builder, handler);
+        WriteValidationResponse(responses, handler, components);
+        WriteAuthenticationResponse(responses, handler, components);
+        WriteAuthorizationResponse(responses, handler, components);
+        WriteTimeoutResponse(responses, handler, components);
+        WriteConstrainedPathResponse(responses, handler);
+
+        var first = true;
+
+        foreach (var response in responses) {
+            if (!first) {
+                builder.Append(',');
+            }
+
+            builder.Append('"').Append(response.Key).Append("\":").Append(response.Value);
+
+            first = false;
+        }
 
         builder.Append('}');
     }
@@ -528,7 +568,7 @@ public static class OpenApiDocumentGenerator {
     /// </para>
     /// </remarks>
     private static void WriteAuthorizationResponse(
-        StringBuilder builder, RequestHandlerModel handler,
+        SortedDictionary<int, string> responses, RequestHandlerModel handler,
         SortedDictionary<string, string> components) {
         if (!EveryAlternativeRequiresAScope(handler) || DeclaresStatus(handler, 403)) {
             return;
@@ -536,9 +576,9 @@ public static class OpenApiDocumentGenerator {
 
         components["ErrorModel"] = ErrorModelSchema;
 
-        builder.Append(",\"403\":{\"description\":\"The caller does not hold what this operation requires.\"," +
-                       "\"content\":{\"application/json\":{\"schema\":" +
-                       "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}");
+        responses[403] = "{\"description\":\"The caller does not hold what this operation requires.\"," +
+                          "\"content\":{\"application/json\":{\"schema\":" +
+                          "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}";
     }
 
     /// <summary>
@@ -597,7 +637,7 @@ public static class OpenApiDocumentGenerator {
     /// taken from so the two paths publish one sentence.
     /// </remarks>
     private static void WriteTimeoutResponse(
-        StringBuilder builder, RequestHandlerModel handler,
+        SortedDictionary<int, string> responses, RequestHandlerModel handler,
         SortedDictionary<string, string> components) {
         if (handler.DeclaredTimeout is not { } timeout || DeclaresStatus(handler, timeout.Status)) {
             return;
@@ -605,17 +645,21 @@ public static class OpenApiDocumentGenerator {
 
         components["ErrorModel"] = ErrorModelSchema;
 
-        builder.Append(",\"").Append(timeout.Status)
-            .Append("\":{\"description\":\"The operation did not finish inside its budget.\"");
+        var builder = new StringBuilder(
+            "{\"description\":\"The operation did not finish inside its budget.\"");
 
+        // A string, like every other response header this writes. A header is a string on the
+        // wire whatever it carries, which is the rule ResponseHeaderModel states.
         if (timeout.RetryAfterSeconds > 0) {
             builder.Append(",\"headers\":{\"Retry-After\":{" +
                            "\"description\":\"How long to wait before trying again, in seconds.\"," +
-                           "\"schema\":{\"type\":\"integer\"}}}");
+                           "\"schema\":{\"type\":\"string\"}}}");
         }
 
-        builder.Append(",\"content\":{\"application/json\":{\"schema\":" +
-                       "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}");
+        responses[timeout.Status] = builder
+            .Append(",\"content\":{\"application/json\":{\"schema\":" +
+                    "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}")
+            .ToString();
     }
 
     /// <summary>
@@ -666,11 +710,18 @@ public static class OpenApiDocumentGenerator {
     /// A handler that returns one type: the status it succeeds with, and the body it sends.
     /// </summary>
     private static void WriteSingleResponse(
-        StringBuilder builder, RequestHandlerModel handler, SortedDictionary<string, string> components,
+        SortedDictionary<int, string> responses, RequestHandlerModel handler,
+        SortedDictionary<string, string> components,
         OpenApiVersion version, int successStatus) {
-        builder.Append('"').Append(successStatus).Append("\":{\"description\":\"")
+        var builder = new StringBuilder("{\"description\":\"")
             .Append(JsonSchemaWriter.Escape(HttpResponseDescription.For(successStatus)))
             .Append('"');
+
+        // A handler returning a plain value has no ResponseSchemas entry to hang a declared header
+        // on, and this is the writer that describes its success.
+        if (handler.SingleResponseHeaders is { Count: > 0 } headers) {
+            WriteResponseHeaders(builder, headers);
+        }
 
         if (handler.ResponseInformation.IsAsyncEnumerable) {
             WriteStreamedResponse(builder, handler, components, version);
@@ -682,7 +733,7 @@ public static class OpenApiDocumentGenerator {
                 .Append("\":{\"schema\":").Append(handler.ResponseSchema.Schema).Append("}}");
         }
 
-        builder.Append('}');
+        responses[successStatus] = builder.Append('}').ToString();
     }
 
     /// <summary>
@@ -701,7 +752,8 @@ public static class OpenApiDocumentGenerator {
     /// </para>
     /// </remarks>
     private static void WriteDeclaredResponses(
-        StringBuilder builder, RequestHandlerModel handler, SortedDictionary<string, string> components,
+        SortedDictionary<int, string> responses, RequestHandlerModel handler,
+        SortedDictionary<string, string> components,
         OpenApiVersion version) {
         var streamedStatus = handler.ResponseInformation.IsAsyncEnumerable
             ? handler.ResponseInformation.DefaultStatusCode ?? 200
@@ -712,14 +764,9 @@ public static class OpenApiDocumentGenerator {
             .OrderBy(group => group.Key);
 
         var successContentType = ContentType(handler);
-        var first = true;
 
         foreach (var group in byStatus) {
-            if (!first) {
-                builder.Append(',');
-            }
-
-            builder.Append('"').Append(group.Key).Append("\":{\"description\":\"")
+            var builder = new StringBuilder("{\"description\":\"")
                 .Append(JsonSchemaWriter.Escape(group.First().Description))
                 .Append('"');
 
@@ -764,9 +811,7 @@ public static class OpenApiDocumentGenerator {
                 builder.Append("}}");
             }
 
-            builder.Append('}');
-
-            first = false;
+            responses[group.Key] = builder.Append('}').ToString();
         }
     }
 
@@ -782,12 +827,16 @@ public static class OpenApiDocumentGenerator {
     /// <c>ResponseHeaderModel</c> gives - a header is a string on the wire whatever it carries.
     /// </remarks>
     private static void WriteResponseHeaders(
-        StringBuilder builder, IEnumerable<ResponseSchemaModel> responses) {
+        StringBuilder builder, IEnumerable<ResponseSchemaModel> responses) =>
+        WriteResponseHeaders(builder, responses.SelectMany(response => response.Headers));
+
+    private static void WriteResponseHeaders(
+        StringBuilder builder, IEnumerable<Generation.Models.ResponseHeaderModel> headers) {
         var seen = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
         var first = true;
 
-        foreach (var response in responses) {
-            foreach (var header in response.Headers) {
+        {
+            foreach (var header in headers) {
                 if (!seen.Add(header.Name)) {
                     continue;
                 }
@@ -839,7 +888,7 @@ public static class OpenApiDocumentGenerator {
     /// 400, whose description then wins.
     /// </remarks>
     private static void WriteValidationResponse(
-        StringBuilder builder, RequestHandlerModel handler,
+        SortedDictionary<int, string> responses, RequestHandlerModel handler,
         SortedDictionary<string, string> components) {
         if (handler.ParametersValidator == null && !handler.HasGeneratedValidation &&
             !HasBindingRefusals(handler)) {
@@ -859,9 +908,9 @@ public static class OpenApiDocumentGenerator {
 
         components["RequestValidationError"] = ValidationErrorSchema;
 
-        builder.Append(",\"400\":{\"description\":\"The request failed validation.\"," +
-                       "\"content\":{\"application/json\":{\"schema\":" +
-                       "{\"$ref\":\"#/components/schemas/RequestValidationError\"}}}}");
+        responses[400] = "{\"description\":\"The request failed validation.\"," +
+                         "\"content\":{\"application/json\":{\"schema\":" +
+                         "{\"$ref\":\"#/components/schemas/RequestValidationError\"}}}}";
     }
 
     /// <summary>
@@ -924,7 +973,7 @@ public static class OpenApiDocumentGenerator {
     /// whose description then wins.
     /// </remarks>
     private static void WriteAuthenticationResponse(
-        StringBuilder builder, RequestHandlerModel handler,
+        SortedDictionary<int, string> responses, RequestHandlerModel handler,
         SortedDictionary<string, string> components) {
         if (handler.SecurityRequirements.Count == 0) {
             return;
@@ -936,12 +985,12 @@ public static class OpenApiDocumentGenerator {
 
         components["ErrorModel"] = ErrorModelSchema;
 
-        builder.Append(",\"401\":{\"description\":\"Authentication required.\"," +
-                       "\"headers\":{\"WWW-Authenticate\":{" +
-                       "\"description\":\"The challenge naming the scheme to authenticate with.\"," +
-                       "\"schema\":{\"type\":\"string\"}}}," +
-                       "\"content\":{\"application/json\":{\"schema\":" +
-                       "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}");
+        responses[401] = "{\"description\":\"Authentication required.\"," +
+                         "\"headers\":{\"WWW-Authenticate\":{" +
+                         "\"description\":\"The challenge naming the scheme to authenticate with.\"," +
+                         "\"schema\":{\"type\":\"string\"}}}," +
+                         "\"content\":{\"application/json\":{\"schema\":" +
+                         "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}";
     }
 
     /// <summary>
@@ -955,7 +1004,7 @@ public static class OpenApiDocumentGenerator {
     /// Skipped where the operation declares its own 404, whose description then wins.
     /// </remarks>
     private static void WriteConstrainedPathResponse(
-        StringBuilder builder, RequestHandlerModel handler) {
+        SortedDictionary<int, string> responses, RequestHandlerModel handler) {
         if (!HasConstrainedPathToken(handler.Name.Path)) {
             return;
         }
@@ -964,8 +1013,8 @@ public static class OpenApiDocumentGenerator {
             return;
         }
 
-        builder.Append(",\"404\":{\"description\":" +
-                       "\"The path did not name a resource: a token failed its route constraint.\"}");
+        responses[404] = "{\"description\":" +
+                         "\"The path did not name a resource: a token failed its route constraint.\"}";
     }
 
     private static bool HasConstrainedPathToken(string path) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -30,7 +30,14 @@ public abstract class BaseRequestModelGenerator {
         var thrown = ThrownResponseSelector.Read(
             context, methodDeclaration, response, cancellationToken);
 
-        var refusals = FilterResponseSelector.Read(context, methodDeclaration, cancellationToken);
+        // Narrowed here rather than in the selector, because this is the first place the verb and
+        // the response shape are both known - and a declaration on a class reaches only the
+        // operations it says it does. [ConditionalGet] on a controller installs on the reads.
+        var declared = FilterResponseSelector
+            .Read(context, methodDeclaration, cancellationToken)
+            .For(nameModel.Method, response.IsAsyncEnumerable);
+
+        var refusals = declared.Refusals;
 
         var model = Compose(
             nameModel,
@@ -48,10 +55,11 @@ public abstract class BaseRequestModelGenerator {
             // handler. The document writer groups by status and does not care which produced an
             // entry. Filter-declared responses go last, so a status the handler declared itself
             // keeps the shape the handler gave it.
-            DeclaredResponses(context, response)
-                .Concat(thrown)
-                .Concat(refusals)
-                .ToList(),
+            declared.WithHeaders(
+                DeclaredResponses(context, response)
+                    .Concat(thrown)
+                    .Concat(refusals)
+                    .ToList()),
             // Complete unless a declaration named only failures and left the success to the return
             // type. [Throws<T>] is one such, and a guard that can refuse the operation is another:
             // both add a status the handler can be answered with instead of running, and neither
@@ -69,6 +77,16 @@ public abstract class BaseRequestModelGenerator {
         model.AdditionalBodyParameters = AdditionalBodyParameters(parameters);
 
         model.DeclaredTimeout = DeclaredTimeoutSelector.Read(context, methodDeclaration);
+
+        // The headers a filter reads before the handler runs, which nothing in the signature
+        // mentions and the document therefore published no parameter for.
+        model.DeclaredHeaderParameters = declared.HeaderParameters();
+
+        // And the ones it writes on a status the handler answers by returning a value, which
+        // WriteSingleResponse rather than WriteDeclaredResponses publishes.
+        model.SingleResponseHeaders = declared.Headers(
+            model.ResponseInformation.DefaultStatusCode ?? 200,
+            System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>());
 
         model.ParameterEnums = ParameterEnums(context, methodDeclaration);
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/DeclaredOperationFacts.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/DeclaredOperationFacts.cs
@@ -1,0 +1,346 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hardened.Generation.Models;
+using Hardened.SourceGenerator.Models.Request;
+
+namespace Hardened.SourceGenerator.Requests;
+
+/// <summary>
+/// What the declarations covering one handler say about its document, before it is known which of
+/// them reach the operation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two front ends read this and only one of them knows the operation's verb when it reads. An
+/// attribute-routed handler carries its route on the same method the declarations are on; a
+/// described one gets its verb from the contract, long after <c>HandlerSelector</c> has walked the
+/// implementation's syntax. So the reading is separated from the narrowing: this holds everything
+/// found, and <see cref="For"/> answers for one operation.
+/// </para>
+/// <para>
+/// Which also keeps this comparable. It reaches a Roslyn incremental cache key through
+/// <c>HandlerInfo</c>, and a value that narrowed at read time would depend on facts that pass did
+/// not have.
+/// </para>
+/// </remarks>
+internal sealed class DeclaredOperationFacts : IEquatable<DeclaredOperationFacts> {
+
+    public static readonly DeclaredOperationFacts Empty = new(
+        Array.Empty<ScopedRefusal>(),
+        Array.Empty<ScopedResponseHeader>(),
+        Array.Empty<ScopedRequestHeader>());
+
+    public DeclaredOperationFacts(
+        IReadOnlyList<ScopedRefusal> refusals,
+        IReadOnlyList<ScopedResponseHeader> responseHeaders,
+        IReadOnlyList<ScopedRequestHeader> requestHeaders) {
+        Refusals = refusals;
+        ResponseHeaders = responseHeaders;
+        RequestHeaders = requestHeaders;
+    }
+
+    public IReadOnlyList<ScopedRefusal> Refusals { get; }
+
+    public IReadOnlyList<ScopedResponseHeader> ResponseHeaders { get; }
+
+    public IReadOnlyList<ScopedRequestHeader> RequestHeaders { get; }
+
+    public bool IsEmpty =>
+        Refusals.Count == 0 && ResponseHeaders.Count == 0 && RequestHeaders.Count == 0;
+
+    /// <summary>The subset reaching an operation with this verb and this response shape.</summary>
+    public OperationDeclarations For(string? httpMethod, bool streams) =>
+        new(Refusals.Where(entry => entry.Scope.Reaches(httpMethod, streams))
+                .Select(entry => entry.Response).ToList(),
+            ResponseHeaders.Where(entry => entry.Scope.Reaches(httpMethod, streams)).ToList(),
+            RequestHeaders.Where(entry => entry.Scope.Reaches(httpMethod, streams)).ToList());
+
+    public bool Equals(DeclaredOperationFacts? other) =>
+        other is not null &&
+        Refusals.SequenceEqual(other.Refusals) &&
+        ResponseHeaders.SequenceEqual(other.ResponseHeaders) &&
+        RequestHeaders.SequenceEqual(other.RequestHeaders);
+
+    public override bool Equals(object? obj) => Equals(obj as DeclaredOperationFacts);
+
+    public override int GetHashCode() {
+        unchecked {
+            var hash = Refusals.Count;
+
+            hash = (hash * 397) ^ ResponseHeaders.Count;
+            hash = (hash * 397) ^ RequestHeaders.Count;
+
+            foreach (var refusal in Refusals) {
+                hash = (hash * 397) ^ refusal.GetHashCode();
+            }
+
+            foreach (var header in ResponseHeaders) {
+                hash = (hash * 397) ^ header.GetHashCode();
+            }
+
+            foreach (var header in RequestHeaders) {
+                hash = (hash * 397) ^ header.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+}
+
+/// <summary>
+/// The reach a declaration stated for itself, as its <c>Methods</c> and <c>NotWhenStreaming</c>
+/// were written.
+/// </summary>
+/// <remarks>
+/// A declaration written on one method describes that method. Written on a class or an assembly it
+/// describes every operation under it - and a filter that stands down on some of them then has the
+/// document claiming a status or a header those operations cannot produce. <c>[ConditionalGet]</c>
+/// is the case: on a controller it installs on the reads and on nothing else, so a 304 published on
+/// the writes beside them is a lie a generated client would write a branch for. So a declaration
+/// states its own reach and this applies it - which keeps the rule that nothing here knows what a
+/// filter does, because the filter says where it applies in the same place it says what it answers.
+/// </remarks>
+internal readonly struct DeclaredScope : IEquatable<DeclaredScope> {
+
+    public DeclaredScope(string? methods, bool notWhenStreaming) {
+        Methods = methods;
+        NotWhenStreaming = notWhenStreaming;
+    }
+
+    public string? Methods { get; }
+
+    public bool NotWhenStreaming { get; }
+
+    /// <summary>
+    /// Whether this reaches an operation with that verb and that response shape.
+    /// </summary>
+    /// <remarks>
+    /// An unwritten restriction reaches everything, which is the ordinary case and the one every
+    /// declaration had before this existed. Matching tolerates spaces, because <c>"GET, HEAD"</c>
+    /// is how somebody writes it.
+    /// </remarks>
+    public bool Reaches(string? httpMethod, bool streams) {
+        if (NotWhenStreaming && streams) {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(Methods) || string.IsNullOrEmpty(httpMethod)) {
+            return true;
+        }
+
+        foreach (var candidate in Methods!.Split(',')) {
+            if (string.Equals(candidate.Trim(), httpMethod, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public bool Equals(DeclaredScope other) =>
+        Methods == other.Methods && NotWhenStreaming == other.NotWhenStreaming;
+
+    public override bool Equals(object? obj) => obj is DeclaredScope other && Equals(other);
+
+    public override int GetHashCode() =>
+        unchecked(((Methods?.GetHashCode() ?? 0) * 397) ^ NotWhenStreaming.GetHashCode());
+}
+
+/// <summary>A status a declaration can answer with, and the operations it reaches.</summary>
+internal sealed class ScopedRefusal : IEquatable<ScopedRefusal> {
+
+    public ScopedRefusal(ResponseSchemaModel response, DeclaredScope scope) {
+        Response = response;
+        Scope = scope;
+    }
+
+    public ResponseSchemaModel Response { get; }
+
+    public DeclaredScope Scope { get; }
+
+    public bool Equals(ScopedRefusal? other) =>
+        other is not null && Response.Equals(other.Response) && Scope.Equals(other.Scope);
+
+    public override bool Equals(object? obj) => Equals(obj as ScopedRefusal);
+
+    public override int GetHashCode() =>
+        unchecked((Response.GetHashCode() * 397) ^ Scope.GetHashCode());
+}
+
+/// <summary>A header a declaration says a response carries, and the operations it reaches.</summary>
+internal sealed class ScopedResponseHeader : IEquatable<ScopedResponseHeader> {
+
+    public ScopedResponseHeader(int status, string name, string? description, DeclaredScope scope) {
+        Status = status;
+        Name = name;
+        Description = description;
+        Scope = scope;
+    }
+
+    public int Status { get; }
+
+    public string Name { get; }
+
+    public string? Description { get; }
+
+    public DeclaredScope Scope { get; }
+
+    public bool Equals(ScopedResponseHeader? other) =>
+        other is not null &&
+        Status == other.Status && Name == other.Name && Description == other.Description &&
+        Scope.Equals(other.Scope);
+
+    public override bool Equals(object? obj) => Equals(obj as ScopedResponseHeader);
+
+    public override int GetHashCode() {
+        unchecked {
+            var hash = Status;
+
+            hash = (hash * 397) ^ Name.GetHashCode();
+            hash = (hash * 397) ^ (Description?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ Scope.GetHashCode();
+
+            return hash;
+        }
+    }
+}
+
+/// <summary>A header a declaration says it reads, and the operations it reaches.</summary>
+internal sealed class ScopedRequestHeader : IEquatable<ScopedRequestHeader> {
+
+    public ScopedRequestHeader(string name, string? description, DeclaredScope scope) {
+        Name = name;
+        Description = description;
+        Scope = scope;
+    }
+
+    public string Name { get; }
+
+    public string? Description { get; }
+
+    public DeclaredScope Scope { get; }
+
+    public bool Equals(ScopedRequestHeader? other) =>
+        other is not null &&
+        Name == other.Name && Description == other.Description && Scope.Equals(other.Scope);
+
+    public override bool Equals(object? obj) => Equals(obj as ScopedRequestHeader);
+
+    public override int GetHashCode() {
+        unchecked {
+            var hash = Name.GetHashCode();
+
+            hash = (hash * 397) ^ (Description?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ Scope.GetHashCode();
+
+            return hash;
+        }
+    }
+}
+
+/// <summary>What the declarations covering one operation say about that operation's document.</summary>
+internal sealed class OperationDeclarations {
+
+    public OperationDeclarations(
+        IReadOnlyList<ResponseSchemaModel> refusals,
+        IReadOnlyList<ScopedResponseHeader> responseHeaders,
+        IReadOnlyList<ScopedRequestHeader> requestHeaders) {
+        Refusals = refusals;
+        ResponseHeaders = responseHeaders;
+        RequestHeaders = requestHeaders;
+    }
+
+    public IReadOnlyList<ResponseSchemaModel> Refusals { get; }
+
+    public IReadOnlyList<ScopedResponseHeader> ResponseHeaders { get; }
+
+    public IReadOnlyList<ScopedRequestHeader> RequestHeaders { get; }
+
+    /// <summary>The header parameters, as the document model carries them.</summary>
+    public IReadOnlyList<DeclaredHeaderParameterModel> HeaderParameters() {
+        if (RequestHeaders.Count == 0) {
+            return Array.Empty<DeclaredHeaderParameterModel>();
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<DeclaredHeaderParameterModel>();
+
+        foreach (var header in RequestHeaders) {
+            if (seen.Add(header.Name)) {
+                result.Add(new DeclaredHeaderParameterModel(header.Name, header.Description));
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// <paramref name="responses"/> with each declared header attached to the status it names.
+    /// </summary>
+    /// <remarks>
+    /// A header on a status nothing declares is dropped. A header is a fact about a response, so
+    /// one naming a status the operation never answers describes nothing - and synthesizing the
+    /// response to hang it on would publish a status the handler cannot produce.
+    /// </remarks>
+    public IReadOnlyList<ResponseSchemaModel> WithHeaders(
+        IReadOnlyList<ResponseSchemaModel> responses) {
+        if (ResponseHeaders.Count == 0 || responses.Count == 0) {
+            return responses;
+        }
+
+        var result = new List<ResponseSchemaModel>(responses.Count);
+
+        foreach (var response in responses) {
+            var added = Headers(response.Status, response.Headers);
+
+            result.Add(added == null
+                ? response
+                : new ResponseSchemaModel(response.Status, response.Description, response.Schema) {
+                    Headers = added
+                });
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// The status's declared headers plus the ones already on it, or null where nothing was added.
+    /// </summary>
+    /// <remarks>
+    /// The response's own win on a name: a contract that declared the header said more about it
+    /// than a filter's blanket statement can.
+    /// </remarks>
+    public IReadOnlyList<ResponseHeaderModel>? Headers(
+        int status, IReadOnlyList<ResponseHeaderModel> existing) {
+        List<ResponseHeaderModel>? merged = null;
+
+        foreach (var declared in ResponseHeaders) {
+            if (declared.Status != status || Names(existing, declared.Name) ||
+                Names(merged, declared.Name)) {
+                continue;
+            }
+
+            (merged ??= new List<ResponseHeaderModel>(existing)).Add(new ResponseHeaderModel {
+                Name = declared.Name,
+                ParameterName = Generation.NamingHelper.ToPascalCase(declared.Name.Replace("-", "")),
+                Description = declared.Description
+            });
+        }
+
+        return merged;
+    }
+
+    private static bool Names(IReadOnlyList<ResponseHeaderModel>? headers, string name) {
+        if (headers == null) {
+            return false;
+        }
+
+        foreach (var header in headers) {
+            if (string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/FilterResponseSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/FilterResponseSelector.cs
@@ -36,22 +36,36 @@ namespace Hardened.SourceGenerator.Requests;
 public static class FilterResponseSelector {
     private const string AnswersStatus = "AnswersStatusAttribute";
 
-    private const string AnswersStatusNamespace = "Hardened.Requests.Abstract.Responses";
+    private const string AnswersHeader = "AnswersHeaderAttribute";
+
+    private const string ReadsHeader = "ReadsHeaderAttribute";
+
+    private const string DeclarationNamespace = "Hardened.Requests.Abstract.Responses";
 
     /// <summary>
     /// Every status the declarations covering <paramref name="method"/> can answer, deduplicated
-    /// and in status order.
+    /// and in status order, plus the headers those declarations say the operation writes and
+    /// reads.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Deduplicated because the three levels overlap and because two attributes may answer the same
     /// status - two rate limits on one operation are one 429. The nearest declaration wins, which
     /// is how the runtime resolves everything else a handler declares twice.
+    /// </para>
+    /// <para>
+    /// Unnarrowed. Which of these reach the operation depends on its verb and on whether it
+    /// streams, and one of the two front ends reading this does not know either yet. See
+    /// <see cref="DeclaredOperationFacts"/>.
+    /// </para>
     /// </remarks>
-    public static IReadOnlyList<ResponseSchemaModel> Read(
+    internal static DeclaredOperationFacts Read(
         GeneratorSyntaxContext context,
         MethodDeclarationSyntax method,
         CancellationToken cancellationToken) {
-        Dictionary<int, ResponseSchemaModel>? byStatus = null;
+        Dictionary<int, ScopedRefusal>? byStatus = null;
+        List<ScopedResponseHeader>? responseHeaders = null;
+        List<ScopedRequestHeader>? requestHeaders = null;
 
         // What has already spoken, keyed on the facet rather than on the status it resolved to.
         // A [Timeout(Status = 503)] on the method and a plain [Timeout] on the assembly are one
@@ -66,7 +80,7 @@ public static class FilterResponseSelector {
                 continue;
             }
 
-            foreach (var (carrier, facet) in Facets(declaration.Type)) {
+            foreach (var (carrier, facet) in Facets(declaration.Type, AnswersStatus)) {
                 if (!(spoken ??= new HashSet<string>()).Add(Key(carrier, facet))) {
                     continue;
                 }
@@ -81,23 +95,124 @@ public static class FilterResponseSelector {
                     ? facet.ConstructorArguments[1].Value as INamedTypeSymbol
                     : null;
 
-                (byStatus ??= new Dictionary<int, ResponseSchemaModel>()).Add(
+                (byStatus ??= new Dictionary<int, ScopedRefusal>()).Add(
                     status.Value,
-                    new ResponseSchemaModel(
-                        status.Value,
-                        Named(facet, "Description") as string ??
-                        HttpResponseDescription.For(status.Value),
-                        body == null
-                            ? null
-                            : JsonSchemaWriter.Write(
-                                body, context.SemanticModel.Compilation.Assembly)));
+                    new ScopedRefusal(
+                        new ResponseSchemaModel(
+                            status.Value,
+                            Named(facet, "Description") as string ??
+                            HttpResponseDescription.For(status.Value),
+                            body == null
+                                ? null
+                                : JsonSchemaWriter.Write(
+                                    body, context.SemanticModel.Compilation.Assembly)),
+                        Scope(facet)));
+            }
+
+            foreach (var (carrier, facet) in Facets(declaration.Type, AnswersHeader)) {
+                AddResponseHeader(carrier, facet, ref spoken, ref responseHeaders);
+            }
+
+            foreach (var (carrier, facet) in Facets(declaration.Type, ReadsHeader)) {
+                AddRequestHeader(carrier, facet, ref spoken, ref requestHeaders);
             }
         }
 
-        return byStatus == null
-            ? System.Array.Empty<ResponseSchemaModel>()
-            : byStatus.OrderBy(entry => entry.Key).Select(entry => entry.Value).ToList();
+        // And the ones written on the handler itself. Both header declarations go on a method or
+        // its class as well as on an attribute's type - a throws-mode 201 has no other way to say
+        // it carries a Location - and those are read off the symbol rather than through
+        // Declarations, because Declarations carries an attribute's type and this needs the
+        // arguments the attribute was written with.
+        foreach (var (carrier, facet) in Written(context, method)) {
+            if (Is(facet, AnswersHeader)) {
+                AddResponseHeader(carrier, facet, ref spoken, ref responseHeaders);
+            }
+            else if (Is(facet, ReadsHeader)) {
+                AddRequestHeader(carrier, facet, ref spoken, ref requestHeaders);
+            }
+        }
+
+        if (byStatus == null && responseHeaders == null && requestHeaders == null) {
+            return DeclaredOperationFacts.Empty;
+        }
+
+        return new DeclaredOperationFacts(
+            byStatus == null
+                ? System.Array.Empty<ScopedRefusal>()
+                : byStatus.OrderBy(entry => entry.Key).Select(entry => entry.Value).ToList(),
+            (IReadOnlyList<ScopedResponseHeader>?)responseHeaders ??
+            System.Array.Empty<ScopedResponseHeader>(),
+            (IReadOnlyList<ScopedRequestHeader>?)requestHeaders ??
+            System.Array.Empty<ScopedRequestHeader>());
     }
+
+    private static void AddResponseHeader(
+        ISymbol carrier, AttributeData facet, ref HashSet<string>? spoken,
+        ref List<ScopedResponseHeader>? headers) {
+        if (facet.ConstructorArguments.Length < 2 ||
+            facet.ConstructorArguments[0].Value is not int status ||
+            facet.ConstructorArguments[1].Value is not string name) {
+            return;
+        }
+
+        // Keyed on the name as well as the status, because two headers on one carrier at one
+        // status are two headers - a 200 carrying both an ETag and a Last-Modified is the
+        // ordinary conditional-request shape.
+        if (!(spoken ??= new HashSet<string>()).Add(
+                carrier.ToDisplayString() + "#h" + status + "#" + name)) {
+            return;
+        }
+
+        (headers ??= new List<ScopedResponseHeader>()).Add(
+            new ScopedResponseHeader(status, name, Named(facet, "Description") as string, Scope(facet)));
+    }
+
+    private static void AddRequestHeader(
+        ISymbol carrier, AttributeData facet, ref HashSet<string>? spoken,
+        ref List<ScopedRequestHeader>? headers) {
+        if (facet.ConstructorArguments.Length < 1 ||
+            facet.ConstructorArguments[0].Value is not string name) {
+            return;
+        }
+
+        if (!(spoken ??= new HashSet<string>()).Add(carrier.ToDisplayString() + "#r#" + name)) {
+            return;
+        }
+
+        (headers ??= new List<ScopedRequestHeader>()).Add(
+            new ScopedRequestHeader(name, Named(facet, "Description") as string, Scope(facet)));
+    }
+
+    /// <summary>
+    /// Every attribute written on the handler, its class and its assembly, as bound data.
+    /// </summary>
+    /// <remarks>
+    /// The same three rungs <see cref="Declarations"/> walks and for the same reason, read off
+    /// the symbols instead: an attribute written here is the declaration rather than a carrier of
+    /// one, so what is wanted is its arguments and not its type.
+    /// </remarks>
+    private static IEnumerable<(ISymbol Carrier, AttributeData Facet)> Written(
+        GeneratorSyntaxContext context, MethodDeclarationSyntax method) {
+        if (context.SemanticModel.GetDeclaredSymbol(method) is not IMethodSymbol handler) {
+            yield break;
+        }
+
+        foreach (var attribute in handler.GetAttributes()) {
+            yield return (handler, attribute);
+        }
+
+        foreach (var attribute in handler.ContainingType.GetAttributes()) {
+            yield return (handler.ContainingType, attribute);
+        }
+
+        foreach (var attribute in context.SemanticModel.Compilation.Assembly.GetAttributes()) {
+            yield return (context.SemanticModel.Compilation.Assembly, attribute);
+        }
+    }
+
+    /// <summary>The reach the declaration stated for itself.</summary>
+    private static DeclaredScope Scope(AttributeData facet) =>
+        new(Named(facet, "Methods") as string, Named(facet, "NotWhenStreaming") is true);
 
     /// <summary>
     /// One declaration written on a handler, its class or its assembly: the attribute's type, and
@@ -201,10 +316,10 @@ public static class FilterResponseSelector {
     /// <c>IAuthorizeAttribute</c>.
     /// </remarks>
     private static IEnumerable<(INamedTypeSymbol Carrier, AttributeData Facet)> Facets(
-        INamedTypeSymbol declaration) {
+        INamedTypeSymbol declaration, string facetName) {
         for (var type = declaration; type != null; type = type.BaseType) {
             foreach (var attribute in type.GetAttributes()) {
-                if (IsAnswersStatus(attribute)) {
+                if (Is(attribute, facetName)) {
                     yield return (type, attribute);
                 }
             }
@@ -212,7 +327,7 @@ public static class FilterResponseSelector {
 
         foreach (var contract in declaration.AllInterfaces) {
             foreach (var attribute in contract.GetAttributes()) {
-                if (IsAnswersStatus(attribute)) {
+                if (Is(attribute, facetName)) {
                     yield return (contract, attribute);
                 }
             }
@@ -234,11 +349,15 @@ public static class FilterResponseSelector {
 
     /// <summary>
     /// By namespace as well as name, so an application's own <c>AnswersStatus</c> is not mistaken
-    /// for a statement about this framework's document.
+    /// for a statement about this framework's document. The same holds for the two header
+    /// declarations read through here.
     /// </summary>
-    private static bool IsAnswersStatus(AttributeData attribute) =>
-        attribute.AttributeClass?.Name == AnswersStatus &&
-        attribute.AttributeClass.ContainingNamespace?.ToDisplayString() == AnswersStatusNamespace;
+    private static bool Is(AttributeData attribute, string facetName) =>
+        attribute.AttributeClass != null && Is(attribute.AttributeClass, facetName);
+
+    private static bool Is(INamedTypeSymbol type, string facetName) =>
+        type.Name == facetName &&
+        type.ContainingNamespace?.ToDisplayString() == DeclarationNamespace;
 
     /// <summary>
     /// The status the facet declares, or the one the declaration was written with where the facet

--- a/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGetAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Conditional/ConditionalGetAttribute.cs
@@ -1,5 +1,7 @@
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Abstract.Responses;
+using Hardened.Requests.Abstract.Headers;
 
 namespace Hardened.Web.Runtime.Conditional;
 
@@ -39,8 +41,33 @@ namespace Hardened.Web.Runtime.Conditional;
 /// a write.
 /// </para>
 /// </summary>
+// What the document says about an operation carrying this. It published nothing at all: no 304,
+// no ETag and no If-None-Match, so a generated client could not make the conditional request the
+// filter exists to answer, and the 304 it would be sent had no branch. GET and HEAD only, and not
+// on a streamed handler, because those are exactly the operations GetFilters installs nothing on.
+[AnswersStatus(304, Methods = Reads, NotWhenStreaming = true,
+    Description = "The caller's copy is current; nothing is sent.")]
+[AnswersHeader(304, KnownHeaders.ETag, Methods = Reads, NotWhenStreaming = true,
+    Description = "The tag the caller already holds, repeated.")]
+[AnswersHeader(200, KnownHeaders.ETag, Methods = Reads, NotWhenStreaming = true,
+    Description = "A tag for this response, to send back in If-None-Match.")]
+[ReadsHeader(KnownHeaders.IfNoneMatch, Methods = Reads, NotWhenStreaming = true,
+    Description = "A tag a previous response carried. Matching it is answered 304.")]
+[ReadsHeader(KnownHeaders.IfModifiedSince, Methods = Reads, NotWhenStreaming = true,
+    Description = "When the caller last read this. Unchanged since then is answered 304.")]
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
 public sealed class ConditionalGetAttribute : Attribute, IRequestFilterProvider {
+
+    /// <summary>
+    /// The methods this answers on, as the document declarations above state it.
+    /// </summary>
+    /// <remarks>
+    /// Spelled once rather than five times, and beside <c>GetFilters</c>'s own check, because a
+    /// document claiming a 304 on an operation the filter stood down on is the defect the
+    /// declarations were added to close.
+    /// </remarks>
+    private const string Reads = "GET,HEAD";
+
     private readonly ConditionalGetFilter _filter = new();
 
     /// <summary>


### PR DESCRIPTION
Closes H-10, H-13 and H-29 from the [0.21 Dispatch trial](https://claude.ai/code/artifact/7b01d3d1-4b28-4a6c-ad1e-1ff6a3b88ae3). Three ways a code-first document said less than the operation does. All three land on one mechanism, which is why they are one PR.

## A handler could not declare a header it writes (H-13)

Response mode publishes `Location` from `Created<T>`, because the type carries the header. A handler returning a plain value carries nothing, so a throws-mode 201 published a bare response and a generated client had nothing to read the new resource's address from. The trial's throws-mode arm found no code-first way to say it.

`[AnswersHeader(201, "Location", Description = "…")]` on the handler is the handler saying what it sends. It goes on an attribute's own type as well, the way `[AnswersStatus]` does — which is how a filter publishes a header without the document generator knowing what the filter does.

## `[ConditionalGet]` published nothing (H-10)

No 304, no `ETag`, no `If-None-Match`. The filter exists to answer a conditional request and no client generated from the document could make one, nor had a branch for the 304 it would be sent.

It now declares all five facts. Two are new surface:

- `[AnswersStatus(304)]` — a bodiless overload. A 304 has no body by definition, and naming an envelope for one would describe a payload the runtime never sends.
- `[ReadsHeader("If-None-Match")]` — a request header a filter reads before the handler runs. Nothing in the signature mentions it, so the document published no parameter for it.

## Which operations a class-level declaration reaches

`[ConditionalGet]` on a controller installs on the reads and stands down on the writes, so publishing its 304 on every operation under the class would be the same defect with the sign flipped. All three declarations take `Methods` and `NotWhenStreaming`, and the filter says where it applies in the same place it says what it answers — the selector still knows nothing about what any filter does.

The narrowing is applied where the verb is known, which is not where the declarations are read. The described front end gets its verb from the contract, long after `HandlerSelector` has walked the implementation's syntax, so `FilterResponseSelector.Read` returns everything it found and each front end narrows with the facts it has.

## Responses were half-sorted (H-29)

The declared block has always been in status order and the synthesized statuses were appended after it, so a bounded read answering 200, 400 and 504 published them `200, 504, 400`. Every writer now puts its response in a status-keyed map. `#270` recorded this as cosmetic and left it.

`[RateLimit]` also declares the `Retry-After` its own `[AnswersStatus]` description already promised.

## Verified

CI-shaped build and full suite green; coverage gate passes at 26 assemblies. `DeclaredHeaderController` in the WebApp SUT carries a class-level `[ConditionalGet]` over a read and a write, and the exported document shows both halves: the GET gains a 304, an `ETag` on both statuses and both conditional parameters; the POST gains a `Location` on its 201 and none of the conditional machinery. Sixteen new tests across the SUT, the described front end and the scope rule. Three public API approvals were regenerated and are in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)