### PR TITLE
Read the status, headers and body a returned response type declares

### DIFF
--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/BareResponseTests.cs
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT.Tests/BareResponseTests.cs
@@ -1,0 +1,97 @@
+using Hardened.Web.Runtime.Responses;
+
+namespace Hardened.IntegrationTests.Responses.SUT.Tests;
+
+/// <summary>
+/// A response type returned on its own, with no declared set around it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Created&lt;T&gt;</c> states its status, its header and which of its members is the body. A
+/// declared set reaches all three through the switch the generator emits; a handler returning one
+/// thing has no switch, and until the serializer read the value itself nothing asked. It answered
+/// 200, with no <c>Location</c>, and the wrapper serialized whole - so the body said
+/// <c>"status": 201</c> in a 200 response.
+/// </para>
+/// <para>
+/// Asserted against the thrown spelling rather than against a literal, because the two are the same
+/// value and the bug was that they disagreed.
+/// </para>
+/// </remarks>
+public class BareResponseTests {
+
+    private record TodoBody(int Id, string Title);
+
+    [HardenedTest]
+    public async Task AReturnedResponseAnswersItsOwnStatus(ITestWebApp app) {
+        var response = await app.Post(new NewTodo("bare"), "/responses/bare");
+
+        Assert.Equal(201, response.StatusCode);
+    }
+
+    [HardenedTest]
+    public async Task AReturnedResponseAppliesItsOwnHeaders(ITestWebApp app) {
+        var response = await app.Post(new NewTodo("bare"), "/responses/bare");
+
+        Assert.Equal("/responses/7", response.Headers["Location"].ToString());
+    }
+
+    /// <summary>
+    /// The payload, not the wrapper that named the status. The wrapper has a public
+    /// <c>Value</c>, so if it were serialized <c>Id</c> would read 0.
+    /// </summary>
+    [HardenedTest]
+    public async Task AReturnedResponseSendsItsBodyRatherThanTheContainer(ITestWebApp app) {
+        var response = await app.Post(new NewTodo("bare"), "/responses/bare");
+
+        // Read once: the body is a stream, and a second Deserialize finds it consumed.
+        var todo = response.Deserialize<TodoBody>();
+
+        Assert.Equal(7, todo.Id);
+        Assert.Equal("bare", todo.Title);
+    }
+
+    /// <summary>
+    /// The whole point: returned and thrown are the same value, so they are the same response.
+    /// </summary>
+    [HardenedTest]
+    public async Task ReturningAndThrowingTheSameValueAnswerIdentically(ITestWebApp app) {
+        var returned = await app.Post(new NewTodo("bare"), "/responses/bare");
+        var thrown = await app.Post(new NewTodo("bare"), "/responses/bare-thrown");
+
+        Assert.Equal(thrown.StatusCode, returned.StatusCode);
+        Assert.Equal(
+            thrown.Headers["Location"].ToString(), returned.Headers["Location"].ToString());
+        Assert.Equal(await thrown.ReadTextAsync(), await returned.ReadTextAsync());
+    }
+
+    /// <summary>
+    /// A bodyless type writes nothing, which is what distinguishes a 204 from a 200 carrying the
+    /// four characters "null".
+    /// </summary>
+    [HardenedTest]
+    public async Task AReturnedBodylessResponseWritesNoBody(ITestWebApp app) {
+        var response = await app.Delete("/responses/bare/1");
+
+        Assert.Equal(204, response.StatusCode);
+        Assert.Equal("", await response.ReadTextAsync());
+    }
+
+    /// <summary>
+    /// A handler that writes a status and then returns a type declaring another gets the type's,
+    /// and gets it identically whether or not a set is written around the type.
+    /// </summary>
+    /// <remarks>
+    /// Asserted as an agreement rather than as a number, because the point is that the two
+    /// spellings are one behaviour. A set has always resolved this contradiction in favour of the
+    /// case; the bare return now does the same rather than differently.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ADeclaredStatusWinsOverOneTheHandlerWrote(ITestWebApp app) {
+        var bare = await app.Post(new NewTodo("bare"), "/responses/bare-overridden");
+        var inSet = await app.Post(new NewTodo("bare"), "/responses/set-overridden");
+
+        Assert.Equal(inSet.StatusCode, bare.StatusCode);
+        Assert.Equal(201, bare.StatusCode);
+    }
+}

--- a/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/TodoController.cs
+++ b/src/IntegrationTests/Responses/Hardened.IntegrationTests.Responses.SUT/TodoController.cs
@@ -1,3 +1,4 @@
+using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Responses;
 using Hardened.Web.Runtime.Attributes;
 using Hardened.Web.Runtime.Responses;
@@ -86,6 +87,65 @@ public class TodoController {
 
         return new Todo(id, "declared");
     }
+
+    #region returned on its own, with no set around it
+
+    /// <summary>
+    /// The same <c>Created&lt;Todo&gt;</c> as <see cref="Create"/>, returned on its own.
+    /// </summary>
+    /// <remarks>
+    /// A handler with one outcome has no set to declare, and the value already states its status,
+    /// its header and which of its members is the body. Until the serializer read that, this
+    /// answered 200 with no <c>Location</c> and the wrapper on the wire - so the body carried
+    /// <c>"status": 201</c> inside a 200.
+    /// </remarks>
+    [Post("/bare")]
+    public Created<Todo> CreateBare(NewTodo request) =>
+        new(new Todo(7, request.Title), "/responses/7");
+
+    /// <summary>The identical value, thrown instead of returned.</summary>
+    /// <remarks>
+    /// The comparison that matters. <c>ResponseException</c> has read all three interfaces since it
+    /// existed, so this path was always right and the returned one was not.
+    /// </remarks>
+    [Post("/bare-thrown")]
+    public Todo CreateBareThrown(NewTodo request) =>
+        throw new Created<Todo>(new Todo(7, request.Title), "/responses/7").AsException();
+
+    /// <summary>A bodyless response returned on its own.</summary>
+    /// <remarks>
+    /// <c>NoContent</c> states <c>HasBody</c> false, which is what stops "null" being written into
+    /// a 204 - the same thing the set's switch does through <c>ShouldSerialize</c>.
+    /// </remarks>
+    [Delete("/bare/{id}")]
+    public NoContent RemoveBare(int id) => new();
+
+    /// <summary>
+    /// Writes a status, then returns a type that declares another.
+    /// </summary>
+    /// <remarks>
+    /// The declared status wins. A handler that says <c>Created&lt;T&gt;</c> has said 201, and an
+    /// earlier write is the contradiction rather than the override - which is what a set already
+    /// does, and <see cref="CreateInSetOverridden"/> is the twin that proves the two agree rather
+    /// than asserting it.
+    /// </remarks>
+    [Post("/bare-overridden")]
+    public Created<Todo> CreateBareOverridden(IExecutionContext context, NewTodo request) {
+        context.Response.Status = 202;
+
+        return new Created<Todo>(new Todo(7, request.Title), "/responses/7");
+    }
+
+    /// <summary>The same contradiction inside a declared set.</summary>
+    [Post("/set-overridden")]
+    public Response<Created<Todo>, Conflict> CreateInSetOverridden(
+        IExecutionContext context, NewTodo request) {
+        context.Response.Status = 202;
+
+        return new Created<Todo>(new Todo(7, request.Title), "/responses/7");
+    }
+
+    #endregion
 }
 
 public record ApiError(string Code, string Message);

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/HttpMethodController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/HttpMethodController.cs
@@ -46,6 +46,19 @@ public class HttpMethodController {
     [Post("/created", SuccessStatus = 201)]
     public string CreateItem() => "created";
 
+    /// <summary>
+    /// A response type returned on its own, which states its own 201 and its own Location.
+    /// </summary>
+    /// <remarks>
+    /// Here because the published document is half of what this states. The type declares the
+    /// status, the header and which member is the body, and a document that described the wrapper
+    /// at 200 would have a generated client wrong about every creation endpoint - which is what it
+    /// did until the generator read the return type.
+    /// </remarks>
+    [Post("/created-by-type")]
+    public global::Hardened.Web.Runtime.Responses.Created<CreatedNote> CreateByType() =>
+        new(new CreatedNote("created"), "/verbs/created-by-type/1");
+
     /// <summary>A declared 204, which also means the body is not written.</summary>
     [Delete("/emptied", SuccessStatus = 204)]
     public string EmptyItem() => "this body is not written";
@@ -65,3 +78,5 @@ public class HttpMethodController {
         return new Created<MathAddModel>(model, $"/verbs/item/{model.Values.Count}");
     }
 }
+
+public record CreatedNote(string Title);

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -5239,6 +5239,46 @@
         "x-hardened-timeout": 300000
       }
     },
+    "/verbs/created-by-type": {
+      "post": {
+        "tags": [
+          "HttpMethod"
+        ],
+        "operationId": "createByType",
+        "summary": "A response type returned on its own, which states its own 201 and its own Location.",
+        "description": "Here because the published document is half of what this states. The type declares the status, the header and which member is the body, and a document that described the wrapper at 200 would have a generated client wrong about every creation endpoint - which is what it did until the generator read the return type.",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedNote"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
     "/verbs/emptied": {
       "delete": {
         "tags": [
@@ -5551,6 +5591,17 @@
           "status": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "CreatedNote": {
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
           }
         }
       },

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
@@ -194,6 +194,8 @@ public class ModelComparisonTests {
     /// makes such a failure unreadable. Streaming framing is the third, and adding it here is what
     /// this test is for. The framing finding is the fourth: a handler whose attribute is removed or
     /// whose return type changes has to change this string, or the diagnostic outlives the code.
+    /// The declared response is the fifth: a handler returning Created&lt;T&gt; dispatches on the
+    /// status, header and body the type states, and a change to any of them has to be visible here.
     /// </remarks>
     [Fact]
     public void AResponseModelDescribesAllOfItsResponseAnnotations() {
@@ -209,6 +211,7 @@ public class ModelComparisonTests {
                 "new Dictionary<int, object> { { 401, Models.DefaultErrorBodies.UnauthorizedProblem } }",
             ProducedContentTypes = "text/plain,text/csv",
             UnionCases = "global::App.Todo|201|01;global::App.NotFound|404|01",
+            DeclaredResponse = "global::App.Created|201|111|global::App.Todo",
             ThrowsDiagnostic = "OutOfStock",
             ValidationErrorStatus = 422,
             StreamFramingDiagnostic = "sse"
@@ -221,7 +224,8 @@ public class ModelComparisonTests {
             "Models.DefaultErrorBodies.NotFoundProblem:" +
             "new Dictionary<int, object> { { 401, Models.DefaultErrorBodies.UnauthorizedProblem } }:" +
             "text/plain,text/csv:" +
-            "global::App.Todo|201|01;global::App.NotFound|404|01::OutOfStock:422:sse",
+            "global::App.Todo|201|01;global::App.NotFound|404|01:" +
+            "global::App.Created|201|111|global::App.Todo::OutOfStock:422:sse",
             model.ToString());
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
@@ -193,6 +193,17 @@ public record ResponseInformationModel {
     public string? StreamFraming { get; set; }
 
     /// <summary>
+    /// The single case a handler returning a response type on its own declares, encoded, or null.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UnionCases"/> for a handler that has no set. A type like <c>Created&lt;T&gt;</c>
+    /// states its status, its headers and which member is its body whether or not a set is written
+    /// around it, and this is where that statement is carried so the dispatch and the document read
+    /// the same one.
+    /// </remarks>
+    public string? DeclaredResponse { get; set; }
+
+    /// <summary>
     /// Both ways a handler can say something about its response, not one of them.
     /// </summary>
     /// <remarks>
@@ -211,7 +222,8 @@ public record ResponseInformationModel {
         return $"{IsAsync}:{OutputType}:{RawResponseContentType}:{StreamFraming}:{ReturnType}" +
                $":{DefaultStatusCode}:{NullResponseBodyExpression}:{DeclaredErrorBodiesExpression}" +
                $":{ProducedContentTypes}" +
-               $":{UnionCases}:{UnionDiagnostic}:{ThrowsDiagnostic}:{ValidationErrorStatus}" +
+               $":{UnionCases}:{DeclaredResponse}:{UnionDiagnostic}:{ThrowsDiagnostic}" +
+               $":{ValidationErrorStatus}" +
                $":{StreamFramingDiagnostic}";
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -84,9 +84,16 @@ public abstract class BaseRequestModelGenerator {
 
         // And the ones it writes on a status the handler answers by returning a value, which
         // WriteSingleResponse rather than WriteDeclaredResponses publishes.
-        model.SingleResponseHeaders = declared.Headers(
-            model.ResponseInformation.DefaultStatusCode ?? 200,
-            System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>());
+        // Seeded with what the return type itself declares - a Created<T> carries a Location - so a
+        // handler returning one publishes the header a set's case would. DeclaredResponses does the
+        // same for a set, off the case type rather than the body's.
+        var typeHeaders = DeclaredResponseHeaders(context, model.ResponseInformation);
+
+        // Headers() answers null when it merged nothing in, so the type's own would be dropped on
+        // every handler no filter also declares a header for - which is all of them.
+        model.SingleResponseHeaders =
+            declared.Headers(model.ResponseInformation.DefaultStatusCode ?? 200, typeHeaders)
+            ?? (typeHeaders.Count > 0 ? typeHeaders : null);
 
         model.ParameterEnums = ParameterEnums(context, methodDeclaration);
 
@@ -235,6 +242,27 @@ public abstract class BaseRequestModelGenerator {
     }
 
     /// <summary>
+    /// The headers the return type declares, for a handler that returns one on its own.
+    /// </summary>
+    /// <remarks>
+    /// Off the response type rather than the body's: a <c>Created&lt;Todo&gt;</c> sends a
+    /// <c>Todo</c> and carries a <c>Location</c>, and the <c>Location</c> is the wrapper's. The
+    /// same read <c>DeclaredResponses</c> makes per case.
+    /// </remarks>
+    private static IReadOnlyList<Hardened.Generation.Models.ResponseHeaderModel> DeclaredResponseHeaders(
+        GeneratorSyntaxContext context, ResponseInformationModel response) {
+        var single = UnionResponseSelector.Decode(response.DeclaredResponse).FirstOrDefault();
+
+        if (single.TypeName == null || !single.AppliesHeaders) {
+            return System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>();
+        }
+
+        return CaseSymbol(context, single.TypeName) is { } symbol
+            ? UnionResponseSelector.DeclaredHeaders(symbol)
+            : System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>();
+    }
+
+    /// <summary>
     /// The symbol for a case type's definition, from the emitted spelling.
     /// </summary>
     /// <remarks>
@@ -307,7 +335,22 @@ public abstract class BaseRequestModelGenerator {
         }
 
         if (response.UnionCases == null) {
-            return declared;
+            // A response type returned on its own describes what it sends, not itself. A schema
+            // written from Created<Todo> describes {value, location, status}, which no client ever
+            // receives - the same defect writing Response<T1..Tn>'s own schema would have been.
+            var single = UnionResponseSelector.Decode(response.DeclaredResponse).FirstOrDefault();
+
+            if (single.BodyTypeName == null) {
+                return declared;
+            }
+
+            // Null rather than the wrapper where the body type will not resolve.
+            // Compilation.GetTypeByMetadataName answers null for a name it finds in more than one
+            // reference, which the forwarded BCL primitives are - so Created<string> lands here.
+            // No schema is a gap; the wrapper is a shape no client ever receives, offered as the
+            // contract.
+            return context.SemanticModel.Compilation.GetTypeByMetadataName(
+                single.BodyTypeName.Replace("global::", ""));
         }
 
         var successStatus = response.DefaultStatusCode ?? 200;
@@ -737,7 +780,16 @@ public abstract class BaseRequestModelGenerator {
 
         var successStatus = DeclaredSuccessStatus(context);
 
+        // What the return type states about itself, for a handler with no set around it. Read
+        // before the status below, because a type's own [HttpStatus] is what the document has to
+        // publish - the same precedence a case has inside a set.
+        var declaredResponse =
+            UnionResponseSelector.ReadDeclared(context.SemanticModel, methodDeclaration, successStatus);
+
+        var declaredCase = UnionResponseSelector.Decode(declaredResponse).FirstOrDefault();
+
         return new ResponseInformationModel {
+            DeclaredResponse = declaredResponse,
             StreamFraming = framing,
             StreamFramingDiagnostic = framing != null && !isAsyncEnumerable ? framing : null,
             IsAsync = isAsync,
@@ -746,7 +798,9 @@ public abstract class BaseRequestModelGenerator {
             OutputType = output,
             ReturnType = returnType,
             RawResponseContentType = rawResponse,
-            DefaultStatusCode = successStatus,
+            // The type's status where it declares one, so a handler returning Created<T> publishes
+            // 201 rather than the 200 nothing asked for.
+            DefaultStatusCode = declaredCase.TypeName != null ? declaredCase.Status : successStatus,
             ProducedContentTypes = DeclaredContentTypes(context),
 
             // Structural, so this recognises Response<T1..Tn>, a generated response union and a

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeMethodCodeGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/InvokeMethodCodeGenerator.cs
@@ -41,7 +41,9 @@ public static class InvokeMethodCodeGenerator {
                  requestHandlerModel.ResponseInformation.ReturnType.Name != typeof(void).Name) {
             EmitSingleResponseDispatch(
                 invokeMethod, invokeStatement, context,
-                requestHandlerModel.ResponseInformation.ReturnTypeProvidesHeaders);
+                requestHandlerModel.ResponseInformation.ReturnTypeProvidesHeaders,
+                UnionResponseSelector.Decode(
+                    requestHandlerModel.ResponseInformation.DeclaredResponse).FirstOrDefault());
         }
         else {
             invokeMethod.AddIndentedStatement(invokeStatement);
@@ -69,7 +71,17 @@ public static class InvokeMethodCodeGenerator {
         MethodDefinition invokeMethod,
         IOutputComponent invokeStatement,
         ParameterDefinition context,
-        bool providesHeaders) {
+        bool providesHeaders,
+        UnionCaseModel declared) {
+        // The return type states its status, its headers and which member is its body. Emitted
+        // directly rather than through a switch: a set switches on its Value to find out which case
+        // it holds, and here the type is the answer.
+        if (declared.TypeName != null) {
+            EmitDeclaredResponseDispatch(invokeMethod, invokeStatement, context, declared);
+
+            return;
+        }
+
         if (!providesHeaders) {
             invokeMethod.Assign(invokeStatement).To(context.Property("Response.ResponseValue"));
 
@@ -84,6 +96,59 @@ public static class InvokeMethodCodeGenerator {
                 "IProvidesResponseHeaders __headerProvider) __headerProvider.ApplyHeaders(context.Response.Headers)"));
 
         invokeMethod.Assign(result).To(context.Property("Response.ResponseValue"));
+    }
+
+    /// <summary>
+    /// The four things a set's switch does for its case, for a handler whose return type is the
+    /// case.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Status, headers, the inner body and bodylessness. A handler returning
+    /// <c>Created&lt;Todo&gt;</c> declares all four in its signature, and before this the emitter
+    /// read none of them: it answered 200 with no <c>Location</c> and serialized the wrapper, so
+    /// the body carried <c>"status": 201</c> inside a 200 response. Thrown, the identical value was
+    /// answered correctly, because <c>ResponseException</c> reads the same three interfaces.
+    /// </para>
+    /// <para>
+    /// No <c>is</c> test and no cast for the headers: the type is known here, which is the whole
+    /// difference from the fallback above. That one is gated on
+    /// <c>ReturnTypeProvidesHeaders</c> because <c>is</c> against a sealed type that provably cannot
+    /// implement an interface is CS8121 rather than a test returning false - a gate only the
+    /// specification bridge ever set, so a hand-written handler never reached it.
+    /// </para>
+    /// </remarks>
+    private static void EmitDeclaredResponseDispatch(
+        MethodDefinition invokeMethod,
+        IOutputComponent invokeStatement,
+        ParameterDefinition context,
+        UnionCaseModel declared) {
+        var result = invokeMethod.Assign(invokeStatement).ToVar(ResultVariable);
+
+        invokeMethod.Assign(CodeOutputComponent.Get(declared.Status.ToString()))
+            .To(context.Property("Response.Status"));
+
+        if (declared.AppliesHeaders) {
+            invokeMethod.AddIndentedStatement(
+                CodeOutputComponent.Get(ResultVariable)
+                    .Invoke("ApplyHeaders", context.Property("Response.Headers")));
+        }
+
+        if (declared.CarriesBody && declared.HasBody) {
+            invokeMethod
+                .Assign(CodeOutputComponent.Get(
+                    "((global::Hardened.Requests.Abstract.Responses.ICarriesResponseBody)" +
+                    ResultVariable + ").Body"))
+                .To(context.Property("Response.ResponseValue"));
+        }
+        else {
+            invokeMethod.Assign(result).To(context.Property("Response.ResponseValue"));
+        }
+
+        if (!declared.HasBody) {
+            invokeMethod.Assign(CodeOutputComponent.Get("false"))
+                .To(context.Property("Response.ShouldSerialize"));
+        }
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnionResponseSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnionResponseSelector.cs
@@ -94,6 +94,8 @@ public static class UnionResponseSelector {
 
     private const string StatusCodeInterfaceName = "IStatusCode";
 
+    private const string StatusResponseInterfaceName = "IHttpStatusResponse";
+
     private const string ResponsesNamespace = "Hardened.Requests.Abstract.Responses";
 
     /// <summary>
@@ -115,6 +117,54 @@ public static class UnionResponseSelector {
         var cases = Cases(returned, successStatus ?? 200);
 
         return cases == null ? null : Encode(cases);
+    }
+
+    /// <summary>
+    /// The one case a handler that returns a response type on its own answers with, encoded, or
+    /// null where the return type states nothing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A handler returning <c>Created&lt;Todo&gt;</c> has declared exactly as much as a one-case
+    /// set: the status, whether headers are contributed, and which member is the body. It is read
+    /// through the same five helpers a set's cases are, because it is the same question asked of one
+    /// type - and the alternative was a second, drifting answer to it.
+    /// </para>
+    /// <para>
+    /// <b>Null for a response set</b>, which <see cref="Read"/> already describes case by case, and
+    /// null for every ordinary return type, which states nothing and needs no dispatch beyond the
+    /// assignment it already gets.
+    /// </para>
+    /// <para>
+    /// The type's own <c>[HttpStatus]</c> beats <paramref name="successStatus"/>, exactly as a
+    /// case's does inside a set. That is not a new precedence rule; it is the existing one asked
+    /// about one type.
+    /// </para>
+    /// </remarks>
+    public static string? ReadDeclared(
+        SemanticModel semanticModel, MethodDeclarationSyntax methodDeclaration, int? successStatus) {
+        var returned = Unwrap(semanticModel.GetTypeInfo(methodDeclaration.ReturnType).Type);
+
+        if (returned == null || !Implements(returned, StatusResponseInterfaceName)) {
+            return null;
+        }
+
+        // A set is described case by case; this is only for a type answering on its own.
+        if (Cases(returned, successStatus ?? 200) != null) {
+            return null;
+        }
+
+        var status = Status(returned, successStatus ?? 200);
+
+        return Encode(new[] {
+            new UnionCaseModel(
+                returned.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                status,
+                AppliesHeaders(returned),
+                HasBody(status),
+                Implements(returned, BodyInterfaceName),
+                BodyType(returned))
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
A handler returning `Created<Todo>` answered 200, with no `Location`, and serialized the wrapper — so the body carried `"status": 201` inside a 200 response:

```
RETURNED   HTTP/1.1 200 OK
           body: {"value":{"id":99,...},"location":"/todos/99","status":201}

THROWN     HTTP/1.1 201 Created
           Location: /todos/99
           body: {"id":99,"title":"probe","done":false}
```

The identical value, thrown, was always right: `ResponseException` has read `IHttpStatusResponse`, `IProvidesResponseHeaders` and `ICarriesResponseBody` since it existed. Only the return path never asked.

## Where it goes

A response set reaches all four things — the status, the headers, the inner body, and bodylessness — through the switch the generator emits around its cases. A handler returning one thing has no switch, and nothing else read the type.

So the generator reads it. `UnionResponseSelector.ReadDeclared` asks the same five helpers a case is built from, of one type; none of them was ever union-specific. The emitter then writes the four assignments directly:

```csharp
var __response = controller.CreateByType();
context.Response.Status = 201;
__response.ApplyHeaders(context.Response.Headers);
context.Response.ResponseValue = ((ICarriesResponseBody)__response).Body;
```

No switch and no `is` test, because the type is known here. That is exactly what the fallback beside it cannot assume, and why that one is gated on `ReturnTypeProvidesHeaders` — a flag only the specification bridge ever sets, so a hand-written handler never reached it and never got even the header half.

## Why build time rather than the serializer

I wrote the runtime version first and threw it away. It made the service right and left the document wrong, which is worse than the bug: the document published 200 with a `CreatedOfString` schema and no `Location`, so a client generated from it was wrong about every creation endpoint written this way. That is the same defect the `SuccessStatus` comment in `ContextSerializationService` records for described operations.

Measured on the SUT that publishes a document:

| | status | schema | headers |
|---|---|---|---|
| before | 200 | the wrapper | none |
| after | 201 | the inner type | `Location` |
| `Response<Created<T>, Conflict>` | 201 | the inner type | `Location` |

The bare return now publishes what the same value inside a set already published.

## One behaviour choice

A declared status beats one the handler wrote earlier, because that is what a set has always done. The test asserts the two spellings agree rather than asserting `201`, so if that precedence should go the other way, both paths move together and the test says so.

## Two pre-existing bugs, fixed only where they blocked this

- `DeclaredOperationFacts.Headers` returns null when its merge added nothing, so a caller passing headers in got null back and dropped them.
- `Compilation.GetTypeByMetadataName` answers null for a name it finds in more than one reference, which is every forwarded BCL primitive. `Created<string>` resolved to nothing, and the schema subject fell back to the wrapper. It now yields null instead: no schema is a gap, the wrapper is a wrong answer. **The union path makes the same lookup and is untouched**, so `Created<string>` inside a set still publishes a response with no schema.

## Verification

CI-shaped Release build of the whole solution exits 0. 118 test suites, 0 failures. Six new integration tests in the Responses SUT cover the status, the headers, the body unwrap, the bodyless case, the returned-versus-thrown agreement and the precedence rule. The `ModelComparisonTests` string moved deliberately: `ResponseInformationModel.ToString()` is what the incremental caches compare, its own comment records that it has silently dropped a property twice, and the new field is now pinned there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)