### PR TITLE
Answer 500 when a response cannot be serialized, as a socket host does

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ErrorHandlingTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ErrorHandlingTests.cs
@@ -214,4 +214,45 @@ public class ErrorHandlingTests {
 
         Assert.Equal("ServerError", error.Type);
     }
+
+    /// <summary>
+    /// A response the serializer cannot write is a 500 through the pipeline host, as it is over a
+    /// socket.
+    /// </summary>
+    /// <remarks>
+    /// <c>IoFilter</c> catches parameter binding and it catches the handler. The response writer
+    /// runs after both, so a payload the serializer refuses throws past every filter - and this
+    /// host caught nothing, so it unwound out of <c>app.Get</c> and failed the test with the raw
+    /// exception. Both socket hosts have always answered 500 here.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AResponseThatCannotBeSerializedIsAServerError(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/unwritable");
+
+        Assert.Equal(500, response.StatusCode);
+    }
+
+    /// <summary>
+    /// And the cause is on the response, which is what <c>testing-responses.md</c> promises of a
+    /// failure and what a test asserting which one it was has to read.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheSerializerFailureIsRecordedOnTheResponse(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/unwritable");
+
+        Assert.NotNull(response.Failure);
+        Assert.Contains("cannot be written", response.Failure!.ToString());
+    }
+
+    /// <summary>
+    /// A handler that threw keeps its own exception as the cause. The envelope is written after
+    /// it, and a failure there would be a consequence rather than the thing to name.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerFailureIsStillTheRecordedCause(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/errors/server");
+
+        Assert.Equal(500, response.StatusCode);
+        Assert.IsType<InvalidOperationException>(response.Failure);
+    }
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/StreamingTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/StreamingTests.cs
@@ -378,6 +378,12 @@ public class StreamingTests {
     /// honest answer is to stop; on the in-memory harness the failure reaches the caller the way an
     /// aborted connection reaches a host, and a client sees the connection end and comes back with
     /// <c>Last-Event-ID</c>.
+    ///
+    /// <para>
+    /// This is the half of <c>PipelineRequest.Run</c>'s rule that does not answer 500. A failure
+    /// before anything is written becomes one, as it does over a socket; a failure after is the
+    /// tear-down itself, and there is no connection here to tear down.
+    /// </para>
     /// </summary>
     [HardenedTest]
     public async Task AFailureAfterTheFirstEventEndsTheStream(ITestWebApp testWebApp) {

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ErrorController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/ErrorController.cs
@@ -76,7 +76,25 @@ public class ErrorController {
     public byte[] RawServerError() =>
         throw new InvalidOperationException("the image was not ready");
 
+    /// <summary>
+    /// A handler that succeeds and a response that cannot be written.
+    /// </summary>
+    /// <remarks>
+    /// The one failure <c>IoFilter</c> does not record. It catches parameter binding and it
+    /// catches the handler; the response writer runs after both, so a payload the serializer
+    /// refuses throws past every filter. Over a socket the host answers 500. Through the pipeline
+    /// host it used to unwind out of <c>app.Get</c> and fail the test with the raw exception,
+    /// which is the divergence a harness exists not to have.
+    /// </remarks>
+    [Get("/unwritable")]
+    public UnwritableBody Unwritable() => new();
+
     public record ConflictBody(string Code, string Message);
+
+    /// <summary>A payload whose getter throws, so writing it fails and running it does not.</summary>
+    public class UnwritableBody {
+        public string Value => throw new NotSupportedException("this value cannot be written");
+    }
 
     public class TenantMismatchException : BadRequestException {
         public TenantMismatchException() : base("tenant does not match") { }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -3170,6 +3170,39 @@
         "x-hardened-timeout": 300000
       }
     },
+    "/errors/unwritable": {
+      "get": {
+        "tags": [
+          "Error"
+        ],
+        "operationId": "unwritable",
+        "summary": "A handler that succeeds and a response that cannot be written.",
+        "description": "The one failure IoFilter does not record. It catches parameter binding and it catches the handler; the response writer runs after both, so a payload the serializer refuses throws past every filter. Over a socket the host answers 500. Through the pipeline host it used to unwind out of app.Get and fail the test with the raw exception, which is the divergence a harness exists not to have.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnwritableBody"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
     "/form/optional": {
       "post": {
         "tags": [
@@ -5740,6 +5773,18 @@
           },
           "priority": {
             "$ref": "#/components/schemas/Priority"
+          }
+        }
+      },
+      "UnwritableBody": {
+        "type": "object",
+        "description": "A payload whose getter throws, so writing it fails and running it does not.",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "string"
           }
         }
       }

--- a/src/Web/Hardened.Web.Testing/PipelineRequest.cs
+++ b/src/Web/Hardened.Web.Testing/PipelineRequest.cs
@@ -118,6 +118,29 @@ internal static class PipelineRequest {
         try {
             await chain.Next();
         }
+        catch (Exception exception) when (!response.ResponseStarted) {
+            // The answer both socket hosts give, for the reason they give it - see
+            // HardenedHttpApplication.ProcessRequestAsync and AspNetCoreRequestHandler. This host
+            // caught nothing, so a failure that got past IoFilter unwound out of app.Get and the
+            // test read a raw exception where the same request over a socket read a 500. IoFilter
+            // records parameter binding and the handler; what escapes it is the response writer
+            // itself, which is where an unserializable payload throws.
+            //
+            // Only where nothing has been written. Once bytes are with the client a socket host
+            // stops and lets the connection tear down, and this host has no connection to tear
+            // down - so the exception reaching the caller is how a stream that failed after its
+            // first event says so, and swallowing it into a 500 would describe a response the
+            // client never got. Hence the filter rather than a branch inside: a rethrow here would
+            // report this frame as the origin.
+            response.Status = 500;
+
+            // Only where nothing was recorded. A handler that threw is already on the response and
+            // is the cause a test wants named; the envelope's own serializer failing afterwards is
+            // a consequence, and overwriting would hide the first.
+            response.ExceptionValue ??= exception;
+
+            requestLogger.RequestFailed(context, exception);
+        }
         finally {
             // In a finally because these ran as straight-line statements after the chain, so a
             // request that threw closed out nothing: no duration, no end, and the scope leaked.


### PR DESCRIPTION
Closes H-16 from the [0.21 Dispatch trial](https://claude.ai/code/artifact/7b01d3d1-4b28-4a6c-ad1e-1ff6a3b88ae3).

`IoFilter` catches a parameter binding failure and it catches the handler. The response writer runs after both, inside a `try`/`finally` with no `catch`, so a payload the serializer refuses throws past every filter. The pipeline host caught nothing either, so it unwound out of `app.Get` and failed the test with the raw exception — while the same request over a socket answered 500 and `testing-responses.md` promises the cause on `TestWebResponse.Failure`. The trial hit it through H-03's enum-keyed dictionary; that one is fixed, and the escape it exposed is not.

`PipelineRequest.Run` now follows the rule both socket hosts already follow — `HardenedHttpApplication.ProcessRequestAsync` and `AspNetCoreRequestHandler` state it in those words. A failure before anything is written sets 500, records the cause where nothing else did, and tells the request logger.

`ExceptionValue` is only set where nothing was recorded. A handler that threw is already on the response and is the cause a test wants named; the envelope's own writer failing afterwards is a consequence, and overwriting would hide the first.

## Only before anything is written

Once bytes are with the client a socket host stops and lets the connection tear down. This host has no connection to tear down, so the exception reaching the caller *is* the tear-down — `StreamingTests.AFailureAfterTheFirstEventEndsTheStream` has always relied on that, and its remarks say so. My first attempt caught unconditionally and broke it, which is the useful half of the story: the rule is `ResponseStarted`, not "catch everything".

It is an exception filter rather than a branch with a rethrow, so the started case does not report this frame as the origin.

## Verified

CI-shaped build and full suite green; coverage gate passes at 26 assemblies. `ErrorController` gains `/errors/unwritable` — a handler that succeeds returning a payload whose getter throws, so the failure is in the writer and nowhere else — with three tests: the 500, the cause on `Failure`, and a handler that threw keeping its own exception as the recorded cause. `StreamingTests` gains a cross-reference to the half of the rule that does not answer 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)