### PR TITLE
Point the documentation at 0.31.0-rc1000, and check it before the tag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -30,10 +30,21 @@ never remove it.
 **Open pull requests are not in this release.** `gh pr list`. Not a blocker. Name them, so nobody
 finds out afterwards that their work missed the cut.
 
-**The pack list covers every packable project.** This has drifted four times. The workflow's own
-`EXPECTED` check compares what it packed against a number, so it catches a *removed* package and is
-blind to an *added* one: a new project reaches the solution, nobody adds it to the list, and the
-release ships without it.
+**Everything the release workflow itself checks, before the tag rather than after it.** This is the
+rule the rest of the section is only an instance of: `release.yaml` runs its guards *after* it has
+already pushed to nuget.org, so a guard that fails leaves a published release and a red run. Read its
+step list and run the same checks here.
+
+```bash
+grep -n 'name: ' .github/workflows/release.yaml | sed -n '/Resolve version/,$p'
+```
+
+Two of them have failed a real release from this repository, and both are cheap to run locally.
+
+*The pack list covers every packable project.* The workflow has a step for this now, and its
+`EXPECTED` count is a separate, weaker guard: `EXPECTED` compares what it packed against a number, so
+it catches a package that was *removed* and is blind to one that was *added*. Run the step's own
+logic, or this equivalent:
 
 ```bash
 sed -n '/name: Pack/,/EXPECTED=/p' .github/workflows/release.yaml \
@@ -44,13 +55,29 @@ find src -name '*.csproj' -not -path '*/obj/*' \
   | while read -r p; do grep -qiE '<IsPackable>\s*false\s*</IsPackable>' "$p" || echo "$p"; done \
   | sort -u > /tmp/packable.txt
 
-comm -13 /tmp/packlist.txt /tmp/packable.txt   # packable, unlisted: must be empty except templates
+comm -13 /tmp/packlist.txt /tmp/packable.txt   # packable, unlisted: templates only
 comm -23 /tmp/packlist.txt /tmp/packable.txt   # listed, not packable: must be empty
 ```
 
-Case-insensitive on `IsPackable`, because at least one project writes `False`. The six projects
-under `src/Templates/**/templates/` are scaffolding content rather than packages and are the only
-allowed entries in the first list. Check `EXPECTED` equals the list length.
+Case-insensitive on `IsPackable`, because at least one project writes `False`. The six projects under
+`src/Templates/**/templates/` are scaffolding content rather than packages and are the only allowed
+entries in the first list.
+
+*The documented version is the one being released.* Every copyable `PackageReference`,
+`<HardenedVersion>` and `dotnet new install` line under `docs/` outside `design/` must cite the new
+version. This failed v0.31.0-rc1000 **after** the packages had shipped, which is the whole reason
+this section is written the way it is.
+
+```bash
+VERSION=<the version>
+COPYABLE='(Version="|<HardenedVersion>|Hardened\.Templates@)[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+'
+grep -rnE "$COPYABLE" docs --include='*.md' --exclude-dir=design | grep -v 'Hardened\.Amz\.' \
+  | grep -oE "$COPYABLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+' | sort -u
+```
+
+Sweep the whole of `docs/` outside `design/`, including the prose line in `reference/packages.md`
+that names the current line. Leave `design/` alone: those are maintainer notes and cite historical
+versions on purpose, and leave any line mentioning `Hardened.Amz.`, which is frozen.
 
 ## 2. Bump the open line
 
@@ -66,8 +93,8 @@ Move it to the next line and update the comment above it to say what has now rel
 the next minor and state the choice in the PR body, because the sequence skips numbers on purpose
 (there was no 0.7.0; 0.23.0 through 0.29.0 were skipped).
 
-Commit it with anything else the release needs, open one pull request, wait for CI, merge. Do not
-put the version in the branch name.
+Commit it with the documentation sweep and anything else the release needs, open **one** pull
+request, wait for CI, merge. Do not put the version in the branch name.
 
 ## 3. Dry run, before the tag
 

--- a/docs/aws/lambda-function.md
+++ b/docs/aws/lambda-function.md
@@ -36,16 +36,16 @@ see [Triggers](/guide/triggers).
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="Hardened.Shared.Runtime" Version="0.30.0-rc1000" />
-    <PackageReference Include="Hardened.Requests.Runtime" Version="0.30.0-rc1000" />
-    <PackageReference Include="Hardened.Functions.Runtime" Version="0.30.0-rc1000" />
+    <PackageReference Include="Hardened.Shared.Runtime" Version="0.31.0-rc1000" />
+    <PackageReference Include="Hardened.Requests.Runtime" Version="0.31.0-rc1000" />
+    <PackageReference Include="Hardened.Functions.Runtime" Version="0.31.0-rc1000" />
 
     <!-- The host, and one adapter for the trigger the handler declares. -->
-    <PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.30.0-rc1000" />
-    <PackageReference Include="Hardened.Aws.Lambda.Invoke" Version="0.30.0-rc1000" />
+    <PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.31.0-rc1000" />
+    <PackageReference Include="Hardened.Aws.Lambda.Invoke" Version="0.31.0-rc1000" />
 
-    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.30.0-rc1000" />
-    <PackageReference Include="Hardened.Function.SourceGenerator" Version="0.30.0-rc1000"
+    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.31.0-rc1000" />
+    <PackageReference Include="Hardened.Function.SourceGenerator" Version="0.31.0-rc1000"
                       PrivateAssets="all" />
 </ItemGroup>
 ```

--- a/docs/aws/sqs.md
+++ b/docs/aws/sqs.md
@@ -26,8 +26,8 @@ Referencing `Hardened.Aws.Lambda.Sqs` is what decides that `[Queue]` means SQS. 
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Aws.Lambda.Sqs" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Aws.Lambda.Sqs" Version="0.31.0-rc1000" />
 ```
 
 `Hardened.Aws.Lambda.Sns` serves `[Topic]` the same way. A topic fans out — every subscriber sees

--- a/docs/azure/blob.md
+++ b/docs/azure/blob.md
@@ -18,9 +18,9 @@ public record BlobNotification(string Container, string Name, long? Size, string
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.Blobs" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.Blobs" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger blob` writes this shape with tests.

--- a/docs/azure/change.md
+++ b/docs/azure/change.md
@@ -17,9 +17,9 @@ public class OrderProjection {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.CosmosDb" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.CosmosDb" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger change` writes this shape with tests.

--- a/docs/azure/event.md
+++ b/docs/azure/event.md
@@ -19,9 +19,9 @@ its body.
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.EventGrid" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.EventGrid" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 The adapter reads the event through `Hardened.CloudEvents`, which names no cloud and is the same

--- a/docs/azure/queue.md
+++ b/docs/azure/queue.md
@@ -27,9 +27,9 @@ Bus queue. See [Triggers](/guide/triggers) for the vocabulary.
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 The same package serves `[Topic]`, from a subscription; see [Topics](/azure/topic).

--- a/docs/azure/stream.md
+++ b/docs/azure/stream.md
@@ -16,9 +16,9 @@ public class TelemetryHandlers {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.EventHubs" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.EventHubs" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger stream` writes this shape with tests.

--- a/docs/azure/timer.md
+++ b/docs/azure/timer.md
@@ -16,9 +16,9 @@ public class Housekeeping {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.Timer" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.Timer" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger timer` writes this shape with tests.

--- a/docs/azure/topic.md
+++ b/docs/azure/topic.md
@@ -16,9 +16,9 @@ public class OrderEventHandlers {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 The same package serves `[Queue]`; the delivery, the headers and the settlement are the ones

--- a/docs/azure/web.md
+++ b/docs/azure/web.md
@@ -19,9 +19,9 @@ public class OrderRoutes {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.Http" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.30.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.Http" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.31.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-web --host azure-functions` writes this shape: a library with the routes

--- a/docs/gcp/blob.md
+++ b/docs/gcp/blob.md
@@ -28,8 +28,8 @@ declare one for a queue message.
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Storage" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Storage" Version="0.31.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger blob` writes this shape with tests.

--- a/docs/gcp/change.md
+++ b/docs/gcp/change.md
@@ -20,8 +20,8 @@ way the DynamoDB adapter unwraps a type-tagged item, so nothing in the handler k
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Firestore" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Firestore" Version="0.31.0-rc1000" />
 ```
 
 This is the one adapter in the line with a Google dependency. Firestore events are

--- a/docs/gcp/event.md
+++ b/docs/gcp/event.md
@@ -18,8 +18,8 @@ its body.
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Eventarc" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Eventarc" Version="0.31.0-rc1000" />
 ```
 
 The adapter reads the event through `Hardened.CloudEvents`, which names no cloud. Binary mode,

--- a/docs/gcp/invoke.md
+++ b/docs/gcp/invoke.md
@@ -20,8 +20,8 @@ public class OrderHandler(OrderLog log) {
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Invoke" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Invoke" Version="0.31.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger invoke` writes this shape with tests. It is the

--- a/docs/gcp/queue.md
+++ b/docs/gcp/queue.md
@@ -27,8 +27,8 @@ subscription. See [Triggers](/guide/triggers) for the vocabulary.
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.31.0-rc1000" />
 ```
 
 The same package serves `[Topic]`, from a different delivery; see [Topics](/gcp/topic).

--- a/docs/gcp/timer.md
+++ b/docs/gcp/timer.md
@@ -15,8 +15,8 @@ public class Rollups {
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Scheduler" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Scheduler" Version="0.31.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger timer` writes this shape with tests.

--- a/docs/gcp/topic.md
+++ b/docs/gcp/topic.md
@@ -17,8 +17,8 @@ public class OrderEventHandlers {
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.30.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.31.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.31.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger topic` writes this shape with tests.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -53,12 +53,12 @@ Two kinds of package reference, the runtime and the source generators:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="Hardened.Shared.Runtime" Version="0.30.0-rc1000" />
-    <PackageReference Include="Hardened.Web.Runtime" Version="0.30.0-rc1000" />
-    <PackageReference Include="Hardened.Web.Kestrel.Runtime" Version="0.30.0-rc1000" />
+    <PackageReference Include="Hardened.Shared.Runtime" Version="0.31.0-rc1000" />
+    <PackageReference Include="Hardened.Web.Runtime" Version="0.31.0-rc1000" />
+    <PackageReference Include="Hardened.Web.Kestrel.Runtime" Version="0.31.0-rc1000" />
 
-    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.30.0-rc1000" />
-    <PackageReference Include="Hardened.Web.SourceGenerator" Version="0.30.0-rc1000" />
+    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.31.0-rc1000" />
+    <PackageReference Include="Hardened.Web.SourceGenerator" Version="0.31.0-rc1000" />
 </ItemGroup>
 ```
 

--- a/docs/guide/project-templates.md
+++ b/docs/guide/project-templates.md
@@ -241,7 +241,7 @@ routes as well as services, add `[HardenedWebModule]` to the module class and re
 Every template writes a `Directory.Packages.props` with one version for every Hardened package:
 
 ```xml
-<HardenedVersion>0.30.0-rc1000</HardenedVersion>
+<HardenedVersion>0.31.0-rc1000</HardenedVersion>
 ```
 
 It is the version the template package shipped with, and `--hardened-version` overrides it.
@@ -251,7 +251,7 @@ Templates do not update themselves. A newer release is a newer template package:
 
 ```bash
 dotnet new install Hardened.Templates                     # latest
-dotnet new install Hardened.Templates@0.30.0-rc1000       # a specific one
+dotnet new install Hardened.Templates@0.31.0-rc1000       # a specific one
 ```
 
 Existing projects keep the version in their own `Directory.Packages.props` until you change it.

--- a/docs/guide/response-caching.md
+++ b/docs/guide/response-caching.md
@@ -23,7 +23,7 @@ nothing. The two compose.
 A store is a package and an attribute on the module:
 
 ```xml
-<PackageReference Include="Hardened.Requests.Caching.Memory" Version="0.30.0-rc1000" />
+<PackageReference Include="Hardened.Requests.Caching.Memory" Version="0.31.0-rc1000" />
 ```
 
 ```csharp

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -54,7 +54,7 @@ Reference both packages:
 ```xml
 <ItemGroup>
     <PackageReference Include="RazorBlade" Version="1.0.0" />
-    <PackageReference Include="Hardened.Templates.RazorBlade" Version="0.30.0-rc1000" />
+    <PackageReference Include="Hardened.Templates.RazorBlade" Version="0.31.0-rc1000" />
 </ItemGroup>
 ```
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -261,7 +261,7 @@ Everything releases on one version line, from a `v*` tag:
 | Every package on this page | `{line}-rc1000` | `{line}-preview{build}` on every push to main |
 | `Hardened.Amz.*`, retired | `0.22.0-rc1000`, its last | none |
 
-The current line is **`0.30.0-rc1000`**. Releases go to nuget.org; the continuous feed is
+The current line is **`0.31.0-rc1000`**. Releases go to nuget.org; the continuous feed is
 [GitHub Packages](https://nuget.pkg.github.com/ipjohnson/index.json). Under one line, `preview`
 sorts below `rc`, so a preview never shadows the release it precedes.
 


### PR DESCRIPTION
`v0.31.0-rc1000` **published correctly** — all 65 packages are on nuget.org and GitHub Packages, and the GitHub release exists. The run went red on its last step, `Check the documented version is this one`, which runs *after* the pushes.

## The documentation

57 citations across 22 pages still said `0.30.0-rc1000`, so a reader following `getting-started.md` would have installed the previous release. Swept to `0.31.0-rc1000`, including the prose line in `reference/packages.md` that names the current line.

`docs/design/` is excluded, as the workflow excludes it: those are maintainer notes and cite historical versions on purpose. No `Hardened.Amz.` line was touched; it is frozen at `0.22.0-rc1000`.

The workflow's own check, run against this branch, now finds exactly one cited version and it is the released one.

## The part worth keeping

**`release.yaml`'s guards run after the point of no return.** Pack, push to nuget.org, push to GitHub Packages and create the release all succeeded before this check ran. A guard that fails there leaves a published release and a red run, and nothing can be taken back — nuget.org can unlist a version but never remove it.

So the release skill's preflight is now derived from the workflow's own step list rather than from what someone remembered:

```bash
grep -n 'name: ' .github/workflows/release.yaml | sed -n '/Resolve version/,$p'
```

with the two that have actually failed a release written out in full: this documentation check, and the pack list.

The pack-list note is corrected as well. I had written it as though the workflow lacked the check; it has one. `EXPECTED` is the weaker guard beside it — it compares what was packed against a number, so it catches a package that was *removed* and is blind to one that was *added*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)