### PR TITLE
Stop four build diagnostics short of the compiler error that follows them

### DIFF
--- a/docs/generator-diagnostics.md
+++ b/docs/generator-diagnostics.md
@@ -54,6 +54,25 @@ public class CatalogHandler : HandlerBase, ICatalogService { }
 C# requires the base class to come first, and the base list is searched by name, so HOAG031 fires
 only when *no* entry matches a described service.
 
+### HOAG032 — declaration is not read on a described handler
+
+A `[Handler]` method carries a declaration the described path never reads, so it compiles, reads as
+a commitment, and changes nothing.
+
+```
+'ReportServiceImpl.Export' carries [RawResponse], which is read from a handler's own syntax and a
+described operation's signature is generated - so it compiles, reads as a commitment, and changes
+nothing. Remove it: the content type a described response commits to comes from the contract's
+media type.
+```
+
+`[RawResponse]` is the only one today. The generator reads it off the handler's own syntax, and a
+described operation has none — its signature is generated from the contract, which says the same
+thing with the response's media type.
+
+A warning, so a project that wants to keep the attribute for its own reasons can say
+`<NoWarn>$(NoWarn);HOAG032</NoWarn>`.
+
 ## Routing
 
 ### HRDR002 — unsupported route token syntax
@@ -419,7 +438,7 @@ the other.
 | `003` | The description was declared as the wrong item kind. `HOAT003`: a spec left in `AdditionalFiles`, which the generator no longer reads. `HSMT003`: a `.smithy` IDL file pointed at `HardenedSmithyAst`, which takes a JSON AST. |
 | `004` | A model or generated source the extract step should have written is missing. Delete the model directory and rebuild. |
 | `005` | The targets file was imported before the specs were declared, so no generated source reached the compilation. Move the `<Import>` below the item group. |
-| `006` | Warning. The reader parsed the document and had something to say about it, including what a degraded trait promises that the code does not enforce. Under `HSMT`, this is also where a prelude shape with no exact C# type is reported - `BigDecimal` becomes `decimal`, `BigInteger` becomes `long` - once per member, naming it. |
+| `006` | Warning. The reader parsed the document and had something to say about it, including what a degraded trait promises that the code does not enforce. Under `HSMT`, this is also where a shape with no exact C# type is reported - `BigDecimal` becomes `decimal`, `BigInteger` becomes `long` - once per member, naming it. A member that meant the narrowing says so with `@narrowed`, and is not reported; see below. |
 | `007` | A slice selected no operations, so nothing would be generated. |
 | `008` | Warning. A slice removed a schema that is still referenced; the reference degrades to `JsonElement`. |
 | `009` | Warning. The spec is sliced but its document is embedded whole, so the served description claims operations the application does not implement. |
@@ -442,6 +461,35 @@ the other.
 | `HSMT012` | The CLI refused the model. One error per finding, at the file, line and column the CLI named; a report that does not parse is passed through whole. |
 | `HSMT013` | Warning. What the CLI said without failing, with the same per-finding attribution. |
 | `HSMT014` | The CLI exited cleanly but wrote no AST. Unlike `HSMT012`, the fix is not in a `.smithy` file. |
+
+### HSMT006 and the narrowed shapes
+
+`BigDecimal` and `BigInteger` have no exact C# type. `BigDecimal` becomes `decimal`, which is exact
+and holds 28 significant digits rather than arbitrarily many; `BigInteger` becomes `long`. Both are
+reported once per member, naming it, whether the member targets the prelude shape or a named shape
+of that type.
+
+A model that reached for `BigDecimal` to get exactness rather than range has arrived, and the
+warning is noise on every build. Say so in the model:
+
+```smithy
+use hardened.api#narrowed
+
+structure Charge {
+    @narrowed
+    amount: BigDecimal
+}
+```
+
+Or once on a shape every such member targets:
+
+```smithy
+@narrowed
+bigDecimal Usd
+```
+
+`<NoWarn>HSMT006</NoWarn>` is the blunt alternative and silences the members that *did* lose
+something, which is why the trait exists.
 
 ### The document export (018, 019, 028–031)
 

--- a/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
@@ -50,8 +50,16 @@ namespace Hardened.Generation;
 /// </remarks>
 internal static class DefaultErrorBody {
 
-    /// <summary>The holder every generated instance is a field on.</summary>
-    public const string HolderTypeName = "DefaultErrorBodies";
+    /// <summary>The holder this document's generated instances are fields on.</summary>
+    /// <remarks>
+    /// Named after the document, the way <c>ErrorFactoryEmitter.HolderName</c> is. It was
+    /// <c>DefaultErrorBodies</c> for every document, so two contracts in one project that each
+    /// declared a fillable 404 body emitted the class twice into one namespace: CS0101, and a
+    /// CS0229 on every handler that named a field on it. Every other per-document holder in this
+    /// emitter already carried the file name; this one did not.
+    /// </remarks>
+    public static string HolderTypeName(string specFileName) =>
+        NamingHelper.ToPascalCase(specFileName) + "ErrorBodies";
 
     /// <summary>The field's simple name for a schema and status.</summary>
     /// <remarks>

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/DefaultErrorBodyEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/DefaultErrorBodyEmitter.cs
@@ -25,7 +25,8 @@ internal static class DefaultErrorBodyEmitter {
         IConstructContainer container,
         IReadOnlyList<SchemaModel> schemas,
         IReadOnlyCollection<(string SchemaName, int StatusCode)> wanted,
-        string modelsNamespace) {
+        string modelsNamespace,
+        string specFileName) {
         if (wanted.Count == 0) {
             return;
         }
@@ -49,7 +50,7 @@ internal static class DefaultErrorBodyEmitter {
                 continue;
             }
 
-            holder ??= CreateHolder(container);
+            holder ??= CreateHolder(container, specFileName);
 
             var typeName = NamingHelper.ToPascalCase(schema.Name);
 
@@ -69,8 +70,8 @@ internal static class DefaultErrorBodyEmitter {
         }
     }
 
-    private static ClassDefinition CreateHolder(IConstructContainer container) {
-        var holder = container.AddClass(DefaultErrorBody.HolderTypeName);
+    private static ClassDefinition CreateHolder(IConstructContainer container, string specFileName) {
+        var holder = container.AddClass(DefaultErrorBody.HolderTypeName(specFileName));
 
         holder.Modifiers |= ComponentModifier.Public | ComponentModifier.Static;
         holder.Comment = DocComment.Format(

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
@@ -143,7 +143,7 @@ internal static class SpecFileEmitter {
             // answer with. Beside the exceptions for the same reason: it is a payload, not part of
             // the contract the implementation implements.
             DefaultErrorBodyEmitter.Emit(
-                models, model.Schemas, NullResponseBodies(model), modelsNamespace);
+                models, model.Schemas, NullResponseBodies(model), modelsNamespace, model.FileName);
 
             // The cases a bare shipped record converts into, one method per record and body the
             // file's response sets need. Beside the null-return bodies, which fill the same members

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerBindingDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerBindingDiagnostics.cs
@@ -6,7 +6,8 @@ using Microsoft.CodeAnalysis;
 namespace Hardened.Idl.SourceGenerator;
 
 /// <summary>
-/// The two ways a described operation ends up with no code behind it and a clean build.
+/// The three ways a described operation ends up doing less than its implementation says, with a
+/// clean build.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -30,6 +31,24 @@ internal static class HandlerBindingDiagnostics {
     /// <summary>A handler whose base list names no described service.</summary>
     public const string NoServiceInterfaceId = "HOAG031";
 
+    /// <summary>A declaration the described path does not read, written on a handler method.</summary>
+    public const string InertDeclarationId = "HOAG032";
+
+    /// <summary>
+    /// The declarations that are code-first syntax only, by attribute name.
+    /// </summary>
+    /// <remarks>
+    /// <c>[RawResponse]</c> commits a response to a content type, and the generator reads it off
+    /// the handler's own syntax. A described operation's signature is generated, so there is no
+    /// syntax to read it from: the attribute compiles on the implementation, reads as a commitment
+    /// in review, and changes nothing. A contract says the same thing with the response's media
+    /// type.
+    /// </remarks>
+    private static readonly Dictionary<string, string> InertDeclarations = new(StringComparer.Ordinal) {
+        ["RawResponseAttribute"] =
+            "the content type a described response commits to comes from the contract's media type"
+    };
+
     /// <summary>
     /// Built per call rather than held in a static field, for the RS2008 reason the other
     /// descriptors in this repository are - see <c>UnresolvedHandler</c>.
@@ -41,6 +60,17 @@ internal static class HandlerBindingDiagnostics {
         "'{0}' is declared by the description but no class carrying [Handler] implements it, so " +
         "its {1} route(s) exist and fail at request time. Implement it, or set " +
         "<NoWarn>$(NoWarn);" + NoHandlerId + "</NoWarn> if this project ships the interface alone.",
+        category: "Hardened.Generation",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static DiagnosticDescriptor InertDeclarationDescriptor() => new(
+        id: InertDeclarationId,
+        title: "Declaration is not read on a described handler",
+        messageFormat:
+        "'{0}.{1}' carries [{2}], which is read from a handler's own syntax and a described " +
+        "operation's signature is generated - so it compiles, reads as a commitment, and changes " +
+        "nothing. Remove it: {3}.",
         category: "Hardened.Generation",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
@@ -95,6 +125,8 @@ internal static class HandlerBindingDiagnostics {
         foreach (var handler in handlers) {
             cancellationToken.ThrowIfCancellationRequested();
 
+            ReportInertDeclarations(handler, diagnostics);
+
             var service = handler.ServiceInterface(declaredNames);
 
             if (service != null) {
@@ -123,5 +155,31 @@ internal static class HandlerBindingDiagnostics {
         }
 
         return diagnostics;
+    }
+
+    /// <summary>
+    /// Every declaration on this handler's methods that the described path does not read.
+    /// </summary>
+    /// <remarks>
+    /// Read off the filters <c>HandlerSelector</c> already collected rather than from a walk of
+    /// its own, so an attribute added to <see cref="InertDeclarations"/> is one line. The location
+    /// is the class's, which is what <c>HandlerInfo</c> carries; the message names the method.
+    /// </remarks>
+    private static void ReportInertDeclarations(HandlerInfo handler, List<Diagnostic> diagnostics) {
+        foreach (var method in handler.MethodFilters) {
+            foreach (var filter in method.Filters) {
+                if (!InertDeclarations.TryGetValue(filter.TypeDefinition.Name, out var instead)) {
+                    continue;
+                }
+
+                diagnostics.Add(Diagnostic.Create(
+                    InertDeclarationDescriptor(),
+                    handler.Location ?? Location.None,
+                    handler.ImplementationType.Name,
+                    method.MethodName,
+                    filter.TypeDefinition.Name.Replace("Attribute", ""),
+                    instead));
+            }
+        }
     }
 }

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/HandlerBindingDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/HandlerBindingDiagnosticsTests.cs
@@ -8,12 +8,14 @@ using Xunit;
 namespace Hardened.OpenApi.SourceGenerator.Tests;
 
 /// <summary>
-/// The two ways a described operation ends up with nothing behind it and a clean build.
+/// The three ways a described operation ends up doing less than its implementation says, with a
+/// clean build.
 /// </summary>
 /// <remarks>
-/// Both were silent. A missing <c>[Handler]</c> produced routes that existed and failed at request
-/// time; a handler whose base list started with a base class was registered against that class, so
-/// the service resolved to nothing. Neither produced a diagnostic of any kind.
+/// All three were silent. A missing <c>[Handler]</c> produced routes that existed and failed at
+/// request time; a handler whose base list started with a base class was registered against that
+/// class, so the service resolved to nothing; and a declaration the described path never reads
+/// compiled on the implementation and changed nothing.
 /// </remarks>
 public class HandlerBindingDiagnosticsTests {
 
@@ -126,4 +128,65 @@ public class HandlerBindingDiagnosticsTests {
         Assert.All(diagnostics, d =>
             Assert.Equal(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning, d.Severity));
     }
+
+    private static HandlerInfo HandlerDeclaring(string method, string attributeName) =>
+        new(TypeDefinition.Get("Test.Api", "PetServiceImpl"),
+            new[] { (ITypeDefinition)TypeDefinition.Get("Test.Api", "IPetService") },
+            Array.Empty<AttributeModel>(),
+            new[] {
+                new HandlerMethodFilterInfo(
+                    method,
+                    new[] {
+                        new AttributeModel(
+                            TypeDefinition.Get("Hardened.Requests.Abstract.Attributes", attributeName),
+                            "", "")
+                    })
+            });
+
+    /// <summary>
+    /// <c>[RawResponse]</c> on a described handler, which the generator reads from a handler's own
+    /// syntax and a described operation does not have.
+    /// </summary>
+    /// <remarks>
+    /// It compiled, read as a commitment to a content type in review, and did nothing at all - the
+    /// described path takes the media type from the contract.
+    /// </remarks>
+    [Fact]
+    public void ADeclarationTheDescribedPathDoesNotReadIsReported() {
+        var diagnostics = Report(
+            new[] { Operation("IPetService", "/pets") },
+            new[] { HandlerDeclaring("ListPets", "RawResponseAttribute") });
+
+        var diagnostic = Assert.Single(diagnostics);
+
+        Assert.Equal(HandlerBindingDiagnostics.InertDeclarationId, diagnostic.Id);
+
+        var message = diagnostic.GetMessage();
+
+        Assert.Contains("PetServiceImpl.ListPets", message);
+        Assert.Contains("[RawResponse]", message);
+        Assert.Contains("media type", message);
+    }
+
+    /// <summary>
+    /// A warning, so a project can silence it. The described path ignoring the attribute is not a
+    /// reason to refuse to build an otherwise correct application.
+    /// </summary>
+    [Fact]
+    public void TheInertDeclarationIsAWarning() =>
+        Assert.Equal(
+            Microsoft.CodeAnalysis.DiagnosticSeverity.Warning,
+            Assert.Single(Report(
+                new[] { Operation("IPetService", "/pets") },
+                new[] { HandlerDeclaring("ListPets", "RawResponseAttribute") })).Severity);
+
+    /// <summary>
+    /// A declaration the described path does read is left alone. Without this the rule could pass
+    /// its other tests by firing on every attribute.
+    /// </summary>
+    [Fact]
+    public void ADeclarationTheDescribedPathReadsIsNotReported() =>
+        Assert.Empty(Report(
+            new[] { Operation("IPetService", "/pets") },
+            new[] { HandlerDeclaring("ListPets", "RateLimitAttribute") }));
 }

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/MultipleSpecificationTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/MultipleSpecificationTests.cs
@@ -119,4 +119,84 @@ public class MultipleSpecificationTests {
             result.GeneratedSources[OpenApiGenerator.DiagnosticHintName]);
         Assert.Contains("IPetService", result.GeneratedSources["pets.g.cs"]);
     }
+
+    /// <summary>
+    /// A document whose null return writes a body, twice.
+    /// </summary>
+    /// <remarks>
+    /// The holder every generated instance is a field on was called <c>DefaultErrorBodies</c>
+    /// whatever document produced it, so two contracts that each declared a fillable 404 emitted
+    /// the class twice into one namespace: CS0101 on the second document, and a CS0229 on every
+    /// handler naming a field. Every other per-document holder this emitter writes already carried
+    /// the file name.
+    /// </remarks>
+    [Fact]
+    public void TwoDocumentsThatEachWriteAnErrorBodyCompile() {
+        var result = OpenApiGenerator.Run(
+            new Dictionary<string, string> {
+                ["pets.yaml"] = ErrorBodySpec("pets", "Pet", "PetProblem"),
+                ["stores.yaml"] = ErrorBodySpec("stores", "Store", "StoreProblem")
+            },
+            OpenApiGenerator.MinimalEntryPoint);
+
+        Assert.Empty(result.Errors);
+    }
+
+    /// <summary>And each holder is named after the document that produced it.</summary>
+    [Fact]
+    public void EachDocumentsErrorBodyHolderIsNamedAfterIt() {
+        var result = OpenApiGenerator.Run(
+            new Dictionary<string, string> {
+                ["pets.yaml"] = ErrorBodySpec("pets", "Pet", "PetProblem"),
+                ["stores.yaml"] = ErrorBodySpec("stores", "Store", "StoreProblem")
+            },
+            OpenApiGenerator.MinimalEntryPoint).AssertNoErrors();
+
+        Assert.Contains("class PetsErrorBodies", result.GeneratedSources["pets.g.cs"]);
+        Assert.Contains("class StoresErrorBodies", result.GeneratedSources["stores.g.cs"]);
+        Assert.DoesNotContain("DefaultErrorBodies", result.GeneratedSources["pets.g.cs"]);
+    }
+
+    /// <summary>
+    /// A GET declaring a 404 over a schema whose members can all be filled, which is what puts an
+    /// instance in the holder.
+    /// </summary>
+    private static string ErrorBodySpec(string tag, string model, string problem) =>
+        $$"""
+        openapi: "3.0.0"
+        info: { title: {{tag}}, version: "1.0" }
+        paths:
+          /{{tag}}/{id}:
+            get:
+              tags: [{{tag}}]
+              operationId: get{{tag}}
+              parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema: { type: string }
+              responses:
+                '200':
+                  description: found
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/{{model}}' }
+                '404':
+                  description: missing
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/{{problem}}' }
+        components:
+          schemas:
+            {{model}}:
+              type: object
+              properties:
+                id: { type: string }
+            {{problem}}:
+              type: object
+              properties:
+                type: { type: string }
+                title: { type: string }
+                status: { type: integer }
+        """;
 }

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/BigDecimalTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/BigDecimalTests.cs
@@ -164,4 +164,92 @@ public class BigDecimalTests {
         Assert.Contains(diagnostics, d => d.Contains("'Money.discount'"));
         Assert.Contains(diagnostics, d => d.Contains("'Money.total'"));
     }
+
+    /// <summary>
+    /// <c>@narrowed</c> on the member, which is the model saying the narrowing is what it wanted.
+    /// </summary>
+    /// <remarks>
+    /// A model reaching for <c>BigDecimal</c> to get exactness rather than range has arrived, and
+    /// had no way to say so: the only route to a warning-free build was suppressing HSMT006 for
+    /// the whole project, which silences the members that did lose something too. The mapping is
+    /// unchanged - only the report.
+    /// </remarks>
+    [Fact]
+    public void NarrowedOnTheMemberSilencesTheReportAndKeepsTheMapping() {
+        var schema = Parse("""
+            "amount": {
+              "target": "smithy.api#BigDecimal",
+              "traits": { "hardened.api#narrowed": {} } }
+            """, out var diagnostics);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal("decimal", Assert.Single(schema.Properties).Format);
+    }
+
+    /// <summary>A member beside it that says nothing is still reported.</summary>
+    [Fact]
+    public void NarrowedSilencesOnlyTheMemberItIsOn() {
+        Parse("""
+            "amount": {
+              "target": "smithy.api#BigDecimal",
+              "traits": { "hardened.api#narrowed": {} } },
+            "fee": { "target": "smithy.api#BigDecimal" }
+            """, out var diagnostics);
+
+        var reported = Assert.Single(diagnostics);
+
+        Assert.Contains("fee", reported);
+        Assert.DoesNotContain("amount", reported);
+    }
+
+    /// <summary>
+    /// A named <c>bigDecimal</c> shape reaches <c>decimal</c>, the same answer the prelude shape
+    /// gets.
+    /// </summary>
+    /// <remarks>
+    /// It reached <c>double</c>. Naming a shape is what a model does to use one type in twenty
+    /// places, so the spelling that scales was the one that lost exactness - and silently, because
+    /// only the prelude path reported the narrowing.
+    /// </remarks>
+    [Fact]
+    public void ANamedBigDecimalShapeReachesDecimalAndIsReported() {
+        var schema = Parse("""
+            "amount": { "target": "com.example#Usd" }
+            """, out var diagnostics, """
+            , "com.example#Usd": { "type": "bigDecimal" }
+            """);
+
+        Assert.Equal("decimal", Assert.Single(schema.Properties).Format);
+        Assert.Contains("becomes decimal", Assert.Single(diagnostics));
+    }
+
+    /// <summary>
+    /// And <c>@narrowed</c> on that shape says it once for every member targeting it.
+    /// </summary>
+    [Fact]
+    public void NarrowedOnTheNamedShapeSilencesEveryMemberTargetingIt() {
+        var schema = Parse("""
+            "amount": { "target": "com.example#Usd" },
+            "fee": { "target": "com.example#Usd" }
+            """, out var diagnostics, """
+            , "com.example#Usd": {
+                "type": "bigDecimal",
+                "traits": { "hardened.api#narrowed": {} } }
+            """);
+
+        Assert.Empty(diagnostics);
+        Assert.All(schema.Properties, property => Assert.Equal("decimal", property.Format));
+    }
+
+    /// <summary>The trait is read rather than reported as one the front end does not model.</summary>
+    [Fact]
+    public void NarrowedIsNotReportedAsAnUnknownTrait() {
+        Parse("""
+            "amount": {
+              "target": "smithy.api#BigDecimal",
+              "traits": { "hardened.api#narrowed": {} } }
+            """, out var diagnostics);
+
+        Assert.DoesNotContain(diagnostics, entry => entry.Contains("narrowed"));
+    }
 }

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -966,7 +966,8 @@ internal static class SmithySpecParser {
         // second naming authority, which is the exact defect NameAllocator was built to remove.
         if (target != null) {
             Describe(context, target, out var type, out var format, out var reference, out var array,
-                model.OperationId + "." + parameter.Name);
+                model.OperationId + "." + parameter.Name,
+                SmithyAst.HasTrait(member.Value, SmithyTraits.Narrowed));
 
             parameter.Type = type;
             parameter.Format = format;
@@ -1000,7 +1001,8 @@ internal static class SmithySpecParser {
 
         if (target != null) {
             Describe(context, target, out var type, out var format, out var reference, out var shape,
-                owner + "." + property.Name);
+                owner + "." + property.Name,
+                SmithyAst.HasTrait(member, SmithyTraits.Narrowed));
 
             property.Type = type;
             property.Format = format;
@@ -1124,6 +1126,10 @@ internal static class SmithySpecParser {
     /// The member being described, for a narrowing diagnostic. Null where the caller has no name
     /// to give - a payload targeting a prelude shape directly, say.
     /// </param>
+    /// <param name="narrowingAccepted">
+    /// Whether the member carries <c>@narrowed</c>, which says the narrowing is what the model
+    /// intended and the diagnostic is not wanted.
+    /// </param>
     private static void Describe(
         ParseContext context,
         string target,
@@ -1131,7 +1137,8 @@ internal static class SmithySpecParser {
         out string? format,
         out string? reference,
         out ShapeFacts facts,
-        string? memberName = null) {
+        string? memberName = null,
+        bool narrowingAccepted = false) {
         type = null;
         format = null;
         reference = null;
@@ -1141,7 +1148,7 @@ internal static class SmithySpecParser {
             type = preludeType;
             format = preludeFormat;
 
-            if (SmithyPrelude.LossDescription(target) is { } loss) {
+            if (!narrowingAccepted && SmithyPrelude.LossDescription(target) is { } loss) {
                 // Once per member, naming it. Three BigDecimal members used to produce three
                 // byte-identical warnings naming none of them, so the count was the only way to
                 // tell how many there were and no way to tell which - and a set of identical
@@ -1212,11 +1219,37 @@ internal static class SmithySpecParser {
                 format = member switch {
                     "long" or "bigInteger" => "int64",
                     "float" => "float",
-                    "double" or "bigDecimal" => "double",
+                    "double" => "double",
+
+                    // decimal, the same answer the prelude path gives smithy.api#BigDecimal and
+                    // for the same reason: a model reaching for bigDecimal reached for exactness,
+                    // and double loses it at every magnitude. This said "double", so naming a
+                    // shape - which is what a model does to use one type in twenty places - was
+                    // the difference between money that adds up and money that does not.
+                    "bigDecimal" => "decimal",
                     "blob" => "byte",
                     "timestamp" => "date-time",
                     _ => null
                 };
+
+                // And the same narrowing, so it is reported the same way. Read off the named shape
+                // as well as the member, so a model that says @narrowed once on the shape does not
+                // have to repeat it at every use.
+                if (!narrowingAccepted && member is "bigDecimal" or "bigInteger" &&
+                    !SmithyAst.HasTrait(shape, SmithyTraits.Narrowed)) {
+                    var where = memberName == null ? "" : $"'{memberName}' ";
+
+                    var message =
+                        $"{where}targets {SmithyPrelude.LocalName(target)}, which " +
+                        (member == "bigDecimal"
+                            ? "becomes decimal, which is exact but holds 28 significant digits " +
+                              "rather than arbitrarily many"
+                            : "becomes long, so a value outside 64 bits does not round-trip") + ".";
+
+                    if (!context.Diagnostics.Contains(message)) {
+                        context.Diagnostics.Add(message);
+                    }
+                }
 
                 return;
         }

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithyTraits.cs
@@ -36,6 +36,18 @@ internal static class SmithyTraits {
     /// </remarks>
     internal const string Timeout = "hardened.api#timeout";
 
+    /// <summary>
+    /// That a member's narrowing to a C# type is intended. This framework's own, not the prelude's.
+    /// </summary>
+    /// <remarks>
+    /// <c>BigDecimal</c> and <c>BigInteger</c> narrow, and HSMT006 says so once per member. A model
+    /// that reached for <c>BigDecimal</c> to get exactness rather than range has arrived, and had
+    /// no way to say so - the only route to a warning-free build was suppressing the code for the
+    /// whole project, which silences the members that did lose something. Defined in
+    /// <c>hardened.smithy</c> beside <see cref="Timeout"/>.
+    /// </remarks>
+    internal const string Narrowed = "hardened.api#narrowed";
+
     internal const string Http = "smithy.api#http";
     internal const string HttpLabel = "smithy.api#httpLabel";
     internal const string HttpQuery = "smithy.api#httpQuery";
@@ -115,6 +127,7 @@ internal static class SmithyTraits {
         Readonly, Idempotent, Input, Output, Private, Internal, Mixin,
         Trait,
         Timeout,
+        Narrowed,
         Streaming
     };
 

--- a/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/hardened.smithy
+++ b/src/SourceGenerators/Hardened.Smithy.SourceGenerator/Package/hardened.smithy
@@ -29,3 +29,20 @@ structure timeout {
     /// a deadline out at a dependency knows nothing about when that dependency recovers.
     retryAfterSeconds: Integer
 }
+
+/// States that a member's narrowing to a C# type is what the model intended, so the build stops
+/// reporting it.
+///
+/// `BigDecimal` and `BigInteger` have no exact C# type. `BigDecimal` becomes `decimal`, which is
+/// exact and holds 28 significant digits rather than arbitrarily many, and `BigInteger` becomes
+/// `long`. Both are reported, because a model that wanted arbitrary precision has lost something
+/// and nothing else would say so.
+///
+/// A model that reached for `BigDecimal` to get exactness rather than range has arrived, and had
+/// no way to say so: the only way to a warning-free build was to suppress `HSMT006` for the whole
+/// project, which silences the members that did lose something too. This is the member saying it
+/// is satisfied.
+///
+/// It goes on the member, or once on a named shape every such member targets.
+@trait(selector: ":is(member, simpleType)")
+structure narrowed {}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnresolvedHandler.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnresolvedHandler.cs
@@ -58,6 +58,29 @@ public static class UnresolvedHandler {
     }
 
     /// <summary>
+    /// Whether emitting this handler would produce code that does not compile.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two reasons, and the second is why this is separate from
+    /// <see cref="UnresolvedParameter"/>. A parameter whose type does not resolve cannot be bound.
+    /// And two parameters that both fall to the request body leave the second with nothing to
+    /// pass, because a request carries one body and the bridge keeps the first - so the emitted
+    /// invocation omits an argument the method requires, and the build fails on a <c>CS7036</c>
+    /// inside <c>obj/</c> beside the <c>HRDR009</c> that explains it. The generated file was a
+    /// second, worse account of a defect already reported in full.
+    /// </para>
+    /// <para>
+    /// Both output stages read this, for the reason the type doc gives: routing to a handler class
+    /// that was never written is uncompilable output, which is worse than the missing route. The
+    /// build fails either way - HRDR009 is an error - so nothing reaches a running service on the
+    /// strength of the skip.
+    /// </para>
+    /// </remarks>
+    public static bool CannotBeEmitted(this RequestHandlerModel model) =>
+        model.UnresolvedParameter() != null || model.AdditionalBodyParameters.Count > 0;
+
+    /// <summary>
     /// True when the handler was skipped, having reported why. Callers emit nothing further.
     /// </summary>
     public static bool ReportIfUnresolved(this RequestHandlerModel model, SourceProductionContext context) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -49,7 +49,7 @@ internal static class SpecHandlerModelBuilder {
                     spec.ResponseModel,
                     spec.ValidatedOperations, filterTypeLookup, spec.Schemas,
                     service.DispatchHeader, Symbols(symbols, operation),
-                    service.TagDescription, spec.BindCancellationToken);
+                    service.TagDescription, spec.BindCancellationToken, spec.FileName);
                 models.Add(model);
             }
         }
@@ -94,7 +94,8 @@ internal static class SpecHandlerModelBuilder {
         string? dispatchHeader = null,
         OperationSymbols? symbols = null,
         string? tagDescription = null,
-        bool bindCancellationToken = false) {
+        bool bindCancellationToken = false,
+        string specFileName = "") {
         var methodName = operation.MethodName;
 
         // Derived by convention from the service's name for a described application, because a
@@ -115,7 +116,8 @@ internal static class SpecHandlerModelBuilder {
         var parameters = BuildParameters(
             operation, modelsNamespace, schemas, symbols, bindCancellationToken);
         var responseInfo = symbols?.ResponseInformation
-                           ?? BuildResponseInfo(operation, schemas, modelsNamespace, responseModel);
+                           ?? BuildResponseInfo(
+                               operation, schemas, modelsNamespace, responseModel, specFileName);
 
         var filters = new List<AttributeModel>();
 
@@ -399,7 +401,7 @@ internal static class SpecHandlerModelBuilder {
 
     private static ResponseInformationModel BuildResponseInfo(
         OperationModel operation, IReadOnlyList<SchemaModel> schemas, string modelsNamespace,
-        SpecResponseModel responseModel) {
+        SpecResponseModel responseModel, string specFileName) {
         ITypeDefinition? returnType = null;
 
         // A stream, ahead of everything else, exactly as ServiceInterfaceEmitter.GetReturnType
@@ -509,7 +511,8 @@ internal static class SpecHandlerModelBuilder {
             DefaultStatusCode =
                 operation.SuccessStatusCode == 200 ? null : operation.SuccessStatusCode,
 
-            NullResponseBodyExpression = NullResponseBody(operation, schemas, modelsNamespace),
+            NullResponseBodyExpression =
+                NullResponseBody(operation, schemas, modelsNamespace, specFileName),
 
             // The set the response is negotiated against. Empty means the description said nothing,
             // which leaves negotiation exactly as it was rather than declaring an empty set.
@@ -546,7 +549,8 @@ internal static class SpecHandlerModelBuilder {
     /// compile - the shared decision is what stops the two drifting.
     /// </remarks>
     private static string? NullResponseBody(
-        OperationModel operation, IReadOnlyList<SchemaModel> schemas, string modelsNamespace) {
+        OperationModel operation, IReadOnlyList<SchemaModel> schemas, string modelsNamespace,
+        string specFileName) {
         var schemaName = DefaultErrorBody.SchemaFor(operation);
 
         if (schemaName == null) {
@@ -559,7 +563,7 @@ internal static class SpecHandlerModelBuilder {
             return null;
         }
 
-        return $"global::{modelsNamespace}.{DefaultErrorBody.HolderTypeName}." +
+        return $"global::{modelsNamespace}.{DefaultErrorBody.HolderTypeName(specFileName)}." +
                DefaultErrorBody.FieldName(schemaName, DefaultErrorBody.NullResponseStatus);
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -69,7 +69,7 @@ public static class RoutingTableGenerator {
         // worse than the missing route. Skipped silently: WebExecutionHandlerCodeGenerator has
         // already reported each one, and it runs per handler rather than per table.
         var routable = models.Right
-            .Where(handler => handler.UnresolvedParameter() == null)
+            .Where(handler => !handler.CannotBeEmitted())
             .ToList();
 
         // Before anything is emitted. An ambiguous pair still produces a table - one of the two

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebExecutionHandlerCodeGenerator.cs
@@ -61,12 +61,21 @@ public class WebExecutionHandlerCodeGenerator {
         // silently over the class's.
         CompressDiagnostics.Report(sourceProductionContext, requestHandlerModel);
 
-        // Two body parameters compile into a CS7036 in generated code, and one body parameter on
-        // a GET compiles into a handler that refuses every request.
+        // Two body parameters, and one body parameter on a GET that refuses every request.
         BodyParameterDiagnostics.Report(sourceProductionContext, requestHandlerModel);
 
         // A zero budget compiles, publishes, and fails the first request.
         TimeoutDeclarationDiagnostics.Report(sourceProductionContext, requestHandlerModel);
+
+        // Every diagnostic first, then the decision. Two body parameters are the one case above
+        // whose generated file does not compile: the invocation omits an argument the method
+        // requires, so a CS7036 in obj/ was reported beside the HRDR009 that already said what was
+        // wrong and how to fix it. Skipping is safe here for the reason it is safe for an
+        // unresolved parameter and unsafe for the rest - the routing table skips the same
+        // handlers, and HRDR009 fails the build regardless.
+        if (requestHandlerModel.CannotBeEmitted()) {
+            return;
+        }
 
         var sourceFile = GenerateFile(requestHandlerModel, sourceProductionContext.CancellationToken, excludeFromCoverage);
 

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/BodyParameterDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/BodyParameterDiagnosticsTests.cs
@@ -76,6 +76,51 @@ public class BodyParameterDiagnosticsTests {
         Assert.Contains("[FromServices]", diagnostic.GetMessage());
     }
 
+    /// <summary>
+    /// And it is the only thing reported: the handler is not emitted, so no compiler error
+    /// arrives beside it.
+    /// </summary>
+    /// <remarks>
+    /// The generated invocation omitted an argument the method requires, so the build failed on a
+    /// <c>CS7036</c> inside <c>obj/</c> as well - a second, worse account of a defect HRDR009
+    /// already stated in full, pointing at a file nobody wrote. Skipping is safe for the reason it
+    /// is safe for an unresolved parameter: the routing table skips the same handlers, and
+    /// HRDR009 is an error, so nothing reaches a running service either way.
+    /// </remarks>
+    [Fact]
+    public void TwoBodyParametersReportNothingBesideHRDR009() {
+        var result = Generate("""
+            [Post("/events")]
+            public string Handle(Reading first, Reading second) => "";
+            """);
+
+        var error = Assert.Single(result.Errors).ToString();
+
+        Assert.Contains(BodyParameterDiagnostics.SeveralBodiesDiagnosticId, error);
+        Assert.DoesNotContain("CS7036", error);
+    }
+
+    /// <summary>
+    /// The routing table skips it too. Routing to a handler class that was never written is
+    /// uncompilable output, which is the failure the skip exists to prevent.
+    /// </summary>
+    [Fact]
+    public void AHandlerWithTwoBodyParametersIsNotRoutedTo() {
+        var result = Generate("""
+            [Post("/events")]
+            public string Handle(Reading first, Reading second) => "";
+
+            [Post("/readings")]
+            public string One(Reading reading) => "";
+            """);
+
+        var routing = result.GeneratedSources
+            .Single(source => source.Key.Contains("Routing", StringComparison.Ordinal)).Value;
+
+        Assert.DoesNotContain("EventController_Handle", routing);
+        Assert.Contains("EventController_One", routing);
+    }
+
     [Fact]
     public void OneBodyParameterIsNotReported() {
         var result = Generate("""


### PR DESCRIPTION
Closes S-17, H-36 and H-34 from the [0.21 Dispatch trial](https://claude.ai/code/artifact/7b01d3d1-4b28-4a6c-ad1e-1ff6a3b88ae3), plus the item H-01 left open. Four places where the build said something true and then said something worse on top of it, or said nothing at all.

## Two contracts collided on `DefaultErrorBodies` (H-01's leftover)

The holder every generated null-return body is a field on was called `DefaultErrorBodies` whatever document produced it. Two contracts in one project that each declared a fillable 404 emitted the class twice into one namespace: `CS0101` on the second document, and a `CS0229` on every handler naming a field.

It is named after its document now — `PetsErrorBodies` beside `StoresErrorBodies` — which is what `ErrorFactoryEmitter` and every other per-document holder in that emitter already did. Both sides derive the name from `DefaultErrorBody.HolderTypeName(fileName)`, because the build task that writes the field and the Roslyn generator that names it run in different processes.

## `HRDR009` was reported and the handler emitted anyway (S-17)

Two parameters that both fall to the request body leave the second with nothing to pass, so the generated invocation omitted an argument the method requires and the build failed on a `CS7036` inside `obj/` as well — a second, worse account of a defect `HRDR009` had already stated in full, pointing at a file nobody wrote.

The handler is now skipped, and the routing table skips it too. That is the rule an unresolved parameter already followed, and the file's own comment explains why both stages have to agree. Skipping is safe here specifically: `HRDR009` is an error, so nothing reaches a running service either way. The other diagnostics in that method still emit, because their handlers compile and the skip would cost a legible route.

## `[RawResponse]` on a described handler did nothing (H-36)

It compiled and read as a commitment to a content type. The generator reads it off a handler's own syntax, and a described operation's signature is generated — so there was nothing to read it from. `HOAG032` says so, and says where that commitment goes instead: the contract's media type. A warning, with the usual `NoWarn`.

## `HSMT006` had no answer (H-34)

`BigDecimal` and `BigInteger` narrow, and the build reports it once per member. A model that reached for `BigDecimal` to get exactness rather than range has arrived and had no way to agree: the only route to a warning-free build was suppressing the code for the whole project, which silences the members that *did* lose something. The trial's Smithy arm did exactly that.

`@narrowed` is the member saying it meant this, or the shape saying it once for every member targeting it:

```smithy
@narrowed
bigDecimal Usd
```

## Found on the way

A named `bigDecimal` shape reached `double`, while `smithy.api#BigDecimal` reached `decimal`. Naming a shape is what a model does to use one type in twenty places, so the spelling that scales was the one that lost exactness — and silently, because only the prelude path reported the narrowing. Both are `decimal` now and both are reported. `SmithyPrelude`'s own comment argues for exactly this and only the prelude path was following it.

**Not fixed, reported.** Building the H-01 repro turned up a separate collision: two documents in one project that each declare a schema of the same name fail to build with `CS0579` and `CS8863` — the same partial record emitted twice into one namespace. It has nothing to do with error bodies and reproduces with two four-line specs sharing one schema name. Not on the trial's list, and how to resolve it is a design question rather than a fix, so it is left alone here.

## Verified

CI-shaped build and full suite green; coverage gate passes at 26 assemblies. Fifteen new tests: the two-document error-body case in `MultipleSpecificationTests`, `HOAG032` in `HandlerBindingDiagnosticsTests`, five narrowing cases in `BigDecimalTests`, and `HRDR009` standing alone plus the routing-table skip in `BodyParameterDiagnosticsTests`. `docs/generator-diagnostics.md` carries `HOAG032` and a section on `@narrowed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)