### PR TITLE
Read declared headers off the primary constructor

### DIFF
--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnionResponseSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/UnionResponseSelector.cs
@@ -494,10 +494,7 @@ public static class UnionResponseSelector {
             return System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>();
         }
 
-        var constructor = caseType.Constructors
-            .Where(candidate => candidate.DeclaredAccessibility == Accessibility.Public)
-            .OrderByDescending(candidate => candidate.Parameters.Length)
-            .FirstOrDefault();
+        var constructor = PrimaryConstructor(caseType);
 
         if (constructor == null) {
             return System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>();
@@ -523,6 +520,74 @@ public static class UnionResponseSelector {
 
         return (IReadOnlyList<Hardened.Generation.Models.ResponseHeaderModel>?)headers
                ?? System.Array.Empty<Hardened.Generation.Models.ResponseHeaderModel>();
+    }
+
+    /// <summary>
+    /// The constructor the convention reads, which is the primary one where the type has one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Widest-wins picked <c>Ok&lt;T&gt;</c>'s convenience overload -
+    /// <c>(T value, string headerName, string headerValue)</c>, three parameters against the
+    /// primary's two - and published <c>headerName</c> and <c>headerValue</c> as header names on
+    /// every 200 a handler declared <c>Ok&lt;T&gt;</c> for. Two headers the service does not send,
+    /// on the one shipped response whose headers are chosen at run time and so has no static set to
+    /// declare at all. It is also the only shipped response with a second constructor, which is why
+    /// widest-wins held everywhere else.
+    /// </para>
+    /// <para>
+    /// Identified through <c>Deconstruct</c> rather than syntax. A positional record emits one
+    /// matching its primary constructor, and that survives into metadata - which is where these
+    /// types are read from, so <c>DeclaringSyntaxReferences</c> is empty and the syntax check that
+    /// would answer this in source has nothing to look at.
+    /// </para>
+    /// <para>
+    /// A case type that is not a positional record has no primary constructor to prefer, and falls
+    /// back to the widest. That covers the generated case types and a hand-written class, neither
+    /// of which this changes.
+    /// </para>
+    /// </remarks>
+    private static IMethodSymbol? PrimaryConstructor(INamedTypeSymbol caseType) {
+        var constructors = caseType.Constructors
+            .Where(candidate => candidate.DeclaredAccessibility == Accessibility.Public)
+            .OrderByDescending(candidate => candidate.Parameters.Length)
+            .ToList();
+
+        if (constructors.Count < 2) {
+            return constructors.FirstOrDefault();
+        }
+
+        var deconstruct = caseType.GetMembers("Deconstruct")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(method => method.Parameters.Length > 0);
+
+        if (deconstruct != null) {
+            var primary = constructors.FirstOrDefault(candidate => Matches(candidate, deconstruct));
+
+            if (primary != null) {
+                return primary;
+            }
+        }
+
+        return constructors[0];
+    }
+
+    /// <summary>Whether a constructor is the one a record's <c>Deconstruct</c> was written from.</summary>
+    private static bool Matches(IMethodSymbol constructor, IMethodSymbol deconstruct) {
+        if (constructor.Parameters.Length != deconstruct.Parameters.Length) {
+            return false;
+        }
+
+        for (var index = 0; index < constructor.Parameters.Length; index++) {
+            if (!string.Equals(
+                    constructor.Parameters[index].Name,
+                    deconstruct.Parameters[index].Name,
+                    StringComparison.Ordinal)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>Whether the case implements one of the response interfaces.</summary>

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDocumentTests.cs
@@ -243,6 +243,50 @@ public class ResponseSetDocumentTests {
         Assert.False(responses.GetProperty("429").TryGetProperty("Detail", out _));
     }
 
+    /// <summary>
+    /// A response whose headers are chosen at run time declares none, rather than the names of the
+    /// parameters a convenience constructor takes.
+    /// </summary>
+    /// <remarks>
+    /// <c>Ok&lt;T&gt;</c> is the only shipped response with a second constructor, and widest-wins
+    /// picked it: <c>(T value, string headerName, string headerValue)</c> against the primary's
+    /// <c>(T Value, IReadOnlyDictionary&lt;string, string&gt; Headers)</c>. Every 200 a handler
+    /// declared <c>Ok&lt;T&gt;</c> for published <c>headerName</c> and <c>headerValue</c> as header
+    /// names, which no response carries. The primary is what the convention reads now, and its
+    /// dictionary is not a string parameter - so a type whose headers are supplied rather than
+    /// fixed declares nothing, which is the truth about it.
+    /// </remarks>
+    [Fact]
+    public void AResponseWithRuntimeChosenHeadersDeclaresNone() {
+        var responses = Responses(Document("""
+                [Get("/todos/{id}")]
+                public Response<Ok<Todo>, NotFound> ById(string id) =>
+                    new Ok<Todo>(new Todo(1, "t"));
+            """), "/todos/{id}", "get");
+
+        var ok = responses.GetProperty("200");
+
+        Assert.False(ok.TryGetProperty("headers", out _));
+    }
+
+    /// <summary>
+    /// The case beside it still declares the header it always sends, so the change is to
+    /// <c>Ok&lt;T&gt;</c> rather than to the convention.
+    /// </summary>
+    [Fact]
+    public void ACaseWithOneConstructorStillDeclaresItsHeader() {
+        var responses = Responses(Document("""
+                [Post("/todos")]
+                public Response<Created<Todo>, Ok<Todo>> Create() =>
+                    new Created<Todo>(new Todo(1, "t"), "/todos/1");
+            """), "/todos", "post");
+
+        Assert.True(responses.GetProperty("201").GetProperty("headers")
+            .TryGetProperty("Location", out _));
+
+        Assert.False(responses.GetProperty("200").TryGetProperty("headers", out _));
+    }
+
     #endregion
 
     #region the statuses the framework itself answers


### PR DESCRIPTION
## The defect

Any handler declaring `Ok<T>` publishes two headers that no response carries:

```json
"200": {
  "description": "OK",
  "headers": {
    "headerName":  { "schema": { "type": "string" } },
    "headerValue": { "schema": { "type": "string" } }
  }
}
```

`curl -D-` on such a route shows `HTTP/1.1 200 OK` and nothing else.

## Why

`UnionResponseSelector.DeclaredHeaders` took the widest public constructor and read every string
parameter as a wire header name. `Ok<T>` is the only shipped response with a second constructor,
and the convenience overload is the wider one:

```csharp
Ok(T value, string headerName, string headerValue)                // 3 parameters
Ok(T Value, IReadOnlyDictionary<string, string>? Headers = null)  // 2, the primary
```

`value` was already excluded by name, leaving `headerName` and `headerValue` as headers.

`Created<T>` was correct throughout, because `(T Value, string Location)` is its only constructor.
That is why widest-wins held everywhere else — it is not a general rule that happened to break
here, it is a rule with exactly one counterexample in the shipped set.

Reading the primary is right for a second reason beyond picking the other overload. `Ok<T>` is the
one shipped response whose headers are supplied at run time rather than fixed by the type, as its
own remarks say — "`Created<T>` can hard-code `Location` because a 201 has exactly one header that
matters. A 200 does not." Its primary takes a dictionary, which is not a string parameter and
contributes nothing, so the type now declares no headers. That is the truth about it rather than a
convenient silence.

## Identifying the primary

Through `Deconstruct`, not syntax. A positional record emits one whose parameters match its primary
constructor, and that survives into metadata — which is where these types are read from, so
`DeclaringSyntaxReferences` is empty and a syntax check has nothing to look at.

A case type that is not a positional record has no primary to prefer and falls back to the widest,
so the generated case types and hand-written classes are unaffected.

## Tests

Two in `ResponseSetDocumentTests`, beside the existing `Created<T>` and `RateLimited` ones:

- `AResponseWithRuntimeChosenHeadersDeclaresNone` — `Response<Ok<Todo>, NotFound>` publishes no
  `headers` on the 200.
- `ACaseWithOneConstructorStillDeclaresItsHeader` — `Created<T>` beside `Ok<T>` in one set still
  declares `Location`, so the change is to `Ok<T>` rather than to the convention.

Both fail on `main`.

## Checks

- `Hardened.SourceGenerator.Tests` 788 passed
- `Hardened.Web.SourceGenerator.Tests` 589 passed
- `Hardened.OpenApi.SourceGenerator.Tests` 593 passed
- `dotnet build filters/framework.slnf -c Release -p:ContinuousIntegrationBuild=true` — 0 warnings

No tracked document changes. No integration SUT handler returns `Ok<T>` — every use of it in the
SUTs is a `Returns<Ok<T>>()` test assertion — which is why the exported documents were clean and
why nothing disagreed with this.

The CI-mode build of `Hardened.slnx` stops at `HSMT011` on this machine, local Smithy CLI 1.56.0
against a pinned 1.73.0. Pre-existing on `main`.

## Not fixed here

`Task<Ok<T>>` as a whole return type also drops `content` from the 200, which is a separate defect
in the bare-return-type path; the declared-set form keeps its body. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)