### PR TITLE
Run the Lambda host's startup services, and make generated responses match the document that declares them

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,6 +243,31 @@ jobs:
           fi
           echo "The pack list covers every packable project."
 
+          # The blind spot in the check above: it reads the XML rather than asking MSBuild, so it
+          # sees a project that says IsPackable and not one that is packable because the SDK's
+          # default says so. A library project that simply omits the property is packable, absent
+          # from the list, and invisible to every check here - the one remaining way this list can
+          # drift silently, after six times that it has.
+          #
+          # Closed by requiring the answer to be written down. A test project inherits
+          # IsPackable=false from Microsoft.NET.Test.Sdk and is exempt; everything else under src
+          # says true or false in its own file, and then the grep above is exhaustive.
+          UNDECLARED=""
+          while IFS= read -r project; do
+            grep -q "IsPackable" "$project" && continue
+            grep -q "Microsoft.NET.Test.Sdk" "$project" && continue
+            UNDECLARED="$UNDECLARED $(basename "$project" .csproj)"
+          done < <(find src -name '*.csproj' \
+                     -not -path '*/obj/*' \
+                     -not -path '*/Hardened.Templates/templates/*' \
+                     | sort)
+
+          if [ -n "$UNDECLARED" ]; then
+            echo "::error::These projects declare no <IsPackable>, so the check above cannot see whether they ship:$UNDECLARED"
+            exit 1
+          fi
+          echo "Every project under src declares whether it packs."
+
       - name: Pack
         run: |
           for project in \

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -107,7 +107,14 @@
         <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
         <PackageVersion Include="Amazon.Lambda.Core" Version="3.3.0" />
         <PackageVersion Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.1" />
-        <PackageVersion Include="Amazon.Lambda.Logging.AspNetCore" Version="3.1.0" />
+        <!--
+          The ILogger provider a Lambda entry point installs, in place of the console one. It writes
+          through Amazon.Lambda.Core's LambdaLogger rather than Console.Out; see the function
+          template's Program.cs for why that matters. 5.0.1 rather than the 3.1.0 this was pinned at
+          because 3.x reports every line to the platform as Trace with the real severity embedded in
+          the message text, so a level filter or an alarm keyed on it matches nothing.
+        -->
+        <PackageVersion Include="Amazon.Lambda.Logging.AspNetCore" Version="5.0.1" />
         <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.2.0" />
         <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.3" />
         <PackageVersion Include="Amazon.Lambda.SNSEvents" Version="2.1.0" />

--- a/docs/design/generator-diagnostics.md
+++ b/docs/design/generator-diagnostics.md
@@ -418,6 +418,7 @@ error, with no `NoWarn`: there is no reading of zero that means anything else.
 | `HOAG020` | An operation declares a markup content type but names no view to render it. |
 | `HRDR0xx`, `HRDV0xx`, `HRDW0xx` | Runtime, validation and web generators. The ones with an entry have a section above. |
 | `HRDAZ001`–`HRDAZ004`, `HRDAZ010` | The Azure Functions generator and the runtime package's build check; see below. |
+| `HRDT001` | The testing package's build check; see below. |
 | `HRDOA001` | `<HardenedOpenApiVersion>` is not 3.0.0, 3.1.0 or 3.2.0. |
 | `HRDOA002` | Warning. A streamed response under a document version with no `itemSchema`; the operation is described as an array of the item under `schema`, so a client generated from the document reads a list rather than a stream. |
 | `HRDOA003` | Warning. `[Enable<OpenApiDocumentPublishing>]` sits on a module declaring no routes, so the document is empty. |
@@ -473,6 +474,19 @@ executable that references the runtime package and not `Microsoft.Azure.Function
 builds, but nothing writes `worker.config.json`, `functions.metadata` or the host's extensions,
 so the host starts no worker and indexes nothing. The runtime package does not reference the Sdk
 itself, because the Sdk is a build-time package the application has to own.
+
+## Testing (HRDT)
+
+### HRDT001 — a test project references no runner package
+
+Raised by `Hardened.Shared.Testing`'s targets rather than by a generator. `[HardenedTest]` ships in
+`Hardened.Shared.Testing.xUnit` and `Hardened.Shared.Testing.NUnit`; the neutral package holds the
+entry point attribute, `ITestContext` and the seam a runner fills. A project on the layout that
+predates the split gets one `CS0246` per test method — forty across four projects in one migration,
+all saying the same thing and none of them saying which package to add.
+
+A warning, because referencing the neutral package without writing a `[HardenedTest]` is
+legitimate.
 
 ## Description build tasks (HOAT, HSMT)
 

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hosting/HardenedLambdaBootstrap.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hosting/HardenedLambdaBootstrap.cs
@@ -1,5 +1,6 @@
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.Core;
+using Hardened.Shared.Runtime.Application;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.Aws.Lambda.Runtime.Hosting;
@@ -9,10 +10,10 @@ namespace Hardened.Aws.Lambda.Runtime.Hosting;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The whole of an application's entry point:
+/// The whole of an application's entry point, once the container is built:
 /// </para>
 /// <code>
-/// await HardenedLambdaBootstrap.Run(new Application());
+/// await HardenedLambdaBootstrap.Run(services.BuildServiceProvider());
 /// </code>
 /// <para>
 /// <b>The container is built before the loop starts, on purpose.</b> Everything a request resolves
@@ -31,9 +32,21 @@ public static class HardenedLambdaBootstrap {
     /// <param name="cancellationToken">
     /// Stops the loop. See the overload below for why a deployed function never uses it.
     /// </param>
-    public static Task Run(
-        IServiceProvider serviceProvider, CancellationToken cancellationToken = default) =>
-        Run(serviceProvider.GetRequiredService<LambdaInvocationHandler>(), cancellationToken);
+    public static async Task Run(
+        IServiceProvider serviceProvider, CancellationToken cancellationToken = default) {
+        // Through the guard, so the services run once per provider however the host was reached -
+        // the same call KestrelServerRunner.StartAsync makes, and for the same reason.
+        //
+        // Nothing here ran it, and a Lambda has no other start signal: the runtime hands over an
+        // invocation and that is the whole lifecycle. So AuthenticationStartupService installed no
+        // middleware, AuthorizationStartupService installed no filter provider and CorsStartupService
+        // never ran - every request arrived anonymous, every route was open, and nothing said so.
+        // Invisible from inside this repository because every test host starts the provider itself,
+        // and only the deployed function was open.
+        await ApplicationLogic.Start(serviceProvider, null);
+
+        await Run(serviceProvider.GetRequiredService<LambdaInvocationHandler>(), cancellationToken);
+    }
 
     /// <summary>
     /// Serves invocations against a handler built by hand, for a host that assembles its own.

--- a/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.Rie.Tests/LambdaRuntimeInterfaceEmulator.cs
+++ b/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.Rie.Tests/LambdaRuntimeInterfaceEmulator.cs
@@ -28,6 +28,28 @@ public sealed class LambdaRuntimeInterfaceEmulator : IAsyncDisposable {
 
     private const int Port = 8080;
 
+    /// <summary>
+    /// A path the emulator does not serve, used to prove that it is answering.
+    /// </summary>
+    /// <remarks>
+    /// Anything except <c>/2015-03-31/functions/function/invocations</c>. A readiness probe must not
+    /// be an invocation: the emulator reserves a single slot for one, and a probe would spend it.
+    /// </remarks>
+    private const string ReadinessPath = "/hardened-readiness-probe";
+
+    /// <summary>
+    /// How long the emulator gets to start answering. Bounded, so a container that never comes up
+    /// fails its fixture rather than holding the run open.
+    /// </summary>
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// How long one invocation gets. Generous, because the first one starts the runtime and the
+    /// application inside the container: that costs 0.2 s with a full core and 20 s with a twentieth
+    /// of one, so this is headroom rather than an expectation.
+    /// </summary>
+    private static readonly TimeSpan InvocationTimeout = TimeSpan.FromSeconds(120);
+
     private readonly IContainer _container;
 
     /// <param name="outputDirectory">The function's build output, mounted at <c>/var/task</c>.</param>
@@ -44,7 +66,20 @@ public sealed class LambdaRuntimeInterfaceEmulator : IAsyncDisposable {
             .WithPortBinding(Port, assignRandomHostPort: true)
             // From the host rather than inside the container: the Lambda image is minimal and an
             // in-container probe depends on tools it may not carry.
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilExternalTcpPortIsAvailable(Port))
+            //
+            // An HTTP request rather than a TCP connect. Docker's port proxy accepts a connection
+            // whatever the container is doing, so UntilExternalTcpPortIsAvailable was satisfied about
+            // ten milliseconds after start at every CPU share from four cores down to a twentieth of
+            // one - long before the emulator was listening. The first invocation then failed at the
+            // transport, and the retry that covered it is what wedged the emulator; see InvokeAsync.
+            //
+            // Any status counts, because the point is that the emulator answered, and the path is one
+            // it does not serve. It replies 404, and a future version replying something else would
+            // still be answering.
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(
+                    request => request.ForPort(Port).ForPath(ReadinessPath).ForStatusCodeMatching(_ => true),
+                    strategy => strategy.WithTimeout(StartupTimeout)))
             .Build();
     }
 
@@ -56,27 +91,40 @@ public sealed class LambdaRuntimeInterfaceEmulator : IAsyncDisposable {
     /// <summary>
     /// One invocation, as the Invoke API would report it.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Sent once. An invocation is not safe to retry: the emulator reserves a single slot for the one
+    /// it is serving, and a second arriving while that reservation is held fails it with
+    /// <c>ReserveFailed: AlreadyReserved</c> and panics the emulator, after which nothing answers the
+    /// first request either. That is what the retry this replaced did, because a transport error on
+    /// the way back is no evidence the invocation was not accepted.
+    /// </para>
+    /// <para>
+    /// The retry existed to cover a container that was not listening yet, which the wait strategy now
+    /// establishes before any of this runs.
+    /// </para>
+    /// </remarks>
     public async Task<InvocationResult> InvokeAsync(string payload, CancellationToken cancellationToken = default) {
         var url = $"http://{_container.Hostname}:{_container.GetMappedPublicPort(Port)}/2015-03-31/functions/function/invocations";
 
-        // Generous, because the first invocation starts the runtime and the application inside it.
-        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(120) };
+        using var client = new HttpClient { Timeout = InvocationTimeout };
 
-        // Docker's port proxy accepts a connection before the emulator behind it listens, so the
-        // first request after start can be refused or reset. A few attempts, spaced out, is the
-        // whole of the cold-start handling; a real failure still surfaces after the last one.
-        HttpResponseMessage response = null!;
+        HttpResponseMessage response;
 
-        for (var attempt = 1; ; attempt++) {
-            try {
-                response = await client.PostAsync(
-                    url, new StringContent(payload, Encoding.UTF8, "application/json"), cancellationToken);
+        try {
+            response = await client.PostAsync(
+                url, new StringContent(payload, Encoding.UTF8, "application/json"), cancellationToken);
+        }
+        // The emulator accepted the request and never answered, which on its own reports as nothing
+        // but elapsed time. The reason is in the container's log, and the usual one is the panic
+        // above, so the log is what the failure carries. Not the caller's own cancellation, which is
+        // the test being torn down and is not this class's to explain.
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested) {
+            var (stdout, stderr) = await _container.GetLogsAsync(ct: CancellationToken.None);
 
-                break;
-            }
-            catch (HttpRequestException) when (attempt < 5) {
-                await Task.Delay(TimeSpan.FromSeconds(attempt), cancellationToken);
-            }
+            throw new TimeoutException(
+                $"The emulator did not answer an invocation within {InvocationTimeout.TotalSeconds:0} s. " +
+                $"It printed:\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}", exception);
         }
 
         using var _ = response;

--- a/src/Clouds/Aws/IntegrationTests/Runtime/Hardened.IntegrationTests.LambdaRuntime.Tests/LambdaRuntimeLoopTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/Runtime/Hardened.IntegrationTests.LambdaRuntime.Tests/LambdaRuntimeLoopTests.cs
@@ -2,7 +2,10 @@ using System.Text.Json;
 using DependencyModules.Testing.Attributes;
 using Hardened.Aws.Lambda.Runtime.Hosting;
 using Hardened.IntegrationTests.Sqs.SUT;
+using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Testing.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -98,5 +101,58 @@ public class LambdaRuntimeLoopTests {
 
         Assert.True(answer.Failed);
         Assert.Contains("handler refused the order", answer.Body);
+    }
+
+    /// <summary>A startup service that records that it ran, and nothing else.</summary>
+    private sealed class Probe : IStartupService {
+        public bool Ran;
+
+        public Task<bool> Startup(IServiceProvider rootProvider) {
+            Ran = true;
+
+            return Task.FromResult(true);
+        }
+    }
+
+    /// <summary>
+    /// The startup services run, over a provider the function built itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Its own provider rather than the injected one, and that is the whole point. Every test host
+    /// in this repository calls <c>ApplicationLogic.Start</c> before it hands a provider out, so a
+    /// test taking one asserts against a container something else already started - which is why
+    /// nothing here noticed that the bootstrap never started one. This builds the container the way
+    /// <c>Program.cs</c> does and leaves the bootstrap as the only thing that could have run them.
+    /// </para>
+    /// <para>
+    /// The startup set is the middleware chain: authentication installs its middleware there,
+    /// authorization installs its filter provider, CORS installs its configuration. A function that
+    /// skips it serves every request anonymous and every route open, with nothing logged.
+    /// </para>
+    /// <para>
+    /// In this class rather than a file of its own, because the runtime client reads its address
+    /// from the environment and xUnit runs two classes as two collections in parallel - which is two
+    /// tests writing one process-wide variable.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task TheBootstrapRunsTheStartupServicesOnTheProviderItIsGiven() {
+        var probe = new Probe();
+
+        var services = new ServiceCollection();
+
+        services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.None));
+        services.AddTransient<IHardenedEnvironment>(_ => new EnvironmentImpl("test"));
+        services.AddSingleton(Substitute.For<IOrderStore>());
+        services.AddSingleton<IStartupService>(probe);
+
+        new SqsTestApp().PopulateServiceCollection(services);
+
+        Assert.False(probe.Ran);
+
+        await Serve(services.BuildServiceProvider(), OneOrder);
+
+        Assert.True(probe.Ran);
     }
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ArrayResponseTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/ArrayResponseTests.cs
@@ -46,4 +46,34 @@ public class ArrayResponseTests {
 
         Assert.NotEmpty(response.Deserialize<List<Pet>>()!);
     }
+
+    /// <summary>
+    /// An optional member the handler left empty is absent from the body rather than null.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>tag</c> is optional and not nullable, which says "may be absent, and is a string if
+    /// present" - so <c>"tag":null</c> is a body this document forbids. Buddy has no tag and Luna
+    /// has one, so both halves are in the same response.
+    /// </para>
+    /// <para>
+    /// The cost of the null was on the client: a generated <c>string tag</c> - which is what
+    /// Refitter writes, and what a Swift <c>Codable</c> struct produces - fails to read it. Kiota
+    /// makes every property nullable and read it happily, which is why this went unnoticed until a
+    /// consumer changed generators.
+    /// </para>
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnOptionalMemberWithNoValueIsAbsentRatherThanNull(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/pets");
+
+        response.Assert.Ok();
+        response.Body.Position = 0;
+
+        using var reader = new StreamReader(response.Body, leaveOpen: true);
+        var body = await reader.ReadToEndAsync();
+
+        Assert.DoesNotContain("null", body);
+        Assert.Contains("\"tag\":\"dog\"", body);
+    }
 }

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/DescribedSecurityTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Hardened.Requests.Testing;
 using Hardened.Web.Runtime.Responses;
 
@@ -46,6 +47,61 @@ public class DescribedSecurityTests {
         var response = await testWebApp.Get("/secured/either");
 
         Assert.Equal(401, response.StatusCode);
+    }
+
+    /// <summary>
+    /// The refusal answers the body the operation declared for that status.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>securedEither</c> declares its 401 as a <c>Problem</c>. The refusal comes from
+    /// <c>AuthorizationFilter</c> rather than from the handler, so the exception carries no body it
+    /// could have written - and the converter answered its generic <c>ErrorModel</c>:
+    /// <c>{"type":"AuthorizationException",…}</c>, an undescribed shape at a described status. A
+    /// client generated from the same document has a typed branch for <c>Problem</c> and none for
+    /// that, so it fails to read its own service's refusal.
+    /// </para>
+    /// <para>
+    /// The instance is the one the build generated from the schema, holding the status and its
+    /// reason phrase and nothing about the request - the same instances a null return writes.
+    /// </para>
+    /// </remarks>
+    [HardenedTest]
+    public async Task ADeclaredRefusalAnswersTheDeclaredBody(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/either");
+
+        Assert.Equal(401, response.StatusCode);
+
+        response.Body.Position = 0;
+
+        using var document = await JsonDocument.ParseAsync(response.Body);
+
+        Assert.Equal(401, document.RootElement.GetProperty("status").GetInt32());
+        Assert.Equal("Unauthorized", document.RootElement.GetProperty("title").GetString());
+
+        // The generic body's members, which the document never described for this status.
+        Assert.False(document.RootElement.TryGetProperty("message", out _));
+    }
+
+    /// <summary>
+    /// And an operation that declares no body for its 401 keeps the generic one.
+    /// </summary>
+    /// <remarks>
+    /// The control on the rule above. <c>securedScoped</c> declares no 401 of its own, so the
+    /// document publishes the framework's <c>ErrorModel</c> for it and the refusal has to keep
+    /// sending that.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ARefusalWithNoDeclaredBodyKeepsTheGenericOne(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/secured/scoped");
+
+        Assert.Equal(401, response.StatusCode);
+
+        response.Body.Position = 0;
+
+        using var document = await JsonDocument.ParseAsync(response.Body);
+
+        Assert.Equal("AuthorizationException", document.RootElement.GetProperty("type").GetString());
     }
 
     /// <summary>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -166,6 +166,19 @@ paths:
             application/json:
               schema:
                 type: string
+        # The one operation here that declares the body of its own refusal, where securedScoped
+        # above lets the framework synthesize one. Nothing in this application throws it: the
+        # authorization filter refuses before the handler runs, with an AuthorizationException that
+        # carries no body of its own - so this declaration is the only thing that can say what shape
+        # a 401 answers with, and the pipeline has to read it back. Declaring it replaces the
+        # synthesized 401 whole, which is why this one carries no WWW-Authenticate: the challenge is
+        # still sent, and securedScoped is where the document declares it.
+        '401':
+          description: Authentication required.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /orders:
     post:
       tags:

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
@@ -734,18 +734,10 @@
           },
           "401": {
             "description": "Authentication required.",
-            "headers": {
-              "WWW-Authenticate": {
-                "description": "The challenge naming the scheme to authenticate with.",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorModel"
+                  "$ref": "#/components/schemas/Problem"
                 }
               }
             }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -408,6 +408,7 @@ namespace Hardened.Requests.Abstract.Execution
     public interface IExecutionRequestHandlerInfo
     {
         string? BodyParameterName { get; }
+        System.Collections.Generic.IReadOnlyDictionary<int, object> DeclaredErrorBodies { get; }
         int? FailureStatus { get; }
         System.Type HandlerType { get; }
         string InvokeMethod { get; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -305,8 +305,9 @@ namespace Hardened.Requests.Runtime.Execution
     }
     public class ExecutionRequestHandlerInfo : Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo
     {
-        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null, Hardened.Requests.Abstract.Authorization.Requirement? requirement = null, int? successStatus = default, object? nullResponseBody = null, System.Collections.Generic.IReadOnlyList<string>? producedContentTypes = null, string? bodyParameterName = null, int? validationErrorStatus = default, Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? timeout = null, bool streamsResponse = false) { }
+        public ExecutionRequestHandlerInfo(string path, string method, System.Type handlerType, string invokeMethod, System.Collections.Generic.IReadOnlyList<Hardened.Requests.Abstract.Execution.IExecutionRequestParameter>? parameters = null, System.Collections.Generic.IReadOnlyList<object>? metadata = null, Hardened.Requests.Abstract.Authorization.Requirement? requirement = null, int? successStatus = default, object? nullResponseBody = null, System.Collections.Generic.IReadOnlyList<string>? producedContentTypes = null, string? bodyParameterName = null, int? validationErrorStatus = default, Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? timeout = null, bool streamsResponse = false, System.Collections.Generic.IReadOnlyDictionary<int, object>? declaredErrorBodies = null) { }
         public string? BodyParameterName { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<int, object> DeclaredErrorBodies { get; }
         public System.Type HandlerType { get; }
         public string InvokeMethod { get; }
         public System.Collections.Generic.IReadOnlyList<object> Metadata { get; }

--- a/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Execution/IExecutionRequestHandlerInfo.cs
@@ -113,6 +113,41 @@ public interface IExecutionRequestHandlerInfo {
     /// </remarks>
     int? ValidationErrorStatus => null;
 
+    /// <summary>
+    /// The body the operation declares for a status, for the refusals the pipeline raises itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A generated instance of the schema the description declared for that status, holding the
+    /// status and its reason phrase and nothing else - the same instances
+    /// <see cref="NullResponseBody"/> is taken from, and shared with it.
+    /// </para>
+    /// <para>
+    /// Read only where the exception carries no body of its own. A handler that throws the
+    /// generated exception type has written one, and that one wins; a refusal the framework raises
+    /// has none, because <c>AuthorizationException</c> and its siblings cannot know the shape a
+    /// document declared. Without this a contract-first application published a <c>Problem</c> for
+    /// its 401 and answered <c>{"type":"AuthorizationException",…}</c> - an undescribed shape at a
+    /// described status, which a generated client has no branch for.
+    /// </para>
+    /// <para>
+    /// Empty means the description declared no body for any status it names, which leaves every
+    /// refusal answering the generic <c>ErrorModel</c> exactly as it did.
+    /// </para>
+    /// </remarks>
+    IReadOnlyDictionary<int, object> DeclaredErrorBodies => NoDeclaredErrorBodies;
+
+    /// <summary>
+    /// What <see cref="DeclaredErrorBodies"/> answers where nothing was declared.
+    /// </summary>
+    /// <remarks>
+    /// A field rather than a fresh instance, because a default member is evaluated on every read
+    /// and this one is read on every refusal. <c>Array.Empty</c> is what the members above use;
+    /// there is no dictionary equivalent to reach for.
+    /// </remarks>
+    private static readonly IReadOnlyDictionary<int, object> NoDeclaredErrorBodies =
+        new Dictionary<int, object>();
+
     IReadOnlyList<IExecutionRequestParameter> Parameters { get; }
 
     IReadOnlyList<object> Metadata => Array.Empty<object>();

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/ExceptionToModelConverterTests.cs
@@ -28,19 +28,22 @@ public class ExceptionToModelConverterTests {
     /// The status the operation's contract declared for validation failures, or null for an
     /// operation that declared none.
     /// </param>
-    private static IExecutionContext Context(int? validationErrorStatus = null) {
+    private static IExecutionContext Context(
+        int? validationErrorStatus = null,
+        IReadOnlyDictionary<int, object>? declaredErrorBodies = null) {
         var response = Substitute.For<IExecutionResponse>();
         response.Headers.Returns(new Dictionary<string, StringValues>());
 
         var context = Substitute.For<IExecutionContext>();
         context.Response.Returns(response);
 
-        if (validationErrorStatus != null) {
+        if (validationErrorStatus != null || declaredErrorBodies != null) {
             // The type the pipeline carries, rather than a substitute: ValidationErrorStatus is a
             // default interface member, and a stub for it would prove the stub works.
             context.HandlerInfo.Returns(new ExecutionRequestHandlerInfo(
                 "/events", "POST", typeof(ExceptionToModelConverterTests), "Handle",
-                validationErrorStatus: validationErrorStatus));
+                validationErrorStatus: validationErrorStatus,
+                declaredErrorBodies: declaredErrorBodies));
         }
 
         return context;
@@ -349,6 +352,86 @@ public class ExceptionToModelConverterTests {
 
         Assert.Equal(409, status);
         Assert.Equal("already exists", Assert.IsType<ErrorModel>(model).Message);
+    }
+
+    /// <summary>
+    /// A refusal with no body of its own answers the one the contract declared for that status.
+    /// </summary>
+    /// <remarks>
+    /// The refusals the pipeline raises are the whole reason this exists.
+    /// <c>AuthorizationException</c> is a <c>StatusCodeException</c> built with <c>value: null</c>,
+    /// so an application whose document declares a <c>Problem</c> for its 401 answered the generic
+    /// model instead - an undescribed shape at a described status.
+    /// </remarks>
+    [Fact]
+    public void ARefusalWithNoBodyAnswersTheDeclaredOne() {
+        var declared = new { Title = "Unauthorized", Status = 401 };
+
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(declaredErrorBodies: new Dictionary<int, object> { { 401, declared } }),
+            new StatusCodeException(401, value: null, message: "authentication required"));
+
+        Assert.Equal(401, status);
+        Assert.Same(declared, model);
+    }
+
+    /// <summary>
+    /// And a status the contract declared nothing for keeps the generic model.
+    /// </summary>
+    [Fact]
+    public void ARefusalAtAnUndeclaredStatusKeepsTheGenericModel() {
+        var (status, model) = Converter.ConvertExceptionToModel(
+            Context(declaredErrorBodies: new Dictionary<int, object> {
+                { 401, new { Title = "Unauthorized" } }
+            }),
+            new StatusCodeException(403, value: null, message: "forbidden"));
+
+        Assert.Equal(403, status);
+        Assert.Equal("forbidden", Assert.IsType<ErrorModel>(model).Message);
+    }
+
+    /// <summary>
+    /// An implementation that predates the member reads as declaring nothing.
+    /// </summary>
+    /// <remarks>
+    /// <c>DeclaredErrorBodies</c> is a default interface member for that reason, and this is the
+    /// stub the default is for: an application's own <c>IExecutionRequestHandlerInfo</c>, compiled
+    /// before the member existed, still loads and still answers.
+    /// </remarks>
+    [Fact]
+    public void AHandlerThatDeclaresNothingReadsAsEmpty() {
+        // Through the interface, because the member is a default one: a call on the class would
+        // not compile, which is the whole shape being pinned.
+        IExecutionRequestHandlerInfo handlerInfo = new MinimalHandlerInfo();
+
+        Assert.Empty(handlerInfo.DeclaredErrorBodies);
+
+        var context = Substitute.For<IExecutionContext>();
+        var response = Substitute.For<IExecutionResponse>();
+
+        response.Headers.Returns(new Dictionary<string, StringValues>());
+        context.Response.Returns(response);
+        context.HandlerInfo.Returns(handlerInfo);
+
+        var (status, model) = Converter.ConvertExceptionToModel(
+            context, new StatusCodeException(401, value: null, message: "authentication required"));
+
+        Assert.Equal(401, status);
+        Assert.Equal("authentication required", Assert.IsType<ErrorModel>(model).Message);
+    }
+
+    /// <summary>An implementation of the interface that overrides none of its default members.</summary>
+    private sealed class MinimalHandlerInfo : IExecutionRequestHandlerInfo {
+        public string Path => "/secured";
+
+        public string Method => "GET";
+
+        public Type HandlerType => typeof(ExceptionToModelConverterTests);
+
+        public string InvokeMethod => "Handle";
+
+        public IReadOnlyList<IExecutionRequestParameter> Parameters { get; } =
+            Array.Empty<IExecutionRequestParameter>();
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -52,6 +52,17 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
 
             var declaredValue = exp is StatusCodeException { Value: { } value } ? value : null;
 
+            // The body the operation declared for that status, where the exception carried none.
+            //
+            // A refusal the pipeline raises rather than the handler has no body it could carry:
+            // AuthorizationException is a StatusCodeException built with value: null, so a
+            // contract-first application whose document declares a Problem for its 401 answered
+            // {"type":"AuthorizationException",...} instead - an undescribed shape at a described
+            // status, and a generated client has a typed branch for the declared body and none for
+            // that one. The same place the declared validation status is read from, and for the
+            // same reason: only the handler knows what its own contract promised.
+            declaredValue ??= Declared(context, statusCodeException.StatusCode);
+
             return (
                 statusCodeException.StatusCode,
                 declaredValue ?? new ErrorModel {
@@ -144,6 +155,21 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
         // and path at Error, which is where it belongs.
         return (500, ServerError);
     }
+
+    /// <summary>
+    /// The body the handler's contract declares for <paramref name="statusCode"/>, or null.
+    /// </summary>
+    /// <remarks>
+    /// One instance per (schema, status) for the life of the process, holding the status and its
+    /// reason phrase and nothing about the request - which is what makes sharing it safe, and what
+    /// keeps a refusal from revealing why it refused. A handler with more to say throws the
+    /// generated exception type, which carries a body it wrote.
+    /// </remarks>
+    private static object? Declared(IExecutionContext context, int statusCode) =>
+        context.HandlerInfo is { } handlerInfo &&
+        handlerInfo.DeclaredErrorBodies.TryGetValue(statusCode, out var body)
+            ? body
+            : null;
 
     /// <summary>
     /// The whole of what a caller learns from an unhandled exception.

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
@@ -19,7 +19,8 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         string? bodyParameterName = null,
         int? validationErrorStatus = null,
         TimeoutPolicy? timeout = null,
-        bool streamsResponse = false) {
+        bool streamsResponse = false,
+        IReadOnlyDictionary<int, object>? declaredErrorBodies = null) {
         Path = path;
         Method = method;
         HandlerType = handlerType;
@@ -34,7 +35,11 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
         ValidationErrorStatus = validationErrorStatus;
         Timeout = timeout ?? IExecutionRequestHandlerInfo.TimeoutFrom(Metadata);
         StreamsResponse = streamsResponse;
+        DeclaredErrorBodies = declaredErrorBodies ?? EmptyDeclaredErrorBodies;
     }
+
+    private static readonly IReadOnlyDictionary<int, object> EmptyDeclaredErrorBodies =
+        new Dictionary<int, object>();
 
     /// <summary>
     /// A copy of <paramref name="source"/> with the named members replaced.
@@ -77,7 +82,8 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
             source.BodyParameterName,
             source.ValidationErrorStatus,
             timeout ?? source.Timeout,
-            source.StreamsResponse) { }
+            source.StreamsResponse,
+            source.DeclaredErrorBodies) { }
 
     public string Path { get; }
 
@@ -115,6 +121,9 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
 
     /// <inheritdoc />
     public bool StreamsResponse { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<int, object> DeclaredErrorBodies { get; }
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/Shared/Hardened.Shared.Testing/Hardened.Shared.Testing.csproj
+++ b/src/Shared/Hardened.Shared.Testing/Hardened.Shared.Testing.csproj
@@ -23,6 +23,19 @@
         <PackageId>Hardened.Shared.Testing</PackageId>
     </PropertyGroup>
 
+    <!--
+      Raises HRDT001 on a test project that takes this package and neither runner package. The
+      attribute a runner discovers lives in those, and its absence used to arrive as one CS0246 per
+      test method. buildTransitive/ and Package\, for the reason Hardened.Requests.Abstract gives.
+    -->
+    <ItemGroup>
+        <Content Include="Package\Hardened.Shared.Testing.targets">
+            <Pack>true</Pack>
+            <PackagePath>buildTransitive/</PackagePath>
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>

--- a/src/Shared/Hardened.Shared.Testing/Package/Hardened.Shared.Testing.targets
+++ b/src/Shared/Hardened.Shared.Testing/Package/Hardened.Shared.Testing.targets
@@ -1,0 +1,32 @@
+<Project>
+    <!--
+        A test project that references this package and no runner package.
+
+        [HardenedTest] is not here. This package holds the entry point attribute, ITestContext and
+        the running-test seam; the attribute that a runner actually discovers ships in
+        Hardened.Shared.Testing.xUnit or Hardened.Shared.Testing.NUnit, and a project on the old
+        single-package layout gets one CS0246 per test method - forty of them across four projects
+        in one migration, all saying the same thing and none of them saying which package to add.
+
+        A warning rather than an error, because referencing this package without writing a
+        [HardenedTest] is legitimate: a project may want ITestContext or the entry point attribute
+        and drive its tests some other way. NoWarn silences it for those.
+
+        Read off @(PackageReference) rather than the resolved graph, because a runner package is
+        the test project's own choice and is always a direct reference - the framework's testing
+        packages deliberately depend on neither, so that one on Moq does not pull in NSubstitute.
+    -->
+    <Target Name="HardenedTestingRunnerReference"
+            BeforeTargets="CoreCompile"
+            Condition="'$(IsTestProject)' == 'true'">
+        <ItemGroup>
+            <_HardenedTestRunner Include="@(PackageReference)"
+                                 Condition="'%(Identity)' == 'Hardened.Shared.Testing.xUnit' Or
+                                            '%(Identity)' == 'Hardened.Shared.Testing.NUnit'" />
+        </ItemGroup>
+
+        <Warning Condition="'@(_HardenedTestRunner)' == ''"
+                 Code="HRDT001"
+                 Text="$(MSBuildProjectName) references Hardened.Shared.Testing and no runner package, so [HardenedTest] is not defined and every test method carrying it is CS0246. Add a PackageReference to Hardened.Shared.Testing.xUnit or Hardened.Shared.Testing.NUnit." />
+    </Target>
+</Project>

--- a/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/DefaultErrorBody.cs
@@ -97,6 +97,49 @@ internal static class DefaultErrorBody {
     public const int NullResponseStatus = 404;
 
     /// <summary>
+    /// The schema this operation declares a body of for each status it names, in status order.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A superset of <see cref="SchemaFor"/>, and for a different consumer. That one answers what a
+    /// null return writes; this one answers what a refusal writes when the exception carries no body
+    /// of its own - which is every refusal the pipeline raises rather than the handler, because a
+    /// framework exception has no way to know the shape a document declared.
+    /// </para>
+    /// <para>
+    /// The failure it closes: a description's <c>security</c> block compiles to
+    /// <c>Requirement.Authenticated()</c>, the filter refuses with an
+    /// <c>AuthorizationException</c> constructed with no value, and the converter fell through to
+    /// its generic <c>ErrorModel</c>. So a contract-first application answered an undescribed shape
+    /// at a described status, and a client generated from the same document had a typed branch for
+    /// the declared body and none for that one.
+    /// </para>
+    /// <para>
+    /// Every declared error rather than the refusals alone, because which statuses the pipeline
+    /// raises is not this assembly's to know: rate limiting answers 429, the negotiator 406, the
+    /// deadline 504. One collection, filled from the description, and the converter takes the entry
+    /// for whatever status was reached.
+    /// </para>
+    /// <para>
+    /// One schema per status, the first the description names. <c>components/responses</c> lets an
+    /// author bind two differently-bodied responses to one status on one operation, and a status
+    /// answers with one body.
+    /// </para>
+    /// </remarks>
+    public static IEnumerable<(string SchemaName, int StatusCode)> DeclaredBodies(
+        OperationModel operation) {
+        var seen = new HashSet<int>();
+
+        foreach (var error in operation.ErrorResponses) {
+            if (error.Ref == null || !seen.Add(error.StatusCode)) {
+                continue;
+            }
+
+            yield return (TypeMapper.GetRefName(error.Ref), error.StatusCode);
+        }
+    }
+
+    /// <summary>
     /// Every constructor argument for the instance, in declaration order, or null when a required
     /// member cannot be filled without inventing a value.
     /// </summary>

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/OperationModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/OperationModel.cs
@@ -18,6 +18,30 @@ internal class OperationModel : IEquatable<OperationModel> {
     }
 
     private string _methodName = "";
+
+    /// <summary>
+    /// The C# name of the container this operation's declared responses are returned in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Allocated by <c>NameAllocator</c> against the same scope the schemas take their names from,
+    /// because the container lands in the models namespace beside them and
+    /// <c>{Operation}Response</c> is one of the commonest schema names in OpenAPI. A contract with
+    /// an operation <c>sync</c> and a schema <c>SyncResponse</c> emitted the name twice into one
+    /// namespace: CS0101 for the type, and a CS0556 behind it, because the container's implicit
+    /// conversion from the schema became a conversion from itself.
+    /// </para>
+    /// <para>
+    /// Falls back to the derived form, so a model built by hand - which every emitter test does -
+    /// gets the name it always had without going through the allocator.
+    /// </para>
+    /// </remarks>
+    public string ResponseContainerName {
+        get => _responseContainerName.Length > 0 ? _responseContainerName : MethodName + "Response";
+        set => _responseContainerName = value ?? "";
+    }
+
+    private string _responseContainerName = "";
     public string Path { get; set; } = "";
     public string HttpMethod { get; set; } = "";
 
@@ -258,6 +282,7 @@ internal class OperationModel : IEquatable<OperationModel> {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
         return OperationId == other.OperationId && Path == other.Path &&
+               ResponseContainerName == other.ResponseContainerName &&
                HttpMethod == other.HttpMethod && DispatchKey == other.DispatchKey &&
                Tag == other.Tag && Tags.SequenceEqual(other.Tags) &&
                Summary == other.Summary &&

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/PropertyModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/PropertyModel.cs
@@ -80,6 +80,31 @@ internal class PropertyModel : IEquatable<PropertyModel>, IConstraintFacets {
     public bool ConstrainedAsRequired => IsRequired && !IsNullable && !IsReadOnly;
 
     /// <summary>
+    /// Whether a response leaves the member out rather than writing <c>null</c> into it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Optional and not nullable means "may be absent, and is of this type if present" - so
+    /// <c>null</c> is a value the document forbids. Nothing said so, and every generated model
+    /// wrote one for every optional member the handler had nothing to put in: a client whose
+    /// generated <c>expiresAt</c> is <c>long</c> - which is what the contract describes, and what a
+    /// Refitter interface and a Swift <c>Codable</c> struct both produce - refuses the body with
+    /// "Cannot get the value of a token type 'Null' as a number". Kiota makes every property
+    /// nullable and read the invalid payload happily, which is why it survived.
+    /// </para>
+    /// <para>
+    /// Required-and-nullable is the opposite case and is left alone: the document says the member is
+    /// always present and may be null, so writing the null is the contract being kept. Optional-and-
+    /// nullable permits both, and keeps what it did.
+    /// </para>
+    /// <para>
+    /// A header-bound member is already <c>[JsonIgnore]</c> in both directions, and a second ignore
+    /// attribute on one declaration does not compile.
+    /// </para>
+    /// </remarks>
+    public bool OmittedWhenNull => !IsRequired && !IsNullable && !IsHeaderBound;
+
+    /// <summary>
     /// The schema's <c>readOnly</c>: the property appears in responses and must not be sent in a
     /// request.
     /// </summary>

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ResponseSetPlan.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ResponseSetPlan.cs
@@ -125,12 +125,19 @@ internal static class ResponseSetPlan {
 
     /// <summary>The name the service interface returns for this operation.</summary>
     /// <remarks>
+    /// <para>
     /// Public because <c>ServiceInterfaceEmitter</c> names it in a signature and this is the only
     /// definition of the scheme. Deriving it a second time there is how a generated type and the
     /// signature that returns it come to disagree.
+    /// </para>
+    /// <para>
+    /// Read off the model rather than composed here, for the reason <see cref="ErrorCaseName"/>
+    /// gives: the container shares a namespace with the schemas, so whether it can keep the name it
+    /// wants needs the whole document. <c>NameAllocator</c> decided it.
+    /// </para>
     /// </remarks>
     public static string ContainerName(OperationModel operation) =>
-        operation.MethodName + "Response";
+        operation.ResponseContainerName;
 
     /// <summary>The case type for one declared success status.</summary>
     /// <remarks>

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -55,7 +55,13 @@ internal static class SpecModelSerializer {
     /// spec record - the <c>secscheme</c> records carrying declared security schemes, and each
     /// operation's <c>SecurityRequirements</c>. Bumped for the new record tag, same reasoning as 4.
     /// </remarks>
-    private const string Header = "#hardened-openapi-model 5";
+    /// <remarks>
+    /// 6 adds each operation's <c>ResponseContainerName</c>, which the name allocator decides
+    /// against the schemas rather than the emitter deriving it. Additive, and bumped anyway: a 5
+    /// reader handed a 6 file would find no name and re-derive the colliding one, which is the
+    /// silent half of the defect the allocation exists to close.
+    /// </remarks>
+    private const string Header = "#hardened-openapi-model 6";
 
     private const char FieldSeparator = '\t';
 
@@ -564,6 +570,7 @@ internal static class SpecModelSerializer {
         record.Add("OperationId", operation.OperationId);
         record.Add("Summary", operation.Summary);
         record.Add("MethodName", operation.MethodName);
+        record.Add("ResponseContainerName", operation.ResponseContainerName);
         record.Add("Path", operation.Path);
         record.Add("HttpMethod", operation.HttpMethod);
         record.Add("DispatchKey", operation.DispatchKey);
@@ -679,6 +686,7 @@ internal static class SpecModelSerializer {
 
     private static OperationModel ReadOperation(Record record) => new() {
         MethodName = record.String("MethodName") ?? "",
+        ResponseContainerName = record.String("ResponseContainerName") ?? "",
         OperationId = record.String("OperationId") ?? "",
         Path = record.String("Path") ?? "",
         HttpMethod = record.String("HttpMethod") ?? "",

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/DefaultErrorBodyEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/DefaultErrorBodyEmitter.cs
@@ -65,8 +65,8 @@ internal static class DefaultErrorBodyEmitter {
                 Indented = false
             };
             field.Comment = DocComment.Format(
-                $"The body a null return writes for {pair.StatusCode}. Holds the status and its " +
-                "reason phrase; nothing about the request that produced it.");
+                $"The body a null return or a refusal writes for {pair.StatusCode}. Holds the " +
+                "status and its reason phrase; nothing about the request that produced it.");
         }
     }
 
@@ -75,9 +75,9 @@ internal static class DefaultErrorBodyEmitter {
 
         holder.Modifiers |= ComponentModifier.Public | ComponentModifier.Static;
         holder.Comment = DocComment.Format(
-            "Bodies a handler's null return writes, one per declared status. Allocated once for " +
-            "the life of the process, and serialized through the generated resolver like any " +
-            "other response.");
+            "Bodies a handler's null return and the pipeline's own refusals write, one per " +
+            "declared status. Allocated once for the life of the process, and serialized through " +
+            "the generated resolver like any other response.");
 
         return holder;
     }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -335,6 +335,15 @@ internal static class JsonTypeInfoEmitter {
             ? $"                    Setter = static (object obj, {genericType} value) => {{ }},"
             : "                    Setter = null,");
 
+        // Absent rather than null for a member the description declares optional and not nullable.
+        // The same decision SchemaEmitter writes as [JsonIgnore(Condition = WhenWritingNull)], and
+        // it has to be made twice: this resolver builds JsonPropertyInfo by hand and never reads
+        // the attribute, so the two serializers answered differently for the same contract.
+        if (prop.OmittedWhenNull) {
+            sb.AppendLine(
+                "                    IgnoreCondition = JsonIgnoreCondition.WhenWritingNull,");
+        }
+
         sb.AppendLine($"                }}){close}");
     }
 

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
@@ -204,6 +204,10 @@ internal static class SchemaEmitter {
             direction.Target = "property";
         }
 
+        if (EmitOmitWhenNull(parameter, property) is { } omit) {
+            omit.Target = "property";
+        }
+
         // Required, except where the type already guarantees it - see
         // TypeMapper.IsNonNullableValueType.
         var emitRequired = property.ConstrainedAsRequired &&
@@ -291,6 +295,7 @@ internal static class SchemaEmitter {
 
         EmitJsonPropertyName(member, property);
         EmitDirection(member, property);
+        EmitOmitWhenNull(member, property);
     }
 
     /// <summary>
@@ -444,6 +449,31 @@ internal static class SchemaEmitter {
         parameter.AddAttribute(
             TypeDefinition.Get("System.Text.Json.Serialization", "JsonPropertyNameAttribute"),
             new CodeOutputComponent($"\"{property.Name}\"") { Indented = false });
+
+    /// <summary>
+    /// Absent rather than null, for a member the description declares optional and not nullable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// See <see cref="PropertyModel.OmittedWhenNull"/> for what the two words mean together and
+    /// what reading a null cost. A server that publishes a document must not answer a body that
+    /// document forbids.
+    /// </para>
+    /// <para>
+    /// Emitted here <em>and</em> as <c>IgnoreCondition</c> in <c>JsonTypeInfoEmitter</c>, the way
+    /// <c>[JsonRequired]</c> is: the reflection-based serializer reads this attribute, and the
+    /// source-generated resolver builds <c>JsonPropertyInfo</c> by hand and never sees it.
+    /// </para>
+    /// </remarks>
+    private static AttributeDefinition? EmitOmitWhenNull(
+        BaseOutputComponent target, PropertyModel property) =>
+        property.OmittedWhenNull
+            ? target.AddAttribute(
+                TypeDefinition.Get("System.Text.Json.Serialization", "JsonIgnoreAttribute"),
+                new CodeOutputComponent(
+                    "Condition = global::System.Text.Json.Serialization." +
+                    "JsonIgnoreCondition.WhenWritingNull") { Indented = false })
+            : null;
 
     private static EnumDefinition EmitEnum(
         IConstructContainer container, SchemaModel schema, string modelsNamespace) {

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
@@ -139,11 +139,11 @@ internal static class SpecFileEmitter {
                 Coverage.Apply(definition, excludeFromCoverage);
             }
 
-            // The body a null return writes, one instance per (schema, status) an operation could
-            // answer with. Beside the exceptions for the same reason: it is a payload, not part of
-            // the contract the implementation implements.
+            // The body a null return writes and the body a refusal writes, one instance per
+            // (schema, status) the document declares. Beside the exceptions for the same reason: it
+            // is a payload, not part of the contract the implementation implements.
             DefaultErrorBodyEmitter.Emit(
-                models, model.Schemas, NullResponseBodies(model), modelsNamespace, model.FileName);
+                models, model.Schemas, GeneratedErrorBodies(model), modelsNamespace, model.FileName);
 
             // The cases a bare shipped record converts into, one method per record and body the
             // file's response sets need. Beside the null-return bodies, which fill the same members
@@ -288,22 +288,14 @@ internal static class SpecFileEmitter {
         return new List<ProblemConversion.Plan>(plans.Values);
     }
 
-    private static IReadOnlyCollection<(string SchemaName, int StatusCode)> NullResponseBodies(
+    private static IReadOnlyCollection<(string SchemaName, int StatusCode)> GeneratedErrorBodies(
         ServiceSpecModel model) {
         var wanted = new HashSet<(string, int)>();
 
         foreach (var service in model.Services) {
             foreach (var operation in service.Operations) {
-                if (operation.HttpMethod != "GET" && operation.HttpMethod != "PUT") {
-                    continue;
-                }
-
-                foreach (var error in operation.ErrorResponses) {
-                    if (error.StatusCode != 404 || error.Ref == null) {
-                        continue;
-                    }
-
-                    wanted.Add((TypeMapper.GetRefName(error.Ref), error.StatusCode));
+                foreach (var declared in DefaultErrorBody.DeclaredBodies(operation)) {
+                    wanted.Add(declared);
                 }
             }
         }

--- a/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Passes/NameAllocator.cs
@@ -140,7 +140,52 @@ internal static class NameAllocator {
 
         AllocateOperationNames(model, file);
         AllocateErrorTypeNames(model, types);
+        AllocateResponseContainerNames(model, types);
         AllocateMemberNames(model);
+    }
+
+    /// <summary>
+    /// The container an operation's declared responses are returned in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>{Operation}Response</c> lands in the models namespace beside the schemas, and that is one
+    /// of the commonest schema names in OpenAPI - a contract declaring an operation <c>sync</c> and
+    /// a schema <c>SyncResponse</c> emitted the name twice into one namespace and did not compile.
+    /// The generated container is what moves, because a document's own type keeps its name.
+    /// </para>
+    /// <para>
+    /// After the operation names, which is where <c>MethodName</c> is decided, and after the error
+    /// types, so a declared error's shape keeps the name it brought. Sorted by the name being asked
+    /// for, so which of two operations that want one identifier gets it does not depend on the
+    /// order the description listed them in.
+    /// </para>
+    /// <para>
+    /// Allocated for every operation rather than only the ones that get a container. Whether one is
+    /// emitted is <c>ResponseSetPlan.RequiresResponseSet</c>, which depends on the response model -
+    /// an MSBuild property this pass does not see - so allocating on that condition would give one
+    /// document two sets of names depending on how it was built.
+    /// </para>
+    /// </remarks>
+    private static void AllocateResponseContainerNames(ServiceSpecModel model, Scope types) {
+        var operations = new List<OperationModel>();
+
+        foreach (var service in model.Services) {
+            operations.AddRange(service.Operations);
+        }
+
+        operations.Sort((left, right) => string.CompareOrdinal(left.MethodName, right.MethodName));
+
+        foreach (var operation in operations) {
+            var desired = operation.MethodName + "Response";
+
+            // Qualified by what distinguishes the container from the schema it collided with: it is
+            // the set of responses rather than one of them, and "response set" is what the rest of
+            // the generator calls it. A number would say nothing, and the document is not what the
+            // two disagreed over.
+            operation.ResponseContainerName =
+                types.Allocate(desired, operation.MethodName + "ResponseSet");
+        }
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/NameAllocatorTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/NameAllocatorTests.cs
@@ -45,6 +45,7 @@ public class NameAllocatorTests {
 
             foreach (var operation in service.Operations) {
                 yield return operation.MethodName;
+                yield return operation.ResponseContainerName;
             }
         }
     }
@@ -272,6 +273,96 @@ public class NameAllocatorTests {
     /// named after its type is GitHub, the repeated enum values are Elasticsearch, the empty value
     /// is Docker and Cloudflare, and the two parameters called <c>path</c> are Kubernetes.
     /// </remarks>
+    /// <summary>
+    /// The response container loses to a schema of the same name.
+    /// </summary>
+    /// <remarks>
+    /// <c>{Operation}Response</c> is one of the commonest schema naming conventions in OpenAPI, and
+    /// the container lands in the models namespace beside the schemas - so a contract declaring an
+    /// operation <c>sync</c> and a schema <c>SyncResponse</c> emitted the name twice into one
+    /// namespace. CS0101 for the duplicate, and CS0556 behind it, because the container's implicit
+    /// conversion from the schema became a conversion from itself. The document's own type keeps
+    /// the name, as it does against every other generated wrapper here.
+    /// </remarks>
+    [Fact]
+    public void TheResponseContainerLosesItsNameToASchema() {
+        var model = Parse(ContainerCollision);
+
+        var schema = Assert.Single(model.Schemas, candidate => candidate.Name == "SyncResponse");
+        var sync = Operation(model, "Sync");
+
+        Assert.NotNull(schema);
+        Assert.Equal("SyncResponseSet", sync.ResponseContainerName);
+
+        // The operation that collides with nothing keeps the derived name, so nothing moved that
+        // did not have to.
+        Assert.Equal("UnlockResponse", Operation(model, "Unlock").ResponseContainerName);
+    }
+
+    private static OperationModel Operation(ServiceSpecModel model, string methodName) {
+        foreach (var service in model.Services) {
+            foreach (var operation in service.Operations) {
+                if (operation.MethodName == methodName) {
+                    return operation;
+                }
+            }
+        }
+
+        throw new KeyNotFoundException(methodName);
+    }
+
+    private const string ContainerCollision = """
+        openapi: "3.0.3"
+        info: { title: T, version: "1.0" }
+        paths:
+          /sync:
+            post:
+              tags: [Sync]
+              operationId: sync
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/SyncResponse' }
+                '401':
+                  description: unauthorized
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Problem' }
+          /unlock:
+            post:
+              tags: [Sync]
+              operationId: unlock
+              responses:
+                '200':
+                  description: ok
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Unlock' }
+                '401':
+                  description: unauthorized
+                  content:
+                    application/json:
+                      schema: { $ref: '#/components/schemas/Problem' }
+        components:
+          schemas:
+            SyncResponse:
+              type: object
+              required: [status]
+              properties: { status: { type: string } }
+            Unlock:
+              type: object
+              required: [cost]
+              properties: { cost: { type: integer } }
+            Problem:
+              type: object
+              required: [title, status]
+              properties:
+                title: { type: string }
+                status: { type: integer }
+        """;
+
     private const string Colliding = """
         openapi: "3.0.3"
         info: { title: T, version: "1.0" }

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OptionalMemberOmittedTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OptionalMemberOmittedTests.cs
@@ -1,0 +1,76 @@
+using Hardened.Generation.Models;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// A member the description declares optional and not nullable is absent from a response rather
+/// than written as <c>null</c>.
+/// </summary>
+/// <remarks>
+/// Both serializers, because they read different things: the reflection-based one reads the
+/// attribute the record carries, the source-generated resolver reads the <c>IgnoreCondition</c> on
+/// the property info it builds by hand. They answered the same contract differently, and the one a
+/// deployed application registers decided whether its own document was honoured.
+/// </remarks>
+public class OptionalMemberOmittedTests {
+
+    private static SchemaModel Subscription() =>
+        new() {
+            Name = "Subscription",
+            Kind = SchemaKind.Object,
+            Required = new List<string> { "status" },
+            Properties = new List<PropertyModel> {
+                // Required and not nullable: always present, never null.
+                new() { Name = "status", Type = "string", IsRequired = true },
+
+                // Optional and not nullable: absent, or an integer. Null is neither.
+                new() { Name = "expiresAt", Type = "integer", Format = "int64" },
+
+                // Required and nullable: always present, and null is one of its values.
+                new() { Name = "productId", Type = "string", IsRequired = true, IsNullable = true },
+
+                // Optional and nullable: the document permits both, so nothing changes.
+                new() { Name = "inTrial", Type = "boolean", IsNullable = true }
+            }
+        };
+
+    [Fact]
+    public void TheRecordCarriesTheIgnoreOnOptionalNonNullableMembersOnly() {
+        var result = EmitterHarness.Schema(Subscription());
+
+        const string ignore =
+            "[property: JsonIgnore(Condition = global::System.Text.Json.Serialization." +
+            "JsonIgnoreCondition.WhenWritingNull)]";
+
+        Assert.Contains(ignore + " long? ExpiresAt", result);
+
+        Assert.DoesNotContain(ignore + " string Status", result);
+        Assert.DoesNotContain(ignore + " string? ProductId", result);
+        Assert.DoesNotContain(ignore + " bool? InTrial", result);
+    }
+
+    [Fact]
+    public void TheResolverCarriesTheSameConditionOnTheSameMembers() {
+        var result = EmitterHarness.JsonTypeInfo(new List<SchemaModel> { Subscription() }, "petstore");
+
+        var expiresAt = Section(result, "expiresAt");
+
+        Assert.Contains("IgnoreCondition = JsonIgnoreCondition.WhenWritingNull", expiresAt);
+
+        Assert.DoesNotContain("IgnoreCondition", Section(result, "status"));
+        Assert.DoesNotContain("IgnoreCondition", Section(result, "productId"));
+        Assert.DoesNotContain("IgnoreCondition", Section(result, "inTrial"));
+    }
+
+    /// <summary>One property's entry, from its wire name to the end of the object literal.</summary>
+    private static string Section(string source, string wireName) {
+        var start = source.IndexOf("PropertyName = \"" + wireName + "\"", System.StringComparison.Ordinal);
+
+        Assert.True(start >= 0, wireName + " has no property info");
+
+        var end = source.IndexOf("})", start, System.StringComparison.Ordinal);
+
+        return source.Substring(start, end - start);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
@@ -205,6 +205,8 @@ public class ModelComparisonTests {
             ReturnType = Type("String"),
             DefaultStatusCode = 201,
             NullResponseBodyExpression = "Models.DefaultErrorBodies.NotFoundProblem",
+            DeclaredErrorBodiesExpression =
+                "new Dictionary<int, object> { { 401, Models.DefaultErrorBodies.UnauthorizedProblem } }",
             ProducedContentTypes = "text/plain,text/csv",
             UnionCases = "global::App.Todo|201|01;global::App.NotFound|404|01",
             ThrowsDiagnostic = "OutOfStock",
@@ -216,7 +218,9 @@ public class ModelComparisonTests {
         // whether to rerun. A field left out of it is a change the generator does not notice.
         Assert.Equal(
             "True:System.Fortunes:text/csv:sse:System.String:201:" +
-            "Models.DefaultErrorBodies.NotFoundProblem:text/plain,text/csv:" +
+            "Models.DefaultErrorBodies.NotFoundProblem:" +
+            "new Dictionary<int, object> { { 401, Models.DefaultErrorBodies.UnauthorizedProblem } }:" +
+            "text/plain,text/csv:" +
             "global::App.Todo|201|01;global::App.NotFound|404|01::OutOfStock:422:sse",
             model.ToString());
     }
@@ -294,6 +298,26 @@ public class ModelComparisonTests {
             baseline.ToString(),
             (baseline with { NullResponseBodyExpression = "Models.DefaultErrorBodies.NotFoundProblem" })
             .ToString());
+    }
+
+    /// <summary>
+    /// And two differing only in the bodies their declared statuses answer with.
+    /// </summary>
+    /// <remarks>
+    /// The failure this prevents: an operation edited to declare a body for its 401 keeping its
+    /// cached handler, so the refusal keeps answering the generic model the document does not
+    /// describe - which is exactly the defect the declared bodies exist to close.
+    /// </remarks>
+    [Fact]
+    public void TwoResponsesDifferingOnlyInDeclaredErrorBodiesAreDifferent() {
+        var baseline = new ResponseInformationModel { IsAsync = true, ReturnType = Type("String") };
+
+        Assert.NotEqual(
+            baseline.ToString(),
+            (baseline with {
+                DeclaredErrorBodiesExpression =
+                    "new Dictionary<int, object> { { 401, Models.DefaultErrorBodies.UnauthorizedProblem } }"
+            }).ToString());
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
@@ -77,6 +77,25 @@ public record ResponseInformationModel {
     public string? NullResponseBodyExpression { get; set; }
 
     /// <summary>
+    /// C# naming the body the contract declares for each status it names, or null where it declares
+    /// none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The dictionary literal the handler info takes, filled from the same generated fields
+    /// <see cref="NullResponseBodyExpression"/> names. What a refusal the pipeline raised writes:
+    /// the exception carries no body, so only the contract can say what shape the status answers
+    /// with.
+    /// </para>
+    /// <para>
+    /// One string for the reason <see cref="ProducedContentTypes"/> is one - this is a
+    /// <c>record</c>, and a collection member would compare by reference and never invalidate the
+    /// incremental cache.
+    /// </para>
+    /// </remarks>
+    public string? DeclaredErrorBodiesExpression { get; set; }
+
+    /// <summary>
     /// Every media type this operation can produce, comma-separated, or null where it said nothing.
     /// </summary>
     /// <remarks>
@@ -190,7 +209,8 @@ public record ResponseInformationModel {
     /// </remarks>
     public override string ToString() {
         return $"{IsAsync}:{OutputType}:{RawResponseContentType}:{StreamFraming}:{ReturnType}" +
-               $":{DefaultStatusCode}:{NullResponseBodyExpression}:{ProducedContentTypes}" +
+               $":{DefaultStatusCode}:{NullResponseBodyExpression}:{DeclaredErrorBodiesExpression}" +
+               $":{ProducedContentTypes}" +
                $":{UnionCases}:{UnionDiagnostic}:{ThrowsDiagnostic}:{ValidationErrorStatus}" +
                $":{StreamFramingDiagnostic}";
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/HandlerInfoCodeGenerator.cs
@@ -94,6 +94,15 @@ public static class HandlerInfoCodeGenerator {
                 $", nullResponseBody: {handlerModel.ResponseInformation.NullResponseBodyExpression}";
         }
 
+        // The bodies the contract declares per status, for the refusals the pipeline raises itself.
+        // A framework exception carries no body, so without this a document promising a Problem for
+        // its 401 answered a shape the document never described.
+        if (!string.IsNullOrEmpty(handlerModel.ResponseInformation.DeclaredErrorBodiesExpression)) {
+            declaredArgs +=
+                ", declaredErrorBodies: " +
+                handlerModel.ResponseInformation.DeclaredErrorBodiesExpression;
+        }
+
         // The media types this operation produces, as the array negotiation reads. Emitted only when
         // the operation declared some - an empty array and no array mean different things, and the
         // second is what leaves an unannotated handler negotiating exactly as it did.

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using CSharpAuthor;
 using Hardened.Generation.Models;
 using Hardened.SourceGenerator.Models.Request;
@@ -430,7 +431,9 @@ internal static class SpecHandlerModelBuilder {
                 ProducedContentTypes = operation.ProducedContentTypes.Count > 0
                     ? string.Join(",", operation.ProducedContentTypes)
                     : null,
-                ValidationErrorStatus = DeclaredValidationStatus(operation)
+                ValidationErrorStatus = DeclaredValidationStatus(operation),
+                DeclaredErrorBodiesExpression =
+                    DeclaredErrorBodies(operation, schemas, modelsNamespace, specFileName)
             };
         }
 
@@ -450,7 +453,14 @@ internal static class SpecHandlerModelBuilder {
                     ? string.Join(",", operation.ProducedContentTypes)
                     : null,
                 ValidationErrorStatus = DeclaredValidationStatus(operation),
-                UnionCases = unionCases
+                UnionCases = unionCases,
+
+                // On this path too, and on the stream above. A declared error is a returned case
+                // here rather than a throw, but the refusals the pipeline raises are neither - an
+                // unauthenticated caller is refused before the handler runs whatever shape its
+                // success takes, so what that refusal writes cannot depend on the response model.
+                DeclaredErrorBodiesExpression =
+                    DeclaredErrorBodies(operation, schemas, modelsNamespace, specFileName)
             };
         }
 
@@ -514,6 +524,9 @@ internal static class SpecHandlerModelBuilder {
             NullResponseBodyExpression =
                 NullResponseBody(operation, schemas, modelsNamespace, specFileName),
 
+            DeclaredErrorBodiesExpression =
+                DeclaredErrorBodies(operation, schemas, modelsNamespace, specFileName),
+
             // The set the response is negotiated against. Empty means the description said nothing,
             // which leaves negotiation exactly as it was rather than declaring an empty set.
             ProducedContentTypes = operation.ProducedContentTypes.Count > 0
@@ -563,9 +576,49 @@ internal static class SpecHandlerModelBuilder {
             return null;
         }
 
-        return $"global::{modelsNamespace}.{DefaultErrorBody.HolderTypeName(specFileName)}." +
-               DefaultErrorBody.FieldName(schemaName, DefaultErrorBody.NullResponseStatus);
+        return Field(modelsNamespace, specFileName, schemaName, DefaultErrorBody.NullResponseStatus);
     }
+
+    /// <summary>
+    /// The bodies this operation's declared statuses answer with, as the dictionary literal the
+    /// handler info takes - or null where the description declares none that can be filled.
+    /// </summary>
+    /// <remarks>
+    /// The same generated fields <see cref="NullResponseBody"/> names, and the same shared decision
+    /// behind them: a status whose schema has a required member nothing can fill gets no instance,
+    /// so it is left out here and the refusal answers the generic model exactly as it did.
+    /// </remarks>
+    private static string? DeclaredErrorBodies(
+        OperationModel operation, IReadOnlyList<SchemaModel> schemas, string modelsNamespace,
+        string specFileName) {
+        var entries = new List<string>();
+
+        foreach (var declared in DefaultErrorBody.DeclaredBodies(operation)) {
+            if (DefaultErrorBody.Arguments(schemas, declared.SchemaName, declared.StatusCode) == null) {
+                continue;
+            }
+
+            entries.Add(
+                "{ " + declared.StatusCode.ToString(CultureInfo.InvariantCulture) + ", " +
+                Field(modelsNamespace, specFileName, declared.SchemaName, declared.StatusCode) +
+                " }");
+        }
+
+        if (entries.Count == 0) {
+            return null;
+        }
+
+        entries.Sort(System.StringComparer.Ordinal);
+
+        return "new global::System.Collections.Generic.Dictionary<int, object> { " +
+               string.Join(", ", entries) + " }";
+    }
+
+    /// <summary>The generated field holding one (schema, status) body, qualified.</summary>
+    private static string Field(
+        string modelsNamespace, string specFileName, string schemaName, int statusCode) =>
+        $"global::{modelsNamespace}.{DefaultErrorBody.HolderTypeName(specFileName)}." +
+        DefaultErrorBody.FieldName(schemaName, statusCode);
 
 
 

--- a/src/Templates/Hardened.Templates/stage-templates.py
+++ b/src/Templates/Hardened.Templates/stage-templates.py
@@ -19,6 +19,43 @@ TOKENS = {
     "0.0.0-DEPENDENCYMODULES-VERSION": sys.argv[4],
 }
 
+# A scaffold pinning a preview cannot restore from nuget.org, because a preview is published to
+# GitHub Packages alone - so `dotnet new` wrote a project that did not build, with NU1101 and
+# nothing saying which feed was missing. This does not add the feed, it names it: an authenticated
+# source with no credentials answers 401, and a 401 fails the whole restore rather than the one
+# package, which would be worse than what it replaces. Commented out, with what to do, so the
+# restore fails exactly as it did and the file says why.
+#
+# The credentials are environment variables rather than a token written into the project. NuGet
+# expands %VAR% in a config value when it restores, so nothing lands on disk.
+#
+# A release is on nuget.org and the marker comes out, leaving the file the two lines it always was.
+PREVIEW_MARKER = "<!--#PREVIEW-SOURCE#-->\n"
+
+PREVIEW_SOURCE = """  <!-- This project pins a preview of Hardened, and previews are published to GitHub Packages
+       rather than nuget.org. To restore it, uncomment the source and the credentials below and
+       set GITHUB_USERNAME and a GITHUB_TOKEN holding read:packages. NuGet expands the variables
+       when it restores, so no token is written into this file.
+
+       Delete all of this once the project pins a released version.
+
+  <packageSources>
+    <add key="hardened-previews" value="https://nuget.pkg.github.com/ipjohnson/index.json" />
+  </packageSources>
+  <packageSourceCredentials>
+    <hardened-previews>
+      <add key="Username" value="%GITHUB_USERNAME%" />
+      <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+    </hardened-previews>
+  </packageSourceCredentials>
+  -->
+"""
+
+
+def preview_source(version):
+    """The feed a preview scaffold needs, or nothing for a released one."""
+    return PREVIEW_SOURCE if "-preview" in version else ""
+
 source, destination = sys.argv[1], sys.argv[2]
 
 if os.path.isdir(destination):
@@ -33,6 +70,7 @@ shutil.copytree(
 )
 
 stamped = {token: 0 for token in TOKENS}
+markers = 0
 
 for root, _, files in os.walk(destination):
     for name in files:
@@ -44,7 +82,10 @@ for root, _, files in os.walk(destination):
         except (UnicodeDecodeError, OSError):
             continue
 
-        if not any(token in content for token in TOKENS):
+        if PREVIEW_MARKER in content:
+            content = content.replace(PREVIEW_MARKER, preview_source(sys.argv[3]))
+            markers += 1
+        elif not any(token in content for token in TOKENS):
             continue
 
         for token, version in TOKENS.items():
@@ -62,3 +103,12 @@ for token, version in TOKENS.items():
         sys.exit(1)
 
     print(f"stage-templates: stamped {version} into {stamped[token]} file(s)")
+
+# One per template. Zero means the marker was renamed or dropped, and a preview scaffold would go
+# back to restoring from a feed that does not have it.
+if markers == 0:
+    print(f"stage-templates: no nuget.config carried {PREVIEW_MARKER.strip()}; a preview scaffold "
+          "would not see the feed its packages are on", file=sys.stderr)
+    sys.exit(1)
+
+print(f"stage-templates: resolved the preview source in {markers} nuget.config file(s)")

--- a/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/Directory.Packages.props
@@ -34,12 +34,19 @@
     generator that no longer matched the interface it emitted against.
   -->
   <ItemGroup Label="Logging">
-    <!-- The console logger the entry point installs. A deployed function writes to CloudWatch
-         through stdout, so this is what makes a log line reach it. -->
+    <!-- The console logger the Cloud Run entry point installs, which is what puts a log line on
+         the stdout Cloud Logging collects. An AWS function uses Amazon.Lambda.Logging.AspNetCore
+         instead; see Program.cs. -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Label="AWS Lambda">
+    <!--
+      The logging provider the entry point installs, on its own line rather than Hardened's: it is
+      AWS's package and moves with the Lambda runtime client. Program.cs says why a Lambda function
+      logs through this and not through the console provider.
+    -->
+    <PackageVersion Include="Amazon.Lambda.Logging.AspNetCore" Version="5.0.1" />
     <PackageVersion Include="Hardened.Aws.Lambda.Runtime" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Aws.Lambda.Invoke" Version="$(HardenedVersion)" />
     <PackageVersion Include="Hardened.Aws.Lambda.Sqs" Version="$(HardenedVersion)" />

--- a/src/Templates/Hardened.Templates/templates/hardened-function/nuget.config
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/nuget.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <!-- Hardened is on nuget.org. No other feed and no token are needed. -->
+  <!-- The feeds this project restores from. A Hardened release is on nuget.org. -->
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+<!--#PREVIEW-SOURCE#-->
 </configuration>

--- a/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Hardened1.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Hardened1.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Hardened.Functions.Runtime" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
 <!--#if (aws) -->
+    <!-- The logging provider Program.cs installs, in place of the console one. -->
+    <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" />
     <!--
       The host, and one adapter for the trigger the handler declares. The adapter is a package
       rather than a flag so a function carries only the event models it can reach: a queue function

--- a/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Program.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-function/src/Hardened1/Program.cs
@@ -19,7 +19,15 @@ using var emulator = await LambdaEmulator.StartIfLocal(typeof(Application));
 
 var services = new ServiceCollection();
 
-services.AddLogging(builder => builder.AddSimpleConsole().SetMinimumLevel(LogLevel.Information));
+// Through the Lambda logger, not the console provider. Amazon.Lambda.RuntimeSupport replaces
+// Console.Out process-wide with its own writer and takes a lock on it, including to print an
+// unhandled exception - which it does before reporting the invocation as failed. A console provider
+// writing from its own background thread is a second party on that lock, and the two can deadlock:
+// the handler's exception is never reported, and the invocation hangs until the function times out
+// rather than failing fast. This provider writes through Amazon.Lambda.Core's LambdaLogger, which
+// is the single-lock path, and it keeps what the console provider loses on the way - the request id
+// on every line, and the JSON shape AWS_LAMBDA_LOG_FORMAT asks for.
+services.AddLogging(builder => builder.AddLambdaLogger().SetMinimumLevel(LogLevel.Information));
 
 // What the framework reads configuration and the environment through. A deployed function gets its
 // settings from the environment, so this is where the process arguments enter.

--- a/src/Templates/Hardened.Templates/templates/hardened-library/nuget.config
+++ b/src/Templates/Hardened.Templates/templates/hardened-library/nuget.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <!-- Hardened is on nuget.org. No other feed and no token are needed. -->
+  <!-- The feeds this project restores from. A Hardened release is on nuget.org. -->
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+<!--#PREVIEW-SOURCE#-->
 </configuration>

--- a/src/Templates/Hardened.Templates/templates/hardened-web/nuget.config
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/nuget.config
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <!-- Hardened is on nuget.org. No other feed and no token are needed. -->
+  <!-- The feeds this project restores from. A Hardened release is on nuget.org. -->
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+<!--#PREVIEW-SOURCE#-->
 </configuration>


### PR DESCRIPTION
Seven of the nine Hardened defects from the YarnBlocks.Backend migration off `Hardened.Amz`, in
the order the report ranks them. Each fix has a test that fails without it.

## Critical — the Lambda host never ran its startup services

`HardenedLambdaBootstrap.Run(IServiceProvider)` resolved the invocation handler and started the
loop. Nothing in `Hardened.Aws.Lambda.Runtime` called `ApplicationLogic.Start`, and a Lambda has no
other start signal, so `AuthenticationStartupService` installed no middleware,
`AuthorizationStartupService` installed no filter provider and `CorsStartupService` never ran. A
deployed function served every request anonymous and every route open, including one carrying
`Requirement.Authenticated()`, and logged nothing about it.

It was invisible from inside this repository because every test host starts the provider itself,
so the suite passed while the deployed function was the only host that did not. The regression test
builds its own provider the way `Program.cs` does and leaves the bootstrap as the only thing that
could have run them. The call goes in `Run(IServiceProvider)`, where `KestrelServerRunner.StartAsync`
puts it, and through the same guard.

**This changes what a deployed function does.** A route a description guards and the function was
serving open is now refused.

## High — optional members serialized as `null`

A member the description declares optional and not nullable may be absent, and is of its declared
type if present, so `null` is a value the document forbids. The generated models carried no
`JsonIgnore`, and the cost was on the client: Refitter declares `long ExpiresAt` from that schema,
and so does a Swift `Codable` struct. Kiota makes every property nullable and read the invalid
payload happily, which is why it survived until a consumer changed generators.

Emitted in both places, the way `[JsonRequired]` is: the reflection-based serializer reads the
attribute, and the source-generated resolver builds `JsonPropertyInfo` by hand and never sees it.
Required-and-nullable keeps writing its null.

**This changes what a spec-first application sends.** An optional member with no value is now absent
rather than null.

## High — the response container collided with the schemas

In Response mode the container is named `{Operation}Response` and emitted into the models namespace
beside the schemas, with no uniquification — and `{Operation}Response` is one of the commonest schema
naming conventions in OpenAPI. A contract with an operation `sync` and a schema `SyncResponse` did
not compile.

`NameAllocator` already arbitrates exactly this and already hands the schema scope to the pass that
names a declared error's wrapper. The container is allocated there too, after the schemas, so the
document's own type keeps the name and the generated one becomes `{Operation}ResponseSet`. That is
a different fix from the one the report suggested (moving the container to the `Services`
namespace): it closes collisions with every other generated type in that namespace as well, and the
repository already has one mechanism for the question.

## High — the release could not see a packable-by-default project

The pack list already has a coverage check, and it would not have caught the 0.30.0 case: the
DynamoDB client landed an hour after the tag, so at that commit there was nothing missing. The two
packages are in the list now and `EXPECTED` is right, so 0.31.0 carries them.

What is fixed is the remaining silent hole. The check greps the XML, so it sees a project that says
`IsPackable` and not one that packs because the SDK's default says so. Every project under `src`
now has to declare which it is; nothing is undeclared today.

## Medium — the pipeline's refusal answered an undeclared body

`AuthorizationException` is a `StatusCodeException` built with `value: null`, so
`ExceptionToModelConverter` fell through to its generic `ErrorModel`: an application whose document
declares a `Problem` for its 401 answered `{"type":"AuthorizationException",…}`, an undescribed
shape at a described status.

The seam was already there one branch earlier — the converter honours
`HandlerInfo.ValidationErrorStatus`, because only the handler knows what its own contract promised.
`DeclaredErrorBodies` is the same thing for the body, filled from the instances `DefaultErrorBody`
already decides. An exception carrying its own body still wins.

## Low — no diagnostic when the test runner package is missing

`HRDT001`, raised by `Hardened.Shared.Testing`'s packaged targets, names both runner packages. A
warning, because referencing the neutral package without writing a `[HardenedTest]` is legitimate.

## Low — the scaffolded nuget.config could not see a preview line

Named rather than added: an authenticated source with no credentials answers 401, and a 401 fails
the whole restore rather than the one package. The block is commented out with what to do, and the
credentials are environment variables rather than a token written into the project.

## Not done

**The renamed generated error types (Low).** `SyncUnauthorizedException` became
`UnauthorizedException` when errors went from one type per operation to one per named response. The
report asks for a release note or a diagnostic naming the replacement. The generator would have to
carry the superseded scheme forever to emit that, for a migration that happened once, so this is
left as the report records it.

**The Amz → Aws migration page (Low).** Out of scope for this branch.

## Verified

`dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` clean,
`dotnet test Hardened.slnx` green across 74 assemblies, `Hardened.Simulators.slnx` green across 10,
`scripts/verify-templates.sh` green with the pinned Smithy CLI, and the public API re-approved. The
coverage gate is the one CI check not reproducible here — the generator assemblies compile their
dependencies from source and this machine has both sibling checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
