### PR TITLE
Restore Lambda response streaming, dropped when the AWS line was rebuilt

### DIFF
--- a/docs/aws/lambda-web.md
+++ b/docs/aws/lambda-web.md
@@ -113,14 +113,41 @@ the tool up. Deleting `Program.cs` leaves the project with no entry point at all
 handler fails on its first invocation with "Entry point not found".
 :::
 
-## Responses are buffered
+## Response mode
 
-The adapter writes a payload format 2.0 response when the handler returns. There is no streaming
-mode: the body has to be a `MemoryStream` the adapter can read back, and an application whose
-handlers return `IAsyncEnumerable<T>` gets that sequence buffered before the response is sent.
+A function answers in one of two ways, and the deployment picks which:
 
-An HTTP API buffers every response anyway, so this matches what a deployment behind one can do.
-`[ServerSentEvents]` handlers work under Kestrel and ASP.NET Core; see
+| `HARDENED_LAMBDA_RESPONSE_MODE` | What leaves the function | Front door |
+|---|---|---|
+| `buffered` (the default) | One payload format 2.0 response when the handler returns | An HTTP API, or a function URL in `BUFFERED` invoke mode |
+| `stream` | A stream that opens at the first body byte | A function URL in `RESPONSE_STREAM` invoke mode |
+
+The variable has to match the invoke mode of the front door in front of it. The wire protocol is
+fixed there rather than chosen by the function: `RESPONSE_STREAM` expects an HTTP prelude before the
+body, `BUFFERED` and an HTTP API expect the JSON envelope, and neither accepts the other. The event
+the function receives is the same document either way, which is why something has to say which.
+
+An unrecognised value fails the application at startup rather than falling back. A deployment that
+spelt it wrong would otherwise run buffered behind a front door expecting the prelude, and the first
+request would be a 500 with nothing in the logs to say why.
+
+```csharp
+// Amending it from the application, for a host that decides its own mode.
+services.ConfigureLambdaResponseMode(mode => mode.Mode = LambdaResponseMode.Stream);
+```
+
+In `stream` mode the status, headers and cookies are sent as the prelude that opens the stream, and
+they are read at the **first body byte** rather than when the handler returns. Anything set after
+the first write is recorded on the response and never reaches the client. That is what makes a
+refusal work: the pipeline serializes it before any handler wrote, so the stream opens with the
+refusal's own status.
+
+Only a web-shaped source can stream. A queue, a topic, a stream record or a scheduled rule has no
+caller holding a connection, so a function serving one stays buffered under a `stream` variable
+rather than failing. That keeps the setting safe to apply account-wide.
+
+`[ServerSentEvents]` handlers need `stream`. Under `buffered` their events are delivered together
+when the invocation ends, or never when the function times out first. See
 [Streaming responses](/guide/streaming).
 
 ## Testing

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -207,13 +207,18 @@ client generated from it reads a list rather than a stream.
 |---|---|
 | Kestrel | yes |
 | ASP.NET Core | yes |
-| Lambda behind API Gateway | no |
+| Cloud Run | yes |
+| Lambda, `HARDENED_LAMBDA_RESPONSE_MODE=stream` | yes |
+| Lambda, `HARDENED_LAMBDA_RESPONSE_MODE=buffered` | no |
+| Azure Functions | no |
 
-The Lambda adapter buffers. The body has to be a `MemoryStream` it can read back, so a handler
-returning `IAsyncEnumerable<T>` has its sequence accumulated before the response is sent and the
-whole thing arrives at once at the end. An HTTP API buffers every response anyway, so this matches
-what a deployment behind one can do. See
-[Responses are buffered](/aws/lambda-web#responses-are-buffered).
+On Lambda, whether a response streams is a deployment setting rather than a property of the handler.
+`stream` needs a function URL in `RESPONSE_STREAM` invoke mode, with or without CloudFront in front.
+A buffered deployment accumulates the whole body before returning it, so a streamed response arrives
+all at once at the end. See [Response mode](/aws/lambda-web#response-mode).
+
+The Azure Functions worker hands the whole body to the host when the invocation returns, so a
+streamed response there arrives at the end whatever the handler does.
 
 ## Compression
 
@@ -227,4 +232,4 @@ per item, so a reader still gets each line as it is produced.
 
 - [Sending requests](/guide/testing-web#the-response): reading a streamed body in a test
 - [Compression](/guide/compression): what is and is not compressed
-- [API Gateway](/aws/lambda-web#responses-are-buffered): why Lambda does not stream
+- [Response mode](/aws/lambda-web#response-mode): what makes a Lambda stream

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -272,4 +272,4 @@ Both were `[DynamoDbModule]` until 0.31.0, in two packages, so an application th
 handled its stream could not name either without qualifying it.
 
 A Lambda response is always buffered. There is no streaming mode and no environment variable that
-selects one; see [API Gateway](/aws/lambda-web#responses-are-buffered).
+selects one; see [Response mode](/aws/lambda-web#response-mode).

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.ApiGateway/ApiGatewayAdapter.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.ApiGateway/ApiGatewayAdapter.cs
@@ -1,7 +1,9 @@
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
+using Amazon.Lambda.Core.ResponseStreaming;
 using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Execution;
 using Hardened.Requests.Abstract.Execution;
@@ -29,7 +31,7 @@ namespace Hardened.Aws.Lambda.ApiGateway;
 /// function does serve several sources and something has to choose.
 /// </para>
 /// </remarks>
-public sealed class ApiGatewayAdapter : IPayloadAdapter {
+public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
     /// <summary>
     /// The field that says this is payload format 2.0, and the whole of how it is told from 1.0.
     /// </summary>
@@ -81,6 +83,38 @@ public sealed class ApiGatewayAdapter : IPayloadAdapter {
     public HostFailurePolicy FailurePolicy => HostFailurePolicy.Answer500;
 
     public IExecutionResponse CreateResponse(Stream output) => new ApiGatewayResponse(output);
+
+    /// <summary>
+    /// The same status, headers and cookies <see cref="WriteResponse"/> would have written, sent as
+    /// the prelude that opens the stream instead of as an envelope around a finished body.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Headers</c> rather than <c>MultiValueHeaders</c>: a function URL reads the single-valued
+    /// collection, and it is the deployment shape that streams. A multi-valued header joins on ","
+    /// here exactly as it does in the buffered envelope, so the two modes put the same bytes on the
+    /// wire.
+    /// </para>
+    /// <para>
+    /// Null and zero both become 200, for the reason the envelope gives: null is "handled, no
+    /// opinion", and zero is not a status a handler can have meant.
+    /// </para>
+    /// </remarks>
+    public HttpResponseStreamPrelude CreatePrelude(IExecutionResponse response) {
+        var prelude = new HttpResponseStreamPrelude {
+            StatusCode = (HttpStatusCode)(response.Status is null or 0 ? 200 : response.Status.Value)
+        };
+
+        foreach (var header in response.Headers) {
+            prelude.Headers[header.Key] = header.Value.ToString();
+        }
+
+        foreach (var cookie in SetCookies((ApiGatewayResponse)response)) {
+            prelude.Cookies.Add(cookie);
+        }
+
+        return prelude;
+    }
 
     /// <remarks>
     /// <para>
@@ -196,21 +230,34 @@ public sealed class ApiGatewayAdapter : IPayloadAdapter {
     private static void WriteCookies(Utf8JsonWriter writer, ApiGatewayResponse response) {
         writer.WriteStartArray("cookies");
 
+        foreach (var cookie in SetCookies(response)) {
+            writer.WriteStringValue(cookie);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    /// <summary>
+    /// The response's cookies as Set-Cookie strings.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the envelope and the prelude, so a cookie cannot be rendered one way buffered and
+    /// another way streamed. <c>Item1</c> is the value: appending the tuple itself resolves to
+    /// <c>Append(object)</c> and emits its <c>ToString()</c>, which is how every Set-Cookie once
+    /// read "name=(value, CookieSetOptions { Expires = , ... })".
+    /// </remarks>
+    private static IEnumerable<string> SetCookies(ApiGatewayResponse response) {
         var builder = new StringBuilder();
 
         foreach (var cookie in response.Cookies.Cookies) {
             builder.Append(cookie.Key);
             builder.Append('=');
-            // Item1 is the value. Appending the tuple itself resolves to Append(object) and emits
-            // its ToString(), which is how every Set-Cookie once read
-            // "name=(value, CookieSetOptions { Expires = , ... })".
             builder.Append(cookie.Value.Item1);
             cookie.Value.Item2.AppendSettings(builder);
 
-            writer.WriteStringValue(builder.ToString());
+            yield return builder.ToString();
+
             builder.Clear();
         }
-
-        writer.WriteEndArray();
     }
 }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/LambdaInvocationHandlerTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/LambdaInvocationHandlerTests.cs
@@ -3,6 +3,7 @@ using Amazon.Lambda.Core;
 using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Execution;
 using Hardened.Aws.Lambda.Runtime.Hosting;
+using Hardened.Aws.Lambda.Runtime.Streaming;
 using Hardened.Aws.Lambda.Runtime.Tests.Infrastructure;
 using Hardened.Aws.Lambda.ApiGateway;
 using Hardened.Aws.Lambda.EventBridge;
@@ -14,6 +15,7 @@ using Hardened.Requests.Abstract.Middleware;
 using Hardened.Requests.Runtime.Middleware;
 using Hardened.Shared.Runtime.Metrics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Hardened.Aws.Lambda.Runtime.Tests.Hosting;
@@ -67,8 +69,19 @@ public class LambdaInvocationHandlerTests {
         var provider = services.BuildServiceProvider();
 
         return (new LambdaInvocationHandler(
-            provider, executor, new NullMetricLoggerProvider(), adapters), executor);
+                provider, executor, new NullMetricLoggerProvider(), adapters,
+                new CapturingResponseStreamFactory(), Mode()),
+            executor);
     }
+
+    /// <summary>
+    /// The response mode as the configuration would have read it. Buffered unless a test says
+    /// otherwise, which is the default a function with no variable set runs under.
+    /// </summary>
+    private static IOptions<ILambdaResponseModeConfiguration> Mode(
+        LambdaResponseMode mode = LambdaResponseMode.Buffered) =>
+        Options.Create<ILambdaResponseModeConfiguration>(
+            new LambdaResponseModeConfiguration { Mode = mode });
 
     private static ILambdaContext Context() =>
         new TestLambdaContext(remainingTime: TimeSpan.FromSeconds(30));
@@ -281,7 +294,8 @@ public class LambdaInvocationHandlerTests {
 
         var handler = new LambdaInvocationHandler(
             services.BuildServiceProvider(), new RecordingExecutor(),
-            new NullMetricLoggerProvider(), [new SqsAdapter()]);
+            new NullMetricLoggerProvider(), [new SqsAdapter()],
+            new CapturingResponseStreamFactory(), Mode());
 
         var failure = await Assert.ThrowsAsync<InvalidOperationException>(
             () => handler.Invoke(Input(Payloads.SqsJson), Context()));
@@ -304,7 +318,8 @@ public class LambdaInvocationHandlerTests {
 
         var handler = new LambdaInvocationHandler(
             services.BuildServiceProvider(), new RecordingExecutor(),
-            new NullMetricLoggerProvider(), [new SqsAdapter()]);
+            new NullMetricLoggerProvider(), [new SqsAdapter()],
+            new CapturingResponseStreamFactory(), Mode());
 
         var failure = await Assert.ThrowsAsync<InvalidOperationException>(
             () => handler.Invoke(Input(Payloads.SqsJson), Context()));

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/StreamedInvocationTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/StreamedInvocationTests.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Text;
+using Amazon.Lambda.Core;
+using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Runtime.Adapters;
+using Hardened.Aws.Lambda.Runtime.Hosting;
+using Hardened.Aws.Lambda.Runtime.Streaming;
+using Hardened.Aws.Lambda.Runtime.Tests.Infrastructure;
+using Hardened.Aws.Lambda.Sqs;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Hardened.Requests.Runtime.Middleware;
+using Hardened.Shared.Runtime.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Hardened.Aws.Lambda.Runtime.Tests.Hosting;
+
+/// <summary>
+/// The invocation loop in stream mode: when it opens a Lambda response stream, what the prelude
+/// carries when it does, and which functions are left buffered under the same variable.
+/// </summary>
+/// <remarks>
+/// The AWS stream is never reached. <c>LambdaResponseStreamFactory</c> is static and its setter is
+/// internal to the AWS packages, so <see cref="IResponseStreamFactory"/> is the seam and
+/// <see cref="CapturingResponseStreamFactory"/> is what these assert through: the prelude each
+/// stream opened with, and every byte written to it.
+/// </remarks>
+public class StreamedInvocationTests {
+
+    // ------------------------------------------------------------------ which mode is served
+
+    /// <summary>
+    /// The whole of the mode's effect on a web-shaped function: a stream, not an envelope.
+    /// </summary>
+    [Fact]
+    public async Task StreamModeOpensAResponseStream() {
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+
+        executor.Body = Writes("hello");
+
+        var output = await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+
+        Assert.Equal("hello", streams.Target.Text);
+
+        // The bootstrap ignores the return value once a stream has been created, so the host does
+        // not build a second body to be thrown away.
+        Assert.Same(Stream.Null, output);
+    }
+
+    /// <summary>
+    /// The default, and what every function that names no variable runs under.
+    /// </summary>
+    [Fact]
+    public async Task BufferedModeWritesTheEnvelopeAndOpensNoStream() {
+        var (handler, executor, streams) = Build(LambdaResponseMode.Buffered, new ApiGatewayAdapter());
+
+        executor.Body = Writes("hello");
+
+        var output = await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+
+        Assert.Empty(streams.Preludes);
+        Assert.Contains("\"body\":\"hello\"", await Text(output));
+    }
+
+    /// <summary>
+    /// A queue function under a stream-mode variable stays buffered rather than failing.
+    /// </summary>
+    /// <remarks>
+    /// The variable describes the front door, and an event source has none. Refusing here would
+    /// break a deployment that sets the variable account-wide for its HTTP functions and shares the
+    /// setting with its queues.
+    /// </remarks>
+    [Fact]
+    public async Task AnAdapterThatCannotStreamStaysBufferedUnderStreamMode() {
+        var (handler, _, streams) = Build(LambdaResponseMode.Stream, new SqsAdapter());
+
+        await handler.Invoke(Input(Payloads.SqsJson), Context());
+
+        Assert.Empty(streams.Preludes);
+    }
+
+    // ------------------------------------------------------------------ the prelude
+
+    /// <summary>
+    /// Status, headers and cookies as they stood at the first byte.
+    /// </summary>
+    [Fact]
+    public async Task ThePreludeCarriesTheStatusHeadersAndCookies() {
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+
+        executor.Body = async context => {
+            context.Response.Status = 201;
+            context.Response.Headers["X-Trace"] = "abc";
+            context.Response.Cookies.Append("session", "s1");
+
+            await context.Response.Body.WriteAsync("hi"u8.ToArray());
+        };
+
+        await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+
+        var prelude = streams.Prelude;
+
+        Assert.Equal(HttpStatusCode.Created, prelude.StatusCode);
+        Assert.Equal("abc", prelude.Headers["X-Trace"]);
+        Assert.Contains(prelude.Cookies, cookie => cookie.StartsWith("session=s1", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Decided at the first byte rather than when the response was created, which is the whole
+    /// reason the stream opens late.
+    /// </summary>
+    /// <remarks>
+    /// A refusal serialized before any handler ran sets its own status and then writes, and this is
+    /// what makes the client see that status rather than the 200 the response started with. Set
+    /// after a write, it is too late and the prelude has gone - which is the documented cost and
+    /// what the 204 rule in the SSE contract exists for.
+    /// </remarks>
+    [Fact]
+    public async Task AStatusSetBeforeTheFirstByteReachesThePrelude() {
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+
+        executor.Body = async context => {
+            await context.Response.Body.WriteAsync("first"u8.ToArray());
+
+            // After the prelude has gone. Recorded on the response, ignored on the wire.
+            context.Response.Status = 500;
+        };
+
+        await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+
+        Assert.Equal(HttpStatusCode.OK, streams.Prelude.StatusCode);
+    }
+
+    // ------------------------------------------------------------------ the empty and failing cases
+
+    /// <summary>
+    /// A response that wrote nothing still opens the stream, and sends one newline.
+    /// </summary>
+    /// <remarks>
+    /// A zero-byte streamed body is not delivered promptly - CloudFront and a function URL both sit
+    /// waiting on data that never arrives - so a reader blocks until the invocation times out.
+    /// </remarks>
+    [Fact]
+    public async Task AnEmptyResponseStillOpensTheStream() {
+        var (handler, _, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+
+        await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+
+        Assert.Single(streams.Preludes);
+        Assert.Equal("\n", streams.Target.Text);
+    }
+
+    /// <summary>
+    /// A throw after the first byte keeps what reached the client and fails the invocation.
+    /// </summary>
+    /// <remarks>
+    /// The stream is already open and the status already sent, so there is nothing to take back.
+    /// The bootstrap writes the failure as trailers and records the invocation as failed, which is
+    /// what a truncated stream should be.
+    /// </remarks>
+    [Fact]
+    public async Task AThrowAfterTheFirstByteKeepsWhatWasWritten() {
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+
+        executor.Body = async context => {
+            await context.Response.Body.WriteAsync("partial"u8.ToArray());
+
+            throw new InvalidOperationException("nothing more to stream");
+        };
+
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => handler.Invoke(Input(Payloads.ApiGatewayJson), Context()));
+
+        Assert.Equal("nothing more to stream", failure.Message);
+        Assert.Equal("partial", streams.Target.Text);
+    }
+
+    /// <summary>
+    /// A throw before the first byte opens no stream at all, so the failure is a complete response
+    /// rather than an empty one with a 200 already on it.
+    /// </summary>
+    [Fact]
+    public async Task AThrowBeforeTheFirstByteOpensNoStream() {
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+
+        executor.Body = _ => throw new InvalidOperationException("nothing to stream");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => handler.Invoke(Input(Payloads.ApiGatewayJson), Context()));
+
+        Assert.Empty(streams.Preludes);
+    }
+
+    // ------------------------------------------------------------------ harness
+
+    private static Func<IExecutionContext, Task> Writes(string body) =>
+        async context => await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(body));
+
+    private static async Task<string> Text(Stream output) {
+        using var reader = new StreamReader(output);
+
+        return await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static (LambdaInvocationHandler Handler, RecordingExecutor Executor,
+        CapturingResponseStreamFactory Streams) Build(
+            LambdaResponseMode mode, params IPayloadAdapter[] adapters) {
+        var executor = new RecordingExecutor();
+        var streams = new CapturingResponseStreamFactory();
+
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IKnownServices>(new StubKnownServices());
+        services.AddSingleton<IMiddlewareService, MiddlewareService>();
+        services.AddSingleton<IHandlerDispatch, StubDispatch>();
+
+        var handler = new LambdaInvocationHandler(
+            services.BuildServiceProvider(), executor, new NullMetricLoggerProvider(), adapters,
+            streams,
+            Options.Create<ILambdaResponseModeConfiguration>(
+                new LambdaResponseModeConfiguration { Mode = mode }));
+
+        return (handler, executor, streams);
+    }
+
+    private static ILambdaContext Context() =>
+        new TestLambdaContext(remainingTime: TimeSpan.FromSeconds(30));
+
+    private static Stream Input(string json) => new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+    /// <summary>Runs whatever a test put in <see cref="Body"/> in place of the real pipeline.</summary>
+    private sealed class RecordingExecutor : IRequestExecutor {
+        public Func<IExecutionContext, Task>? Body;
+
+        public void Begin(IExecutionContext context) { }
+
+        public Task RunChain(IExecutionContext context, HostFailurePolicy onFailure) => Task.CompletedTask;
+
+        public void End(IExecutionContext context) { }
+
+        public Task Run(IExecutionContext context, HostFailurePolicy onFailure) =>
+            Body?.Invoke(context) ?? Task.CompletedTask;
+    }
+
+    private sealed class StubDispatch : IHandlerDispatch {
+        public Task Execute(IExecutionChain chain) => Task.CompletedTask;
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Infrastructure/CapturingResponseStreamFactory.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Infrastructure/CapturingResponseStreamFactory.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using Amazon.Lambda.Core.ResponseStreaming;
+using Hardened.Aws.Lambda.Runtime.Streaming;
+using Xunit;
+
+namespace Hardened.Aws.Lambda.Runtime.Tests.Infrastructure;
+
+/// <summary>
+/// The stream-opening seam, recording the prelude each stream opened with and keeping every byte
+/// written to it.
+/// </summary>
+internal sealed class CapturingResponseStreamFactory : IResponseStreamFactory {
+    public List<HttpResponseStreamPrelude> Preludes { get; } = [];
+
+    public int PlainStreams { get; private set; }
+
+    public SignallingStream Target { get; } = new();
+
+    /// <summary>The prelude of the one stream a test expects to have been opened.</summary>
+    public HttpResponseStreamPrelude Prelude => Assert.Single(Preludes);
+
+    public Stream CreateStream() {
+        PlainStreams++;
+
+        return Target;
+    }
+
+    public Stream CreateHttpStream(HttpResponseStreamPrelude prelude) {
+        Preludes.Add(prelude);
+
+        return Target;
+    }
+}
+
+/// <summary>
+/// A memory stream that says when it has been written to, so a test can wait for the pump rather
+/// than sleep, and that can be told to fail every write.
+/// </summary>
+internal sealed class SignallingStream : MemoryStream {
+    private readonly TaskCompletionSource _firstWrite = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Completes on the first write that reached this stream.</summary>
+    public Task FirstWrite => _firstWrite.Task;
+
+    public Exception? FailWith { get; set; }
+
+    /// <summary>Everything written to the stream, as the reader on the far end would see it.</summary>
+    public string Text => Encoding.UTF8.GetString(ToArray());
+
+    public override void Write(ReadOnlySpan<byte> buffer) {
+        Throw();
+        base.Write(buffer);
+        _firstWrite.TrySetResult();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count) {
+        Throw();
+        base.Write(buffer, offset, count);
+        _firstWrite.TrySetResult();
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {
+        Throw();
+        var result = base.WriteAsync(buffer, cancellationToken);
+        _firstWrite.TrySetResult();
+
+        return result;
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+        Throw();
+        var result = base.WriteAsync(buffer, offset, count, cancellationToken);
+        _firstWrite.TrySetResult();
+
+        return result;
+    }
+
+    private void Throw() {
+        if (FailWith != null) {
+            throw FailWith;
+        }
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/LambdaResponseModeConfigurationTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/LambdaResponseModeConfigurationTests.cs
@@ -1,0 +1,117 @@
+using Hardened.Aws.Lambda.Runtime.Streaming;
+using Hardened.Shared.Runtime.Application;
+using Hardened.Shared.Runtime.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hardened.Aws.Lambda.Runtime.Tests.Streaming;
+
+/// <summary>
+/// The deployment setting that says which wire protocol the front door expects. Read once, at
+/// startup, and wrong in exactly one way.
+/// </summary>
+public class LambdaResponseModeConfigurationTests {
+
+    [Theory]
+    [InlineData(null, LambdaResponseMode.Buffered)]
+    [InlineData("", LambdaResponseMode.Buffered)]
+    [InlineData("   ", LambdaResponseMode.Buffered)]
+    [InlineData("buffered", LambdaResponseMode.Buffered)]
+    [InlineData("Buffered", LambdaResponseMode.Buffered)]
+    [InlineData("stream", LambdaResponseMode.Stream)]
+    [InlineData("STREAM", LambdaResponseMode.Stream)]
+    [InlineData(" stream ", LambdaResponseMode.Stream)]
+    public void TheSettingParsesCaseInsensitivelyWithBufferedAsTheDefault(string? value, LambdaResponseMode expected) {
+        Assert.Equal(expected, LambdaResponseModeConfiguration.Parse(value));
+    }
+
+    /// <summary>
+    /// A value that is neither fails rather than falling back. A misspelt setting would otherwise
+    /// run buffered behind a front door expecting the prelude, and every response would be a 500
+    /// with nothing in the logs to say why.
+    /// </summary>
+    [Theory]
+    [InlineData("streaming")]
+    [InlineData("RESPONSE_STREAM")]
+    [InlineData("true")]
+    public void AnUnrecognisedValueFailsNamingTheVariableAndTheChoices(string value) {
+        var failure = Assert.Throws<InvalidOperationException>(() => LambdaResponseModeConfiguration.Parse(value));
+
+        Assert.Contains(LambdaResponseModeConfiguration.EnvironmentVariable, failure.Message);
+        Assert.Contains(value, failure.Message);
+        Assert.Contains("'buffered'", failure.Message);
+        Assert.Contains("'stream'", failure.Message);
+    }
+
+    /// <summary>
+    /// What the CDK writes is what the application reads, by construction rather than by two
+    /// string literals that happen to agree.
+    /// </summary>
+    [Theory]
+    [InlineData(LambdaResponseMode.Buffered)]
+    [InlineData(LambdaResponseMode.Stream)]
+    public void TheWrittenValueParsesBackToTheMode(LambdaResponseMode mode) {
+        Assert.Equal(mode, LambdaResponseModeConfiguration.Parse(LambdaResponseModeConfiguration.ValueOf(mode)));
+    }
+
+    [Fact]
+    public void TheEnvironmentVariableSetsTheMode() {
+        var environment = new EnvironmentImpl(environmentValues: new Dictionary<string, string> {
+            [LambdaResponseModeConfiguration.EnvironmentVariable] = "stream"
+        });
+        var configuration = new LambdaResponseModeConfiguration();
+
+        LambdaResponseModeConfiguration.FromEnvironment(environment, configuration);
+
+        Assert.Equal(LambdaResponseMode.Stream, configuration.Mode);
+    }
+
+    [Fact]
+    public void AnEnvironmentWithoutTheVariableIsBuffered() {
+        var configuration = new LambdaResponseModeConfiguration();
+
+        LambdaResponseModeConfiguration.FromEnvironment(
+            new EnvironmentImpl(environmentValues: new Dictionary<string, string>()), configuration);
+
+        Assert.Equal(LambdaResponseMode.Buffered, configuration.Mode);
+    }
+
+    [Fact]
+    public void AFreshConfigurationIsBuffered() {
+        Assert.Equal(LambdaResponseMode.Buffered, new LambdaResponseModeConfiguration().Mode);
+    }
+
+    /// <summary>
+    /// The application's amendment runs after the variable has been read, and wins over it.
+    /// </summary>
+    /// <remarks>
+    /// That order is what makes <c>ConfigureLambdaResponseMode</c> worth having: an application only
+    /// ever deployed behind a streaming function URL can say so in code rather than depending on a
+    /// variable being set correctly in every stack that creates it.
+    /// </remarks>
+    [Fact]
+    public void ConfigureLambdaResponseModeWinsOverTheEnvironment() {
+        var services = new ServiceCollection();
+
+        services.ConfigureLambdaResponseMode(mode => mode.Mode = LambdaResponseMode.Stream);
+
+        var environment = new EnvironmentImpl(environmentValues: new Dictionary<string, string> {
+            [LambdaResponseModeConfiguration.EnvironmentVariable] = "buffered"
+        });
+
+        // The provider the runtime module registers, then whatever the extension added beside it.
+        IConfigurationPackage[] packages = [
+            new SimpleConfigurationPackage(new IConfigurationValueProvider[] {
+                new NewConfigurationValueProvider<ILambdaResponseModeConfiguration, LambdaResponseModeConfiguration>(
+                    LambdaResponseModeConfiguration.FromEnvironment)
+            }),
+            .. services.BuildServiceProvider().GetServices<IConfigurationPackage>()
+        ];
+
+        var manager = new ConfigurationManager(environment, packages);
+
+        Assert.Equal(
+            LambdaResponseMode.Stream,
+            manager.GetConfiguration<ILambdaResponseModeConfiguration>().Mode);
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/ResponseStreamTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/ResponseStreamTests.cs
@@ -1,0 +1,264 @@
+using System.Text;
+using Hardened.Aws.Lambda.Runtime.Streaming;
+using Xunit;
+
+namespace Hardened.Aws.Lambda.Runtime.Tests.Streaming;
+
+/// <summary>
+/// The body of a response in stream mode: a pipe the pipeline writes into, opened onto the Lambda
+/// response stream at the first byte and pumped until completion.
+/// </summary>
+public class ResponseStreamTests {
+
+    /// <summary>
+    /// A memory stream that says when it has been written to, so a test waits for the pump rather
+    /// than sleeping, and that can be told to refuse every write.
+    /// </summary>
+    private sealed class Target : MemoryStream {
+        private readonly TaskCompletionSource _firstWrite = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task FirstWrite => _firstWrite.Task;
+
+        public Exception? FailWith { get; init; }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {
+            if (FailWith != null) {
+                throw FailWith;
+            }
+
+            var result = base.WriteAsync(buffer, cancellationToken);
+            _firstWrite.TrySetResult();
+
+            return result;
+        }
+
+        public string Text => Encoding.UTF8.GetString(ToArray());
+    }
+
+    private sealed class Opener {
+        public Target Target { get; init; } = new();
+
+        public int Opened { get; private set; }
+
+        public Stream Open() {
+            Opened++;
+
+            return Target;
+        }
+    }
+
+    private static byte[] Bytes(string text) => Encoding.UTF8.GetBytes(text);
+
+    [Fact]
+    public void TheStreamIsWriteOnly() {
+        var stream = new ResponseStream(new Opener().Open);
+
+        Assert.True(stream.CanWrite);
+        Assert.False(stream.CanRead);
+        Assert.False(stream.CanSeek);
+    }
+
+    [Fact]
+    public void ANewStreamHasWrittenNothingAndOpenedNothing() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        Assert.Equal(0, stream.Length);
+        Assert.Equal(0, stream.Position);
+        Assert.False(stream.HasResponseStarted);
+        Assert.Equal(0, opener.Opened);
+    }
+
+    /// <summary>
+    /// The Lambda stream opens at the first byte and not before. Opening earlier would commit the
+    /// prelude before the pipeline had finished deciding the status and headers.
+    /// </summary>
+    [Fact]
+    public async Task TheFirstWriteOpensTheLambdaStream() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        await stream.WriteAsync(Bytes("x"), TestContext.Current.CancellationToken);
+
+        Assert.True(stream.HasResponseStarted);
+        Assert.Equal(1, opener.Opened);
+    }
+
+    /// <summary>
+    /// The bootstrap allows one stream per invocation and throws on a second, so however many
+    /// writes and flushes follow, the opener runs once.
+    /// </summary>
+    [Fact]
+    public async Task TheLambdaStreamOpensOnce() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        await stream.WriteAsync(Bytes("a"), TestContext.Current.CancellationToken);
+        stream.Write(Bytes("b"), 0, 1);
+        stream.WriteByte((byte)'c');
+        await stream.FlushAsync(TestContext.Current.CancellationToken);
+        await stream.CompleteAsync();
+
+        Assert.Equal(1, opener.Opened);
+        Assert.Equal("abc", opener.Target.Text);
+    }
+
+    /// <summary>
+    /// An asynchronous write is on its way before the writer continues: the pump takes it as soon
+    /// as the pipe hands it over, with no timer in between. The hand-rolled host coalesced on a
+    /// 100 ms clock.
+    /// </summary>
+    [Fact]
+    public async Task AnAsyncWriteReachesTheLambdaStreamWithoutWaitingForCompletion() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        await stream.WriteAsync(Bytes("first item"), TestContext.Current.CancellationToken);
+        await opener.Target.FirstWrite.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.Equal("first item", opener.Target.Text);
+    }
+
+    /// <summary>
+    /// Synchronous writes sit in the pipe until something flushes. Completion is that something for
+    /// a serializer that never does.
+    /// </summary>
+    [Fact]
+    public async Task SynchronousWritesReachTheLambdaStreamAtCompletion() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        stream.Write(Bytes("hello"), 0, 5);
+        stream.WriteByte((byte)'!');
+
+        Assert.Equal(6, stream.Length);
+        Assert.True(stream.HasResponseStarted);
+
+        await stream.CompleteAsync();
+
+        Assert.Equal("hello!", opener.Target.Text);
+    }
+
+    [Fact]
+    public async Task AnAsynchronousFlushSendsWhatSynchronousWritesLeftInThePipe() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        stream.Write(Bytes("sync"), 0, 4);
+        await stream.FlushAsync(TestContext.Current.CancellationToken);
+        await opener.Target.FirstWrite.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.Equal("sync", opener.Target.Text);
+    }
+
+    /// <summary>
+    /// A flush with nothing written opens the stream: it is how a handler sends the status and
+    /// headers ahead of a slow body.
+    /// </summary>
+    [Fact]
+    public async Task AFlushWithNothingWrittenOpensTheLambdaStream() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        await stream.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(stream.HasResponseStarted);
+        Assert.Equal(1, opener.Opened);
+    }
+
+    /// <summary>
+    /// The synchronous flush cannot wait on the pump without blocking the thread the pump needs,
+    /// so it does nothing - and in particular does not open the stream.
+    /// </summary>
+    [Fact]
+    public void TheSynchronousFlushDoesNothing() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        stream.Flush();
+
+        Assert.False(stream.HasResponseStarted);
+        Assert.Equal(0, opener.Opened);
+    }
+
+    /// <summary>
+    /// A response that never wrote has no stream to close; completing it must not open one, or a
+    /// buffered function would stream an empty body on every invocation.
+    /// </summary>
+    [Fact]
+    public async Task CompletingAStreamThatNeverStartedOpensNothing() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+
+        await stream.CompleteAsync();
+
+        Assert.Equal(0, opener.Opened);
+        Assert.False(stream.HasResponseStarted);
+    }
+
+    /// <summary>
+    /// Completion returns only when every byte is on the Lambda stream, whatever the size. The
+    /// bootstrap writes the terminator the moment the handler returns, and a write still in the
+    /// pipe at that point would corrupt the chunked body.
+    /// </summary>
+    [Fact]
+    public async Task CompletionWaitsForEveryByte() {
+        var opener = new Opener();
+        var stream = new ResponseStream(opener.Open);
+        var large = new byte[1_000_000];
+        Random.Shared.NextBytes(large);
+
+        await stream.WriteAsync(large, TestContext.Current.CancellationToken);
+        stream.Write(large, 0, large.Length);
+        await stream.CompleteAsync();
+
+        Assert.Equal(2_000_000, opener.Target.Length);
+        Assert.Equal(large, opener.Target.ToArray().Take(1_000_000));
+        Assert.Equal(large, opener.Target.ToArray().Skip(1_000_000));
+    }
+
+    [Fact]
+    public async Task SuccessiveWritesAccumulateInTheLength() {
+        var stream = new ResponseStream(new Opener().Open);
+
+        await stream.WriteAsync(new byte[10], TestContext.Current.CancellationToken);
+        await stream.WriteAsync(new byte[20].AsMemory(), TestContext.Current.CancellationToken);
+        stream.Write(new byte[5], 0, 5);
+
+        Assert.Equal(35, stream.Length);
+        Assert.Equal(35, stream.Position);
+    }
+
+    /// <summary>
+    /// The runtime refusing a write - a connection reset, a stream already failed - is the
+    /// invocation's failure, surfaced where the host waits for the bytes.
+    /// </summary>
+    [Fact]
+    public async Task AWriteTheLambdaStreamRefusesSurfacesFromCompletion() {
+        var opener = new Opener { Target = new Target { FailWith = new IOException("connection reset") } };
+        var stream = new ResponseStream(opener.Open);
+
+        await stream.WriteAsync(Bytes("x"), TestContext.Current.CancellationToken);
+
+        var failure = await Assert.ThrowsAsync<IOException>(stream.CompleteAsync);
+
+        Assert.Equal("connection reset", failure.Message);
+    }
+
+    /// <summary>
+    /// Position is how many bytes have gone out, not a cursor. Bytes already sent cannot be unsent.
+    /// </summary>
+    [Fact]
+    public void ThePositionCannotBeMoved() {
+        var stream = new ResponseStream(new Opener().Open);
+
+        Assert.Throws<NotSupportedException>(() => stream.Position = 10);
+        Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        Assert.Throws<NotSupportedException>(() => stream.SetLength(100));
+    }
+
+    [Fact]
+    public void ReadingIsNotSupported() {
+        Assert.Throws<NotSupportedException>(() => new ResponseStream(new Opener().Open).Read(new byte[1], 0, 1));
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/RuntimeResponseStreamFactoryTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/RuntimeResponseStreamFactoryTests.cs
@@ -1,0 +1,28 @@
+using Amazon.Lambda.Core.ResponseStreaming;
+using Hardened.Aws.Lambda.Runtime.Streaming;
+using Xunit;
+
+namespace Hardened.Aws.Lambda.Runtime.Tests.Streaming;
+
+/// <summary>
+/// The default seam is the AWS factory, which only the bootstrap can initialise. Outside an
+/// invocation it says so rather than handing back a stream that goes nowhere - which is the
+/// reason the seam exists, and why tests substitute it.
+/// </summary>
+public class RuntimeResponseStreamFactoryTests {
+
+    [Fact]
+    public void OutsideABootstrapInvocationAPlainStreamCannotBeOpened() {
+        var failure = Assert.Throws<InvalidOperationException>(() => new RuntimeResponseStreamFactory().CreateStream());
+
+        Assert.Contains("not initialized", failure.Message);
+    }
+
+    [Fact]
+    public void OutsideABootstrapInvocationAnHttpStreamCannotBeOpened() {
+        var failure = Assert.Throws<InvalidOperationException>(
+            () => new RuntimeResponseStreamFactory().CreateHttpStream(new HttpResponseStreamPrelude()));
+
+        Assert.Contains("not initialized", failure.Message);
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Adapters/IStreamingPayloadAdapter.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Adapters/IStreamingPayloadAdapter.cs
@@ -1,0 +1,35 @@
+using Amazon.Lambda.Core.ResponseStreaming;
+using Hardened.Requests.Abstract.Execution;
+
+namespace Hardened.Aws.Lambda.Runtime.Adapters;
+
+/// <summary>
+/// An adapter whose source can take a streamed response, and which knows what to put in the
+/// prelude that opens one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Separate from <see cref="IPayloadAdapter"/> rather than a member on it, because most adapters
+/// have no answer to give. A queue message, a stream record and a scheduled rule have no caller
+/// holding a connection and no status to send one, so asking every adapter to build an HTTP prelude
+/// would put a <c>NotSupportedException</c> in five implementations to serve one.
+/// </para>
+/// <para>
+/// This is also what decides the mode per function rather than per deployment.
+/// <c>HARDENED_LAMBDA_RESPONSE_MODE</c> is read once whatever the function serves, and a function
+/// whose adapter does not implement this stays buffered under it - which is right, because the
+/// variable describes the front door and an event source has none.
+/// </para>
+/// </remarks>
+public interface IStreamingPayloadAdapter : IPayloadAdapter {
+    /// <summary>
+    /// The status, headers and cookies to open the response stream with.
+    /// </summary>
+    /// <remarks>
+    /// Called at the first body byte rather than when the response is created, so what it reads is
+    /// whatever the pipeline had decided by then. A refusal serialized before any handler ran opens
+    /// the stream with the refusal's status, and a handler that set headers beside its first item
+    /// has them here.
+    /// </remarks>
+    HttpResponseStreamPrelude CreatePrelude(IExecutionResponse response);
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hardened.Aws.Lambda.Runtime.csproj
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hardened.Aws.Lambda.Runtime.csproj
@@ -64,6 +64,13 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Primitives" />
+        <!--
+          The response body in stream mode. Serializers write synchronously and a Lambda
+          response stream blocks on its async path, so ResponseStream lands those writes in a
+          pipe and pumps it. Not in the shared framework for a plain class library, only for
+          an ASP.NET Core app.
+        -->
+        <PackageReference Include="System.IO.Pipelines" />
     </ItemGroup>
 
 </Project>

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hosting/LambdaInvocationHandler.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hosting/LambdaInvocationHandler.cs
@@ -2,10 +2,12 @@ using System.Runtime.ExceptionServices;
 using Amazon.Lambda.Core;
 using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Execution;
+using Hardened.Aws.Lambda.Runtime.Streaming;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Middleware;
 using Hardened.Shared.Runtime.Metrics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Hardened.Aws.Lambda.Runtime.Hosting;
 
@@ -27,20 +29,38 @@ namespace Hardened.Aws.Lambda.Runtime.Hosting;
 /// </para>
 /// </remarks>
 public class LambdaInvocationHandler {
+    /// <summary>
+    /// What a streamed response with an empty body sends instead of nothing.
+    /// </summary>
+    /// <remarks>
+    /// A zero-byte streamed body is not delivered promptly: CloudFront and a function URL both wait
+    /// on data that never comes, and a reader waiting on the first byte hangs until the invocation
+    /// times out. One newline ends it.
+    /// </remarks>
+    private static readonly byte[] EmptyStreamedBody = "\n"u8.ToArray();
+
     private readonly IServiceProvider _rootServiceProvider;
     private readonly IRequestExecutor _executor;
     private readonly IMetricLoggerProvider _metricLoggerProvider;
     private readonly IPayloadAdapter[] _adapters;
+    private readonly IResponseStreamFactory _streams;
+    private readonly LambdaResponseMode _mode;
 
     public LambdaInvocationHandler(
         IServiceProvider rootServiceProvider,
         IRequestExecutor executor,
         IMetricLoggerProvider metricLoggerProvider,
-        IEnumerable<IPayloadAdapter> adapters) {
+        IEnumerable<IPayloadAdapter> adapters,
+        IResponseStreamFactory streams,
+        IOptions<ILambdaResponseModeConfiguration> mode) {
         _rootServiceProvider = rootServiceProvider;
         _executor = executor;
         _metricLoggerProvider = metricLoggerProvider;
         _adapters = adapters.ToArray();
+        _streams = streams;
+        // Read once, when the handler is built. The mode is a property of the deployment, so
+        // re-reading it per invocation would ask the same question of the same environment.
+        _mode = mode.Value.Mode;
     }
 
     /// <summary>
@@ -70,17 +90,28 @@ public class LambdaInvocationHandler {
         using var deadline = LambdaExecutionContext.ForInvocation(lambdaContext);
         using var scope = _rootServiceProvider.CreateScope();
 
+        // The mode is the deployment's, and whether it can be honoured is the adapter's. A function
+        // whose source has no caller holding a connection stays buffered under a stream-mode
+        // variable rather than failing, because the variable describes a front door it does not have.
+        return _mode == LambdaResponseMode.Stream && adapter is IStreamingPayloadAdapter streaming
+            ? await Streamed(streaming, payload, lambdaContext, scope, deadline.Token)
+            : await Buffered(adapter, payload, lambdaContext, scope, deadline.Token);
+    }
+
+    /// <summary>
+    /// One payload back when the handler returns, which is what every source but a streaming front
+    /// door expects.
+    /// </summary>
+    private async Task<Stream> Buffered(
+        IPayloadAdapter adapter,
+        LambdaPayload payload,
+        ILambdaContext lambdaContext,
+        IServiceScope scope,
+        CancellationToken deadline) {
         var body = new MemoryStream();
         var output = new MemoryStream();
 
-        var context = new LambdaExecutionContext(
-            _rootServiceProvider,
-            scope.ServiceProvider,
-            scope.ServiceProvider.GetRequiredService<IKnownServices>(),
-            adapter.CreateRequest(payload, lambdaContext),
-            adapter.CreateResponse(body),
-            deadline.Token,
-            _metricLoggerProvider.CreateLogger("lambda-invocation"));
+        var context = Context(adapter, payload, lambdaContext, scope, deadline, adapter.CreateResponse(body));
 
         await _executor.Run(context, adapter.FailurePolicy);
 
@@ -101,6 +132,82 @@ public class LambdaInvocationHandler {
 
         return output;
     }
+
+    /// <summary>
+    /// A body that leaves as it is written, opening the Lambda response stream at its first byte.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One mechanism, three timings, and the pipeline never asks which it is running. A streaming
+    /// handler opens the stream at its first item and writes a chunk per item after it; a buffered
+    /// operation opens it when the serializer writes the body, one write and a close; a refusal
+    /// opens it with the refusal's own status when the error serializer writes.
+    /// </para>
+    /// <para>
+    /// Nothing catches here. A throw before the first byte never opens a stream, so it reaches the
+    /// bootstrap and is reported as a failed invocation with a complete error response. A throw
+    /// after the first byte cannot be taken back, and the bootstrap writes it as trailers - which is
+    /// what a truncated stream should be.
+    /// </para>
+    /// </remarks>
+    private async Task<Stream> Streamed(
+        IStreamingPayloadAdapter adapter,
+        LambdaPayload payload,
+        ILambdaContext lambdaContext,
+        IServiceScope scope,
+        CancellationToken deadline) {
+        IExecutionResponse? response = null;
+
+        // Built when the stream opens rather than when the response is created, so the prelude
+        // carries whatever the pipeline had decided by the first byte.
+        var body = new ResponseStream(() => _streams.CreateHttpStream(adapter.CreatePrelude(response!)));
+
+        response = adapter.CreateResponse(body);
+
+        var context = Context(adapter, payload, lambdaContext, scope, deadline, response);
+
+        try {
+            await _executor.Run(context, adapter.FailurePolicy);
+
+            if (body.Length == 0) {
+                await body.WriteAsync(EmptyStreamedBody);
+            }
+
+            await body.CompleteAsync();
+        }
+        catch {
+            // What was written before the failure still goes, so the client's view of the stream is
+            // the handler's up to the point it broke. A failure completing is second to the one
+            // already in flight.
+            try {
+                await body.CompleteAsync();
+            }
+            catch {
+                // The exception in flight is the one to surface.
+            }
+
+            throw;
+        }
+
+        // Ignored by the bootstrap once a stream has been created, and every response here creates
+        // one: the empty case wrote a newline above.
+        return Stream.Null;
+    }
+
+    private LambdaExecutionContext Context(
+        IPayloadAdapter adapter,
+        LambdaPayload payload,
+        ILambdaContext lambdaContext,
+        IServiceScope scope,
+        CancellationToken deadline,
+        IExecutionResponse response) =>
+        new(_rootServiceProvider,
+            scope.ServiceProvider,
+            scope.ServiceProvider.GetRequiredService<IKnownServices>(),
+            adapter.CreateRequest(payload, lambdaContext),
+            response,
+            deadline,
+            _metricLoggerProvider.CreateLogger("lambda-invocation"));
 
     private bool _installed;
 

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Modules/LambdaRuntimeModule.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Modules/LambdaRuntimeModule.cs
@@ -1,9 +1,12 @@
 using DependencyModules.Runtime.Attributes;
 using DependencyModules.Runtime.Interfaces;
 using Hardened.Aws.Lambda.Runtime.Hosting;
+using Hardened.Aws.Lambda.Runtime.Streaming;
 using Hardened.Requests.Runtime.DependencyInjection;
+using Hardened.Shared.Runtime.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Hardened.Aws.Lambda.Runtime.Modules;
 
@@ -34,5 +37,22 @@ namespace Hardened.Aws.Lambda.Runtime.Modules;
 public partial class LambdaRuntimeModule : IServiceCollectionConfiguration {
     public void ConfigureServices(IServiceCollection services) {
         services.TryAddSingleton<LambdaInvocationHandler>();
+
+        // The AWS bootstrap's stream, behind a seam. LambdaResponseStreamFactory is static and its
+        // setter is internal to the AWS packages, so a test can reach a streamed response only by
+        // replacing this.
+        services.TryAddSingleton<IResponseStreamFactory, RuntimeResponseStreamFactory>();
+
+        // Read from the environment at startup, and amendable from the application the way every
+        // other Hardened configuration is.
+        services.AddSingleton<IConfigurationPackage>(
+            new SimpleConfigurationPackage(new IConfigurationValueProvider[] {
+                new NewConfigurationValueProvider<ILambdaResponseModeConfiguration, LambdaResponseModeConfiguration>(
+                    LambdaResponseModeConfiguration.FromEnvironment)
+            }));
+
+        services.TryAddSingleton(
+            s => Options.Create(s.GetRequiredService<IConfigurationManager>()
+                .GetConfiguration<ILambdaResponseModeConfiguration>()));
     }
 }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/IResponseStreamFactory.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/IResponseStreamFactory.cs
@@ -1,0 +1,38 @@
+using Amazon.Lambda.Core.ResponseStreaming;
+
+namespace Hardened.Aws.Lambda.Runtime.Streaming;
+
+/// <summary>
+/// Opens the stream a response is written to. Creating it is what opts the invocation into
+/// streaming.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="LambdaResponseStreamFactory"/> is static and its setter is internal to the AWS
+/// packages, so nothing built on it can be exercised outside a real invocation. This is the seam:
+/// the hosts open every stream through it, and tests capture the prelude and the bytes through it.
+/// </para>
+/// </remarks>
+public interface IResponseStreamFactory {
+    /// <summary>
+    /// A stream with no prelude, for a function invoked through the Lambda API.
+    /// </summary>
+    Stream CreateStream();
+
+    /// <summary>
+    /// A stream that opens with the HTTP prelude, for a function URL in <c>RESPONSE_STREAM</c> mode.
+    /// </summary>
+    Stream CreateHttpStream(HttpResponseStreamPrelude prelude);
+}
+
+/// <summary>
+/// The AWS bootstrap's stream. Valid only inside an invocation
+/// <c>Amazon.Lambda.RuntimeSupport</c> is running; anywhere else the factory reports itself
+/// uninitialised.
+/// </summary>
+public sealed class RuntimeResponseStreamFactory : IResponseStreamFactory {
+    public Stream CreateStream() => LambdaResponseStreamFactory.CreateStream();
+
+    public Stream CreateHttpStream(HttpResponseStreamPrelude prelude) =>
+        LambdaResponseStreamFactory.CreateHttpStream(prelude);
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/LambdaResponseMode.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/LambdaResponseMode.cs
@@ -1,0 +1,30 @@
+namespace Hardened.Aws.Lambda.Runtime.Streaming;
+
+/// <summary>
+/// How a response leaves the function: as one payload when the handler returns, or as a stream
+/// that opens at the first body byte.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The wire protocol is fixed by the front door, not chosen by the function. A function URL in
+/// <c>RESPONSE_STREAM</c> invoke mode expects the HTTP prelude and the eight null bytes before the
+/// body; a function URL in <c>BUFFERED</c> mode and an API Gateway HTTP API expect the payload
+/// format 2.0 JSON. Neither accepts the other, and the event the function receives is the same
+/// document either way, so the deployment has to say which. That is
+/// <see cref="LambdaResponseModeConfiguration.EnvironmentVariable"/>, set beside the invoke mode
+/// the function URL was created with.
+/// </para>
+/// </remarks>
+public enum LambdaResponseMode {
+    /// <summary>
+    /// The body collects and the whole response goes back when the handler returns. The default,
+    /// and the only mode an HTTP API or a <c>BUFFERED</c> function URL can serve.
+    /// </summary>
+    Buffered,
+
+    /// <summary>
+    /// Every response travels as a stream: a buffered operation is one write and a close, a
+    /// streaming one is a write per item. Requires a function URL in <c>RESPONSE_STREAM</c> mode.
+    /// </summary>
+    Stream
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/LambdaResponseModeConfiguration.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/LambdaResponseModeConfiguration.cs
@@ -1,0 +1,63 @@
+using Hardened.Shared.Runtime.Application;
+
+namespace Hardened.Aws.Lambda.Runtime.Streaming;
+
+/// <summary>
+/// The response mode the function was deployed with. See <see cref="LambdaResponseMode"/>.
+/// </summary>
+public interface ILambdaResponseModeConfiguration {
+    LambdaResponseMode Mode { get; }
+}
+
+/// <summary>
+/// Read once at startup from <see cref="EnvironmentVariable"/>, and open to amendment through the
+/// application's configuration:
+/// </summary>
+/// <code>
+/// config.Amend((LambdaResponseModeConfiguration mode) => mode.Mode = LambdaResponseMode.Stream);
+/// </code>
+/// <remarks>
+/// An unrecognised value fails the application at startup rather than falling back to buffered. A
+/// deployment that spelt the variable wrong would otherwise run buffered behind a front door
+/// expecting the prelude, and the first request would be a 500 with nothing in the logs to say why.
+/// </remarks>
+public class LambdaResponseModeConfiguration : ILambdaResponseModeConfiguration {
+    public const string EnvironmentVariable = "HARDENED_LAMBDA_RESPONSE_MODE";
+
+    public const string BufferedValue = "buffered";
+
+    public const string StreamValue = "stream";
+
+    public LambdaResponseMode Mode { get; set; } = LambdaResponseMode.Buffered;
+
+    /// <summary>
+    /// The mode a setting names. Null or empty is buffered, the confirmed default.
+    /// </summary>
+    public static LambdaResponseMode Parse(string? value) {
+        if (string.IsNullOrWhiteSpace(value) || Matches(value!, BufferedValue)) {
+            return LambdaResponseMode.Buffered;
+        }
+
+        if (Matches(value!, StreamValue)) {
+            return LambdaResponseMode.Stream;
+        }
+
+        throw new InvalidOperationException(
+            $"{EnvironmentVariable} is '{value}'. It must be '{BufferedValue}' or '{StreamValue}'. " +
+            "A function URL in RESPONSE_STREAM invoke mode takes 'stream'; every other deployment " +
+            "takes 'buffered'.");
+    }
+
+    /// <summary>
+    /// The value a mode is written as, which is what the CDK puts in the environment.
+    /// </summary>
+    public static string ValueOf(LambdaResponseMode mode) =>
+        mode == LambdaResponseMode.Stream ? StreamValue : BufferedValue;
+
+    public static void FromEnvironment(IHardenedEnvironment environment, LambdaResponseModeConfiguration configuration) {
+        configuration.Mode = Parse(environment.Value<string>(EnvironmentVariable));
+    }
+
+    private static bool Matches(string value, string expected) =>
+        string.Equals(value.Trim(), expected, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/LambdaResponseModeServiceCollectionExtensions.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/LambdaResponseModeServiceCollectionExtensions.cs
@@ -1,0 +1,40 @@
+using Hardened.Shared.Runtime.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hardened.Aws.Lambda.Runtime.Streaming;
+
+public static class LambdaResponseModeServiceCollectionExtensions {
+
+    /// <summary>
+    /// Amends the response mode the environment was read into.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public void ConfigureServices(IServiceCollection services) {
+    ///     services.ConfigureLambdaResponseMode(mode => mode.Mode = LambdaResponseMode.Stream);
+    /// }
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// An amender rather than a replacement value, so it runs after
+    /// <c>HARDENED_LAMBDA_RESPONSE_MODE</c> has been read and wins over it. That order is what makes
+    /// this useful: an application that knows it is only ever deployed behind a streaming function
+    /// URL can say so in code and stop depending on a variable being set correctly.
+    /// </remarks>
+    public static IServiceCollection ConfigureLambdaResponseMode(
+        this IServiceCollection services, Action<LambdaResponseModeConfiguration> configure) {
+        services.AddSingleton<IConfigurationPackage>(
+            new SimpleConfigurationPackage(
+                Array.Empty<IConfigurationValueProvider>(),
+                new IConfigurationValueAmender[] {
+                    new SimpleConfigurationValueAmender<LambdaResponseModeConfiguration>(
+                        (_, configuration) => {
+                            configure(configuration);
+
+                            return configuration;
+                        })
+                }));
+
+        return services;
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/ResponseStream.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/ResponseStream.cs
@@ -1,0 +1,172 @@
+using System.IO.Pipelines;
+
+namespace Hardened.Aws.Lambda.Runtime.Streaming;
+
+/// <summary>
+/// The body of a response in stream mode. The pipeline writes into a pipe; the first byte opens
+/// the Lambda response stream and starts a pump that copies the pipe into it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Opening late is the point. Creating the stream sends the prelude, so status and headers have to
+/// be final by then, and the pipeline has finished deciding them by the time it writes the first
+/// byte. A refusal serialized by the pipeline opens the stream with the refusal's status; a
+/// response that throws before writing never opens one, and the error goes back through the
+/// bootstrap's error endpoint as a complete failure.
+/// </para>
+/// <para>
+/// A pipe rather than the Lambda stream directly because serializers write synchronously and
+/// <c>LambdaResponseStream.Write</c> blocks on its async path. Synchronous writes land in the pipe
+/// and reach the socket at the next <see cref="FlushAsync"/> or at <see cref="CompleteAsync"/>;
+/// asynchronous writes reach it as they happen. Each read the pump takes becomes one write on the
+/// Lambda stream, which the runtime flushes per write, so a per-item flush is a chunk per item and
+/// there is no timer between them.
+/// </para>
+/// </remarks>
+public sealed class ResponseStream : Stream {
+    private readonly Pipe _pipe = new();
+    private readonly Func<Stream> _open;
+    private Task? _pump;
+    private long _written;
+
+    /// <param name="open">
+    /// Opens the Lambda response stream. Called once, on the first write or flush, and never when
+    /// nothing is written.
+    /// </param>
+    public ResponseStream(Func<Stream> open) {
+        _open = open;
+    }
+
+    /// <summary>
+    /// Whether the Lambda response stream has been opened, which is the moment the prelude is
+    /// committed.
+    /// </summary>
+    public bool HasResponseStarted => _pump != null;
+
+    public override bool CanRead => false;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => true;
+
+    /// <summary>The bytes written so far.</summary>
+    public override long Length => _written;
+
+    public override long Position {
+        get => _written;
+        set => throw new NotSupportedException("Seeking in this stream is not supported.");
+    }
+
+    public override void Write(byte[] buffer, int offset, int count) {
+        Write(buffer.AsSpan(offset, count));
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer) {
+        EnsureStarted();
+
+        var span = _pipe.Writer.GetSpan(buffer.Length);
+        buffer.CopyTo(span);
+        _pipe.Writer.Advance(buffer.Length);
+
+        _written += buffer.Length;
+    }
+
+    public override void WriteByte(byte value) {
+        EnsureStarted();
+
+        var span = _pipe.Writer.GetSpan(1);
+        span[0] = value;
+        _pipe.Writer.Advance(1);
+
+        _written += 1;
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+        return WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+    }
+
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {
+        EnsureStarted();
+
+        await _pipe.Writer.WriteAsync(buffer, cancellationToken);
+
+        _written += buffer.Length;
+    }
+
+    public override async Task FlushAsync(CancellationToken cancellationToken) {
+        EnsureStarted();
+
+        await _pipe.Writer.FlushAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Nothing. A synchronous flush cannot wait on the pump without blocking the thread it runs
+    /// on; the bytes go at the next asynchronous flush or at completion.
+    /// </summary>
+    public override void Flush() { }
+
+    /// <summary>
+    /// Closes the pipe and waits until every byte written has been handed to the Lambda stream.
+    /// The host calls it once after the pipeline returns, and before it returns to the bootstrap,
+    /// so the runtime's terminator cannot race a write still in flight. A stream that never
+    /// started has nothing to wait for.
+    /// </summary>
+    public async Task CompleteAsync() {
+        if (_pump == null) {
+            return;
+        }
+
+        await _pipe.Writer.CompleteAsync();
+        await _pump;
+    }
+
+    private void EnsureStarted() {
+        if (_pump != null) {
+            return;
+        }
+
+        var target = _open();
+
+        _pump = PumpAsync(target);
+    }
+
+    private async Task PumpAsync(Stream target) {
+        var reader = _pipe.Reader;
+
+        try {
+            while (true) {
+                var result = await reader.ReadAsync();
+                var buffer = result.Buffer;
+
+                if (!buffer.IsEmpty) {
+                    foreach (var segment in buffer) {
+                        await target.WriteAsync(segment);
+                    }
+
+                    await target.FlushAsync();
+                }
+
+                reader.AdvanceTo(buffer.End);
+
+                if (result.IsCompleted) {
+                    break;
+                }
+            }
+        }
+        finally {
+            await reader.CompleteAsync();
+        }
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) {
+        throw new NotSupportedException("Reading from this stream is not supported.");
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) {
+        throw new NotSupportedException("Seeking in this stream is not supported.");
+    }
+
+    public override void SetLength(long value) {
+        throw new NotSupportedException("SetLength is not supported for this stream.");
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.ApiGateway.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.ApiGateway.approved.txt
@@ -1,10 +1,11 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Hardened.Aws.Lambda.Runtime.Tests")]
 namespace Hardened.Aws.Lambda.ApiGateway
 {
-    public sealed class ApiGatewayAdapter : Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter
+    public sealed class ApiGatewayAdapter : Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter, Hardened.Aws.Lambda.Runtime.Adapters.IStreamingPayloadAdapter
     {
         public ApiGatewayAdapter() { }
         public Hardened.Requests.Abstract.Execution.HostFailurePolicy FailurePolicy { get; }
+        public Amazon.Lambda.Core.ResponseStreaming.HttpResponseStreamPrelude CreatePrelude(Hardened.Requests.Abstract.Execution.IExecutionResponse response) { }
         public Hardened.Requests.Abstract.Execution.IExecutionRequest CreateRequest(Hardened.Aws.Lambda.Runtime.Execution.LambdaPayload payload, Amazon.Lambda.Core.ILambdaContext context) { }
         public Hardened.Requests.Abstract.Execution.IExecutionResponse CreateResponse(System.IO.Stream output) { }
         public bool Handles(System.Text.Json.JsonElement payload) { }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.Runtime.approved.txt
@@ -9,6 +9,10 @@ namespace Hardened.Aws.Lambda.Runtime.Adapters
         bool Handles(System.Text.Json.JsonElement payload);
         System.Threading.Tasks.ValueTask WriteResponse(Hardened.Requests.Abstract.Execution.IExecutionContext context, System.IO.Stream output);
     }
+    public interface IStreamingPayloadAdapter : Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter
+    {
+        Amazon.Lambda.Core.ResponseStreaming.HttpResponseStreamPrelude CreatePrelude(Hardened.Requests.Abstract.Execution.IExecutionResponse response);
+    }
 }
 namespace Hardened.Aws.Lambda.Runtime.Development
 {
@@ -122,7 +126,7 @@ namespace Hardened.Aws.Lambda.Runtime.Hosting
     }
     public class LambdaInvocationHandler
     {
-        public LambdaInvocationHandler(System.IServiceProvider rootServiceProvider, Hardened.Requests.Abstract.Execution.IRequestExecutor executor, Hardened.Shared.Runtime.Metrics.IMetricLoggerProvider metricLoggerProvider, System.Collections.Generic.IEnumerable<Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter> adapters) { }
+        public LambdaInvocationHandler(System.IServiceProvider rootServiceProvider, Hardened.Requests.Abstract.Execution.IRequestExecutor executor, Hardened.Shared.Runtime.Metrics.IMetricLoggerProvider metricLoggerProvider, System.Collections.Generic.IEnumerable<Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter> adapters, Hardened.Aws.Lambda.Runtime.Streaming.IResponseStreamFactory streams, Microsoft.Extensions.Options.IOptions<Hardened.Aws.Lambda.Runtime.Streaming.ILambdaResponseModeConfiguration> mode) { }
         public System.Collections.Generic.IReadOnlyList<Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter> Adapters { get; }
         public Hardened.Requests.Abstract.Middleware.IMiddlewareService Middleware { get; }
         public System.Threading.Tasks.Task<System.IO.Stream> Invoke(System.IO.Stream input, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
@@ -145,5 +149,64 @@ namespace Hardened.Aws.Lambda.Runtime.Modules
     {
         public LambdaRuntimeModuleAttribute() { }
         public DependencyModules.Runtime.Interfaces.IDependencyModule GetModule() { }
+    }
+}
+namespace Hardened.Aws.Lambda.Runtime.Streaming
+{
+    public interface ILambdaResponseModeConfiguration
+    {
+        Hardened.Aws.Lambda.Runtime.Streaming.LambdaResponseMode Mode { get; }
+    }
+    public interface IResponseStreamFactory
+    {
+        System.IO.Stream CreateHttpStream(Amazon.Lambda.Core.ResponseStreaming.HttpResponseStreamPrelude prelude);
+        System.IO.Stream CreateStream();
+    }
+    public enum LambdaResponseMode
+    {
+        Buffered = 0,
+        Stream = 1,
+    }
+    public class LambdaResponseModeConfiguration : Hardened.Aws.Lambda.Runtime.Streaming.ILambdaResponseModeConfiguration
+    {
+        public const string BufferedValue = "buffered";
+        public const string EnvironmentVariable = "HARDENED_LAMBDA_RESPONSE_MODE";
+        public const string StreamValue = "stream";
+        public LambdaResponseModeConfiguration() { }
+        public Hardened.Aws.Lambda.Runtime.Streaming.LambdaResponseMode Mode { get; set; }
+        public static void FromEnvironment(Hardened.Shared.Runtime.Application.IHardenedEnvironment environment, Hardened.Aws.Lambda.Runtime.Streaming.LambdaResponseModeConfiguration configuration) { }
+        public static Hardened.Aws.Lambda.Runtime.Streaming.LambdaResponseMode Parse(string? value) { }
+        public static string ValueOf(Hardened.Aws.Lambda.Runtime.Streaming.LambdaResponseMode mode) { }
+    }
+    public static class LambdaResponseModeServiceCollectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection ConfigureLambdaResponseMode(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Hardened.Aws.Lambda.Runtime.Streaming.LambdaResponseModeConfiguration> configure) { }
+    }
+    public sealed class ResponseStream : System.IO.Stream
+    {
+        public ResponseStream(System.Func<System.IO.Stream> open) { }
+        public override bool CanRead { get; }
+        public override bool CanSeek { get; }
+        public override bool CanWrite { get; }
+        public bool HasResponseStarted { get; }
+        public override long Length { get; }
+        public override long Position { get; set; }
+        public System.Threading.Tasks.Task CompleteAsync() { }
+        public override void Flush() { }
+        public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { }
+        public override int Read(byte[] buffer, int offset, int count) { }
+        public override long Seek(long offset, System.IO.SeekOrigin origin) { }
+        public override void SetLength(long value) { }
+        public override void Write(System.ReadOnlySpan<byte> buffer) { }
+        public override void Write(byte[] buffer, int offset, int count) { }
+        public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default) { }
+        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { }
+        public override void WriteByte(byte value) { }
+    }
+    public sealed class RuntimeResponseStreamFactory : Hardened.Aws.Lambda.Runtime.Streaming.IResponseStreamFactory
+    {
+        public RuntimeResponseStreamFactory() { }
+        public System.IO.Stream CreateHttpStream(Amazon.Lambda.Core.ResponseStreaming.HttpResponseStreamPrelude prelude) { }
+        public System.IO.Stream CreateStream() { }
     }
 }


### PR DESCRIPTION
Hardened.Amz shipped Lambda response streaming. #305 rebuilt the AWS line host by host rather than porting it, so the feature did not survive, and nothing decided against it.

Three things say it was an omission. `Directory.Packages.props:97` still pins `Amazon.Lambda.Core` 3.3.0 and `RuntimeSupport` 2.2.0 with a comment saying they are "the pair that ships response streaming through LambdaResponseStreamFactory", and nothing in the repository called that factory. `Amazon.CDK.Lib` and `Cdklabs.CdkMonitoringConstructs` are pinned with no consumer either. The same class of loss was already found once, in the commit that restored the DynamoDB client because the rebuild "lost working code with no successor and no note".

The documentation went the other way. `1c50b652`, "Rewrite the AWS documentation against the packages that shipped", replaced the `HARDENED_LAMBDA_RESPONSE_MODE` table in `streaming.md` with "Lambda behind API Gateway | no" and deleted `cdk.md`. That brought the docs into line with the regression rather than catching it. The copy still in `Hardened.Docs` documents the feature as it worked.

## What this restores

`HARDENED_LAMBDA_RESPONSE_MODE` picks the mode, buffered by default. An unrecognised value fails at startup rather than falling back: a deployment that spelt it wrong would otherwise run buffered behind a front door expecting the prelude, and the first request would be a 500 with nothing in the logs to say why.

Four files port from Amz unchanged but for their namespace, and none of them touches a host: `ResponseStream`, `LambdaResponseMode`, `LambdaResponseModeConfiguration` and `IResponseStreamFactory`.

## Where the seam went

Amz selected between two processors behind `LambdaWebHost`. This repository has one `LambdaInvocationHandler` behind `IPayloadAdapter`, so the branch belongs there rather than beside it. In stream mode the handler opens a `ResponseStream` whose first byte builds the prelude and returns `Stream.Null`, which the bootstrap ignores once a stream exists.

Streaming is opt-in per adapter through a new `IStreamingPayloadAdapter` rather than a member on `IPayloadAdapter`. A queue message has no caller holding a connection and no status to send one, so a function serving one stays buffered under a stream-mode variable rather than failing. That keeps the variable safe to set account-wide.

`ApiGatewayAdapter` builds the prelude from the same status, headers and cookies it would have written into the envelope. The Set-Cookie rendering is now one method both modes call, so a cookie cannot come out one way buffered and another way streamed.

`LambdaInvocationHandler`'s constructor takes two more services. It is resolved from the container, so this reaches an application only if it built one by hand.

## Not in this change

The startup warning for an application whose `[ServerSentEvents]` handlers are deployed buffered. Amz emitted the handler list from its own `ApplicationFileWriter`; this repository's generator knows the attribute but emits no such list, so that is a generator change of its own. It matters, because the build cannot refuse the combination when the mode is an environment variable.

The CDK half. `FunctionUrlFunctionCreate`, the `RESPONSE_STREAM` invoke mode and the variable it writes beside it lived in `Hardened.Amz.Cdk`, and there is no CDK project here to land them in.

## Verification

CI-shaped Release build of the whole solution exits 0. 253 tests in `Hardened.Aws.Lambda.Runtime.Tests`, of which 23 come across from Amz for the ported files and 9 are new: which mode a function serves, what the prelude carries, that it is read at the first byte and not before, that an empty response still opens the stream, that a throw either side of the first byte does the right thing, and that `ConfigureLambdaResponseMode` wins over the environment. Public API re-approved for both assemblies. The ApiGateway, Invoke, Sqs, Events and LambdaRuntime integration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)