### PR TITLE
Warn when [ServerSentEvents] handlers are deployed in buffered mode

### DIFF
--- a/docs/aws/lambda-web.md
+++ b/docs/aws/lambda-web.md
@@ -147,8 +147,23 @@ caller holding a connection, so a function serving one stays buffered under a `s
 rather than failing. That keeps the setting safe to apply account-wide.
 
 `[ServerSentEvents]` handlers need `stream`. Under `buffered` their events are delivered together
-when the invocation ends, or never when the function times out first. See
-[Streaming responses](/guide/streaming).
+when the invocation ends, or never when the function times out first. An application that has them
+and was deployed buffered logs a warning at startup naming the routes:
+
+```
+HARDENED_LAMBDA_RESPONSE_MODE is buffered and 1 handler(s) answer text/event-stream:
+GET /orders/live. Their events are delivered when the invocation ends, or never if it times
+out first. Deploy behind a function URL in RESPONSE_STREAM invoke mode with
+HARDENED_LAMBDA_RESPONSE_MODE=stream, or remove [ServerSentEvents].
+```
+
+A warning rather than a refusal to start: the other routes are served correctly, and the build
+cannot catch this on its own. The compilation that knows a handler carries `[ServerSentEvents]` does
+not know how the function will be deployed, and the deployment that sets the mode has no view of the
+handlers. Newline-delimited streams are not named, because they arrive late in buffered mode but
+intact.
+
+See [Streaming responses](/guide/streaming).
 
 ## Testing
 

--- a/docs/guide/streaming.md
+++ b/docs/guide/streaming.md
@@ -215,7 +215,8 @@ client generated from it reads a list rather than a stream.
 On Lambda, whether a response streams is a deployment setting rather than a property of the handler.
 `stream` needs a function URL in `RESPONSE_STREAM` invoke mode, with or without CloudFront in front.
 A buffered deployment accumulates the whole body before returning it, so a streamed response arrives
-all at once at the end. See [Response mode](/aws/lambda-web#response-mode).
+all at once at the end. An application with `[ServerSentEvents]` handlers deployed in buffered mode
+logs a warning at startup naming them. See [Response mode](/aws/lambda-web#response-mode).
 
 The Azure Functions worker hands the whole body to the host when the invocation returns, so a
 streamed response there arrives at the end whatever the handler does.

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/ServerSentEventsResponseModeStartupServiceTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Streaming/ServerSentEventsResponseModeStartupServiceTests.cs
@@ -1,0 +1,137 @@
+using Hardened.Aws.Lambda.Runtime.Streaming;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Hardened.Aws.Lambda.Runtime.Tests.Streaming;
+
+/// <summary>
+/// The one thing that can say the response mode and the application's event-stream handlers
+/// disagree. The build cannot: the mode is an environment variable and the same assembly serves
+/// both modes.
+/// </summary>
+public class ServerSentEventsResponseModeStartupServiceTests {
+
+    [Fact]
+    public async Task BufferedWithEventHandlersWarnsAndNamesThem() {
+        var log = await Run(LambdaResponseMode.Buffered, "GET /orders/live", "GET /prices/live");
+
+        var warning = Assert.Single(log.Warnings);
+
+        Assert.Contains(LambdaResponseModeConfiguration.EnvironmentVariable, warning);
+        Assert.Contains("GET /orders/live", warning);
+        Assert.Contains("GET /prices/live", warning);
+        Assert.Contains("RESPONSE_STREAM", warning);
+    }
+
+    /// <summary>
+    /// The combination the warning exists to catch is the only one it fires on.
+    /// </summary>
+    [Fact]
+    public async Task StreamModeWithEventHandlersIsSilent() {
+        var log = await Run(LambdaResponseMode.Stream, "GET /orders/live");
+
+        Assert.Empty(log.Warnings);
+    }
+
+    /// <summary>
+    /// The ordinary application. The routing generator emits no manifest when no handler is framed
+    /// as events, so there is nothing registered and nothing to say.
+    /// </summary>
+    [Fact]
+    public async Task BufferedWithNoEventHandlersIsSilent() {
+        var log = await Run(LambdaResponseMode.Buffered);
+
+        Assert.Empty(log.Warnings);
+    }
+
+    /// <summary>
+    /// Two tables in one application, which is what a library contributing routes looks like.
+    /// </summary>
+    [Fact]
+    public async Task HandlersFromEveryManifestAreNamed() {
+        var services = Services(LambdaResponseMode.Buffered);
+        var log = new RecordingLoggerProvider();
+
+        services.AddSingleton<IServerSentEventManifest>(new Manifest("GET /orders/live"));
+        services.AddSingleton<IServerSentEventManifest>(new Manifest("GET /prices/live"));
+        services.AddLogging(logging => logging.AddProvider(log));
+
+        await new ServerSentEventsResponseModeStartupService().Startup(services.BuildServiceProvider());
+
+        var warning = Assert.Single(log.Warnings);
+
+        Assert.Contains("GET /orders/live", warning);
+        Assert.Contains("GET /prices/live", warning);
+        Assert.Contains("2 handler(s)", warning);
+    }
+
+    /// <summary>
+    /// Startup does not depend on there being somewhere to log to.
+    /// </summary>
+    [Fact]
+    public async Task AnApplicationWithNoLoggerStillStarts() {
+        var services = Services(LambdaResponseMode.Buffered);
+
+        services.AddSingleton<IServerSentEventManifest>(new Manifest("GET /orders/live"));
+
+        Assert.True(
+            await new ServerSentEventsResponseModeStartupService().Startup(services.BuildServiceProvider()));
+    }
+
+    private static async Task<RecordingLoggerProvider> Run(
+        LambdaResponseMode mode, params string[] handlers) {
+        var services = Services(mode);
+        var log = new RecordingLoggerProvider();
+
+        if (handlers.Length > 0) {
+            services.AddSingleton<IServerSentEventManifest>(new Manifest(handlers));
+        }
+
+        services.AddLogging(logging => logging.AddProvider(log));
+
+        await new ServerSentEventsResponseModeStartupService().Startup(services.BuildServiceProvider());
+
+        return log;
+    }
+
+    private static ServiceCollection Services(LambdaResponseMode mode) {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(
+            Options.Create<ILambdaResponseModeConfiguration>(
+                new LambdaResponseModeConfiguration { Mode = mode }));
+
+        return services;
+    }
+
+    private sealed class Manifest(params string[] handlers) : IServerSentEventManifest {
+        public IReadOnlyList<string> Handlers { get; } = handlers;
+    }
+
+    /// <summary>Keeps the rendered text of every warning, which is what the assertions read.</summary>
+    private sealed class RecordingLoggerProvider : ILoggerProvider {
+        public List<string> Warnings { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new Recording(this);
+
+        public void Dispose() { }
+
+        private sealed class Recording(RecordingLoggerProvider provider) : ILogger {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter) {
+                if (logLevel == LogLevel.Warning) {
+                    provider.Warnings.Add(formatter(state, exception));
+                }
+            }
+        }
+    }
+}

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Modules/LambdaRuntimeModule.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Modules/LambdaRuntimeModule.cs
@@ -3,6 +3,7 @@ using DependencyModules.Runtime.Interfaces;
 using Hardened.Aws.Lambda.Runtime.Hosting;
 using Hardened.Aws.Lambda.Runtime.Streaming;
 using Hardened.Requests.Runtime.DependencyInjection;
+using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Runtime.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -54,5 +55,10 @@ public partial class LambdaRuntimeModule : IServiceCollectionConfiguration {
         services.TryAddSingleton(
             s => Options.Create(s.GetRequiredService<IConfigurationManager>()
                 .GetConfiguration<ILambdaResponseModeConfiguration>()));
+
+        // Says at startup when the mode and the application's [ServerSentEvents] handlers disagree.
+        // Enumerable rather than Try, because a startup service is one of many and replacing the
+        // set is not what registering another one means.
+        services.AddSingleton<IStartupService, ServerSentEventsResponseModeStartupService>();
     }
 }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/ServerSentEventsResponseModeStartupService.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Streaming/ServerSentEventsResponseModeStartupService.cs
@@ -1,0 +1,70 @@
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Shared.Runtime.Application;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Hardened.Aws.Lambda.Runtime.Streaming;
+
+/// <summary>
+/// Says, at startup, when an application carries server-sent event handlers but was deployed
+/// buffered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The build cannot refuse this combination, which is why it is checked here.</b> The mode is an
+/// environment variable and the same assembly serves both, so the compilation that knows a handler
+/// carries <c>[ServerSentEvents]</c> does not know how the function will be deployed, and the
+/// deployment that knows the mode has no view of the handlers. Only the running application holds
+/// both, and the routing generator hands it the list through
+/// <see cref="IServerSentEventManifest"/>.
+/// </para>
+/// <para>
+/// In buffered mode every event is delivered when the invocation ends, or never when the function
+/// times out first. That is not a degraded event stream but a broken one: a browser
+/// <c>EventSource</c> holds a connection open expecting events as they happen, and gets a single
+/// response minutes later or a timeout.
+/// </para>
+/// <para>
+/// A warning rather than a throw. The application still serves its other routes correctly, and a
+/// function refusing to start over one route's framing would take an entire deployment down for
+/// something the operator may already know about.
+/// </para>
+/// <para>
+/// Newline-delimited streams are not listed and get no warning. They arrive late in buffered mode
+/// but intact, because nothing about NDJSON depends on when a line reaches the reader.
+/// </para>
+/// </remarks>
+internal class ServerSentEventsResponseModeStartupService : IStartupService {
+    public Task<bool> Startup(IServiceProvider rootProvider) {
+        // Empty for every application without an event stream, which is the ordinary case: the
+        // routing generator emits no manifest at all when no handler is framed as events.
+        var handlers = rootProvider.GetServices<IServerSentEventManifest>()
+            .SelectMany(manifest => manifest.Handlers)
+            .ToArray();
+
+        if (handlers.Length == 0) {
+            return Task.FromResult(true);
+        }
+
+        if (rootProvider.GetRequiredService<IOptions<ILambdaResponseModeConfiguration>>().Value.Mode ==
+            LambdaResponseMode.Stream) {
+            return Task.FromResult(true);
+        }
+
+        var logger = rootProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(ServerSentEventsResponseModeStartupService).FullName!);
+
+        logger?.LogWarning(
+            "{Variable} is buffered and {Count} handler(s) answer text/event-stream: {Handlers}. " +
+            "Their events are delivered when the invocation ends, or never if it times out first. " +
+            "Deploy behind a function URL in RESPONSE_STREAM invoke mode with {Variable}=stream, or " +
+            "remove [ServerSentEvents].",
+            LambdaResponseModeConfiguration.EnvironmentVariable,
+            handlers.Length,
+            string.Join(", ", handlers),
+            LambdaResponseModeConfiguration.EnvironmentVariable);
+
+        return Task.FromResult(true);
+    }
+}

--- a/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/HttpFunctionTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/HttpFunctionTests.cs
@@ -28,6 +28,25 @@ public class HttpFunctionTests {
         Assert.Equal(7, order.Quantity);
     }
 
+    /// <summary>
+    /// A literal segment beside a wildcard at the same depth, which nothing else in the repository
+    /// routes.
+    /// </summary>
+    /// <remarks>
+    /// <c>/orders/live</c> has to beat <c>/orders/{id}</c> rather than arriving as an order whose id
+    /// is the word "live". It is the shape anyone reaches for when adding an event stream to an
+    /// existing resource, and until this route existed no test said which way the generated table
+    /// resolved it.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ALiteralSegmentBeatsTheWildcardBesideIt(ITestWebApp app) {
+        var response = await app.Get("/orders/live");
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Contains("text/event-stream", response.Headers["Content-Type"].ToString());
+        Assert.Contains("live-1", await response.ReadTextAsync());
+    }
+
     [HardenedTest]
     public async Task APostBindsItsBody(ITestWebApp app) {
         var response = await app.Post(new Order { Id = "o-2", Quantity = 3 }, "/orders");

--- a/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/ServerSentEventManifestTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/ServerSentEventManifestTests.cs
@@ -1,0 +1,42 @@
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Shared.Testing.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
+
+/// <summary>
+/// The whole chain the buffered-mode warning rests on, through a real application rather than a
+/// fixture: the routing generator finds the framing, emits a manifest, and registers it where the
+/// host can resolve it.
+/// </summary>
+/// <remarks>
+/// Each half is covered on its own - the emitted source by the web pipeline fixtures, the warning by
+/// <c>ServerSentEventsResponseModeStartupServiceTests</c> - and neither says the two meet. A
+/// manifest that is generated and never registered would pass both and warn about nothing.
+/// </remarks>
+public class ServerSentEventManifestTests {
+
+    [HardenedTest]
+    public void TheEventStreamHandlerIsInTheManifest(IServiceProvider provider) {
+        var handlers = provider.GetServices<IServerSentEventManifest>()
+            .SelectMany(manifest => manifest.Handlers)
+            .ToArray();
+
+        Assert.Equal(["GET /orders/live"], handlers);
+    }
+
+    /// <summary>
+    /// The three ordinary routes are not listed. Only a handler framed as events belongs here, and
+    /// a manifest naming every route would have the host warn about all of them.
+    /// </summary>
+    [HardenedTest]
+    public void OrdinaryHandlersAreNotListed(IServiceProvider provider) {
+        var handlers = provider.GetServices<IServerSentEventManifest>()
+            .SelectMany(manifest => manifest.Handlers)
+            .ToArray();
+
+        Assert.DoesNotContain(handlers, handler => handler.Contains("/orders/{id}"));
+        Assert.DoesNotContain(handlers, handler => handler == "POST /orders");
+    }
+}

--- a/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT/OrderController.cs
+++ b/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT/OrderController.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Hardened.Web.Runtime.Attributes;
 
 namespace Hardened.IntegrationTests.ApiGateway.SUT;
@@ -20,4 +21,21 @@ public class OrderController {
 
     [Delete("/orders/{id}")]
     public void Remove(string id) { }
+
+    /// <summary>
+    /// An event stream, so this application has something for the routing generator to put in its
+    /// <c>IServerSentEventManifest</c> and for the host to warn about when it is deployed buffered.
+    /// </summary>
+    /// <remarks>
+    /// A literal segment beside <c>/orders/{id}</c> on purpose. Nothing else in the repository
+    /// routes a literal and a wildcard at the same depth, and an event stream at
+    /// <c>/orders/live</c> is the shape anyone would reach for.
+    /// </remarks>
+    [Get("/orders/live")]
+    [ServerSentEvents]
+    public async IAsyncEnumerable<Order> Live([EnumeratorCancellation] CancellationToken cancellationToken) {
+        yield return new Order { Id = "live-1", Quantity = 1 };
+
+        await Task.Yield();
+    }
 }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -976,6 +976,10 @@ namespace Hardened.Requests.Abstract.Serializer
         Hardened.Requests.Abstract.Serializer.IRequestDeserializer FindRequestDeserializer(Hardened.Requests.Abstract.Execution.IExecutionContext context);
         Hardened.Requests.Abstract.Serializer.IResponseSerializer FindResponseSerializer(Hardened.Requests.Abstract.Execution.IExecutionContext context);
     }
+    public interface IServerSentEventManifest
+    {
+        System.Collections.Generic.IReadOnlyList<string> Handlers { get; }
+    }
     public interface ISseEvent
     {
         object? Data { get; }

--- a/src/Requests/Hardened.Requests.Abstract/Serializer/IServerSentEventManifest.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Serializer/IServerSentEventManifest.cs
@@ -1,0 +1,33 @@
+namespace Hardened.Requests.Abstract.Serializer;
+
+/// <summary>
+/// The handlers an application answers as <c>text/event-stream</c>, known at startup.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written by the routing generator, which is the only place the answer is available before a
+/// request arrives. A routing table builds its handlers lazily, so enumerating them to ask would
+/// mean constructing every filter chain in the application at startup to read one flag off each.
+/// A table with no such handler emits no manifest at all.
+/// </para>
+/// <para>
+/// <b>It exists for the hosts whose framing depends on their deployment.</b> Kestrel and ASP.NET
+/// Core flush whatever they are given, so nothing there has a question to ask. A Lambda's response
+/// mode is an environment variable, so the same assembly serves both and the build cannot refuse
+/// the combination - which leaves the application itself as the only thing that can say the two
+/// disagree. See <c>Hardened.Aws.Lambda.Runtime</c>'s
+/// <c>ServerSentEventsResponseModeStartupService</c>.
+/// </para>
+/// <para>
+/// Here rather than beside the routing table because <c>Hardened.Aws.Lambda.Runtime</c> references
+/// no web package, deliberately: an adapter produces an <c>IExecutionRequest</c> and the pipeline
+/// routes it. Which handlers are framed as events is a pipeline fact, not a routing one.
+/// </para>
+/// </remarks>
+public interface IServerSentEventManifest {
+    /// <summary>
+    /// One entry per handler, as the verb and path an operator would recognise from a log line -
+    /// <c>GET /orders/live</c>.
+    /// </summary>
+    IReadOnlyList<string> Handlers { get; }
+}

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
@@ -96,6 +96,9 @@
         <Compile Include="../Hardened.SourceGenerator/Web/EnumWireConverterEmitter.cs">
             <Link>Web/%(FileName)%(Extension)</Link>
         </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Web/ServerSentEventManifestEmitter.cs">
+            <Link>Web/%(FileName)%(Extension)</Link>
+        </Compile>
         <Compile Include="../Hardened.SourceGenerator/Validation/ParameterValidatorRegistration.cs">
             <Link>Validation/%(FileName)%(Extension)</Link>
         </Compile>

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/Fixtures/WebPipeline/streaming-response/Application.Routing.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/Fixtures/WebPipeline/streaming-response/Application.Routing.cs
@@ -3,10 +3,12 @@
 #pragma warning disable CS1591 // generated members carry no doc comments
 using DependencyModules.Runtime.Helpers;
 using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.PathTokens;
 using Hardened.Web.Runtime.Handlers;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using TestApp.Generated;
 
@@ -23,6 +25,10 @@ namespace TestApp
             serviceCollection.AddSingleton<
                 IWebExecutionRequestHandlerProvider,
                 Application.RoutingTable
+            >();
+            serviceCollection.AddSingleton<
+                IServerSentEventManifest,
+                Application.ServerSentEvents
             >();
             serviceCollection.AddTransient<FeedController>();
             serviceCollection.AddTransient<Application.Links>();
@@ -88,6 +94,16 @@ namespace TestApp
                 }
                 return handlerInfo;
             }
+        }
+
+        /// <summary>
+        /// The handlers this application answers as text/event-stream. Read by a host whose framing depends on its deployment; see IServerSentEventManifest.
+        /// </summary>
+        private sealed class ServerSentEvents : IServerSentEventManifest
+        {
+            private static readonly string[] _handlers = new string[] { "GET /feed" };
+
+            public IReadOnlyList<string> Handlers => _handlers;
         }
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
@@ -275,6 +275,11 @@ public static class KnownTypes {
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Serializer,
                 "IContextSerializationService");
 
+        /// <summary>The list of event-stream handlers a routing table emits for a host to read.</summary>
+        public static readonly ITypeDefinition IServerSentEventManifest =
+            TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Serializer,
+                "IServerSentEventManifest");
+
         public static readonly ITypeDefinition IExecutionRequestParameter =
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Execution,
                 "IExecutionRequestParameter");

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -250,13 +250,18 @@ public static class RoutingTableGenerator {
         var routingType = TypeDefinition.Get(appModel.EntryPointType.Namespace,
             appModel.EntryPointType.Name + "." + options.ClassName);
 
-        // Before the DI method, which registers what this emits.
+        // Before the DI method, which registers what these emit.
         var enums = EnumWireConverterEmitter.Collect(endPointModels);
 
         EnumWireConverterEmitter.Emit(appClass, enums);
 
+        var eventStreams = ServerSentEventManifestEmitter.Collect(endPointModels);
+
+        ServerSentEventManifestEmitter.Emit(appClass, eventStreams);
+
         GenerateDependencyInjection(
-            appClass, routingType, appModel, endPointModels, enums, cancellationToken, options);
+            appClass, routingType, appModel, endPointModels, enums, eventStreams, cancellationToken,
+            options);
     }
 
     private static void CreateConstructor(ClassDefinition appClass) {
@@ -273,6 +278,7 @@ public static class RoutingTableGenerator {
         ITypeDefinition routingTableType,
         EntryPointSelector.Model applicationModel, IReadOnlyList<RequestHandlerModel> webEndPointModels,
         IReadOnlyList<EnumVocabulary> enums,
+        IReadOnlyList<string> eventStreams,
         CancellationToken cancellationToken,
         RoutingTableOptions options) {
         cancellationToken.ThrowIfCancellationRequested();
@@ -292,6 +298,18 @@ public static class RoutingTableGenerator {
 
         diMethod.AddIndentedStatement(serviceCollection.InvokeGeneric("AddSingleton",
             new[] { KnownTypes.Web.IWebExecutionRequestHandlerProvider, routingTableType }));
+
+        // Only where a handler is framed as events, so an application with none generates exactly
+        // what it generated before this existed.
+        if (eventStreams.Count > 0) {
+            diMethod.AddIndentedStatement(serviceCollection.InvokeGeneric("AddSingleton",
+                new[] {
+                    KnownTypes.Requests.IServerSentEventManifest,
+                    TypeDefinition.Get(applicationModel.EntryPointType.Namespace,
+                        applicationModel.EntryPointType.Name + "." +
+                        ServerSentEventManifestEmitter.ContainerName)
+                }));
+        }
 
         // The service-wide negotiation policy, from [ContentNegotiation] on the entry point. There
         // is no description to consult here; the spec-first table reads both. Same helper either

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/ServerSentEventManifestEmitter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/ServerSentEventManifestEmitter.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Shared;
+using Hardened.SourceGenerator.Requests;
+
+namespace Hardened.SourceGenerator.Web;
+
+/// <summary>
+/// The list of handlers an application answers as <c>text/event-stream</c>, for a host whose
+/// framing depends on how it was deployed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Emitted rather than discovered, because a routing table builds its handlers lazily: asking each
+/// one at startup would mean constructing every filter chain in the application to read one flag
+/// off each. Here the answer is already known, and costs a string per handler.
+/// </para>
+/// <para>
+/// <b>Nothing is emitted when no handler is framed as events</b>, which is almost every
+/// application. That is also what keeps this off the checked-in routing fixtures: a table with no
+/// event stream generates exactly what it generated before.
+/// </para>
+/// <para>
+/// Its one consumer is the Lambda host, whose response mode is an environment variable rather than
+/// a property of the build - so the same assembly serves both modes and only the running
+/// application can say the mode and the handlers disagree. Kestrel and ASP.NET Core flush whatever
+/// they are given and never ask.
+/// </para>
+/// </remarks>
+internal static class ServerSentEventManifestEmitter {
+
+    public const string ContainerName = "ServerSentEvents";
+
+    private const string HandlersField = "_handlers";
+
+    /// <summary>
+    /// The handlers framed as events, as the verb and path an operator reads off a log line.
+    /// </summary>
+    /// <remarks>
+    /// Ordered and deduplicated so the emitted list does not move between builds over nothing,
+    /// which would dirty the incremental cache and the fixtures with it.
+    /// </remarks>
+    public static IReadOnlyList<string> Collect(IReadOnlyList<RequestHandlerModel> handlers) =>
+        handlers
+            .Where(handler =>
+                handler.ResponseInformation.StreamFraming == StreamFramingNames.ServerSentEvents)
+            .Select(handler => handler.Name.Method + " " + handler.Name.Path)
+            .Distinct()
+            .OrderBy(name => name, System.StringComparer.Ordinal)
+            .ToList();
+
+    public static void Emit(ClassDefinition appClass, IReadOnlyList<string> handlers) {
+        if (handlers.Count == 0) {
+            return;
+        }
+
+        var container = appClass.AddClass(ContainerName);
+
+        container.Modifiers |= ComponentModifier.Private | ComponentModifier.Sealed;
+        container.AddBaseType(KnownTypes.Requests.IServerSentEventManifest);
+        container.Comment =
+            "The handlers this application answers as text/event-stream. Read by a host whose " +
+            "framing depends on its deployment; see IServerSentEventManifest.";
+
+        var field = container.AddField(typeof(string[]), HandlersField);
+
+        field.Modifiers |=
+            ComponentModifier.Private | ComponentModifier.Static | ComponentModifier.Readonly;
+        field.InitializeValue = new CodeOutputComponent(
+            "new string[] { " + string.Join(", ", handlers.Select(Quoted)) + " }") { Indented = false };
+
+        var property = container.AddProperty(
+            new GenericTypeDefinition(
+                TypeDefinitionEnum.InterfaceDefinition,
+                "System.Collections.Generic",
+                "IReadOnlyList",
+                new[] { TypeDefinition.Get(typeof(string)) }),
+            "Handlers");
+
+        property.Modifiers |= ComponentModifier.Public;
+        property.Set = null;
+        property.Get.LambdaSyntax = true;
+        property.Get.AddCode(HandlersField + ";");
+    }
+
+    private static string Quoted(string value) => "\"" + value.Replace("\"", "\\\"") + "\"";
+}


### PR DESCRIPTION
The follow-up scoped out of #313, and the only thing that can catch this.

Under `HARDENED_LAMBDA_RESPONSE_MODE=buffered` an event stream's events are delivered together when the invocation ends, or never when the function times out first. That is a broken stream rather than a slow one: a browser `EventSource` holds a connection open expecting events as they happen. Nothing said so, and nothing at build time can. The compilation that knows a handler carries `[ServerSentEvents]` does not know how the function will be deployed, and the deployment that sets the mode has no view of the handlers. Only the running application holds both.

## Where the list comes from

The routing generator emits it. A routing table builds its handlers lazily, so asking each one at startup would mean constructing every filter chain in the application to read one flag off each — and the generator already knows, at the point it writes the table, which handlers are framed as events.

**Nothing is emitted when no handler is framed that way**, which is almost every application. That is what keeps this off the checked-in fixtures: exactly one of the twelve web pipeline fixtures moves, and it is the streaming one.

`IServerSentEventManifest` lives in `Hardened.Requests.Abstract` rather than beside the routing table, because `Hardened.Aws.Lambda.Runtime` references no web package by design. Which handlers are framed as events is a pipeline fact, not a routing one.

Amz warned from a generated `Main` that has no counterpart here, so the check is an `IStartupService`, which `ApplicationLogic.Start` already runs before the invocation loop. A warning rather than a throw: the other routes are served correctly, and a function refusing to start would take a deployment down over one route's framing. Newline-delimited streams are not named — they arrive late in buffered mode but intact.

## Two questions the SUT now answers

The API Gateway SUT gains an event stream at `GET /orders/live`. That is what lets a test assert the whole chain rather than its two halves: a manifest that is generated and never registered would pass both a fixture comparison and a unit test of the warning, and warn about nothing.

The same route settles something nothing in the repository answered. It is a literal segment beside `/orders/{id}` at the same depth, and no other controller here routes that shape — which came up when we looked at adding an event stream to the todo template. It resolves to the event stream, not to an order whose id is the word "live".

## Verification

CI-shaped Release build of the whole solution exits 0. 788 source generator tests, 593 OpenAPI generator tests, 258 in the Lambda runtime including 5 new for the warning, 53 public API approvals, and 9 in the API Gateway SUT including the two new end-to-end ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)