### PR TITLE
Run each invocation against a container of its own, on the hosts that can

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,7 +80,7 @@
       breaks. Same no-float rationale as ValidationModulesVersion.
     -->
     <PropertyGroup>
-        <DependencyModulesVersion Condition="'$(DependencyModulesVersion)' == ''">1.3.1</DependencyModulesVersion>
+        <DependencyModulesVersion Condition="'$(DependencyModulesVersion)' == ''">1.4.0</DependencyModulesVersion>
     </PropertyGroup>
 
     <!--

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,7 +80,7 @@
       breaks. Same no-float rationale as ValidationModulesVersion.
     -->
     <PropertyGroup>
-        <DependencyModulesVersion Condition="'$(DependencyModulesVersion)' == ''">1.4.0</DependencyModulesVersion>
+        <DependencyModulesVersion Condition="'$(DependencyModulesVersion)' == ''">1.5.0</DependencyModulesVersion>
     </PropertyGroup>
 
     <!--

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaEnvelopeDelivery.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaEnvelopeDelivery.cs
@@ -1,8 +1,10 @@
 using System.Text;
 using System.Text.Json;
 using Amazon.Lambda.Core;
+using DependencyModules.Testing.Attributes.Interfaces;
 using Hardened.Aws.Lambda.Runtime.Hosting;
 using Hardened.Functions.Testing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hardened.Aws.Lambda.Testing;
 
@@ -25,7 +27,7 @@ namespace Hardened.Aws.Lambda.Testing;
 /// </para>
 /// </remarks>
 public sealed class LambdaEnvelopeDelivery : ITriggerDelivery {
-    private readonly LambdaInvocationHandler _handler;
+    private readonly Func<ValueTask<LambdaInvocationHandler>> _handler;
     private readonly string _region;
     private readonly string _account;
 
@@ -33,7 +35,39 @@ public sealed class LambdaEnvelopeDelivery : ITriggerDelivery {
         LambdaInvocationHandler handler,
         string region = "us-east-1",
         string account = "123456789012") {
-        _handler = handler;
+        _handler = () => new ValueTask<LambdaInvocationHandler>(handler);
+        _region = region;
+        _account = account;
+    }
+
+    /// <summary>
+    /// The delivery the harness builds: a handler off a container of its own for every invocation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A container per invocation, because an execution environment is not promised between them.
+    /// Two queue handlers deployed as two functions are two processes, so a send that passed only
+    /// because the previous one warmed a singleton is a test that cannot fail for the reason
+    /// production will.
+    /// </para>
+    /// <para>
+    /// The handler comes with the container rather than being held here, and that is the fidelity
+    /// worth having: <c>LambdaInvocationHandler</c> installs dispatch on its first invocation and
+    /// keeps a flag saying it has, so a fresh handler on a fresh container is a cold environment
+    /// doing exactly what a cold environment does.
+    /// </para>
+    /// <para>
+    /// A batch is one invocation and therefore one container. Three messages in one send arrive as
+    /// one event carrying three records, and the fan-out to a handler call per message happens
+    /// inside it.
+    /// </para>
+    /// </remarks>
+    public LambdaEnvelopeDelivery(
+        ITestContainerSource source,
+        string region = "us-east-1",
+        string account = "123456789012") {
+        _handler = async () =>
+            (await source.CreateAsync()).GetRequiredService<LambdaInvocationHandler>();
         _region = region;
         _account = account;
     }
@@ -63,7 +97,7 @@ public sealed class LambdaEnvelopeDelivery : ITriggerDelivery {
 
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(payload));
 
-        await _handler.Invoke(input, new TestContext(name));
+        await (await _handler()).Invoke(input, new TestContext(name));
     }
 
     /// <summary>
@@ -80,7 +114,7 @@ public sealed class LambdaEnvelopeDelivery : ITriggerDelivery {
 
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(payload));
 
-        var output = await _handler.Invoke(input, new TestContext(path.TrimStart('/')));
+        var output = await (await _handler()).Invoke(input, new TestContext(path.TrimStart('/')));
 
         if (responseType == null) {
             return null;

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaTestingAttribute.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaTestingAttribute.cs
@@ -38,6 +38,10 @@ public class LambdaTestingAttribute : Attribute, ITestServiceSetupAttribute {
         serviceCollection.AddTriggerTesting();
 
         serviceCollection.RemoveAll<ITriggerDelivery>();
-        serviceCollection.AddSingleton<ITriggerDelivery, LambdaEnvelopeDelivery>();
+
+        // Over the container source rather than over a handler resolved once, so every invocation
+        // gets the environment a deployed function is not promised to keep.
+        serviceCollection.AddSingleton<ITriggerDelivery>(provider =>
+            new LambdaEnvelopeDelivery(provider.GetRequiredService<ITestContainerSource>()));
     }
 }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaWebHost.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaWebHost.cs
@@ -40,12 +40,25 @@ public sealed class LambdaWebTestingAttribute : TestHostAttribute {
 /// </summary>
 public sealed class LambdaWebHost : ITestHost {
     private IServiceProvider? _provider;
+    private ITestContainerSource? _source;
+    private bool _started;
 
     /// <summary>
     /// Terminal. API Gateway has nothing behind it to hand an unmatched path to, so a path with no
     /// route is a 404 here exactly as it is in a deployed function.
     /// </summary>
     public bool IsTerminal => true;
+
+    /// <summary>
+    /// A container per request, because an execution environment is not promised between
+    /// invocations.
+    /// </summary>
+    /// <remarks>
+    /// The case the whole boundary exists for. Two requests to a deployed function may be served by
+    /// two environments or by one, and nothing says which, so a handler that leaned on what the
+    /// previous request left in a singleton fails here rather than intermittently in production.
+    /// </remarks>
+    public TestContainerPolicy ContainerPolicy => TestContainerPolicy.PerInvocation;
 
     /// <summary>
     /// What a relative path resolves against. Nothing sends to it - the request never reaches a
@@ -59,17 +72,53 @@ public sealed class LambdaWebHost : ITestHost {
     /// the path worth exercising.
     /// </remarks>
     public Task StartAsync(IServiceProvider provider, CancellationToken cancellationToken) {
+        if (_started) {
+            return Task.CompletedTask;
+        }
+
+        _started = true;
         _provider = provider;
+        _source = provider.GetService<ITestContainerSource>();
 
         return ApplicationLogic.Start(provider, null);
     }
 
+    /// <summary>
+    /// The container one invocation runs against.
+    /// </summary>
+    /// <remarks>
+    /// Its <c>LambdaInvocationHandler</c> comes with it, which is the point: the handler installs
+    /// dispatch on its first invocation and holds a flag saying it has, so a fresh handler on a
+    /// fresh container is a cold environment doing what a cold environment does.
+    /// </remarks>
+    private async ValueTask<IServiceProvider> ContainerForRequestAsync(bool reuse = false) {
+        if (_source is not { } source) {
+            return Provider;
+        }
+
+        return reuse ? _reused ??= await source.CreateAsync() : await source.CreateAsync();
+    }
+
+    /// <summary>
+    /// The one environment a caller marked <c>[Shared]</c> reaches, which is what a warm sandbox is.
+    /// </summary>
+    private IServiceProvider? _reused;
+
     public HttpMessageHandler CreateHandler(TestCredential? credential) =>
         new HostHandler(this, credential);
 
+    public HttpMessageHandler CreateHandler(TestCredential? credential, bool reuseContainer) =>
+        new HostHandler(this, credential, reuseContainer);
+
+    public Task<TestWebResponse> SendAsync(
+        TestHostRequest request, CancellationToken cancellationToken) =>
+        SendAsync(request, cancellationToken, reuseContainer: false);
+
     public async Task<TestWebResponse> SendAsync(
-        TestHostRequest request, CancellationToken cancellationToken) {
-        var handler = Provider.GetRequiredService<LambdaInvocationHandler>();
+        TestHostRequest request, CancellationToken cancellationToken, bool reuseContainer) {
+        var provider = await ContainerForRequestAsync(reuseContainer);
+
+        var handler = provider.GetRequiredService<LambdaInvocationHandler>();
 
         using var input = new MemoryStream(Encoding.UTF8.GetBytes(Event(request)));
 
@@ -171,10 +220,13 @@ public sealed class LambdaWebHost : ITestHost {
     private sealed class HostHandler : HttpMessageHandler {
         private readonly LambdaWebHost _host;
         private readonly TestCredential? _credential;
+        private readonly bool _reuseContainer;
 
-        public HostHandler(LambdaWebHost host, TestCredential? credential) {
+        public HostHandler(
+            LambdaWebHost host, TestCredential? credential, bool reuseContainer = false) {
             _host = host;
             _credential = credential;
+            _reuseContainer = reuseContainer;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(
@@ -196,7 +248,8 @@ public sealed class LambdaWebHost : ITestHost {
                     headers,
                     body,
                     _credential),
-                cancellationToken);
+                cancellationToken,
+                _reuseContainer);
 
             var message = new HttpResponseMessage((HttpStatusCode)response.StatusCode) {
                 Content = new StreamContent(response.Body)

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaWebHost.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Testing/LambdaWebHost.cs
@@ -96,13 +96,12 @@ public sealed class LambdaWebHost : ITestHost {
             return Provider;
         }
 
-        return reuse ? _reused ??= await source.CreateAsync() : await source.CreateAsync();
+        // The test's own container, for the reason PipelineHost gives: it is where every pinned
+        // parameter came from, so a client asked to reuse lands where the test already is. That is
+        // also the honest picture of a warm sandbox, which is one environment rather than a second
+        // one nobody named.
+        return reuse ? Provider : await source.CreateAsync();
     }
-
-    /// <summary>
-    /// The one environment a caller marked <c>[Shared]</c> reaches, which is what a warm sandbox is.
-    /// </summary>
-    private IServiceProvider? _reused;
 
     public HttpMessageHandler CreateHandler(TestCredential? credential) =>
         new HostHandler(this, credential);

--- a/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/HostClientTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/HostClientTests.cs
@@ -1,0 +1,80 @@
+using System.Net.Http.Json;
+using DependencyModules.Testing.Attributes;
+using Hardened.IntegrationTests.ApiGateway.SUT;
+using Hardened.Shared.Testing.Attributes;
+using Hardened.Web.Testing;
+using Xunit;
+
+namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
+
+/// <summary>
+/// An ordinary <c>HttpClient</c> against the Lambda web host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The suite drives <see cref="ITestWebApp"/> everywhere else, which reaches the host directly. A
+/// client goes the other way, through the message handler the host hands out, and that is a
+/// separate path with its own request translation - so a client that worked on the pipeline and not
+/// behind API Gateway would have gone unnoticed.
+/// </para>
+/// <para>
+/// It also says the portability claim in a second voice. Nothing here mentions Lambda; the same
+/// test passes on the pipeline and over a socket, and only <c>[LambdaWebTesting]</c> in
+/// <c>Bootstrap.cs</c> decides which.
+/// </para>
+/// </remarks>
+public class HostClientTests {
+
+    [HardenedTest]
+    public async Task AClientReachesTheHandlerThroughTheHost(HttpClient client) {
+        var order = await client.GetFromJsonAsync<Order>("/orders/c-1");
+
+        Assert.NotNull(order);
+        Assert.Equal("c-1", order!.Id);
+    }
+
+    /// <summary>
+    /// Every request builds an environment of its own, which is what a deployed function is not
+    /// promised to avoid.
+    /// </summary>
+    /// <remarks>
+    /// Asserted through the answers rather than by looking at containers, because a container is not
+    /// something a test holds. Both calls answer, which is the whole claim: nothing the first
+    /// invocation left behind was needed by the second.
+    /// </remarks>
+    [HardenedTest]
+    public async Task EachRequestGetsItsOwnEnvironment(HttpClient client) {
+        var first = await client.GetFromJsonAsync<Order>("/orders/c-1");
+        var second = await client.GetFromJsonAsync<Order>("/orders/c-2");
+
+        Assert.Equal("c-1", first!.Id);
+        Assert.Equal("c-2", second!.Id);
+    }
+
+    /// <summary>
+    /// A client marked <c>[Shared]</c> sends every request to the container the test was resolved
+    /// from, which is the warm sandbox a test whose subject is the reuse asks for.
+    /// </summary>
+    [HardenedTest]
+    public async Task ASharedClientStillAnswers([Shared] HttpClient client) {
+        var order = await client.GetFromJsonAsync<Order>("/orders/c-3");
+
+        Assert.Equal("c-3", order!.Id);
+    }
+
+    /// <summary>
+    /// The host says which deployment it stands for, and behind API Gateway that is one environment
+    /// per invocation.
+    /// </summary>
+    /// <remarks>
+    /// Read by a person rather than by the harness, which is why it is asserted: a property nothing
+    /// consumes is a property that can drift away from what the host actually does. The claim is
+    /// about the deployment, not a preference - a sandbox is not promised between invocations, so a
+    /// handler leaning on what the last one left behind has to fail here.
+    /// </remarks>
+    [HardenedTest]
+    public void TheHostRebuildsItsContainerPerInvocation(ITestHost host) {
+        Assert.Equal(TestContainerPolicy.PerInvocation, host.ContainerPolicy);
+    }
+}
+

--- a/src/Clouds/Aws/IntegrationTests/Events/Hardened.IntegrationTests.Events.SUT.Tests/ContainerIsolationTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/Events/Hardened.IntegrationTests.Events.SUT.Tests/ContainerIsolationTests.cs
@@ -1,0 +1,85 @@
+using DependencyModules.Testing.Attributes;
+using Hardened.IntegrationTests.Events.SUT;
+using Hardened.Shared.Testing.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.IntegrationTests.Events.SUT.Tests;
+
+/// <summary>
+/// What an invocation keeps from the one before it, through the real Lambda envelope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The case the whole boundary exists for. Two queues deployed as two functions are two processes,
+/// and a sandbox is not promised between invocations of one function either, so a handler that
+/// leaned on what a previous invocation left in a singleton fails intermittently in production and
+/// never in a test that reused one container.
+/// </para>
+/// <para>
+/// These go through <c>[LambdaTesting]</c>, so each send builds the envelope its source sends and
+/// runs it through <c>LambdaInvocationHandler</c> on a container of its own - which also means a
+/// fresh handler, installing dispatch for the first time, exactly as a cold environment does.
+/// </para>
+/// </remarks>
+public class ContainerIsolationTests {
+
+    /// <summary>
+    /// Every send gets its own container, so a singleton never carries anything forward.
+    /// </summary>
+    /// <remarks>
+    /// Asserted through a mock rather than by reading the counter afterwards, because the counter
+    /// the test could hold belongs to the container the test was resolved from and not to any of
+    /// the ones the sends ran on. The mock is pinned, so what every container did is visible here,
+    /// and that is the arrangement <c>[Mock]</c> declaring itself shared exists to give.
+    /// </remarks>
+    [HardenedTest]
+    public async Task EachInvocationRunsOnItsOwnContainer(
+        EventsTestApp.Queues queues, [Mock] ITriggerLog log) {
+        await queues.OrdersNew(new Order { Id = "q-1" });
+        await queues.OrdersNew(new Order { Id = "q-2" });
+
+        Received.InOrder(() => {
+            log.Record("queue:q-1");
+            log.Record("queue:q-2");
+        });
+    }
+
+    /// <summary>
+    /// Two queues are two functions, so nothing one leaves behind is there for the other.
+    /// </summary>
+    [HardenedTest]
+    public async Task TwoSourcesDoNotShareAContainer(
+        EventsTestApp.Queues queues, EventsTestApp.Topics topics, [Mock] ITriggerLog log) {
+        await queues.OrdersNew(new Order { Id = "q-1" });
+        await topics.OrderEvents(new Order { Id = "t-1" });
+
+        Received.InOrder(() => {
+            log.Record("queue:q-1");
+            log.Record("topic:t-1");
+        });
+    }
+
+    /// <summary>
+    /// A batch is one invocation, so three messages in one send share the container the other two
+    /// sends do not.
+    /// </summary>
+    /// <remarks>
+    /// The distinction the façade's <c>params</c> signature makes: three messages in one call arrive
+    /// as one SQS event carrying three records, and the fan-out to a handler call per message is the
+    /// batch filter's work inside that single invocation. Three separate calls would be three
+    /// invocations and three containers.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ABatchIsOneInvocationAndOneContainer(
+        EventsTestApp.Queues queues, [Mock] ITriggerLog log) {
+        await queues.OrdersNew(
+            new Order { Id = "b-1" }, new Order { Id = "b-2" }, new Order { Id = "b-3" });
+
+        Received.InOrder(() => {
+            log.Record("queue:b-1");
+            log.Record("queue:b-2");
+            log.Record("queue:b-3");
+        });
+    }
+}

--- a/src/Clouds/Aws/IntegrationTests/Events/Hardened.IntegrationTests.Events.SUT.Tests/HandBuiltDeliveryTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/Events/Hardened.IntegrationTests.Events.SUT.Tests/HandBuiltDeliveryTests.cs
@@ -1,0 +1,58 @@
+using DependencyModules.Testing.Attributes;
+using Hardened.Aws.Lambda.Runtime.Hosting;
+using Hardened.Aws.Lambda.Testing;
+using Hardened.IntegrationTests.Events.SUT;
+using Hardened.Shared.Testing.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.IntegrationTests.Events.SUT.Tests;
+
+/// <summary>
+/// The delivery built over a handler rather than over a container source.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The harness never takes this route: <c>[LambdaTesting]</c> registers the delivery over the
+/// source, so every send gets an environment of its own. This constructor is the other one, for a
+/// harness assembled by hand that already holds a <see cref="LambdaInvocationHandler"/> and wants to
+/// send envelopes to it - the same arrangement <c>PipelineHost</c>'s provider constructor offers on
+/// the web side.
+/// </para>
+/// <para>
+/// It is one handler for the life of the delivery, so it models a warm sandbox, and it is kept
+/// rather than removed because a hand-built harness has no container source to hand over.
+/// </para>
+/// </remarks>
+public class HandBuiltDeliveryTests {
+
+    [HardenedTest]
+    public async Task ADeliveryOverAHandlerReachesTheHandler(
+        IServiceProvider provider, [Mock] ITriggerLog log) {
+        var delivery = new LambdaEnvelopeDelivery(
+            provider.GetRequiredService<LambdaInvocationHandler>());
+
+        await delivery.Deliver([new Order { Id = "h-1" }], "QUEUE", "/orders-new");
+
+        log.Received().Record("queue:h-1");
+    }
+
+    /// <summary>
+    /// One handler for every send, which is what makes this the warm arrangement.
+    /// </summary>
+    [HardenedTest]
+    public async Task EverySendReachesTheSameHandler(
+        IServiceProvider provider, [Mock] ITriggerLog log) {
+        var delivery = new LambdaEnvelopeDelivery(
+            provider.GetRequiredService<LambdaInvocationHandler>());
+
+        await delivery.Deliver([new Order { Id = "h-1" }], "QUEUE", "/orders-new");
+        await delivery.Deliver([new Order { Id = "h-2" }], "QUEUE", "/orders-new");
+
+        Received.InOrder(() => {
+            log.Record("queue:h-1");
+            log.Record("queue:h-2");
+        });
+    }
+}

--- a/src/Functions/Hardened.Functions.Testing/FunctionTestingAttribute.cs
+++ b/src/Functions/Hardened.Functions.Testing/FunctionTestingAttribute.cs
@@ -36,7 +36,28 @@ namespace Hardened.Functions.Testing;
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
-public class FunctionTestingAttribute : Attribute, ITestServiceSetupAttribute {
+public class FunctionTestingAttribute : Attribute, ITestServiceSetupAttribute, ISharedTestRegistration {
+
+    /// <summary>
+    /// The façades this test takes, which are the parameters that must not be pinned.
+    /// </summary>
+    /// <remarks>
+    /// A test parameter is one instance for the whole test, because it was handed over to be looked
+    /// at. A façade is the exception: it is handed over to drive with, and it builds a container per
+    /// call, so pinning one would pin the very thing that is supposed to be rebuilt and every send
+    /// would reach the same container while the test believed otherwise.
+    ///
+    /// Answered here because nothing else can know. A façade is an ordinary type in an ordinary
+    /// signature, indistinguishable from a service the application registered until you know which
+    /// harness put it there - and the rule for recognising one is already written down, in the
+    /// constructor <see cref="TriggerInvoker.Constructor"/> looks for.
+    /// </remarks>
+    public IReadOnlyList<Type> IsolatedServices(System.Reflection.MethodInfo testMethod) =>
+        testMethod.GetParameters()
+            .Select(parameter => parameter.ParameterType)
+            .Where(type => TriggerInvoker.Constructor(type) != null)
+            .Distinct()
+            .ToArray();
     public void SetupServiceCollection(
         ITestMethodContext testMethod, IServiceCollection serviceCollection) {
         serviceCollection.AddTriggerTesting();

--- a/src/Functions/Hardened.Functions.Testing/PipelineDelivery.cs
+++ b/src/Functions/Hardened.Functions.Testing/PipelineDelivery.cs
@@ -1,4 +1,6 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
+using DependencyModules.Testing.Attributes.Interfaces;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Middleware;
 using Hardened.Requests.Runtime.QueryString;
@@ -26,10 +28,39 @@ namespace Hardened.Functions.Testing;
 /// </remarks>
 public sealed class PipelineDelivery : ITriggerDelivery {
     private readonly IServiceProvider _provider;
-    private bool _installed;
+    private readonly ITestContainerSource? _source;
 
     public PipelineDelivery(IServiceProvider provider) {
         _provider = provider;
+        _source = provider.GetService<ITestContainerSource>();
+    }
+
+    /// <summary>
+    /// The container one delivery runs against, composed and started.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A container per delivery, because two sends are two invocations and a trigger source makes
+    /// no promise that one environment serves both. Two queue handlers deployed as two functions are
+    /// two processes, so a handler passing only because the previous send warmed a singleton is a
+    /// test that cannot fail for the reason production will.
+    /// </para>
+    /// <para>
+    /// A batch is one delivery and therefore one container, which is right: three messages in one
+    /// send are one invocation, and the fan-out to a handler call per message happens inside it.
+    /// </para>
+    /// <para>
+    /// What crosses between them is what the test declared - a <c>[Mock]</c>, anything marked
+    /// <c>[Shared]</c>, and the harness services the entry point pins. Absent where the harness was
+    /// built by hand rather than run by the runner, and then there is one container as before.
+    /// </para>
+    /// </remarks>
+    private async ValueTask<IServiceProvider> ContainerForDeliveryAsync() {
+        var provider = _source is { } source ? await source.CreateAsync() : _provider;
+
+        Install(provider);
+
+        return provider;
     }
 
     /// <summary>
@@ -39,16 +70,16 @@ public sealed class PipelineDelivery : ITriggerDelivery {
         new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     public async Task Deliver(IReadOnlyList<object> messages, string scheme, string path) {
-        Install();
+        var provider = await ContainerForDeliveryAsync();
 
         var bodies = messages
             .Select(message => JsonSerializer.SerializeToUtf8Bytes(message, Wire))
             .ToArray();
 
-        using var scope = _provider.CreateScope();
+        using var scope = provider.CreateScope();
 
         var context = new TestExecutionContext(
-            _provider,
+            provider,
             scope.ServiceProvider,
             scope.ServiceProvider.GetRequiredService<IKnownServices>(),
             new TriggerRequest(scheme, path, bodies),
@@ -57,7 +88,7 @@ public sealed class PipelineDelivery : ITriggerDelivery {
 
         // Rethrow, because every trigger family does: failing the invocation is what makes a source
         // redeliver, and a test asserting that a bad message fails has to see the exception.
-        await _provider.GetRequiredService<IRequestExecutor>()
+        await provider.GetRequiredService<IRequestExecutor>()
             .Run(context, HostFailurePolicy.Rethrow);
     }
 
@@ -68,7 +99,7 @@ public sealed class PipelineDelivery : ITriggerDelivery {
     /// the response type is passed rather than assumed.
     /// </remarks>
     public async Task<object?> Call(object message, string scheme, string path, Type? responseType) {
-        Install();
+        var provider = await ContainerForDeliveryAsync();
 
         var body = JsonSerializer.SerializeToUtf8Bytes(message, Wire);
 
@@ -84,7 +115,7 @@ public sealed class PipelineDelivery : ITriggerDelivery {
             response,
             CancellationToken.None);
 
-        await _provider.GetRequiredService<IRequestExecutor>()
+        await provider.GetRequiredService<IRequestExecutor>()
             .Run(context, HostFailurePolicy.Rethrow);
 
         return response.ResponseValue;
@@ -95,17 +126,21 @@ public sealed class PipelineDelivery : ITriggerDelivery {
     /// </summary>
     /// <remarks>
     /// The same thing a host does at start. <c>MiddlewareService</c> holds a plain list, so
-    /// appending per message would put a second copy of dispatch in the chain and run every handler
-    /// twice from the second message onwards.
+    /// appending twice would put a second copy of dispatch in the chain and run every handler twice.
+    ///
+    /// Once per container rather than once per delivery, and a flag would be the wrong shape now: a
+    /// fresh container has a fresh empty chain, so it needs its own dispatch, and the previous
+    /// container's flag says nothing about it. <c>MiddlewareService</c> is per container, so asking
+    /// whether this one has been composed is the question that keeps its answer.
     /// </remarks>
-    private void Install() {
-        if (_installed) {
+    private static void Install(IServiceProvider provider) {
+        var middleware = provider.GetRequiredService<IMiddlewareService>();
+
+        if (Composed.TryGetValue(middleware, out _)) {
             return;
         }
 
-        _installed = true;
-
-        var dispatch = _provider.GetServices<IHandlerDispatch>().ToArray();
+        var dispatch = provider.GetServices<IHandlerDispatch>().ToArray();
 
         if (dispatch.Length != 1) {
             var kinds = dispatch.Select(one => one.GetType().Name).Distinct().ToArray();
@@ -124,8 +159,19 @@ public sealed class PipelineDelivery : ITriggerDelivery {
                           "will run. Split the web routes and the triggers into two applications.");
         }
 
-        _provider.GetRequiredService<IMiddlewareService>().Use(_ => dispatch[0]);
+        middleware.Use(_ => dispatch[0]);
+
+        Composed.Add(middleware, Composed);
     }
+
+    /// <summary>
+    /// The chains dispatch has already been appended to.
+    /// </summary>
+    /// <remarks>
+    /// Weak on the key, so a container the test is finished with is collectable rather than held
+    /// alive by a record that it was composed.
+    /// </remarks>
+    private static readonly ConditionalWeakTable<IMiddlewareService, object> Composed = new();
 
     /// <summary>
     /// One invocation, which is not a batch and never fans out.

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/ContainerIsolationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/ContainerIsolationTests.cs
@@ -1,0 +1,66 @@
+using DependencyModules.Testing.Attributes;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// What a request keeps from the one before it, on a host that is not promised between them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pair below is the whole boundary, asserted against the same handler. <c>/response-cache/uncached</c>
+/// answers a counter held in a singleton and declares no caching, so it counts invocations against
+/// one container and nothing else.
+/// </para>
+/// <para>
+/// It matters because the arrangement it stands for is not exotic. Two requests to a deployed
+/// function may be served by two execution environments or by one, and nothing says which, so a
+/// handler leaning on what the previous request left in a singleton fails intermittently in
+/// production and never here. Under the pipeline host it now fails here first.
+/// </para>
+/// </remarks>
+public class ContainerIsolationTests {
+
+    /// <summary>
+    /// Two requests, two containers, so the singleton behind the second has never been used.
+    /// </summary>
+    [HardenedTest]
+    public async Task ARequestKeepsNothingFromTheOneBefore(ITestWebApp testWebApp) {
+        var first = await testWebApp.Get("/response-cache/uncached");
+        var second = await testWebApp.Get("/response-cache/uncached");
+
+        Assert.Equal("1", first.Deserialize<string>());
+        Assert.Equal("1", second.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// The escape hatch, for a test whose subject is the reuse itself.
+    /// </summary>
+    /// <remarks>
+    /// The same handler and the same two requests, and the only difference is the attribute. A
+    /// response cache serving a second read, a rate limiter tripping on the eleventh call and a
+    /// connection held open are all this shape, and all of them are asking to model one warm
+    /// environment rather than two cold ones.
+    /// </remarks>
+    [HardenedTest]
+    public async Task SharedPutsEveryRequestOnOneContainer([Shared] ITestWebApp testWebApp) {
+        var first = await testWebApp.Get("/response-cache/uncached");
+        var second = await testWebApp.Get("/response-cache/uncached");
+
+        Assert.Equal("1", first.Deserialize<string>());
+        Assert.Equal("2", second.Deserialize<string>());
+    }
+
+    /// <summary>
+    /// A client is a caller, so two of them marked shared are two callers on one environment rather
+    /// than two environments.
+    /// </summary>
+    [HardenedTest]
+    public async Task TwoSharedClientsReachTheSameContainer(
+        [Shared] ITestWebApp first, [Shared] ITestWebApp second) {
+        await first.Get("/response-cache/uncached");
+
+        var seen = await second.Get("/response-cache/uncached");
+
+        Assert.Equal("2", seen.Deserialize<string>());
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ConditionalGetTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ConditionalGetTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Testing.Attributes;
 using Hardened.IntegrationTests.WebApp.SUT.Controllers;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Testing;
@@ -205,7 +206,7 @@ public class ConditionalGetTests {
     /// different feature.
     /// </summary>
     [HardenedTest]
-    public async Task A304FromAHandlersOwnTagStillRanTheHandler(ITestWebApp testWebApp) {
+    public async Task A304FromAHandlersOwnTagStillRanTheHandler([Shared] ITestWebApp testWebApp) {
         await testWebApp.Get(Document, IfNoneMatch(ConditionalController.Version));
 
         var next = await testWebApp.Get(Document);

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/ResponseCacheTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Testing.Attributes;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Runtime.Caching;
 using Hardened.Requests.Testing;
@@ -31,7 +32,7 @@ public class ResponseCacheTests {
     /// The value the strategy was named on is in the key, so a different one is a different entry.
     /// </summary>
     [HardenedTest]
-    public async Task ADifferentQueryValueIsADifferentEntry(ITestWebApp testWebApp) {
+    public async Task ADifferentQueryValueIsADifferentEntry([Shared] ITestWebApp testWebApp) {
         await testWebApp.Get("/response-cache/catalog?culture=en-GB");
 
         var other = await testWebApp.Get("/response-cache/catalog?culture=fr-FR");
@@ -44,7 +45,7 @@ public class ResponseCacheTests {
     /// asked for.
     /// </summary>
     [HardenedTest]
-    public async Task AHandlerThatDeclaresNothingIsNotCached(ITestWebApp testWebApp) {
+    public async Task AHandlerThatDeclaresNothingIsNotCached([Shared] ITestWebApp testWebApp) {
         await testWebApp.Get("/response-cache/uncached");
 
         var second = await testWebApp.Get("/response-cache/uncached");
@@ -56,7 +57,7 @@ public class ResponseCacheTests {
     /// Two strategies compose into one key. Changing either half misses; changing neither hits.
     /// </summary>
     [HardenedTest]
-    public async Task ComposedStrategiesBothCount(ITestWebApp testWebApp) {
+    public async Task ComposedStrategiesBothCount([Shared] ITestWebApp testWebApp) {
         var first = await testWebApp.Get(
             "/response-cache/composed?culture=en-GB", Language("en-GB"));
 
@@ -90,7 +91,7 @@ public class ResponseCacheTests {
     /// silent.
     /// </summary>
     [HardenedTest]
-    public async Task AResourceScopedHandlerIsNotCached(ITestWebApp testWebApp) {
+    public async Task AResourceScopedHandlerIsNotCached([Shared] ITestWebApp testWebApp) {
         await testWebApp.Get("/response-cache/owned/7");
 
         var second = await testWebApp.Get("/response-cache/owned/7");
@@ -157,7 +158,7 @@ public class ResponseCacheTests {
     /// says so, and it keys the entry on the caller.
     /// </remarks>
     [HardenedTest]
-    public async Task AnOwnerScopedHandlerAnswersEachCallerTheirOwn(ITestWebApp testWebApp) {
+    public async Task AnOwnerScopedHandlerAnswersEachCallerTheirOwn([Shared] ITestWebApp testWebApp) {
         var first = await testWebApp.Get(
             "/response-cache/owned-by-subject", Caller("pets:read", "subscriber-one"));
 
@@ -211,7 +212,7 @@ public class ResponseCacheTests {
     /// application could not reach its own entries at all, so an hour-long entry meant an hour.
     /// </summary>
     [HardenedTest]
-    public async Task APublishReachesACachedRead(ITestWebApp testWebApp) {
+    public async Task APublishReachesACachedRead([Shared] ITestWebApp testWebApp) {
         var first = await testWebApp.Get("/response-cache/tagged");
         var cached = await testWebApp.Get("/response-cache/tagged");
 

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/TimeoutTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/TimeoutTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Testing.Attributes;
 using Hardened.IntegrationTests.WebApp.SUT.Controllers;
 using Hardened.Requests.Abstract.Errors;
 using Hardened.Requests.Abstract.Headers;
@@ -123,7 +124,7 @@ public class TimeoutTests {
     /// fires; five attempts at fifty milliseconds each cannot fit in a hundred and fifty.
     /// </summary>
     [HardenedTest]
-    public async Task OneBudgetCoversEveryRetryAttempt(ITestWebApp testWebApp) {
+    public async Task OneBudgetCoversEveryRetryAttempt([Shared] ITestWebApp testWebApp) {
         await testWebApp.Get("/timeout/retried");
 
         var attempts = (await testWebApp.Get("/timeout/calls/retried")).Deserialize<int>();

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/HandlerInfoPathTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/HandlerInfoPathTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Testing.Attributes;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
 
@@ -20,6 +21,12 @@ namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
 /// filter silently never ran — for every route in every library that owns a URL space, which is
 /// the arrangement <c>[BasePath]</c> on a module exists to support.
 /// </para>
+/// <para>
+/// <c>[Shared]</c> on the registry because these tests configure it and then assert on a request:
+/// every request runs against a container of its own, so a filter registered into the container the
+/// test happens to hold would reach none of them. Pinning it makes the registry the test writes to
+/// and the one every container reads one object, which is what the test means.
+/// </para>
 /// </remarks>
 public class HandlerInfoPathTests {
 
@@ -33,7 +40,7 @@ public class HandlerInfoPathTests {
     /// </remarks>
     [HardenedTest]
     public async Task EveryHandlerReportsThePathItIsServedAt(
-        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
+        ITestWebApp testWebApp, [Shared] IGlobalFilterRegistry registry) {
         var seen = PathsSeenByAPerHandlerFilter(registry);
 
         await testWebApp.Get("/web-library/string-methods/concat/a/b");
@@ -47,7 +54,7 @@ public class HandlerInfoPathTests {
     /// </summary>
     [HardenedTest]
     public async Task APathPrefixFilterMatchesRoutesUnderAModuleBasePath(
-        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
+        ITestWebApp testWebApp, [Shared] IGlobalFilterRegistry registry) {
         registry.RegisterFilter(handlerInfo =>
             handlerInfo.Path.StartsWith("/web-library", StringComparison.Ordinal)
                 ? new RequestFilterInfo(_ => new StampFilter(), FilterOrder.HandlerCreation)
@@ -66,7 +73,7 @@ public class HandlerInfoPathTests {
     /// </summary>
     [HardenedTest]
     public async Task AHandlerOutsideAnyModuleBasePathIsUnaffected(
-        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
+        ITestWebApp testWebApp, [Shared] IGlobalFilterRegistry registry) {
         var seen = PathsSeenByAPerHandlerFilter(registry);
 
         await testWebApp.Get("/binding/path/42");

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/HandlerInfoPathTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/HandlerInfoPathTests.cs
@@ -1,4 +1,3 @@
-using DependencyModules.Testing.Attributes;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.RequestFilter;
 
@@ -22,10 +21,10 @@ namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
 /// the arrangement <c>[BasePath]</c> on a module exists to support.
 /// </para>
 /// <para>
-/// <c>[Shared]</c> on the registry because these tests configure it and then assert on a request:
-/// every request runs against a container of its own, so a filter registered into the container the
-/// test happens to hold would reach none of them. Pinning it makes the registry the test writes to
-/// and the one every container reads one object, which is what the test means.
+/// These configure the registry and then assert on a request, and every request runs against a
+/// container of its own. The registry is a test parameter, so it is one object across all of them
+/// without anything being said: a parameter is handed over to be looked at, and a filter registered
+/// into a container the test merely happened to hold would reach none of the ones that ran.
 /// </para>
 /// </remarks>
 public class HandlerInfoPathTests {
@@ -40,7 +39,7 @@ public class HandlerInfoPathTests {
     /// </remarks>
     [HardenedTest]
     public async Task EveryHandlerReportsThePathItIsServedAt(
-        ITestWebApp testWebApp, [Shared] IGlobalFilterRegistry registry) {
+        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
         var seen = PathsSeenByAPerHandlerFilter(registry);
 
         await testWebApp.Get("/web-library/string-methods/concat/a/b");
@@ -54,7 +53,7 @@ public class HandlerInfoPathTests {
     /// </summary>
     [HardenedTest]
     public async Task APathPrefixFilterMatchesRoutesUnderAModuleBasePath(
-        ITestWebApp testWebApp, [Shared] IGlobalFilterRegistry registry) {
+        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
         registry.RegisterFilter(handlerInfo =>
             handlerInfo.Path.StartsWith("/web-library", StringComparison.Ordinal)
                 ? new RequestFilterInfo(_ => new StampFilter(), FilterOrder.HandlerCreation)
@@ -73,7 +72,7 @@ public class HandlerInfoPathTests {
     /// </summary>
     [HardenedTest]
     public async Task AHandlerOutsideAnyModuleBasePathIsUnaffected(
-        ITestWebApp testWebApp, [Shared] IGlobalFilterRegistry registry) {
+        ITestWebApp testWebApp, IGlobalFilterRegistry registry) {
         var seen = PathsSeenByAPerHandlerFilter(registry);
 
         await testWebApp.Get("/binding/path/42");

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/StartupServicesRunOnceTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/StartupServicesRunOnceTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Testing.Attributes;
 using System.Reflection;
 using Hardened.Shared.Runtime.Application;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,9 +26,17 @@ public class StartupServicesRunOnceTests {
     }
 
     /// <summary>The chain the services composed still answers, with the handler behind them.</summary>
+    /// <remarks>
+    /// <c>[Shared]</c> so the request runs against the container the test was resolved from. The
+    /// counter is a test parameter and therefore one object across every container, so a request on
+    /// a container of its own would run the services again against that same counter and 2 would be
+    /// correct - true, and useless as a guard, because it stops telling "once each in two
+    /// containers" apart from the regression this exists to catch, which is twice in one.
+    /// </remarks>
     [HardenedTest]
     [CountingStartupService]
-    public async Task TheChainAnswersAfterTheOneRun(CountingStartupService service, ITestWebApp app) {
+    public async Task TheChainAnswersAfterTheOneRun(
+        CountingStartupService service, [Shared] ITestWebApp app) {
         var response = await app.Get("/verbs/item/1");
 
         response.Assert.Ok();

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.Testing.approved.txt
@@ -2,6 +2,7 @@ namespace Hardened.Aws.Lambda.Testing
 {
     public sealed class LambdaEnvelopeDelivery : Hardened.Functions.Testing.ITriggerDelivery
     {
+        public LambdaEnvelopeDelivery(DependencyModules.Testing.Attributes.Interfaces.ITestContainerSource source, string region = "us-east-1", string account = "123456789012") { }
         public LambdaEnvelopeDelivery(Hardened.Aws.Lambda.Runtime.Hosting.LambdaInvocationHandler handler, string region = "us-east-1", string account = "123456789012") { }
         public System.Threading.Tasks.Task<object?> Call(object message, string scheme, string path, System.Type? responseType) { }
         public System.Threading.Tasks.Task Deliver(System.Collections.Generic.IReadOnlyList<object> messages, string scheme, string path) { }
@@ -16,10 +17,13 @@ namespace Hardened.Aws.Lambda.Testing
     {
         public LambdaWebHost() { }
         public System.Uri BaseAddress { get; }
+        public Hardened.Web.Testing.TestContainerPolicy ContainerPolicy { get; }
         public bool IsTerminal { get; }
         public System.Net.Http.HttpMessageHandler CreateHandler(Hardened.Web.Testing.TestCredential? credential) { }
+        public System.Net.Http.HttpMessageHandler CreateHandler(Hardened.Web.Testing.TestCredential? credential, bool reuseContainer) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.Task<Hardened.Web.Testing.TestWebResponse> SendAsync(Hardened.Web.Testing.TestHostRequest request, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Hardened.Web.Testing.TestWebResponse> SendAsync(Hardened.Web.Testing.TestHostRequest request, System.Threading.CancellationToken cancellationToken, bool reuseContainer) { }
         public System.Threading.Tasks.Task StartAsync(System.IServiceProvider provider, System.Threading.CancellationToken cancellationToken) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false)]

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Functions.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Functions.Testing.approved.txt
@@ -1,9 +1,10 @@
 namespace Hardened.Functions.Testing
 {
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method)]
-    public class FunctionTestingAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute
+    public class FunctionTestingAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ISharedTestRegistration, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute
     {
         public FunctionTestingAttribute() { }
+        public System.Collections.Generic.IReadOnlyList<System.Type> IsolatedServices(System.Reflection.MethodInfo testMethod) { }
         public void SetupServiceCollection(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
     }
     public interface ITriggerDelivery

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Shared.Testing.approved.txt
@@ -25,7 +25,7 @@ namespace Hardened.Shared.Testing.Attributes
         public string Variable { get; }
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method)]
-    public class HardenedTestEntryPointAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider, DependencyModules.Runtime.Interfaces.IModuleEnvironmentProvider, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute, DependencyModules.Testing.Attributes.Interfaces.ITestStartupAttribute
+    public class HardenedTestEntryPointAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider, DependencyModules.Runtime.Interfaces.IModuleEnvironmentProvider, DependencyModules.Testing.Attributes.Interfaces.ISharedTestRegistration, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute, DependencyModules.Testing.Attributes.Interfaces.ITestStartupAttribute
     {
         public HardenedTestEntryPointAttribute(System.Type entryPoint) { }
         public System.Type EntryPoint { get; }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Testing.approved.txt
@@ -233,9 +233,10 @@ namespace Hardened.Web.Testing
         public WebAssertionException(string message) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly)]
-    public class WebTestingAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute, DependencyModules.Testing.Attributes.Interfaces.ITestStartupAttribute
+    public class WebTestingAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ISharedTestRegistration, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute, DependencyModules.Testing.Attributes.Interfaces.ITestStartupAttribute
     {
         public WebTestingAttribute() { }
+        public System.Collections.Generic.IReadOnlyList<System.Type> IsolatedServices(System.Reflection.MethodInfo testMethod) { }
         public void SetupServiceCollection(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
         public System.Threading.Tasks.Task StartupAsync(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, System.IServiceProvider serviceProvider) { }
     }

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Testing.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Testing.approved.txt
@@ -45,9 +45,12 @@ namespace Hardened.Web.Testing
     public interface ITestHost : System.IAsyncDisposable
     {
         System.Uri BaseAddress { get; }
+        Hardened.Web.Testing.TestContainerPolicy ContainerPolicy { get; }
         bool IsTerminal { get; }
         System.Net.Http.HttpMessageHandler CreateHandler(Hardened.Web.Testing.TestCredential? credential);
+        System.Net.Http.HttpMessageHandler CreateHandler(Hardened.Web.Testing.TestCredential? credential, bool reuseContainer);
         System.Threading.Tasks.Task<Hardened.Web.Testing.TestWebResponse> SendAsync(Hardened.Web.Testing.TestHostRequest request, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<Hardened.Web.Testing.TestWebResponse> SendAsync(Hardened.Web.Testing.TestHostRequest request, System.Threading.CancellationToken cancellationToken, bool reuseContainer);
         System.Threading.Tasks.Task StartAsync(System.IServiceProvider provider, System.Threading.CancellationToken cancellationToken);
     }
     public interface ITestWebApp : Hardened.Shared.Testing.ITestContext
@@ -83,10 +86,13 @@ namespace Hardened.Web.Testing
     {
         public PipelineHost(System.IServiceProvider provider) { }
         public System.Uri BaseAddress { get; }
+        public Hardened.Web.Testing.TestContainerPolicy ContainerPolicy { get; }
         public bool IsTerminal { get; }
         public System.Net.Http.HttpMessageHandler CreateHandler(Hardened.Web.Testing.TestCredential? credential) { }
+        public System.Net.Http.HttpMessageHandler CreateHandler(Hardened.Web.Testing.TestCredential? credential, bool reuseContainer) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.Task<Hardened.Web.Testing.TestWebResponse> SendAsync(Hardened.Web.Testing.TestHostRequest request, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Hardened.Web.Testing.TestWebResponse> SendAsync(Hardened.Web.Testing.TestHostRequest request, System.Threading.CancellationToken cancellationToken, bool reuseContainer) { }
         public System.Threading.Tasks.Task StartAsync(System.IServiceProvider provider, System.Threading.CancellationToken cancellationToken) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false)]
@@ -98,6 +104,7 @@ namespace Hardened.Web.Testing
     public sealed class PipelineHttpMessageHandler : System.Net.Http.HttpMessageHandler
     {
         public PipelineHttpMessageHandler(System.IServiceProvider rootServiceProvider) { }
+        public PipelineHttpMessageHandler(System.Func<System.Threading.Tasks.ValueTask<System.IServiceProvider>> container, Hardened.Web.Testing.TestCredential? credential) { }
         public PipelineHttpMessageHandler(System.IServiceProvider rootServiceProvider, Hardened.Web.Testing.TestCredential? credential) { }
         protected override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { }
     }
@@ -131,6 +138,11 @@ namespace Hardened.Web.Testing
     {
         public TestClientRouteAttribute(System.Type routeType) { }
         public System.Type RouteType { get; }
+    }
+    public enum TestContainerPolicy
+    {
+        Reused = 0,
+        PerInvocation = 1,
     }
     public sealed class TestCredential : System.IEquatable<Hardened.Web.Testing.TestCredential>
     {

--- a/src/Shared/Hardened.Shared.Testing/Attributes/HardenedTestEntryPointAttribute.cs
+++ b/src/Shared/Hardened.Shared.Testing/Attributes/HardenedTestEntryPointAttribute.cs
@@ -14,12 +14,42 @@ namespace Hardened.Shared.Testing.Attributes;
 [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
 public class HardenedTestEntryPointAttribute
     : Attribute, IDependencyModuleProvider, IModuleEnvironmentProvider,
-      ITestServiceSetupAttribute, ITestStartupAttribute {
+      ITestServiceSetupAttribute, ITestStartupAttribute, ISharedTestRegistration {
     public HardenedTestEntryPointAttribute(Type entryPoint) {
         EntryPoint = entryPoint;
     }
 
     public Type EntryPoint { get; }
+
+    /// <summary>
+    /// What this attribute registered that belongs to the test rather than to a container.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A test that builds a container per invocation rebuilds everything in it, and these four are
+    /// the ones for which that has no reading. A test has one cancellation, so a second
+    /// <see cref="TestCancellationToken"/> is a token nothing the test holds can trip. The
+    /// environment is already one object on purpose - <c>SeededEnvironment</c> exists so the
+    /// instance a module condition reads and the one a service resolves are the same - and building
+    /// it again per container would undo that. <c>AppConfig</c> is assembled from the test's own
+    /// attributes and is identical every time, so sharing it is the cheaper way to be correct.
+    /// <see cref="ITestContext"/> holds the token and the logger, and is the test.
+    /// </para>
+    /// <para>
+    /// <b>What is deliberately not here.</b> <c>ILoggerProvider</c> is per container and harmless,
+    /// because every container writes to the same runner sink through <see cref="CurrentTest"/>.
+    /// <c>IApplicationRoot</c> has to be per container: <c>ServiceProviderApplicationRoot</c> wraps
+    /// whichever provider built it, so a shared one would hand every container the first
+    /// container's services and quietly undo the isolation around it.
+    /// </para>
+    /// </remarks>
+    IReadOnlyList<Type> ISharedTestRegistration.SharedServices => [
+        typeof(TestCancellationToken),
+        typeof(IHardenedEnvironment),
+        typeof(IModuleEnvironment),
+        typeof(IConfigurationPackage),
+        typeof(ITestContext)
+    ];
 
     public IDependencyModule GetModule() {
         return (IDependencyModule)Activator.CreateInstance(EntryPoint)!;

--- a/src/Web/Hardened.Web.Testing.Tests/Hosts/ContainerPolicyTests.cs
+++ b/src/Web/Hardened.Web.Testing.Tests/Hosts/ContainerPolicyTests.cs
@@ -1,0 +1,109 @@
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Middleware;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hardened.Web.Testing.Tests.Hosts;
+
+/// <summary>
+/// What each host says about the deployment it stands for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ITestHost.ContainerPolicy"/> is read by a person rather than by the harness: each host
+/// already branches on whether it was handed a container source, and the property is where the
+/// arrangement is stated so someone can find it. That makes it exactly the kind of thing that drifts
+/// without anything noticing, which is why it is asserted rather than left to the remarks.
+/// </para>
+/// <para>
+/// The two answers are not symmetrical, and the asymmetry is the point. Per-invocation is a claim
+/// about a deployment: an execution environment is not promised between invocations. Reused is a
+/// limit on what a host can check, because a socket cannot be restarted underneath a client the test
+/// already holds, and it says nothing about whether sharing is safe where the application really
+/// runs.
+/// </para>
+/// </remarks>
+public class ContainerPolicyTests {
+
+    /// <summary>A host that answers nothing, so the interface's own default is what it reports.</summary>
+    private sealed class BareHost : ITestHost {
+        public bool IsTerminal => true;
+
+        public Uri BaseAddress => new("http://bare/");
+
+        public Task StartAsync(IServiceProvider provider, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public HttpMessageHandler CreateHandler(TestCredential? credential) =>
+            throw new NotSupportedException();
+
+        public Task<TestWebResponse> SendAsync(
+            TestHostRequest request, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public ValueTask DisposeAsync() => default;
+    }
+
+    /// <summary>
+    /// The default is the conservative one: a host that has not thought about it keeps one
+    /// container, which is what every host did before there was a choice to make.
+    /// </summary>
+    [Fact]
+    public void AHostThatSaysNothingReusesItsContainer() {
+        ITestHost host = new BareHost();
+
+        Assert.Equal(TestContainerPolicy.Reused, host.ContainerPolicy);
+    }
+
+    /// <summary>
+    /// The pipeline rebuilds, and it is the host the overwhelming majority of tests run under, which
+    /// is what puts the strict reading where it costs least.
+    /// </summary>
+    [Fact]
+    public void ThePipelineHostBuildsAContainerPerInvocation() {
+        ITestHost host = new PipelineHost(new ServiceCollection().BuildServiceProvider());
+
+        Assert.Equal(TestContainerPolicy.PerInvocation, host.ContainerPolicy);
+    }
+}
+
+/// <summary>
+/// What a host appends to a container it did not compose.
+/// </summary>
+public class PipelineHostCompositionTests {
+
+    /// <summary>
+    /// A host over a container someone else built appends nothing to it.
+    /// </summary>
+    /// <remarks>
+    /// The constructor taking a provider is the harness-built-by-hand route, and it is also what an
+    /// application root reaches, having composed its own chain already. Appending routing behind
+    /// that would put a second terminal handler in a chain that has one.
+    /// </remarks>
+    [Fact]
+    public async Task AHostOverAnAlreadyComposedContainerAppendsNothing() {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IMiddlewareService, RecordingMiddleware>();
+
+        await using var provider = services.BuildServiceProvider();
+
+        var host = new PipelineHost(provider);
+
+        await host.StartAsync(provider, CancellationToken.None);
+
+        Assert.Equal(
+            0,
+            ((RecordingMiddleware)provider.GetRequiredService<IMiddlewareService>()).Appended);
+    }
+
+    /// <summary>Counts what was appended, and does nothing else.</summary>
+    private sealed class RecordingMiddleware : IMiddlewareService {
+        public int Appended { get; private set; }
+
+        public void Use(Func<IExecutionContext, IExecutionFilter> middlewareFunc) => Appended++;
+
+        public IExecutionChain GetExecutionChain(IExecutionContext context) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/Web/Hardened.Web.Testing/Hosts/ITestHost.cs
+++ b/src/Web/Hardened.Web.Testing/Hosts/ITestHost.cs
@@ -23,6 +23,28 @@ namespace Hardened.Web.Testing;
 public interface ITestHost : IAsyncDisposable {
 
     /// <summary>
+    /// Whether a request here runs against a container of its own.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The deployment model the host stands for, rather than a preference. An execution environment
+    /// is not promised between invocations, so the Lambda hosts and the in-process pipeline answer
+    /// <see cref="TestContainerPolicy.PerInvocation"/>, and a handler that leaned on what a previous
+    /// request left behind fails here rather than in production.
+    /// </para>
+    /// <para>
+    /// A socket host answers <see cref="TestContainerPolicy.Reused"/>, and that is forced rather
+    /// than chosen: the test holds an <see cref="HttpClient"/> bound to the loopback port the kernel
+    /// picked, so restarting the server per request would leave every client the harness handed out
+    /// addressing a closed socket. It is a limit on what those hosts can check rather than a claim
+    /// that sharing is safe on them. A service behind a load balancer is many instances, and state
+    /// crossing requests is as unsafe there as it is on Lambda; run the same handlers under
+    /// <see cref="PipelineHostAttribute"/> for that check.
+    /// </para>
+    /// </remarks>
+    TestContainerPolicy ContainerPolicy => TestContainerPolicy.Reused;
+
+    /// <summary>
     /// Whether an unmatched path is a 404 here, or is handed to something behind the host. The
     /// pipeline and Kestrel are terminal; the ASP.NET Core host is not, because falling through
     /// to the rest of the ASP.NET pipeline is the behaviour it exists to show.
@@ -47,8 +69,42 @@ public interface ITestHost : IAsyncDisposable {
     /// </summary>
     HttpMessageHandler CreateHandler(TestCredential? credential);
 
+    /// <summary>
+    /// The same, for a caller whose requests are meant to reach one container.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// What <c>[Shared]</c> on a client parameter reaches. Pinning the parameter alone would hand
+    /// the test one client object and change nothing about where its requests go, because the host
+    /// decides that - so the mark has to arrive here, at the point the client is built.
+    /// </para>
+    /// <para>
+    /// A host that reuses anyway ignores it, which is why this defaults to the plain overload
+    /// rather than being something every host has to answer.
+    /// </para>
+    /// </remarks>
+    HttpMessageHandler CreateHandler(TestCredential? credential, bool reuseContainer) =>
+        CreateHandler(credential);
+
     /// <summary>One request, as <see cref="ITestWebApp"/> sends it.</summary>
     Task<TestWebResponse> SendAsync(TestHostRequest request, CancellationToken cancellationToken);
+
+    /// <summary>The same, for a caller whose requests are meant to reach one container.</summary>
+    Task<TestWebResponse> SendAsync(
+        TestHostRequest request, CancellationToken cancellationToken, bool reuseContainer) =>
+        SendAsync(request, cancellationToken);
+}
+
+/// <summary>
+/// Whether a host runs each request against its own container.
+/// </summary>
+public enum TestContainerPolicy {
+
+    /// <summary>One container for every request the host serves.</summary>
+    Reused,
+
+    /// <summary>A container per request, built from the test's own composition.</summary>
+    PerInvocation
 }
 
 /// <summary>

--- a/src/Web/Hardened.Web.Testing/Hosts/PipelineHost.cs
+++ b/src/Web/Hardened.Web.Testing/Hosts/PipelineHost.cs
@@ -113,23 +113,15 @@ public sealed class PipelineHost : ITestHost {
             return Provider;
         }
 
+        // The test's own container, not one more of its own. It is composed and started already,
+        // it is where every pinned parameter came from, and it is the one thing in the test a reader
+        // can point at - so "one container for this client" and "the container the test is in" being
+        // the same container is the reading that needs no explaining. Two clients that both ask
+        // therefore land together, which is what modelling one warm environment means.
         if (reuse) {
-            return _reused ??= await Build(source);
+            return Provider;
         }
 
-        return await Build(source);
-    }
-
-    /// <summary>
-    /// The one container a caller marked <c>[Shared]</c> reaches, built on its first request.
-    /// </summary>
-    /// <remarks>
-    /// Held here rather than per client, so two clients that both asked to reuse are two callers on
-    /// one warm environment - which is the thing they asked to model.
-    /// </remarks>
-    private IServiceProvider? _reused;
-
-    private async ValueTask<IServiceProvider> Build(ITestContainerSource source) {
         var provider = await source.CreateAsync();
 
         Compose(provider);

--- a/src/Web/Hardened.Web.Testing/Hosts/PipelineHost.cs
+++ b/src/Web/Hardened.Web.Testing/Hosts/PipelineHost.cs
@@ -1,5 +1,6 @@
 using DependencyModules.Testing.Attributes.Interfaces;
 using DependencyModules.Testing.Impl;
+using DependencyModules.Testing.Attributes;
 using Hardened.Requests.Abstract.Middleware;
 using Hardened.Shared.Runtime.Application;
 using Hardened.Shared.Testing.Attributes;
@@ -39,6 +40,8 @@ public sealed class PipelineHostAttribute : TestHostAttribute {
 public sealed class PipelineHost : ITestHost {
     private readonly bool _appendHandler;
     private IServiceProvider? _provider;
+    private ITestContainerSource? _source;
+    private bool _started;
 
     /// <summary>A host over a container that is already built and composed, for a harness built by hand.</summary>
     public PipelineHost(IServiceProvider provider) {
@@ -52,6 +55,17 @@ public sealed class PipelineHost : ITestHost {
 
     public bool IsTerminal => true;
 
+    /// <summary>
+    /// A container per request, because nothing here holds a socket that a rebuild would close.
+    /// </summary>
+    /// <remarks>
+    /// The strict reading, and the default one: this host names no cloud, so it does not get to
+    /// assume the most forgiving deployment. It is also the host the overwhelming majority of tests
+    /// run under, which is what puts the check where it costs least - the two hosts that cannot
+    /// rebuild are the ones a suite has few of.
+    /// </remarks>
+    public TestContainerPolicy ContainerPolicy => TestContainerPolicy.PerInvocation;
+
     public Uri BaseAddress => TestClientBuilder.BaseAddress;
 
     /// <summary>
@@ -61,26 +75,108 @@ public sealed class PipelineHost : ITestHost {
     /// <c>KestrelServerRunner</c> does for Kestrel.
     /// </summary>
     public async Task StartAsync(IServiceProvider provider, CancellationToken cancellationToken) {
+        if (_started) {
+            return;
+        }
+
+        _started = true;
         _provider = provider;
+
+        // Absent where the harness was built by hand rather than run by the runner, which is the
+        // constructor taking a provider outright. Then there is one container and this is a host
+        // over it, exactly as it was.
+        _source = provider.GetService<ITestContainerSource>();
 
         await ApplicationLogic.Start(provider, null);
 
-        if (_appendHandler) {
-            var handler = provider.GetRequiredService<IWebExecutionHandlerService>();
-
-            provider.GetRequiredService<IMiddlewareService>().Use(_ => handler);
-        }
+        Compose(provider);
     }
 
-    public HttpMessageHandler CreateHandler(TestCredential? credential) =>
-        new PipelineHttpMessageHandler(Provider, credential);
+    /// <summary>
+    /// The container one request runs against.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Built here rather than reused, so nothing an application singleton accumulated reaches the
+    /// next request. What survives is what the test declared: a <c>[Mock]</c>, anything marked
+    /// <see cref="SharedAttribute"/>, and the handful of harness services the entry point pins.
+    /// </para>
+    /// <para>
+    /// The startup services run against it on the way out, because <c>ApplicationLogic.Start</c>
+    /// keys its guard on the provider rather than on the process. A container that skipped them
+    /// would answer every route anonymously with no filter provider installed, which is a container
+    /// that looks composed and is not.
+    /// </para>
+    /// </remarks>
+    private async ValueTask<IServiceProvider> ContainerForRequestAsync(bool reuse = false) {
+        if (_source is not { } source) {
+            return Provider;
+        }
 
-    public async Task<TestWebResponse> SendAsync(TestHostRequest request, CancellationToken cancellationToken) {
+        if (reuse) {
+            return _reused ??= await Build(source);
+        }
+
+        return await Build(source);
+    }
+
+    /// <summary>
+    /// The one container a caller marked <c>[Shared]</c> reaches, built on its first request.
+    /// </summary>
+    /// <remarks>
+    /// Held here rather than per client, so two clients that both asked to reuse are two callers on
+    /// one warm environment - which is the thing they asked to model.
+    /// </remarks>
+    private IServiceProvider? _reused;
+
+    private async ValueTask<IServiceProvider> Build(ITestContainerSource source) {
+        var provider = await source.CreateAsync();
+
+        Compose(provider);
+
+        return provider;
+    }
+
+    /// <summary>
+    /// Puts routing and the handler filter at the end of one container's chain.
+    /// </summary>
+    /// <remarks>
+    /// Per container rather than once, because <c>MiddlewareService</c> is a singleton holding a
+    /// plain list and a fresh container has a fresh empty one. This is what <c>UseHardened</c> does
+    /// for the ASP.NET pipeline and <c>KestrelServerRunner</c> does for Kestrel.
+    /// </remarks>
+    private void Compose(IServiceProvider provider) {
+        if (!_appendHandler) {
+            return;
+        }
+
+        var handler = provider.GetRequiredService<IWebExecutionHandlerService>();
+
+        provider.GetRequiredService<IMiddlewareService>().Use(_ => handler);
+    }
+
+    /// <remarks>
+    /// The handler outlives one request - a typed client holds it for the test - so it is handed the
+    /// way to build a container rather than one container.
+    /// </remarks>
+    public HttpMessageHandler CreateHandler(TestCredential? credential) =>
+        CreateHandler(credential, reuseContainer: false);
+
+    public HttpMessageHandler CreateHandler(TestCredential? credential, bool reuseContainer) =>
+        new PipelineHttpMessageHandler(() => ContainerForRequestAsync(reuseContainer), credential);
+
+    public Task<TestWebResponse> SendAsync(
+        TestHostRequest request, CancellationToken cancellationToken) =>
+        SendAsync(request, cancellationToken, reuseContainer: false);
+
+    public async Task<TestWebResponse> SendAsync(
+        TestHostRequest request, CancellationToken cancellationToken, bool reuseContainer) {
         var executionRequest = PipelineRequest.CreateRequest(
             request.Method, request.PathAndQuery, request.Headers, request.Body, request.Credential);
         var body = new MemoryStream();
 
-        var response = await PipelineRequest.Run(Provider, executionRequest, body, cancellationToken);
+        var response = await PipelineRequest.Run(
+            await ContainerForRequestAsync(reuseContainer), executionRequest, body, cancellationToken);
 
         return new TestWebResponse(response);
     }

--- a/src/Web/Hardened.Web.Testing/PipelineHttpMessageHandler.cs
+++ b/src/Web/Hardened.Web.Testing/PipelineHttpMessageHandler.cs
@@ -39,12 +39,28 @@ namespace Hardened.Web.Testing;
 /// </para>
 /// </remarks>
 public sealed class PipelineHttpMessageHandler : HttpMessageHandler {
-    private readonly IServiceProvider _rootServiceProvider;
+    private readonly Func<ValueTask<IServiceProvider>> _container;
     private readonly TestCredential? _credential;
 
     /// <param name="rootServiceProvider">The application's root container, which the chain is resolved from.</param>
     public PipelineHttpMessageHandler(IServiceProvider rootServiceProvider)
         : this(rootServiceProvider, null) {
+    }
+
+    /// <summary>
+    /// A handler over a host that builds a container per request.
+    /// </summary>
+    /// <remarks>
+    /// A delegate rather than a container, because this outlives one request: a typed client holds
+    /// one handler for the whole test and sends through it many times, and each of those sends is a
+    /// separate invocation as far as the deployment is concerned.
+    /// </remarks>
+    /// <param name="container">Produces the container for one request.</param>
+    /// <param name="credential">As above.</param>
+    public PipelineHttpMessageHandler(
+        Func<ValueTask<IServiceProvider>> container, TestCredential? credential) {
+        _container = container;
+        _credential = credential;
     }
 
     /// <param name="credential">
@@ -53,7 +69,7 @@ public sealed class PipelineHttpMessageHandler : HttpMessageHandler {
     /// its own.
     /// </param>
     public PipelineHttpMessageHandler(IServiceProvider rootServiceProvider, TestCredential? credential) {
-        _rootServiceProvider = rootServiceProvider;
+        _container = () => new ValueTask<IServiceProvider>(rootServiceProvider);
         _credential = credential;
     }
 
@@ -63,7 +79,8 @@ public sealed class PipelineHttpMessageHandler : HttpMessageHandler {
 
         var body = new MemoryStream();
 
-        var response = await PipelineRequest.Run(_rootServiceProvider, executionRequest, body, cancellationToken);
+        var response = await PipelineRequest.Run(
+            await _container(), executionRequest, body, cancellationToken);
 
         return ToResponse(response, body, request);
     }

--- a/src/Web/Hardened.Web.Testing/TestClientBuilder.cs
+++ b/src/Web/Hardened.Web.Testing/TestClientBuilder.cs
@@ -40,10 +40,20 @@ internal static class TestClientBuilder {
     private static readonly ConcurrentDictionary<Assembly, IReadOnlyList<ITestClientRoute>> Routes = new();
     private static readonly ConcurrentDictionary<Assembly, IReadOnlyList<ITestClientReader>> Readers = new();
 
-    public static HttpClient CreateHttpClient(IServiceProvider rootServiceProvider, TestCredential? credential) {
+    public static HttpClient CreateHttpClient(
+        IServiceProvider rootServiceProvider, TestCredential? credential) =>
+        CreateHttpClient(rootServiceProvider, credential, reuseContainer: false);
+
+    /// <param name="reuseContainer">
+    /// Whether every request this client makes reaches one container, which is what
+    /// <c>[Shared]</c> on the parameter asks for. False is a container per request, on a host that
+    /// rebuilds.
+    /// </param>
+    public static HttpClient CreateHttpClient(
+        IServiceProvider rootServiceProvider, TestCredential? credential, bool reuseContainer) {
         var host = HostOf(rootServiceProvider);
 
-        var client = new HttpClient(host.CreateHandler(credential)) {
+        var client = new HttpClient(host.CreateHandler(credential, reuseContainer)) {
             BaseAddress = host.BaseAddress
         };
 
@@ -88,8 +98,16 @@ internal static class TestClientBuilder {
         throw new InvalidOperationException(NoRouteMessage(clientType, testAssembly));
     }
 
-    public static TestClientContext CreateContext(IServiceProvider rootServiceProvider, TestCredential? credential) =>
-        new(HostOf(rootServiceProvider), credential, CreateHttpClient(rootServiceProvider, credential));
+    public static TestClientContext CreateContext(
+        IServiceProvider rootServiceProvider, TestCredential? credential) =>
+        CreateContext(rootServiceProvider, credential, reuseContainer: false);
+
+    /// <param name="reuseContainer">As on <see cref="CreateHttpClient"/>.</param>
+    public static TestClientContext CreateContext(
+        IServiceProvider rootServiceProvider, TestCredential? credential, bool reuseContainer) =>
+        new(HostOf(rootServiceProvider),
+            credential,
+            CreateHttpClient(rootServiceProvider, credential, reuseContainer));
 
     public static string NoRouteMessage(Type clientType, Assembly testAssembly) =>
         $"{clientType.FullName} cannot be built for a test parameter. None of the three routes " +

--- a/src/Web/Hardened.Web.Testing/TestWebApp.cs
+++ b/src/Web/Hardened.Web.Testing/TestWebApp.cs
@@ -16,6 +16,7 @@ public class TestWebApp : TestContext, ITestWebApp {
     private readonly TestCredential? _credential;
     private readonly Assembly? _testAssembly;
     private ITestHost? _host;
+    private bool _reuseContainer;
 
     public TestWebApp(IApplicationRoot applicationRoot, ILogger logger)
         : this(applicationRoot, logger, null, null) {
@@ -112,7 +113,9 @@ public class TestWebApp : TestContext, ITestWebApp {
             : SetupBodyStream(bodyValue);
 
         return await Host.SendAsync(
-            new TestHostRequest(httpMethod, path, headers, body, _credential), testWebRequest.Token.Value);
+            new TestHostRequest(httpMethod, path, headers, body, _credential),
+            testWebRequest.Token.Value,
+            _reuseContainer);
     }
 
     /// <summary>
@@ -120,6 +123,20 @@ public class TestWebApp : TestContext, ITestWebApp {
     /// built by hand, which no attribute registered a host for.
     /// </summary>
     private ITestHost Host => _host ??= TestClientBuilder.HostOf(_applicationRoot.Provider);
+
+    /// <summary>
+    /// Sends every request to one container, which is what <c>[Shared]</c> on the parameter asks
+    /// for and what a test whose subject is the reuse needs.
+    /// </summary>
+    /// <remarks>
+    /// Set at construction by the harness rather than exposed to a test, so the only way to ask is
+    /// the attribute. A host that reuses anyway ignores it.
+    /// </remarks>
+    internal TestWebApp ReusingOneContainer() {
+        _reuseContainer = true;
+
+        return this;
+    }
 
     private Stream SetupBodyStream(object? bodyValue) {
         if (bodyValue == null)

--- a/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
+++ b/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
@@ -77,11 +77,18 @@ public class WebTestingAttribute : Attribute, ITestServiceSetupAttribute, ITestS
         var testAssembly = declaringType.Assembly;
         var credential = TestCredential.Resolve(testMethod);
 
+        // [Shared] on the ITestWebApp parameter, read here because the mark has to reach the way
+        // the client is built rather than only the instance the test is handed: pinning the object
+        // would change nothing about which container its requests reach.
+        var sharedWebApp = SharedParameter(testMethod, typeof(ITestWebApp));
+
         serviceCollection.AddTransient<ITestWebApp>(sp => {
             var loggerType = typeof(ILogger<>).MakeGenericType(declaringType);
             var logger = (ILogger)sp.GetRequiredService(loggerType);
             var appRoot = sp.GetRequiredService<IApplicationRoot>();
-            return new TestWebApp(appRoot, logger, credential, testAssembly);
+            var app = new TestWebApp(appRoot, logger, credential, testAssembly);
+
+            return sharedWebApp ? app.ReusingOneContainer() : app;
         });
 
         RegisterClientParameters(testMethod, serviceCollection, credential, testAssembly);
@@ -114,9 +121,12 @@ public class WebTestingAttribute : Attribute, ITestServiceSetupAttribute, ITestS
                 continue;
             }
 
+            var reuse = IsShared(parameter);
+
             if (type == typeof(HttpClient)) {
                 serviceCollection.AddScoped(type, sp =>
-                    TestClientBuilder.CreateHttpClient(sp.GetRequiredService<IApplicationRoot>().Provider, credential));
+                    TestClientBuilder.CreateHttpClient(
+                        sp.GetRequiredService<IApplicationRoot>().Provider, credential, reuse));
 
                 continue;
             }
@@ -124,7 +134,8 @@ public class WebTestingAttribute : Attribute, ITestServiceSetupAttribute, ITestS
             if (TestClientBuilder.HasRoute(type, testAssembly)) {
                 serviceCollection.AddScoped(type, sp => TestClientBuilder.Build(
                     type,
-                    TestClientBuilder.CreateContext(sp.GetRequiredService<IApplicationRoot>().Provider, credential),
+                    TestClientBuilder.CreateContext(
+                        sp.GetRequiredService<IApplicationRoot>().Provider, credential, reuse),
                     testAssembly));
 
                 continue;
@@ -137,6 +148,25 @@ public class WebTestingAttribute : Attribute, ITestServiceSetupAttribute, ITestS
             }
         }
     }
+
+    /// <summary>
+    /// Whether a parameter asked for one container across its calls.
+    /// </summary>
+    /// <remarks>
+    /// <c>[Shared]</c> on a client is the escape hatch for a test whose subject is the reuse itself:
+    /// a response cache serving a second request, a rate limiter tripping on the eleventh, a filter
+    /// the test registered reaching a later request. Without it every request runs against a
+    /// container of its own on a host that rebuilds.
+    /// </remarks>
+    private static bool IsShared(System.Reflection.ParameterInfo parameter) =>
+        parameter.GetCustomAttributes(inherit: true)
+            .OfType<ISharedTestRegistration>()
+            .Any(registration => registration.Shared);
+
+    /// <summary>The same, for a parameter named by type rather than held.</summary>
+    private static bool SharedParameter(ITestMethodContext testMethod, Type type) =>
+        testMethod.Method.GetParameters()
+            .Any(parameter => parameter.ParameterType == type && IsShared(parameter));
 
     /// <summary>
     /// The narrowest host in scope: the attributes arrive widest first, so they are read from the

--- a/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
+++ b/src/Web/Hardened.Web.Testing/WebTestingAttribute.cs
@@ -40,7 +40,42 @@ namespace Hardened.Web.Testing;
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Assembly)]
-public class WebTestingAttribute : Attribute, ITestServiceSetupAttribute, ITestStartupAttribute {
+public class WebTestingAttribute
+    : Attribute, ITestServiceSetupAttribute, ITestStartupAttribute, ISharedTestRegistration {
+
+    /// <summary>
+    /// The clients this test takes, which are the parameters that must not be pinned.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A test parameter is one instance for the whole test, because it was handed over to be looked
+    /// at. A client is the exception: it is handed over to send with, and on a host that rebuilds it
+    /// reaches a container per request, so pinning one would pin the thing that is supposed to be
+    /// rebuilt and every request would reach the same container while the test believed otherwise.
+    /// </para>
+    /// <para>
+    /// The same three the harness supplies itself, recognised the same way it recognises them when
+    /// it registers them: <see cref="ITestWebApp"/>, an <c>HttpClient</c>, and a type
+    /// <c>TestClientBuilder.HasRoute</c> answers for. Nothing infers - a generated client is an
+    /// ordinary type in an ordinary signature until you know the harness built it.
+    /// </para>
+    /// <para>
+    /// <c>[Shared]</c> on one of these still means something, and something different: not "pin the
+    /// object" but "send every request to one container", which is read at construction in
+    /// <see cref="IsShared"/> and threaded to the host.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<Type> IsolatedServices(System.Reflection.MethodInfo testMethod) {
+        var testAssembly = testMethod.DeclaringType!.Assembly;
+
+        return testMethod.GetParameters()
+            .Select(parameter => parameter.ParameterType)
+            .Where(type => type == typeof(ITestWebApp) ||
+                           type == typeof(HttpClient) ||
+                           TestClientBuilder.HasRoute(type, testAssembly))
+            .Distinct()
+            .ToArray();
+    }
     public void SetupServiceCollection(ITestMethodContext testMethod, IServiceCollection serviceCollection) {
         var host = ResolveHost(testMethod, serviceCollection);
 


### PR DESCRIPTION
The Framework half of [the container isolation plan](https://claude.ai/code/artifact/edfa53db-a5e4-4ab6-84a8-75a9dfbab8e3), on **DependencyModules 1.5.0**. The rule for what survives a container rebuild is settled separately in [What gets pinned](https://claude.ai/code/artifact/87062bb1-66fc-4c6e-849f-7e442f047bb0).

## Why

A test method's invocations all shared one container, and that models a topology that need not exist. Two queue handlers deployed as two functions are two processes, and a sandbox is not promised between invocations of one function either. A handler leaning on what a previous invocation left in a singleton failed intermittently in production and never here.

## The boundary follows the host the test already declares

No flag of its own. `TestHostAttribute` resolves narrowest-first and `WebTestingAttribute` falls back to `PipelineHostAttribute`, so the deployment model is already stated and the container policy follows from it.

| Host | Container per invocation | Because |
|---|---|---|
| `PipelineHostAttribute` (default) | **fresh** | In-process, no socket. Names no cloud, so it takes the strict reading. |
| `LambdaTestingAttribute` | **fresh** | An execution environment is not promised between invocations. |
| `LambdaWebTestingAttribute` | **fresh** | Same. A web application on Lambda is not one process. |
| `KestrelTestingAttribute` | reused | Forced by the socket. |
| `AspNetCoreTestingAttribute` | reused | Forced by the socket. |

**The socket hosts are forced, not chosen.** They hand the test an `HttpClient` bound to the loopback port the kernel picked, so restarting the server per request would leave every client the harness handed out addressing a closed socket. That is a limit on what those hosts can check, **not** a claim that sharing is safe on them: a service behind a load balancer is many instances, and state crossing requests is as unsafe there as on Lambda. `ITestHost.ContainerPolicy` says which a host is and its remarks say why.

## What crosses between containers

Every test parameter, because a parameter exists to be looked at. `FunctionTestingAttribute` and `WebTestingAttribute` name the exceptions through `ISharedTestRegistration.IsolatedServices` — a façade, `ITestWebApp`, `HttpClient`, a generated client — each recognised exactly the way it is already recognised when the harness registers it, so nothing infers.

`HardenedTestEntryPointAttribute` names the four services no parameter holds: the cancellation token, the environment, the config package and the test context. Deliberately not `ILoggerProvider`, harmless per container, and **never** `IApplicationRoot` or `ITestHost`, both of which break if pinned.

## `[Shared]` reaches construction, not just the instance

Pinning a client object changes nothing about which container its requests reach, because the host decides that. So the mark is read where the client is built and threaded down through two default-interface-member overloads on `ITestHost`. It means **the container the test was resolved from**: that is where every pinned parameter came from, so a client asked to reuse lands where the test already is.

## Migration

Eight response-cache, timeout and conditional-get tests take `[Shared]` on their client, all of them tests whose subject is the reuse itself. `StartupServicesRunOnceTests` takes it too, so its counter still distinguishes "twice in one container" from "once each in two". Everything else migrated untouched, including every trigger, Lambda, Azure and GCP integration suite.

## Two things that changed shape

`PipelineDelivery.Install` moved from an instance flag to a `ConditionalWeakTable` keyed on `IMiddlewareService`, because a fresh container has a fresh empty chain and the old flag said nothing about it.

`LambdaEnvelopeDelivery` takes the container source rather than a handler resolved once, so the handler comes with the container. `LambdaInvocationHandler` installs dispatch on its first invocation and keeps a flag saying it has, so a fresh handler on a fresh container is a cold environment doing what a cold environment does.

## Tests

Six new, three per side. The web pair is the clearest: the same handler and the same two requests, differing only by the attribute, answering `1, 1` isolated and `1, 2` shared. The trigger side adds one asserting a batch is one invocation and therefore one container.

## Verified

- Full suite in Release with `ContinuousIntegrationBuild=true`: **8341 passed, 0 failed**, with the pinned Smithy CLI 1.73.0.
- Public API re-approved. Additive: new members, one new enum, interfaces added to three attributes. No member removed, no signature changed.
- `scripts/verify-templates.sh` found the one thing the suite could not — the `DependencyModulesVersion` pin was still 1.4.0, so every scaffolded project resolved the old package. Fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)