### PR TITLE
Qualify an imported module's links with global::

### DIFF
--- a/src/SourceGenerators/Hardened.SourceGenerator/Links/LinkGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Links/LinkGenerator.cs
@@ -451,8 +451,13 @@ public static class LinkGenerator {
             property.Modifiers |= ComponentModifier.Public;
             property.Set = null;
             property.Get.LambdaSyntax = true;
+            // global::, because the namespace alone binds to whatever is in scope at the point of
+            // use. An application named for a type in its own root namespace - Todo.Host importing
+            // Todo.TodoLibrary, where Todo is also a record - otherwise resolves the first segment
+            // to that type and fails with CS0426. The property's own type is qualified already;
+            // this is the one place the name was built by hand.
             property.Get.AddCode(
-                $"_{imported.PropertyName} ??= new {imported.LinksType.Namespace}.{imported.LinksType.Name}(_context);");
+                $"_{imported.PropertyName} ??= new global::{imported.LinksType.Namespace}.{imported.LinksType.Name}(_context);");
 
             var backing = links.AddField(
                 imported.LinksType.MakeNullable(), "_" + imported.PropertyName);

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/ImportedLinkQualificationTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/ImportedLinkQualificationTests.cs
@@ -1,0 +1,85 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// An imported module's links are constructed through a fully qualified name.
+/// </summary>
+/// <remarks>
+/// The property's type comes from CSharpAuthor and is qualified already; the constructor call
+/// beside it was built by hand and was not. An application named for a type in its own root
+/// namespace is where that shows: <c>Todo.Host</c> importing <c>Todo.TodoLibrary</c>, in an
+/// assembly that also declares <c>record Todo</c>, binds the leading <c>Todo</c> to the record
+/// rather than the namespace and fails with CS0426. That is the shape
+/// <c>dotnet new hardened-web -n Todo</c> produces, so the name most likely to be typed for a todo
+/// sample was the one name that could not build.
+/// </remarks>
+public class ImportedLinkQualificationTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),       // Hardened.Web.Runtime
+        typeof(FromBodyAttribute)   // Hardened.Requests.Abstract
+    ];
+
+    /// <summary>
+    /// A library publishing links, and a type sharing the root namespace's name beside them.
+    /// </summary>
+    /// <remarks>
+    /// Written out rather than generated. The host generator resolves an imported links type by
+    /// metadata name against the compilation, so what matters here is that the reference contains
+    /// <c>Todo.TodoLibrary+Links</c> and <c>Todo.Todo</c> - not how they got there. Generating them
+    /// would test the library half of the generator on the way to the host half.
+    /// </remarks>
+    private const string Library =
+        """
+        using System;
+        using Hardened.Web.Runtime.Links;
+
+        namespace Todo;
+
+        public record Todo(int Id, string Title);
+
+        public class TodoLibraryAttribute : Attribute { }
+
+        public partial class TodoLibrary {
+            public sealed class Links {
+                public Links(ILinkContext context) { }
+            }
+        }
+        """;
+
+    private const string Host =
+        """
+        using Hardened.Shared.Runtime.Attributes;
+        using Todo;
+
+        namespace Todo.Host;
+
+        [HardenedModule]
+        [TodoLibrary]
+        public partial class Application { }
+        """;
+
+    [Fact]
+    public void AnImportedLinkIsQualifiedAgainstATypeSharingTheRootNamespaceName() {
+        var library = GeneratorTestHarness.CompileLibrary(Library, "Todo", Anchors);
+
+        var result = GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Application.cs"] = Host },
+            [new WebLibrarySourceGenerator()],
+            Anchors,
+            additionalReferences: [library.Reference]);
+
+        Assert.DoesNotContain(
+            result.Errors,
+            diagnostic => diagnostic.Id == "CS0426");
+
+        Assert.DoesNotContain(
+            result.Errors,
+            diagnostic => diagnostic.Id.StartsWith("CS", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## The defect

`dotnet new hardened-web -n Todo` does not compile, on any of the five hosts:

```
src/Todo.Host/obj/Debug/net8.0/generated/Hardened.Web.SourceGenerator/
  Hardened.Web.SourceGenerator.WebLibrarySourceGenerator/Application.Links.cs(29,92):
  error CS0426: The type name 'TodoLibrary' does not exist in the type 'Todo'
```

The generated line:

```csharp
public global::Todo.TodoLibrary.Links TodoLibrary => _TodoLibrary ??= new Todo.TodoLibrary.Links(_context);
```

The property's type comes from CSharpAuthor and is qualified. The constructor call beside it was
built by hand in `WriteImportedLinks` and was not. From inside `namespace Todo.Host` the enclosing
namespace `Todo` is in scope and contains the template's own `public record Todo`, so the leading
segment binds to the record rather than the namespace and the lookup for `TodoLibrary` inside it
fails.

The trigger is an application named for a type in its own root namespace. The web template ships a
`Todo` record in every generated project, so `-n Todo` — the name most likely to be typed for a todo
sample — was the one name that could not build.

## The change

One line in `LinkGenerator.WriteImportedLinks`, matching what line 491 of the same file already does
for the routes type.

## The test

`ImportedLinkQualificationTests` compiles a library carrying `Todo.TodoLibrary+Links` and a
`Todo.Todo` record beside it, then runs the web generator over a `Todo.Host` entry point importing
it. Without the fix it reproduces the original diagnostic at the same position:

```
Application.Links.cs(29,92): error CS0426: The type name 'TodoLibrary' does not exist in the type 'Todo'
```

The library is written out rather than generated, so the test exercises the host half of the
generator rather than the library half on the way to it.

## Checks

- `Hardened.SourceGenerator.Tests` 788 passed
- `Hardened.Web.SourceGenerator.Tests` 587 passed
- `Hardened.OpenApi.SourceGenerator.Tests` 593 passed
- `dotnet build filters/framework.slnf -c Release -p:ContinuousIntegrationBuild=true` — 0 warnings

The CI-mode build of `Hardened.slnx` stops at `HSMT011` on this machine, because the local Smithy
CLI is 1.56.0 against a pinned 1.73.0. Verified pre-existing on `origin/main`, unrelated to this
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)