### PR TITLE
Restore the DynamoDB client and its test container as Hardened.Aws

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -264,6 +264,8 @@ jobs:
             src/Clouds/Aws/Hardened.Aws.Lambda.Sns/Hardened.Aws.Lambda.Sns.csproj \
             src/Clouds/Aws/Hardened.Aws.Lambda.Sqs/Hardened.Aws.Lambda.Sqs.csproj \
             src/Clouds/Aws/Hardened.Aws.Lambda.Testing/Hardened.Aws.Lambda.Testing.csproj \
+            src/Clouds/Aws/Hardened.Aws.DynamoDbClient/Hardened.Aws.DynamoDbClient.csproj \
+            src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/Hardened.Aws.DynamoDbClient.Testing.csproj \
             src/Clients/Hardened.Kiota.Testing/Hardened.Kiota.Testing.csproj \
             src/Clients/Hardened.Refit.Testing/Hardened.Refit.Testing.csproj \
             src/Templates/Hardened.Templates.RazorBlade/Hardened.Templates.RazorBlade.csproj \
@@ -321,7 +323,8 @@ jobs:
           # is the shape every later one takes: one package, one trigger, one line here.
           # 41 with Hardened.Aws.Lambda.Kinesis, the second adapter added after the split.
           # 42 with Hardened.Aws.Lambda.S3.
-          EXPECTED=42
+          # 44 with the DynamoDB client and its testing package, restored from the Amz line.
+          EXPECTED=44
           ACTUAL=$(ls -1 ./artifacts/*.nupkg 2>/dev/null | wc -l | tr -d ' ')
 
           if [ "$ACTUAL" != "$EXPECTED" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,18 @@ projects to filter.
 | `docs` | The published site, and the maintainer notes under `design/` |
 
 `Hardened.Docs` was a repository of its own until 2026-09-06 and is now `docs/`. `Hardened.Amz` was
-imported and then removed: the AWS line is being replaced by new `Hardened.Aws` projects rather than
-renamed, so its source earns no place here. It stays on nuget.org at `0.22.0-rc1000`, restorable and
-no longer moving, and its history is in this repository's — `git log` and `git blame` answer for it
-under `src/Clouds/Aws` at any commit before it was removed.
+imported and then removed: the AWS *line* is being replaced by new `Hardened.Aws` projects rather
+than renamed, so the hosts, their generators and their testing packages earn no place here. It stays
+on nuget.org at `0.22.0-rc1000`, restorable and no longer moving, and its history is in this
+repository's — `git log` and `git blame` answer for it under `src/Clouds/Aws` at any commit before
+it was removed.
+
+`Hardened.Aws.DynamoDbClient` and `Hardened.Aws.DynamoDbClient.Testing` are the exception, restored
+from that history rather than rewritten. They are the one part of the Amz line that was not a host:
+a client provider and a Testcontainers attribute, binding `Hardened.Shared.Runtime` and
+`Hardened.Shared.Testing` and nothing on the host seam. Nothing about them was made wrong by the
+rebuild, so replacing them would have been retyping. A further Amz package earns the same treatment
+only on the same test — that it touches no host.
 
 ## Commands
 

--- a/Hardened.slnx
+++ b/Hardened.slnx
@@ -59,6 +59,9 @@
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.Sqs/Hardened.Aws.Lambda.Sqs.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.Testing/Hardened.Aws.Lambda.Testing.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hardened.Aws.Lambda.Runtime.Tests.csproj" />
+    <Project Path="src/Clouds/Aws/Hardened.Aws.DynamoDbClient/Hardened.Aws.DynamoDbClient.csproj" />
+    <Project Path="src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/Hardened.Aws.DynamoDbClient.Testing.csproj" />
+    <Project Path="src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/Hardened.Aws.DynamoDbClient.Tests.csproj" />
   </Folder>
   <Folder Name="/IntegrationTests/Aot/">
     <Project Path="src/IntegrationTests/Aot/Hardened.IntegrationTests.Aot.SUT/Hardened.IntegrationTests.Aot.SUT.csproj" />

--- a/docs/aws/dynamodb.md
+++ b/docs/aws/dynamodb.md
@@ -4,7 +4,7 @@
 life of the process.
 
 ```csharp
-using Hardened.Amz.DynamoDbClient;
+using Hardened.Aws.DynamoDbClient;
 using Hardened.Shared.Runtime.Attributes;
 
 [HardenedModule]
@@ -24,7 +24,7 @@ public class OrderRepository(IDynamoDbClientProvider clients) {
 Deployed, nothing needs to be set: the SDK resolves credentials from the role and the region from
 the environment. Locally, `DYNAMODB_SERVICE_URL=http://localhost:8000` points the default client
 at DynamoDB Local. Source:
-[`src/Clients/DynamoDb`](https://github.com/ipjohnson/Hardened.Amz/tree/main/src/Clients/DynamoDb)
+[`src/Clouds/Aws/Hardened.Aws.DynamoDbClient`](https://github.com/ipjohnson/Hardened.Framework/tree/main/src/Clouds/Aws/Hardened.Aws.DynamoDbClient)
 in [Hardened.Framework](https://github.com/ipjohnson/Hardened.Framework).
 
 ## A provider rather than a client

--- a/docs/aws/testing.md
+++ b/docs/aws/testing.md
@@ -104,8 +104,8 @@ a conditional write exactly as the service does. Derive from it and override `Dd
 the tables:
 
 ```csharp
-using Hardened.Amz.DynamoDbClient;
-using Hardened.Amz.DynamoDbClient.Testing;
+using Hardened.Aws.DynamoDbClient;
+using Hardened.Aws.DynamoDbClient.Testing;
 
 public class OrdersDatabaseAttribute : LocalDynamoDbAttribute {
     protected override async Task DdbSetup(

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -240,13 +240,13 @@ From [Hardened.Framework](https://github.com/ipjohnson/Hardened.Framework).
 | `[LambdaWebApplication(Version)]` | `Hardened.Amz.Web.Lambda.Runtime` | States the payload format. `ProxyIntegrationType.HttpApiV2` is the default and the only implemented value; `.ApiGateway` is `HRDAWS001` |
 | `[SqsLambda]` | `Hardened.Amz.Function.Sqs.Runtime` | SQS batch runtime. Applied alongside `[LambdaFunctionModule]` |
 | `[DynamoStreamLambda]` | `Hardened.Amz.Function.DDB.Runtime` | DynamoDB Streams runtime. Applied alongside `[LambdaFunctionModule]` |
-| `[DynamoDbModule]` | `Hardened.Amz.DynamoDbClient` | Registers `IDynamoDbClientProvider` |
+| `[DynamoDbModule]` | `Hardened.Aws.DynamoDbClient` | Registers `IDynamoDbClientProvider` |
 | `[HardenedCdk]` | `Hardened.Amz.Cdk` | CDK deployment application |
 | `[NewImage]` / `[OldImage]` | `Hardened.Amz.Function.DDB.Runtime.Attributes` | Binds a stream record's images |
 | `[FromContext(name?)]` | `Hardened.Amz.Function.Lambda.Runtime` | Binds a named value from the invocation's headers |
 | `[ThrowException]` | `Hardened.Amz.Function.Lambda.Runtime` | Rethrows, so the invocation fails instead of returning the error |
 | `[LambdaFunctionTesting]` | `Hardened.Amz.Function.Lambda.Testing` | Installs the Lambda test harnesses |
-| `[LocalDynamoDb(Image?)]` | `Hardened.Amz.DynamoDbClient.Testing` | Points the client provider at DynamoDB Local in a container |
+| `[LocalDynamoDb(Image?)]` | `Hardened.Aws.DynamoDbClient.Testing` | Points the client provider at DynamoDB Local in a container |
 
 Whether a Lambda response streams is `HARDENED_LAMBDA_RESPONSE_MODE`, a deployment setting rather
 than an attribute; see [Response mode](/aws/lambda-web#response-mode).

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -107,7 +107,14 @@ and answers 404 to everything.
 
 ## AWS
 
-The AWS line as it was last released, `0.22.0-rc1000` on nuget.org, from
+The DynamoDB client is on the version line above, in this repository.
+
+| Package | Contents |
+|---|---|
+| `Hardened.Aws.DynamoDbClient` | `IDynamoDbClientProvider`, `DynamoDbOptions`, `[DynamoDbModule]` |
+| `Hardened.Aws.DynamoDbClient.Testing` | `[LocalDynamoDb]` and `LocalDynamoDb`: DynamoDB Local in a container |
+
+Everything below is the AWS line as it was last released, `0.22.0-rc1000` on nuget.org, from
 [Hardened.Amz](https://github.com/ipjohnson/Hardened.Amz). It is not on the version line above and
 does not move: it is being replaced by new `Hardened.Aws` packages rather than renamed.
 
@@ -137,8 +144,6 @@ package choice; see [Response mode](/aws/lambda-web#response-mode).
 
 | Package | Contents |
 |---|---|
-| `Hardened.Amz.DynamoDbClient` | `IDynamoDbClientProvider`, `DynamoDbOptions`, `[DynamoDbModule]` |
-| `Hardened.Amz.DynamoDbClient.Testing` | `[LocalDynamoDb]` and `LocalDynamoDb`: DynamoDB Local in a container |
 | `Hardened.Amz.Cdk` | CDK constructs, stage and region types, the deploy command |
 
 ### Source generators

--- a/docs/reference/repository.md
+++ b/docs/reference/repository.md
@@ -25,10 +25,14 @@ The framework is documented in the [Guide](/guide/getting-started), the AWS pack
 `Hardened.Docs` held this site and is now `docs/`, so a page and the change that made it wrong land
 in the same commit.
 
-`Hardened.Amz` held the AWS packages. Its history is here and its source is not: the line is being
-replaced by new `Hardened.Aws` projects rather than renamed, so there was nothing to carry forward.
-It stays on nuget.org at `0.22.0-rc1000`, restorable and no longer moving, and the
-[AWS pages](/aws/) describe it as released.
+`Hardened.Amz` held the AWS packages. Its history is here and almost none of its source is: the
+line is being replaced by new `Hardened.Aws` projects rather than renamed. It stays on nuget.org at
+`0.22.0-rc1000`, restorable and no longer moving, and the [AWS pages](/aws/) describe it as
+released.
+
+The [DynamoDB client](/aws/dynamodb) and its testing package came across, as
+`Hardened.Aws.DynamoDbClient` and `Hardened.Aws.DynamoDbClient.Testing`. They were the only part of
+that line that was not a host, so the rebuild left them correct as they stood.
 
 ## What is deliberately outside
 

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/Hardened.Aws.DynamoDbClient.Testing.csproj
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/Hardened.Aws.DynamoDbClient.Testing.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Description>Runs Hardened tests against a real DynamoDB in a container, rather than a fake.</Description>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>true</IsPackable>
+        <PackageId>Hardened.Aws.DynamoDbClient.Testing</PackageId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Testing\Hardened.Shared.Testing.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Testcontainers.DynamoDb" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Hardened.Aws.DynamoDbClient\Hardened.Aws.DynamoDbClient.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/LocalDynamoDb.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/LocalDynamoDb.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using Amazon.DynamoDBv2;
+using Amazon.Runtime;
+using Testcontainers.DynamoDb;
+
+namespace Hardened.Aws.DynamoDbClient.Testing;
+
+/// <summary>
+/// DynamoDB Local in a container, shared by every test in the process that asks for the same image.
+///
+/// <para>
+/// Usable on its own, without any of the rest of this package — take <see cref="Endpoint"/> and wire
+/// a client however you already do, or call <see cref="CreateClient"/> for one that is already
+/// pointed at it. Nothing here knows what a table or a key looks like.
+/// </para>
+///
+/// <para>
+/// One container per image rather than per test: starting one costs seconds, and tests that need
+/// isolation from each other should be using distinct keys rather than distinct databases. Requires
+/// a Docker daemon.
+/// </para>
+///
+/// <para>
+/// The image is an argument rather than a setting. It used to be a mutable static, which carried an
+/// implicit "set this before anything touches Endpoint" contract — set it late and it was silently
+/// ignored, and two tests wanting different versions could not both get what they asked for. Asking
+/// per call means the answer cannot depend on what ran first.
+/// </para>
+/// </summary>
+public static class LocalDynamoDb {
+    /// <summary>What <see cref="Endpoint"/> starts when no image is named.</summary>
+    public const string DefaultImage = "amazon/dynamodb-local:latest";
+
+    private static readonly ConcurrentDictionary<string, Lazy<DynamoDbContainer>> Containers =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Starts <see cref="DefaultImage"/> on first call and returns its endpoint.</summary>
+    public static string Endpoint => EndpointFor(DefaultImage);
+
+    /// <summary>
+    /// Starts <paramref name="image"/> on first call and returns its endpoint. Repeated calls for
+    /// the same image return the same container.
+    /// </summary>
+    /// <param name="image">
+    /// A full Docker image name including the tag, so a suite can pin a version rather than track
+    /// <c>latest</c>.
+    /// </param>
+    public static string EndpointFor(string image) => ContainerFor(image).GetConnectionString();
+
+    /// <summary>
+    /// A client pointed at the container. DynamoDB Local authenticates nothing, but the SDK signs
+    /// every request, so credentials have to exist; these are arbitrary and meaningless.
+    /// </summary>
+    public static IAmazonDynamoDB CreateClient(string image = DefaultImage) =>
+        new AmazonDynamoDBClient(
+            new BasicAWSCredentials("local", "local"),
+            new AmazonDynamoDBConfig { ServiceURL = EndpointFor(image) });
+
+    /// <summary>
+    /// Stops every container started here, and forgets them — a later call starts a fresh one.
+    ///
+    /// <para>
+    /// Testcontainers' Ryuk reaps containers when the run ends regardless, so this is not needed for
+    /// correctness. It is here so that a suite can end its containers at a point it chooses rather
+    /// than leaving the lifetime to a sidecar, which makes the lifetime legible and reclaims the
+    /// memory before the process finishes.
+    /// </para>
+    /// </summary>
+    public static void StopAll() {
+        foreach (var container in Containers.Values) {
+            // A container whose Lazy has not run has nothing to stop. One being started right now
+            // is a suite tearing down while it is still working, which is its own problem.
+            if (container.IsValueCreated) {
+                container.Value.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
+
+        Containers.Clear();
+    }
+
+    private static DynamoDbContainer ContainerFor(string image) =>
+        Containers.GetOrAdd(image,
+            key => new Lazy<DynamoDbContainer>(() => Start(key), LazyThreadSafetyMode.ExecutionAndPublication))
+            .Value;
+
+    private static DynamoDbContainer Start(string image) {
+        var container = new DynamoDbBuilder(image).Build();
+
+        // Blocking is deliberate — callers are synchronous DI registration paths, and this happens
+        // once per image per process.
+        container.StartAsync().GetAwaiter().GetResult();
+
+        return container;
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/LocalDynamoDbAttribute.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Testing/LocalDynamoDbAttribute.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using Amazon.DynamoDBv2;
+using Hardened.Shared.Runtime.Application;
+using Hardened.Shared.Testing.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hardened.Aws.DynamoDbClient.Testing;
+
+/// <summary>
+/// Points the application's <see cref="IDynamoDbClientProvider"/> at a real DynamoDB in a container,
+/// so data tests exercise the engine rather than a fake. Asserting an item shape against a mock only
+/// confirms the test agrees with itself.
+///
+/// <para>
+/// Derive from this and override <see cref="DdbSetup"/> to create the tables under test:
+/// </para>
+/// <code>
+/// public class OrdersDatabaseAttribute : LocalDynamoDbAttribute {
+///     protected override async Task DdbSetup(..., IServiceProvider services) {
+///         var client = services.GetRequiredService&lt;IDynamoDbClientProvider&gt;().GetClient();
+///         await client.CreateTableAsync(...);
+///     }
+/// }
+/// </code>
+///
+/// <para>
+/// This is the Hardened-flavoured convenience. <see cref="LocalDynamoDb"/> is the same container
+/// without any of it, for a project wiring its clients some other way.
+/// </para>
+/// </summary>
+public class LocalDynamoDbAttribute : Attribute,
+    IHardenedTestDependencyRegistrationAttribute,
+    IHardenedTestStartupAttribute {
+
+    /// <summary>
+    /// The container image, so a suite can pin a version rather than track <c>latest</c>:
+    /// <c>[LocalDynamoDb(Image = "amazon/dynamodb-local:3.3.1")]</c>. Attributes naming different
+    /// images get their own containers.
+    /// </summary>
+    public string Image { get; set; } = LocalDynamoDb.DefaultImage;
+
+    public void RegisterDependencies(
+        AttributeCollection attributeCollection,
+        MethodInfo methodInfo,
+        IHardenedEnvironment environment,
+        IServiceCollection serviceCollection) {
+        var image = Image;
+
+        // Registered last, so it wins over whatever the application registered.
+        serviceCollection.AddSingleton<IDynamoDbClientProvider>(_ => new ContainerClientProvider(image));
+    }
+
+    public Task Startup(
+        AttributeCollection attributeCollection,
+        MethodInfo methodInfo,
+        IHardenedEnvironment environment,
+        IServiceProvider serviceProvider) =>
+        DdbSetup(attributeCollection, methodInfo, environment, serviceProvider);
+
+    /// <summary>Create the tables under test. Runs before every test carrying this attribute.</summary>
+    protected virtual Task DdbSetup(
+        AttributeCollection attributeCollection,
+        MethodInfo methodInfo,
+        IHardenedEnvironment environment,
+        IServiceProvider serviceProvider) => Task.CompletedTask;
+
+    /// <summary>
+    /// Every name resolves to the same container. A test asserting behaviour across two accounts is
+    /// asserting something DynamoDB Local cannot represent, so pretending otherwise would only make
+    /// the failure harder to read.
+    /// </summary>
+    private sealed class ContainerClientProvider(string image) : IDynamoDbClientProvider, IDisposable {
+        private readonly Lazy<IAmazonDynamoDB> _client = new(() => LocalDynamoDb.CreateClient(image));
+
+        public IAmazonDynamoDB GetClient(string clientName = "") => _client.Value;
+
+        public void Dispose() {
+            if (_client.IsValueCreated) {
+                _client.Value.Dispose();
+            }
+        }
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/DefaultClientSettingsTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/DefaultClientSettingsTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using Amazon.Runtime;
+using Hardened.Shared.Runtime.Attributes;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Aws.DynamoDbClient.Tests;
+
+/// <summary>
+/// The default client — the one every consumer gets until it configures something else, and the one
+/// path nothing used to exercise.
+///
+/// <para>
+/// There are two shapes, and the difference is not cosmetic. Deployed, the SDK resolves the region
+/// and the role's credentials for itself. Pointed at DynamoDB Local, it must be told the endpoint
+/// and handed credentials that mean nothing, because DynamoDB Local authenticates nothing but the
+/// SDK still signs every request. Getting that branch wrong fails at the first call, not at startup.
+/// </para>
+/// </summary>
+public class DefaultClientSettingsTests {
+
+    private const string LocalUrl = "http://localhost:8000";
+
+    /// <summary>
+    /// The SDK normalises what it is handed, so a URL with no path comes back with a trailing
+    /// slash. Asserted as it is stored rather than as it was written, since that is what a caller
+    /// reading <c>Config.ServiceURL</c> will see.
+    /// </summary>
+    private const string AsTheSdkStoresIt = LocalUrl + "/";
+
+    [Fact]
+    public void WithNothingConfiguredEverythingIsLeftToTheSdk() {
+        var (config, credentials) = Settings(new DynamoDbOptions());
+
+        Assert.Null(credentials);
+        Assert.Null(config.RegionEndpoint);
+        Assert.Null(config.ServiceURL);
+    }
+
+    [Fact]
+    public void ARegionIsParsedIntoAnEndpoint() {
+        var (config, _) = Settings(new DynamoDbOptions { Region = "eu-west-1" });
+
+        Assert.Equal("eu-west-1", config.RegionEndpoint.SystemName);
+    }
+
+    /// <summary>
+    /// The region arrives from an environment variable, so an unset one shows up as empty rather
+    /// than absent. That has to mean "the SDK decides", not "the region is the empty string".
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnEmptyRegionIsLeftToTheSdk(string region) {
+        var (config, _) = Settings(new DynamoDbOptions { Region = region });
+
+        Assert.Null(config.RegionEndpoint);
+    }
+
+    [Fact]
+    public void AServiceUrlPointsTheClientAtIt() {
+        var (config, _) = Settings(new DynamoDbOptions { ServiceUrl = LocalUrl });
+
+        Assert.Equal(AsTheSdkStoresIt, config.ServiceURL);
+    }
+
+    /// <summary>
+    /// The whole reason the branch exists. DynamoDB Local checks no credentials, but the SDK refuses
+    /// to send a request it cannot sign, so credentials that mean nothing still have to be there.
+    /// </summary>
+    [Fact]
+    public void AServiceUrlSuppliesCredentialsBecauseTheSdkSignsEveryRequest() {
+        var (_, credentials) = Settings(new DynamoDbOptions { ServiceUrl = LocalUrl });
+
+        Assert.IsType<BasicAWSCredentials>(credentials);
+    }
+
+    /// <summary>
+    /// <c>RegionEndpoint</c> and <c>ServiceURL</c> are mutually exclusive on the SDK's config:
+    /// assigning either clears the other. The region used to be assigned first and then wiped by the
+    /// endpoint, so a process with both <c>AWS_REGION</c> and <c>DYNAMODB_SERVICE_URL</c> set — the
+    /// ordinary local-development shape — silently signed as <c>us-east-1</c> whatever its region
+    /// said. It is carried as the signing region instead.
+    /// </summary>
+    [Fact]
+    public void ARegionGivenAlongsideAServiceUrlSurvivesAsTheSigningRegion() {
+        var (config, credentials) = Settings(new DynamoDbOptions {
+            ServiceUrl = LocalUrl,
+            Region = "us-west-2",
+        });
+
+        Assert.Equal(AsTheSdkStoresIt, config.ServiceURL);
+        Assert.Equal("us-west-2", config.AuthenticationRegion);
+        Assert.NotNull(credentials);
+
+        // Not an incidental detail — it is the reason the region has to go somewhere else.
+        Assert.Null(config.RegionEndpoint);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnEmptyServiceUrlMeansDeployed(string serviceUrl) {
+        var (config, credentials) = Settings(new DynamoDbOptions { ServiceUrl = serviceUrl, Region = "us-west-2" });
+
+        Assert.Null(credentials);
+        Assert.Null(config.ServiceURL);
+    }
+
+    /// <summary>
+    /// The settings above are only worth anything if the default client is actually built from them,
+    /// so this goes through the provider rather than the helper.
+    /// </summary>
+    [Fact]
+    public void TheDefaultClientIsBuiltFromTheOptions() {
+        var options = new DynamoDbOptions {
+            ServiceUrl = LocalUrl,
+            Region = "us-west-2",
+        };
+
+        var provider = new DynamoDbClientProvider(
+            Options.Create<IDynamoDbOptions>(options),
+            Substitute.For<IServiceProvider>());
+
+        var client = provider.GetClient();
+
+        Assert.Equal(AsTheSdkStoresIt, client.Config.ServiceURL);
+        Assert.Equal("us-west-2", client.Config.AuthenticationRegion);
+    }
+
+    /// <summary>
+    /// These two names are this package's contract with the environment it is deployed into, and
+    /// nothing else in this repository mentions them: the code that reads them is generated at the
+    /// consuming application's entry point, so renaming one here compiles, packs and publishes
+    /// cleanly, and then silently stops configuring anything.
+    /// </summary>
+    [Fact]
+    public void TheEnvironmentVariableNamesAreFixed() {
+        Assert.Equal("DYNAMODB_SERVICE_URL", EnvironmentVariableBehind("_serviceUrl"));
+        Assert.Equal("AWS_REGION", EnvironmentVariableBehind("_region"));
+    }
+
+    private static (Amazon.DynamoDBv2.AmazonDynamoDBConfig Config, AWSCredentials? Credentials) Settings(
+        DynamoDbOptions options) =>
+        DynamoDbClientProvider.DefaultClientSettings(options);
+
+    private static string? EnvironmentVariableBehind(string fieldName) =>
+        typeof(DynamoDbOptions)
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetCustomAttribute<FromEnvironmentVariableAttribute>()
+            ?.EnvironmentVariable;
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/DynamoDbClientProviderTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/DynamoDbClientProviderTests.cs
@@ -1,0 +1,151 @@
+using Amazon.DynamoDBv2;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Aws.DynamoDbClient.Tests;
+
+/// <summary>
+/// The provider exists so that more than one client can exist — a second account, an assumed role,
+/// another region — each with its own credentials, built when first asked for rather than when the
+/// service collection is assembled.
+/// </summary>
+public class DynamoDbClientProviderTests {
+
+    [Fact]
+    public void ANamedFactoryDecidesEverythingAboutItsClient() {
+        var expected = Substitute.For<IAmazonDynamoDB>();
+
+        var provider = Build(options => options.Clients["audit"] = _ => expected);
+
+        Assert.Same(expected, provider.GetClient("audit"));
+    }
+
+    [Fact]
+    public void NamedClientsAreIndependent() {
+        var audit = Substitute.For<IAmazonDynamoDB>();
+        var billing = Substitute.For<IAmazonDynamoDB>();
+
+        var provider = Build(options => {
+            options.Clients["audit"] = _ => audit;
+            options.Clients["billing"] = _ => billing;
+        });
+
+        Assert.Same(audit, provider.GetClient("audit"));
+        Assert.Same(billing, provider.GetClient("billing"));
+    }
+
+    [Fact]
+    public void AnUnknownNameFailsLoudlyAndSaysWhatIsConfigured() {
+        var provider = Build(options => options.Clients["audit"] = _ => Substitute.For<IAmazonDynamoDB>());
+
+        var error = Assert.Throws<InvalidOperationException>(() => provider.GetClient("typo"));
+
+        Assert.Contains("'typo'", error.Message);
+        Assert.Contains("'audit'", error.Message);
+    }
+
+    [Fact]
+    public void AFactoryRunsOnceAndTheClientIsReused() {
+        // AmazonDynamoDBClient owns a connection pool, so building one per call is how sockets run
+        // out. Caching is the behaviour, not an optimisation.
+        var built = 0;
+
+        var provider = Build(options => options.Clients["audit"] = _ => {
+            built++;
+            return Substitute.For<IAmazonDynamoDB>();
+        });
+
+        provider.GetClient("audit");
+        provider.GetClient("audit");
+
+        Assert.Equal(1, built);
+    }
+
+    [Fact]
+    public void AFactoryIsNotRunUntilItsClientIsAsked() {
+        var built = false;
+
+        Build(options => options.Clients["audit"] = _ => {
+            built = true;
+            return Substitute.For<IAmazonDynamoDB>();
+        });
+
+        Assert.False(built, "constructing the provider should not construct any client");
+    }
+
+    [Fact]
+    public void TheDefaultClientCanBeReplacedWholesale() {
+        var expected = Substitute.For<IAmazonDynamoDB>();
+
+        var provider = Build(options => options.DefaultClient = _ => expected);
+
+        Assert.Same(expected, provider.GetClient());
+    }
+
+    /// <summary>
+    /// The provider owns every client it built, so nothing else can close them. Before it was
+    /// IDisposable they lived until the process exited, holding their connection pools open.
+    /// </summary>
+    [Fact]
+    public void DisposingClosesEveryClientItBuilt() {
+        var audit = Substitute.For<IAmazonDynamoDB>();
+        var billing = Substitute.For<IAmazonDynamoDB>();
+
+        var provider = Build(options => {
+            options.Clients["audit"] = _ => audit;
+            options.Clients["billing"] = _ => billing;
+        });
+
+        provider.GetClient("audit");
+        provider.GetClient("billing");
+        provider.Dispose();
+
+        audit.Received(1).Dispose();
+        billing.Received(1).Dispose();
+    }
+
+    /// <summary>
+    /// A client never asked for was never built, so there is nothing to close and asking for one
+    /// during teardown would be the opposite of what disposal is for.
+    /// </summary>
+    [Fact]
+    public void DisposingDoesNotBuildClientsNobodyAskedFor() {
+        var built = false;
+
+        var provider = Build(options => options.Clients["audit"] = _ => {
+            built = true;
+            return Substitute.For<IAmazonDynamoDB>();
+        });
+
+        provider.Dispose();
+
+        Assert.False(built);
+    }
+
+    /// <summary>
+    /// Dispose has to be idempotent — a container disposing a singleton it also owns a reference to
+    /// is ordinary — and it is the cache being cleared that makes it so.
+    /// </summary>
+    [Fact]
+    public void DisposingTwiceClosesEachClientOnce() {
+        var client = Substitute.For<IAmazonDynamoDB>();
+
+        var provider = Build(options => options.Clients["audit"] = _ => client);
+
+        provider.GetClient("audit");
+        provider.Dispose();
+        provider.Dispose();
+
+        client.Received(1).Dispose();
+    }
+
+    private static DynamoDbClientProvider Build(Action<DynamoDbOptions> configure) {
+        var options = new DynamoDbOptions();
+        configure(options);
+
+        return new DynamoDbClientProvider(
+            Options.Create<IDynamoDbOptions>(options),
+            Substitute.For<IServiceProvider>());
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/Hardened.Aws.DynamoDbClient.Tests.csproj
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/Hardened.Aws.DynamoDbClient.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Hardened.Aws.DynamoDbClient\Hardened.Aws.DynamoDbClient.csproj" />
+        <ProjectReference Include="..\Hardened.Aws.DynamoDbClient.Testing\Hardened.Aws.DynamoDbClient.Testing.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/LocalDynamoDbTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/LocalDynamoDbTests.cs
@@ -1,0 +1,122 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using Hardened.Aws.DynamoDbClient.Testing;
+using Xunit;
+
+namespace Hardened.Aws.DynamoDbClient.Tests;
+
+/// <summary>
+/// The container is the whole value of the Testing package, and until now it was only exercised
+/// incidentally, by another repository's data tests.
+///
+/// <para>
+/// Every test here goes through <see cref="LocalDynamoDb"/> alone — no service collection, no
+/// module, no attribute — which is also the claim the class makes about itself: that a project
+/// wiring its clients some other way can still use it.
+/// </para>
+/// </summary>
+[Collection(LocalDynamoDbCollection.Name)]
+public class LocalDynamoDbTests {
+
+    /// <summary>A real tag rather than <c>latest</c>, so the container is a different one.</summary>
+    private const string PinnedImage = "amazon/dynamodb-local:3.3.1";
+
+    [RequiresDockerFact]
+    public void TheContainerStartsOnceAndKeepsItsEndpoint() {
+        var first = LocalDynamoDb.Endpoint;
+        var second = LocalDynamoDb.Endpoint;
+
+        Assert.StartsWith("http://", first);
+        Assert.Equal(first, second);
+    }
+
+    /// <summary>
+    /// The point of a container rather than a fake: the assertion is about what DynamoDB did with
+    /// the item, not about what a mock was told.
+    /// </summary>
+    [RequiresDockerFact]
+    public async Task AnItemRoundTripsThroughARealTable() {
+        using var client = LocalDynamoDb.CreateClient();
+
+        await CreateTable(client, "round-trip");
+
+        await client.PutItemAsync("round-trip", new Dictionary<string, AttributeValue> {
+            ["id"] = new("the-key"),
+            ["value"] = new("kept"),
+        });
+
+        var response = await client.GetItemAsync("round-trip", new Dictionary<string, AttributeValue> {
+            ["id"] = new("the-key"),
+        });
+
+        Assert.Equal("kept", response.Item["value"].S);
+    }
+
+    /// <summary>
+    /// The image used to be a mutable static, so a suite could only ever have one and which one
+    /// depended on what ran first. Two named images now mean two containers.
+    /// </summary>
+    [RequiresDockerFact]
+    public void DifferentImagesGetDifferentContainers() {
+        var byDefault = LocalDynamoDb.EndpointFor(LocalDynamoDb.DefaultImage);
+        var pinned = LocalDynamoDb.EndpointFor(PinnedImage);
+
+        Assert.NotEqual(byDefault, pinned);
+    }
+
+    /// <summary>A pinned image is a working DynamoDB, not just a second endpoint.</summary>
+    [RequiresDockerFact]
+    public async Task APinnedImageServesRequestsToo() {
+        using var client = LocalDynamoDb.CreateClient(PinnedImage);
+
+        await CreateTable(client, "pinned");
+
+        var tables = await client.ListTablesAsync();
+
+        Assert.Contains("pinned", tables.TableNames);
+    }
+
+    private static Task CreateTable(IAmazonDynamoDB client, string name) =>
+        client.CreateTableAsync(new CreateTableRequest {
+            TableName = name,
+            KeySchema = [new KeySchemaElement("id", KeyType.HASH)],
+            AttributeDefinitions = [new AttributeDefinition("id", ScalarAttributeType.S)],
+
+            // DynamoDB Local ignores throughput, but the API still requires it unless the table is
+            // on-demand, and provisioned works on every version worth testing against.
+            ProvisionedThroughput = new ProvisionedThroughput(1, 1),
+        });
+}
+
+/// <summary>
+/// Holds every container-backed test in one collection so they share the containers rather than
+/// racing to start them, and so there is a single point at which the containers are stopped.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class LocalDynamoDbCollection : ICollectionFixture<LocalDynamoDbLifetime> {
+    public const string Name = "local-dynamodb";
+}
+
+/// <summary>
+/// Stops the containers when the collection is finished with them. Testcontainers' Ryuk would reap
+/// them at the end of the run regardless; ending them here is what makes the lifetime something the
+/// suite states rather than something a sidecar decides.
+///
+/// <para>
+/// It also states the requirement up front. Without a daemon these tests fail either way — §10 of
+/// testing-conventions.md says they should — but failing here fails once, saying what is missing and
+/// how to exclude it, rather than once per test with a socket error that has to be read twice to
+/// find out it was never about the code.
+/// </para>
+/// </summary>
+public sealed class LocalDynamoDbLifetime : IDisposable {
+    public LocalDynamoDbLifetime() {
+        if (!DockerDaemon.IsAvailable) {
+            throw new InvalidOperationException(
+                "These tests run DynamoDB Local in a container and no Docker daemon answered. " +
+                $"Start one, or exclude them: dotnet test --filter \"Category!={RequiresDockerFactAttribute.Category}\".");
+        }
+    }
+
+    public void Dispose() => LocalDynamoDb.StopAll();
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/RequiresDockerFactAttribute.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient.Tests/RequiresDockerFactAttribute.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.v3;
+
+namespace Hardened.Aws.DynamoDbClient.Tests;
+
+/// <summary>
+/// A fact that needs a Docker daemon. It carries the <c>Category=RequiresDocker</c> trait, so a
+/// machine without one excludes it by saying so:
+/// <code>dotnet test --filter "Category!=RequiresDocker"</code>
+///
+/// <para>
+/// It does not skip. <c>testing-conventions.md</c> §10 is explicit that a Docker test fails rather
+/// than skips on a machine without a daemon, and §3.3 of <c>TESTING-PLAN.md</c> fails the build on
+/// any skipped test at all — so a skip would not have been the quiet outcome it looks like. The
+/// trait is what makes the exclusion a decision the runner records rather than one the test makes
+/// on its own, silently, at the moment it would otherwise have told you something.
+/// </para>
+///
+/// <para>
+/// This is the repository's one pattern for an external requirement. A second test needing Docker
+/// uses this attribute rather than inventing its own detection.
+/// </para>
+/// </summary>
+public sealed class RequiresDockerFactAttribute(
+    [CallerFilePath] string? sourceFilePath = null,
+    [CallerLineNumber] int sourceLineNumber = -1)
+    : FactAttribute(sourceFilePath, sourceLineNumber), ITraitAttribute {
+
+    /// <summary>The trait every Docker-dependent test in this repository carries.</summary>
+    public const string Category = "RequiresDocker";
+
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() =>
+        [new KeyValuePair<string, string>("Category", Category)];
+}
+
+/// <summary>
+/// Whether a Docker daemon is reachable. Public so a fixture can say why a container did not start,
+/// rather than leaving a connection failure to be read as a defect in the code under test.
+/// </summary>
+public static class DockerDaemon {
+    private static readonly Lazy<bool> Available =
+        new(Detect, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public static bool IsAvailable => Available.Value;
+
+    private static bool Detect() {
+        try {
+            // `docker info` talks to the daemon, unlike `docker version`, which answers from the
+            // client alone and so reports success with nothing running.
+            using var probe = Process.Start(new ProcessStartInfo("docker", "info") {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            });
+
+            if (probe is null) {
+                return false;
+            }
+
+            if (!probe.WaitForExit(milliseconds: 15_000)) {
+                probe.Kill(entireProcessTree: true);
+
+                return false;
+            }
+
+            return probe.ExitCode == 0;
+        }
+        catch (Exception) {
+            // Docker is not on the path, or cannot be run. Either way there is no daemon to use.
+            return false;
+        }
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/DynamoDbClientProvider.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/DynamoDbClientProvider.cs
@@ -1,0 +1,111 @@
+using System.Collections.Concurrent;
+using Amazon;
+using Amazon.DynamoDBv2;
+using Amazon.Runtime;
+using DependencyModules.Runtime.Attributes;
+using Microsoft.Extensions.Options;
+
+namespace Hardened.Aws.DynamoDbClient;
+
+/// <summary>
+/// Builds each client on first use and keeps it for the process.
+///
+/// <para>
+/// Caching matters: <c>AmazonDynamoDBClient</c> is thread-safe and owns a connection pool, so
+/// constructing one per request is a well-known way to exhaust sockets.
+/// </para>
+/// </summary>
+[SingletonService(As = typeof(IDynamoDbClientProvider))]
+public sealed class DynamoDbClientProvider(
+    IOptions<IDynamoDbOptions> options,
+    IServiceProvider serviceProvider) : IDynamoDbClientProvider, IDisposable {
+
+    private readonly ConcurrentDictionary<string, IAmazonDynamoDB> _clients = new(StringComparer.Ordinal);
+
+    public IAmazonDynamoDB GetClient(string clientName = "") =>
+        _clients.GetOrAdd(clientName, Build);
+
+    private IAmazonDynamoDB Build(string clientName) {
+        if (!string.IsNullOrEmpty(clientName)) {
+            if (!options.Value.Clients.TryGetValue(clientName, out var factory)) {
+                throw new InvalidOperationException(
+                    $"No DynamoDB client is configured under the name '{clientName}'. " +
+                    $"Configured names: {Describe(options.Value.Clients.Keys)}.");
+            }
+
+            return factory(serviceProvider);
+        }
+
+        if (options.Value.DefaultClient is { } defaultFactory) {
+            return defaultFactory(serviceProvider);
+        }
+
+        return BuildFromOptions();
+    }
+
+    private IAmazonDynamoDB BuildFromOptions() {
+        var (config, credentials) = DefaultClientSettings(options.Value);
+
+        return credentials is null
+            ? new AmazonDynamoDBClient(config)
+            : new AmazonDynamoDBClient(credentials, config);
+    }
+
+    /// <summary>
+    /// What the default client is built from, as a value rather than a client.
+    ///
+    /// <para>
+    /// Separated because the decision here is the interesting part and a built client hides half of
+    /// it: the SDK exposes a client's endpoint and region but not its credentials, and choosing
+    /// credentials is exactly what the <c>ServiceUrl</c> branch does.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// The configuration, and the credentials to build with — <c>null</c> meaning the SDK should
+    /// resolve them itself from the environment and the role.
+    /// </returns>
+    internal static (AmazonDynamoDBConfig Config, AWSCredentials? Credentials) DefaultClientSettings(
+        IDynamoDbOptions options) {
+        var config = new AmazonDynamoDBConfig();
+        var hasRegion = !string.IsNullOrWhiteSpace(options.Region);
+
+        if (string.IsNullOrWhiteSpace(options.ServiceUrl)) {
+            // Deployed: the SDK resolves credentials from the role, and the region for itself when
+            // nothing here has said which one.
+            if (hasRegion) {
+                config.RegionEndpoint = RegionEndpoint.GetBySystemName(options.Region);
+            }
+
+            return (config, null);
+        }
+
+        config.ServiceURL = options.ServiceUrl;
+
+        // RegionEndpoint and ServiceURL are mutually exclusive on the SDK's config — assigning
+        // either clears the other — so a region given alongside an endpoint has to be carried as
+        // the signing region or it is silently dropped. Which is what happened: a process with
+        // both AWS_REGION and DYNAMODB_SERVICE_URL set, the ordinary local-development shape,
+        // signed as us-east-1 whatever its region said.
+        if (hasRegion) {
+            config.AuthenticationRegion = options.Region;
+        }
+
+        // DynamoDB Local authenticates nothing, but the SDK signs every request, so credentials
+        // have to exist. These values are arbitrary and meaningless.
+        return (config, new BasicAWSCredentials("local", "local"));
+    }
+
+    private static string Describe(IEnumerable<string> names) {
+        var listed = string.Join(", ", names.Select(n => $"'{n}'"));
+
+        return listed.Length == 0 ? "none" : listed;
+    }
+
+    public void Dispose() {
+        foreach (var client in _clients.Values) {
+            client.Dispose();
+        }
+
+        _clients.Clear();
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/DynamoDbModule.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/DynamoDbModule.cs
@@ -1,0 +1,14 @@
+using Hardened.Shared.Runtime.Attributes;
+
+namespace Hardened.Aws.DynamoDbClient;
+
+/// <summary>
+/// Registers <see cref="IDynamoDbClientProvider"/>. Import it from an application module:
+/// <code>
+/// [HardenedModule]
+/// [DynamoDbModule]
+/// public partial class MyApp { }
+/// </code>
+/// </summary>
+[HardenedModule]
+public partial class DynamoDbModule { }

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/DynamoDbOptions.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/DynamoDbOptions.cs
@@ -1,0 +1,45 @@
+using Amazon.DynamoDBv2;
+using Hardened.Shared.Runtime.Attributes;
+
+namespace Hardened.Aws.DynamoDbClient;
+
+/// <summary>
+/// How clients are built.
+///
+/// <para>
+/// The default client is described by two environment variables, because that covers the common
+/// case and needs no code. Anything else — different credentials, an assumed role, a second region,
+/// a custom retry policy — is a factory registered under a name, which receives the service provider
+/// so it can resolve whatever it needs to build a client.
+/// </para>
+/// </summary>
+[ConfigurationModel]
+public partial class DynamoDbOptions {
+
+    /// <summary>
+    /// Overrides the default client's endpoint. This is what points a process at DynamoDB Local, and
+    /// it should never be set in a deployed environment.
+    /// </summary>
+    [FromEnvironmentVariable("DYNAMODB_SERVICE_URL")]
+    private string _serviceUrl = "";
+
+    /// <summary>Left to the SDK's own resolution when empty, which is the deployed case.</summary>
+    [FromEnvironmentVariable("AWS_REGION")]
+    private string _region = "";
+
+    /// <summary>
+    /// Named clients. The key is what <c>GetClient(name)</c> takes; the factory decides everything
+    /// about the client, credentials included.
+    /// <code>
+    /// config.Amend((DynamoDbOptions o) => o.Clients["audit"] = provider =>
+    ///     new AmazonDynamoDBClient(assumedRoleCredentials, new AmazonDynamoDBConfig { ... }));
+    /// </code>
+    /// </summary>
+    private Dictionary<string, Func<IServiceProvider, IAmazonDynamoDB>> _clients = new();
+
+    /// <summary>
+    /// Replaces how the default client is built. Set this and <see cref="ServiceUrl"/> and
+    /// <see cref="Region"/> are ignored — a caller supplying a factory has said everything.
+    /// </summary>
+    private Func<IServiceProvider, IAmazonDynamoDB>? _defaultClient;
+}

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/Hardened.Aws.DynamoDbClient.csproj
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/Hardened.Aws.DynamoDbClient.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Description>A DynamoDB client provider for Hardened applications: named clients that bring their own credentials, built on first use and cached for the process.</Description>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsAotCompatible>true</IsAotCompatible>
+        <IsPackable>true</IsPackable>
+        <PackageId>Hardened.Aws.DynamoDbClient</PackageId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.DependencyModules.SourceGenerator\Hardened.DependencyModules.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all"/>
+        <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AWSSDK.DynamoDBv2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!--
+          DefaultClientSettings is internal: the AWS SDK exposes a built client's endpoint but not
+          its credentials, and which credentials the ServiceUrl branch chooses is the behaviour
+          worth asserting. Separating the decision keeps that testable without reflection.
+        -->
+        <InternalsVisibleTo Include="Hardened.Aws.DynamoDbClient.Tests" />
+    </ItemGroup>
+
+</Project>

--- a/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/IDynamoDbClientProvider.cs
+++ b/src/Clouds/Aws/Hardened.Aws.DynamoDbClient/IDynamoDbClientProvider.cs
@@ -1,0 +1,28 @@
+using Amazon.DynamoDBv2;
+
+namespace Hardened.Aws.DynamoDbClient;
+
+/// <summary>
+/// Supplies DynamoDB clients by name.
+///
+/// <para>
+/// A provider rather than a registered <see cref="IAmazonDynamoDB"/>, because one registration can
+/// only describe one client. Reaching a second account, assuming a different role, or talking to
+/// another region all need their own credentials and configuration, and a container that resolves a
+/// single instance has nowhere to put them. Construction is also deferred: a factory runs when a
+/// client is first asked for, not when the collection is built.
+/// </para>
+///
+/// <para>
+/// Returns the SDK's interface, so a caller can substitute one in a test without going through this
+/// at all.
+/// </para>
+/// </summary>
+public interface IDynamoDbClientProvider {
+    /// <param name="clientName">
+    /// Empty for the default client. A name selects one configured under that name — a second
+    /// region, another account, a role with narrower permissions.
+    /// </param>
+    /// <exception cref="InvalidOperationException">No client is configured under that name.</exception>
+    IAmazonDynamoDB GetClient(string clientName = "");
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.DynamoDbClient.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.DynamoDbClient.Testing.approved.txt
@@ -1,0 +1,19 @@
+namespace Hardened.Aws.DynamoDbClient.Testing
+{
+    public static class LocalDynamoDb
+    {
+        public const string DefaultImage = "amazon/dynamodb-local:latest";
+        public static string Endpoint { get; }
+        public static Amazon.DynamoDBv2.IAmazonDynamoDB CreateClient(string image = "amazon/dynamodb-local:latest") { }
+        public static string EndpointFor(string image) { }
+        public static void StopAll() { }
+    }
+    public class LocalDynamoDbAttribute : System.Attribute, Hardened.Shared.Testing.Attributes.IHardenedOrderedAttribute, Hardened.Shared.Testing.Attributes.IHardenedTestDependencyRegistrationAttribute, Hardened.Shared.Testing.Attributes.IHardenedTestStartupAttribute
+    {
+        public LocalDynamoDbAttribute() { }
+        public string Image { get; set; }
+        protected virtual System.Threading.Tasks.Task DdbSetup(Hardened.Shared.Testing.Attributes.AttributeCollection attributeCollection, System.Reflection.MethodInfo methodInfo, Hardened.Shared.Runtime.Application.IHardenedEnvironment environment, System.IServiceProvider serviceProvider) { }
+        public void RegisterDependencies(Hardened.Shared.Testing.Attributes.AttributeCollection attributeCollection, System.Reflection.MethodInfo methodInfo, Hardened.Shared.Runtime.Application.IHardenedEnvironment environment, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public System.Threading.Tasks.Task Startup(Hardened.Shared.Testing.Attributes.AttributeCollection attributeCollection, System.Reflection.MethodInfo methodInfo, Hardened.Shared.Runtime.Application.IHardenedEnvironment environment, System.IServiceProvider serviceProvider) { }
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.DynamoDbClient.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.DynamoDbClient.approved.txt
@@ -1,0 +1,53 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Hardened.Aws.DynamoDbClient.Tests")]
+namespace Hardened.Aws.DynamoDbClient
+{
+    [DependencyModules.Runtime.Attributes.SingletonService(As=typeof(Hardened.Aws.DynamoDbClient.IDynamoDbClientProvider))]
+    public sealed class DynamoDbClientProvider : Hardened.Aws.DynamoDbClient.IDynamoDbClientProvider, System.IDisposable
+    {
+        public DynamoDbClientProvider(Microsoft.Extensions.Options.IOptions<Hardened.Aws.DynamoDbClient.IDynamoDbOptions> options, System.IServiceProvider serviceProvider) { }
+        public void Dispose() { }
+        public Amazon.DynamoDBv2.IAmazonDynamoDB GetClient(string clientName = "") { }
+    }
+    [Hardened.Shared.Runtime.Attributes.HardenedModule]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class DynamoDbModule : DependencyModules.Runtime.Interfaces.IDependencyModule
+    {
+        public DynamoDbModule() { }
+        public Microsoft.Extensions.DependencyInjection.ServiceProvider CreateServiceProvider(Hardened.Shared.Runtime.Application.IHardenedEnvironment environment, System.Action<Hardened.Shared.Runtime.Application.IHardenedEnvironment, Microsoft.Extensions.DependencyInjection.IServiceCollection>? overrideDependencies, System.Action<Microsoft.Extensions.Logging.ILoggingBuilder>? loggingBuilderAction, System.Action<Hardened.Shared.Runtime.Application.IHardenedEnvironment, Microsoft.Extensions.DependencyInjection.IServiceCollection>? initDependencies = null) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public void PopulateServiceCollection(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public class ConfigurationProvider : Hardened.Shared.Runtime.Configuration.IConfigurationPackage
+        {
+            public ConfigurationProvider() { }
+            public System.Collections.Generic.IEnumerable<Hardened.Shared.Runtime.Configuration.IConfigurationValueAmender> ConfigurationValueAmenders(Hardened.Shared.Runtime.Application.IHardenedEnvironment environment) { }
+            public System.Collections.Generic.IEnumerable<Hardened.Shared.Runtime.Configuration.IConfigurationValueProvider> ConfigurationValueProviders(Hardened.Shared.Runtime.Application.IHardenedEnvironment environment) { }
+        }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class DynamoDbModuleAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider
+    {
+        public DynamoDbModuleAttribute() { }
+        public DependencyModules.Runtime.Interfaces.IDependencyModule GetModule() { }
+    }
+    [Hardened.Shared.Runtime.Attributes.ConfigurationModel]
+    public class DynamoDbOptions : Hardened.Aws.DynamoDbClient.IDynamoDbOptions
+    {
+        public DynamoDbOptions() { }
+        public System.Collections.Generic.Dictionary<string, System.Func<System.IServiceProvider, Amazon.DynamoDBv2.IAmazonDynamoDB>> Clients { get; set; }
+        public System.Func<System.IServiceProvider, Amazon.DynamoDBv2.IAmazonDynamoDB>? DefaultClient { get; set; }
+        public string Region { get; set; }
+        public string ServiceUrl { get; set; }
+    }
+    public interface IDynamoDbClientProvider
+    {
+        Amazon.DynamoDBv2.IAmazonDynamoDB GetClient(string clientName = "");
+    }
+    public interface IDynamoDbOptions
+    {
+        System.Collections.Generic.Dictionary<string, System.Func<System.IServiceProvider, Amazon.DynamoDBv2.IAmazonDynamoDB>> Clients { get; }
+        System.Func<System.IServiceProvider, Amazon.DynamoDBv2.IAmazonDynamoDB>? DefaultClient { get; }
+        string Region { get; }
+        string ServiceUrl { get; }
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Hardened.PublicApi.Tests.csproj
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Hardened.PublicApi.Tests.csproj
@@ -40,6 +40,8 @@
         <ProjectReference Include="..\..\Clients\Hardened.Kiota.Testing\Hardened.Kiota.Testing.csproj"/>
         <ProjectReference Include="..\..\Functions\Hardened.Functions.Runtime\Hardened.Functions.Runtime.csproj"/>
         <ProjectReference Include="..\..\Functions\Hardened.Functions.Testing\Hardened.Functions.Testing.csproj"/>
+        <ProjectReference Include="..\..\Clouds\Aws\Hardened.Aws.DynamoDbClient\Hardened.Aws.DynamoDbClient.csproj"/>
+        <ProjectReference Include="..\..\Clouds\Aws\Hardened.Aws.DynamoDbClient.Testing\Hardened.Aws.DynamoDbClient.Testing.csproj"/>
         <ProjectReference Include="..\..\Clouds\Aws\Hardened.Aws.Lambda.Testing\Hardened.Aws.Lambda.Testing.csproj"/>
         <ProjectReference Include="..\..\Clouds\Aws\Hardened.Aws.Lambda\Hardened.Aws.Lambda.csproj"/>
         <ProjectReference Include="..\..\Clients\Hardened.Refit.Testing\Hardened.Refit.Testing.csproj"/>

--- a/src/PublicApi/Hardened.PublicApi.Tests/PublicApiSurfaceTests.cs
+++ b/src/PublicApi/Hardened.PublicApi.Tests/PublicApiSurfaceTests.cs
@@ -33,6 +33,8 @@ public class PublicApiSurfaceTests {
 
     /// <summary>Every shipped net8.0 assembly, by name.</summary>
     private static readonly string[] Shipped = [
+        "Hardened.Aws.DynamoDbClient",
+        "Hardened.Aws.DynamoDbClient.Testing",
         "Hardened.Aws.Lambda.ApiGateway",
         "Hardened.Aws.Lambda.DynamoDb",
         "Hardened.Aws.Lambda.EventBridge",


### PR DESCRIPTION
Brings `Hardened.Amz.DynamoDbClient` and `Hardened.Amz.DynamoDbClient.Testing` onto this line as `Hardened.Aws.DynamoDbClient` and `Hardened.Aws.DynamoDbClient.Testing`.

## Why these two and not the rest

#305 replaced the AWS line host by host, and its removal of the Amz source took these with it. They were not hosts. A client provider and a Testcontainers attribute bind `Hardened.Shared.Runtime` and `Hardened.Shared.Testing` and nothing on the seam that was rebuilt, so nothing about them was made wrong and dropping them lost working code with no successor and no note.

Nothing at 0.30 replaces either. `Hardened.Aws.Lambda.DynamoDb` is the Streams adapter, and the shared name makes the gap easy to miss reading the package list. `[LocalDynamoDb]` in particular has no substitute at any version: it puts DynamoDB Local behind the application's own `IDynamoDbClientProvider` with no test method changing.

Two smaller signs the drop was incidental rather than decided. The release notes do not mention them, and `AWSSDK.DynamoDBv2` and `Testcontainers.DynamoDb` are still pinned in `Directory.Packages.props` with no project referencing them. They have a consumer again. `Amazon.CDK.Lib` and `Cdklabs.CdkMonitoringConstructs` are still orphaned there and are not addressed here.

## What is in the diff

Source restored from `03e25e12^` rather than rewritten, `Amz` renamed to `Aws` throughout, and the three projects placed flat under `src/Clouds/Aws` beside the Lambda packages. Relative paths shorten by two levels with the move.

Three changes beyond the rename, each to match what the other `Hardened.Aws` projects now do:

- `PrivateAssets="all"` on the analyzer `ProjectReference`s, which every sibling has and the packable project was missing.
- `OutputType=Exe` on the test project, for self-executing xUnit v3.
- A comment about using xunit.v3 "rather than the xunit 2.9 the other test projects here use" deleted. Nothing here uses xunit 2.x.

Wiring: `Hardened.slnx` edited directly, both packages added to `Shipped` and to the PublicApi project references with their surfaces approved, the pack list in `release.yaml` extended and `EXPECTED` moved 42 to 44. `framework.slnf` is untouched, since it holds no `Clouds` projects.

Docs: `aws/dynamodb`, `aws/testing`, `reference/attributes` and `reference/packages` moved onto the new names, and `aws/dynamodb`'s source link now points into this repository instead of at a path in Hardened.Amz. The rest of the AWS section still describes the frozen 0.22 line and is left alone.

`AGENTS.md` and `reference/repository` both said the Amz source earns no place here. That is now true of the hosts rather than of the line, and both name the test for any future exception: the package touches no host.

## Checks

- 24 tests pass against 0.30 unchanged, none skipped, container tests included. That is the evidence that nothing here needed rewriting.
- `PublicApiSurfaceTests` green at 35, with the two new approved files in the diff for review.
- `dotnet build Hardened.slnx` clean. Under `-p:ContinuousIntegrationBuild=true` the only failure is `HSMT011`, the Smithy CLI on this machine being 1.56.0 against the 1.73.0 pin, which is documented in AGENTS.md and unrelated to these files. Both new projects build clean with the CI flags.
- `npm run build` under `docs/` succeeds, so no dead internal links.

## Notes for review

- **No coverage baseline entries.** An assembly the run reports that the baseline does not name is printed rather than fatal, and AGENTS.md says never to write a baseline from a local run. Take both floors from the first CI run here.
- The approved surface shows `LocalDynamoDbAttribute` implementing `IHardenedOrderedAttribute`, which it did not before. That is inherited from `IHardenedTestDependencyRegistrationAttribute` at 0.30 and is not a change to this code.
- These ship on 0.31.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)