### PR TITLE
Stop publishing a 400 the router already answered

### DIFF
--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -102,6 +102,12 @@ and a wrong value means "no such URL". Leave it off when the value is input bein
 Parsing is invariant, so the same request matches on every machine. Where two constraints could
 match one segment, the narrower is tried first, in the order of the table.
 
+A constrained token changes the published document as well as the wire. The operation gains a 404
+describing the refusal, and loses the 400 it would have published for a conversion the constraint
+now guarantees — see [what the document says](/guide/validation#what-the-document-says). The router
+answers that 404 before binding, so it carries no body; where the operation declares a 404 of its
+own, the description says so.
+
 ### Declaring your own constraint
 
 ```csharp

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -144,6 +144,24 @@ rule a client is validated against is the one the document advertises. Operation
 validators also publish the 400 itself, with the envelope's schema, under
 `components.schemas.RequestValidationError`. See [The OpenAPI document](/guide/openapi-document).
 
+An operation the router already guards publishes no 400. A constraint on a path token is a
+[route constraint](/guide/routing#constraining-what-a-token-matches), tested before any filter or
+binder runs, so a value that would have failed it is a 404 and the validator never sees one:
+
+| Declaration | Refused by | Published |
+|---|---|---|
+| `pattern` on a path token | the router | 404, with no body |
+| `{id:int}` with an `int` parameter | the router | 404, with no body |
+| `required` on a path token | the router, as a route that did not match | 404, with no body |
+| `pattern` on a query value or a header | the validator | 400, the envelope |
+| `minimum` on a path token | the validator | 400, the envelope |
+| a parameter whose type the constraint does not cover, `{id:long}` binding an `int` | the binder | 400, the envelope |
+
+So `pattern` and `minimum` on the same token answer differently, and deliberately: the first says
+which URLs name a resource, the second judges a request that named one. Where the operation declares
+a 404 of its own, its description says the router answers that status too, and without the declared
+body — two 404s reach the wire and a document can key one.
+
 ## Rules the vocabulary cannot express
 
 A business rule is handler code. Throw the same exception the generated filters throw and the

--- a/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/ServerSentEventManifestTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/ServerSentEventManifestTests.cs
@@ -23,7 +23,23 @@ public class ServerSentEventManifestTests {
             .SelectMany(manifest => manifest.Handlers)
             .ToArray();
 
-        Assert.Equal(["GET /orders/live"], handlers);
+        Assert.Contains("GET /orders/live", handlers);
+    }
+
+    /// <summary>
+    /// Token names only. The route is <c>/orders/{id:int}/live</c>, and the constraint is how the
+    /// router decides what matches: an operator reading this line wants the route they wrote, and a
+    /// constraint a contract declared is named after a hash of its pattern -
+    /// <c>{deviceId:spec_p_588343bc}</c> - which appears in nobody's source.
+    /// </summary>
+    [HardenedTest]
+    public void AConstrainedRouteIsListedWithoutItsConstraint(IServiceProvider provider) {
+        var handlers = provider.GetServices<IServerSentEventManifest>()
+            .SelectMany(manifest => manifest.Handlers)
+            .ToArray();
+
+        Assert.Contains("GET /orders/{id}/live", handlers);
+        Assert.DoesNotContain(handlers, handler => handler.Contains(":int"));
     }
 
     /// <summary>
@@ -36,7 +52,8 @@ public class ServerSentEventManifestTests {
             .SelectMany(manifest => manifest.Handlers)
             .ToArray();
 
-        Assert.DoesNotContain(handlers, handler => handler.Contains("/orders/{id}"));
-        Assert.DoesNotContain(handlers, handler => handler == "POST /orders");
+        Assert.DoesNotContain("GET /orders/{id}", handlers);
+        Assert.DoesNotContain("DELETE /orders/{id}", handlers);
+        Assert.DoesNotContain("POST /orders", handlers);
     }
 }

--- a/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT/OrderController.cs
+++ b/src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT/OrderController.cs
@@ -38,4 +38,18 @@ public class OrderController {
 
         await Task.Yield();
     }
+
+    /// <summary>
+    /// The same thing under a constrained token, so the manifest has a route whose template carries
+    /// routing syntax. The host prints these to an operator, and a constraint is not part of the
+    /// route anyone wrote down - a pattern a contract declared is named after a hash of itself.
+    /// </summary>
+    [Get("/orders/{id:int}/live")]
+    [ServerSentEvents]
+    public async IAsyncEnumerable<Order> LiveForOrder(
+        int id, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        yield return new Order { Id = id.ToString(), Quantity = 1 };
+
+        await Task.Yield();
+    }
 }

--- a/src/Clouds/Azure/Hardened.Azure.Functions.SourceGenerator/Hardened.Azure.Functions.SourceGenerator.csproj
+++ b/src/Clouds/Azure/Hardened.Azure.Functions.SourceGenerator/Hardened.Azure.Functions.SourceGenerator.csproj
@@ -89,6 +89,20 @@
             <Link>Validation\%(RecursiveDir)/%(FileName)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Compile>
+        <!--
+            Two files rather than Web/Routing/**, which brings the route tree and everything it
+            binds against. A function has no routes; the document writer these two serve is shared
+            with the hosts that do, and it reads a token's constraint to decide whether binding can
+            still refuse the value.
+        -->
+        <Compile Include="../../../SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteConstraintFacts.cs">
+            <Link>Web\Routing\RouteConstraintFacts.cs</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../../../SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTemplate.cs">
+            <Link>Web\Routing\RouteTemplate.cs</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
     </ItemGroup>
 
     <Import Project="../../../SourceGenerators/ValidationModulesImpl.props"/>

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
@@ -429,16 +429,6 @@
         "responses": {
           "204": {
             "description": "Pet deleted"
-          },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
-                }
-              }
-            }
           }
         }
       },
@@ -470,18 +460,8 @@
               }
             }
           },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
-                }
-              }
-            }
-          },
           "404": {
-            "description": "No pet with that id",
+            "description": "No pet with that id. A token that fails its route constraint answers this status too, before the handler and with no body.",
             "content": {
               "application/json": {
                 "schema": {
@@ -632,16 +612,6 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
-                }
-              }
-            }
           }
         }
       }
@@ -775,16 +745,6 @@
               "application/json": {
                 "schema": {
                   "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
                 }
               }
             }

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
@@ -302,7 +302,7 @@
             }
           },
           "404": {
-            "description": "Not Found",
+            "description": "Not Found. A token that fails its route constraint answers this status too, before the handler and with no body.",
             "content": {
               "application/json": {
                 "schema": {
@@ -365,16 +365,6 @@
                 },
                 "itemSchema": {
                   "$ref": "#/components/schemas/PetEventStream"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
                 }
               }
             }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -884,16 +884,6 @@
               }
             }
           },
-          "400": {
-            "description": "The request failed validation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RequestValidationError"
-                }
-              }
-            }
-          },
           "404": {
             "description": "The path did not name a resource: a token failed its route constraint."
           },

--- a/src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Function.SourceGenerator/Hardened.Function.SourceGenerator.csproj
@@ -80,6 +80,20 @@
             <Link>Validation\%(RecursiveDir)/%(FileName)%(Extension)</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Compile>
+        <!--
+            Two files rather than Web/Routing/**, which brings the route tree and everything it
+            binds against. A function has no routes; the document writer these two serve is shared
+            with the hosts that do, and it reads a token's constraint to decide whether binding can
+            still refuse the value.
+        -->
+        <Compile Include="../Hardened.SourceGenerator/Web/Routing/RouteConstraintFacts.cs">
+            <Link>Web\Routing\RouteConstraintFacts.cs</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Web/Routing/RouteTemplate.cs">
+            <Link>Web\Routing\RouteTemplate.cs</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
     </ItemGroup>
 
     <Import Project="../ValidationModulesImpl.props"/>

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ParameterModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ParameterModel.cs
@@ -110,12 +110,26 @@ internal class ParameterModel : IEquatable<ParameterModel>, IConstraintFacets {
     /// </summary>
     public bool RequiredByConstraint { get; set; }
 
+    /// <summary>
+    /// Whether anything declared here still reaches a generated validator.
+    /// </summary>
+    /// <remarks>
+    /// Two of these declarations are the router's rather than the validator's, and neither counts.
+    /// A path parameter is present whenever the route matched, so <c>required</c> on one is a check
+    /// that cannot fail; a pattern compiled into a route constraint has already refused every value
+    /// that would have failed it. Counted, each one promised a 400 for an operation that declared
+    /// nothing else - <c>OperationParameters</c> emits no attribute for either, so there was no
+    /// validator to answer it.
+    /// </remarks>
     public bool HasValidationConstraints =>
-        IsRequired || MinLength.HasValue || MaxLength.HasValue ||
+        (IsRequired && !IsPath) || MinLength.HasValue || MaxLength.HasValue ||
         Minimum.HasValue || Maximum.HasValue ||
         ExclusiveMinimum || ExclusiveMaximum ||
-        Pattern != null || MinItems.HasValue || MaxItems.HasValue ||
+        (Pattern != null && RouteConstraint == null) || MinItems.HasValue || MaxItems.HasValue ||
         EnumValues is { Count: > 0 };
+
+    /// <summary>Whether the parameter binds from a path segment.</summary>
+    private bool IsPath => string.Equals(In, "path", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Every member, including the ones only the document reads.

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SpecFileEmitter.cs
@@ -172,15 +172,19 @@ internal static class SpecFileEmitter {
 
         EmitFilterTypes(file, model, excludeFromCoverage);
 
-        // Interfaces first: building them registers the patterns their constraints reference, and
-        // the [GeneratedRegex] members are written from the registry once it is complete.
         var validation = root.AddNamespace(ValidationNamespace);
-        var operations = ValidationEmitter.Emit(validation, model, modelsNamespace, patterns);
 
-        // Before the patterns are written, because assigning route constraints registers the
-        // patterns they compile to and EmitPatterns writes from what was registered.
+        // Route constraints first, because assigning one decides what the interfaces are for:
+        // a path parameter guarded by a compiled constraint needs no [Pattern] on the validation
+        // path, and where that was its only constraint the operation needs no interface at all.
+        // Run afterwards, the interface was already built and carried a check the router had
+        // already made - which is also what put an unreachable 400 in the document.
         RouteConstraintEmitter.Emit(validation, model, patterns);
 
+        var operations = ValidationEmitter.Emit(validation, model, modelsNamespace, patterns);
+
+        // Last, because both passes above register the patterns they reference and this writes the
+        // [GeneratedRegex] members from what was registered.
         ValidationEmitter.EmitPatterns(validation, patterns);
 
         // Recorded so the generator is told which interface each handler implements, rather than

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/ConstraintAttributes.cs
@@ -51,7 +51,8 @@ internal static class ConstraintAttributes {
     /// </param>
     public static IReadOnlyList<Model> ForParameter(
         ParameterModel parameter, bool required, string csType, PatternRegistry patterns) =>
-        Build(parameter, required, patterns, csType);
+        Build(parameter, required, patterns, csType,
+            patternIsARouteConstraint: !string.IsNullOrEmpty(parameter.RouteConstraint));
 
     /// <param name="required">
     /// From the caller rather than the model: it also knows whether the C# type makes
@@ -63,7 +64,7 @@ internal static class ConstraintAttributes {
     /// </param>
     public static IReadOnlyList<Model> ForProperty(
         PropertyModel property, bool required, PatternRegistry patterns, string csType) =>
-        Build(property, required, patterns, csType);
+        Build(property, required, patterns, csType, patternIsARouteConstraint: false);
 
     /// <param name="csType">
     /// The type the member will have. Every constraint below is a comparison the validation
@@ -72,8 +73,15 @@ internal static class ConstraintAttributes {
     /// member that fell back to JsonElement, and OpenAI types parameters as generated enums; all
     /// three produced CS0019 on an operator that does not exist for the operands.
     /// </param>
+    /// <param name="patternIsARouteConstraint">
+    /// True where <see cref="RouteConstraintEmitter"/> compiled this member's pattern into the
+    /// route. The router then refuses a non-matching value before binding, so the same test on the
+    /// validation path can never fail: it costs a regex match on every request that got through, and
+    /// it made the document declare a 400 for an operation whose only constraint was that pattern.
+    /// </param>
     private static IReadOnlyList<Model> Build(
-        IConstraintFacets facets, bool required, PatternRegistry patterns, string csType) {
+        IConstraintFacets facets, bool required, PatternRegistry patterns, string csType,
+        bool patternIsARouteConstraint) {
         var numeric = TypeMapper.IsNumeric(csType);
         var stringLike = TypeMapper.IsStringLike(csType);
         var counted = TypeMapper.HasItemCount(csType);
@@ -127,7 +135,7 @@ internal static class ConstraintAttributes {
             attributes.Add(new Model(Attribute("RangeAttribute"), arguments));
         }
 
-        if (stringLike && !string.IsNullOrEmpty(pattern)) {
+        if (stringLike && !string.IsNullOrEmpty(pattern) && !patternIsARouteConstraint) {
             var arguments = patterns.AttributeArguments(pattern!);
 
             // Null when the runtime's regex engine will not take it; the pattern is reported once

--- a/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Validation/OperationParameters.cs
@@ -62,8 +62,16 @@ internal static class OperationParameters {
 
             // Suppressed where the C# type already guarantees presence, exactly as SchemaEmitter
             // has always done for properties. A required integer path parameter is the common case.
+            //
+            // Suppressed on a path parameter whatever its type, because the route guarantees
+            // presence there: a request that reached the handler matched the template, and a segment
+            // that is absent or empty matched nothing and was answered 404. Emitted, it generated a
+            // validator for an operation that had nothing else to check, and the document then
+            // published a 400 for a refusal no caller can provoke - the same unfailable-check
+            // reasoning HRDV003 gives for a value type.
             var emitRequired = parameter.ConstrainedAsRequired &&
-                               !TypeMapper.IsNonNullableValueType(csType, spec.Schemas);
+                               !TypeMapper.IsNonNullableValueType(csType, spec.Schemas) &&
+                               !IsPathParameter(parameter);
 
             var attributes = ConstraintAttributes.ForParameter(
                 parameter, emitRequired, csType, patterns);
@@ -112,6 +120,13 @@ internal static class OperationParameters {
                 members)
             : null;
     }
+
+    /// <remarks>
+    /// The same test <see cref="RouteConstraintEmitter"/> makes, and for the same reason: a path
+    /// parameter is decided by the router rather than by a validator.
+    /// </remarks>
+    private static bool IsPathParameter(ParameterModel parameter) =>
+        string.Equals(parameter.In, "path", System.StringComparison.OrdinalIgnoreCase);
 
     private static SchemaModel? BodySchema(OperationModel operation, ServiceSpecModel spec) {
         if (operation.RequestBodyRef == null) {

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OperationParametersTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/OperationParametersTests.cs
@@ -33,15 +33,20 @@ public class OperationParametersTests {
         bool required = false,
         int? minLength = null,
         int? maxLength = null,
-        string? refName = null) =>
+        string? refName = null,
+        string @in = "path",
+        string? pattern = null,
+        string? routeConstraint = null) =>
         new() {
             Name = name,
-            In = "path",
+            In = @in,
             Type = type,
             IsRequired = required,
             MinLength = minLength,
             MaxLength = maxLength,
-            Ref = refName
+            Ref = refName,
+            Pattern = pattern,
+            RouteConstraint = routeConstraint
         };
 
     private static OperationModel Operation(params ParameterModel[] parameters) =>
@@ -132,10 +137,21 @@ public class OperationParametersTests {
 
     [Fact]
     public void ARequiredStringParameterCarriesRequired() {
-        var model = Build(Operation(Parameter(required: true, minLength: 1)));
+        var model = Build(Operation(Parameter(@in: "query", required: true, minLength: 1)));
 
         Assert.Contains(
             model!.Members[0].Attributes, attribute => attribute.Type.Name == "RequiredAttribute");
+    }
+
+    /// <summary>
+    /// Suppressed on a path parameter whatever its type: a request that reached the handler matched
+    /// the template, and a segment that is absent or empty matched nothing and was answered 404. So
+    /// <c>[Required]</c> there is a check that cannot fail, and an operation constrained only that
+    /// way used to get a validator - and a 400 in its document that no caller could provoke.
+    /// </summary>
+    [Fact]
+    public void ARequiredPathParameterDoesNotCarryRequired() {
+        Assert.Null(Build(Operation(Parameter(required: true))));
     }
 
     /// <summary>
@@ -185,11 +201,51 @@ public class OperationParametersTests {
     public void ARequiredStringParameterStillCarriesRequiredAlongsideAValueType() {
         var model = Build(Operation(
             Parameter("petId", type: "integer", required: true),
-            Parameter("name", required: true, minLength: 1)));
+            Parameter("name", @in: "query", required: true, minLength: 1)));
 
         Assert.Empty(model!.Members[0].Attributes);
         Assert.Contains(
             model.Members[1].Attributes, attribute => attribute.Type.Name == "RequiredAttribute");
+    }
+
+    #endregion
+
+    #region constraints the route already makes
+
+    /// <summary>
+    /// A pattern <c>RouteConstraintEmitter</c> compiled into the route is tested by the router,
+    /// before binding, so the same test on the validation path can never fail. Emitted anyway it
+    /// cost a regex match on every request that got through, and it published a 400 for an
+    /// operation whose only declaration was that pattern.
+    /// </summary>
+    [Fact]
+    public void APathPatternCompiledIntoTheRouteIsNotAlsoAValidatorCheck() {
+        Assert.Null(Build(Operation(
+            Parameter(pattern: "^[a-z]+$", routeConstraint: "spec_p_18b2c15a"))));
+    }
+
+    /// <summary>
+    /// The pattern the registry refused compiles to no route constraint, so it stays where it was:
+    /// on the validation path, which is the behaviour before route constraints existed.
+    /// </summary>
+    [Fact]
+    public void APathPatternWithNoRouteConstraintIsStillAValidatorCheck() {
+        var model = Build(Operation(Parameter(pattern: "^[a-z]+$")));
+
+        Assert.Contains(
+            model!.Members[0].Attributes, attribute => attribute.Type.Name == "PatternAttribute");
+    }
+
+    /// <summary>
+    /// A query parameter's pattern is never a route constraint - it judges a request that did name
+    /// a resource - so it is unaffected.
+    /// </summary>
+    [Fact]
+    public void AQueryPatternIsAValidatorCheck() {
+        var model = Build(Operation(Parameter(@in: "query", pattern: "^[a-z]+$")));
+
+        Assert.Contains(
+            model!.Members[0].Attributes, attribute => attribute.Type.Name == "PatternAttribute");
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/Hardened.OpenApi.SourceGenerator.Tests.csproj
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/Hardened.OpenApi.SourceGenerator.Tests.csproj
@@ -97,4 +97,19 @@
         <None Include="Fixtures/**/*" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 
+    <!--
+        The route-template and constraint-fact suites, for the reason their own remarks give:
+        both files are source-linked into several generator assemblies, coverage is measured per
+        assembly, and a test in one assembly covers that assembly's copy and nothing else. This
+        project is the one that references Hardened.Idl.SourceGenerator, so it is where the copy
+        the described front end compiles gets driven. The tests are the same tests; nothing is
+        restated.
+    -->
+    <ItemGroup>
+        <Compile Include="../Hardened.SourceGenerator.Tests/Web/RouteConstraintFactsTests.cs"
+                 Link="Web/RouteConstraintFactsTests.cs"/>
+        <Compile Include="../Hardened.SourceGenerator.Tests/Web/RouteTemplateTests.cs"
+                 Link="Web/RouteTemplateTests.cs"/>
+    </ItemGroup>
+
 </Project>

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/DocumentWriterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/DocumentWriterTests.cs
@@ -41,9 +41,10 @@ public class DocumentWriterTests {
     private static RequestHandlerModel Handler(
         RequestParameterInformation? parameter = null,
         IReadOnlyList<ResponseSchemaModel>? responses = null,
-        IReadOnlyList<string>? security = null) =>
+        IReadOnlyList<string>? security = null,
+        string path = "/todos/{id}") =>
         new(
-            new RequestHandlerNameModel("/todos/{id}", "GET"),
+            new RequestHandlerNameModel(path, "GET"),
             Type("TodoController"),
             "GetTodo",
             TypeDefinition.Get("TestApp.Generated", "TodoController_GetTodo"),
@@ -237,6 +238,73 @@ public class DocumentWriterTests {
             .GetProperty("responses");
 
         Assert.Equal("My own.", responses.GetProperty("400").GetProperty("description").GetString());
+    }
+
+    #endregion
+
+    #region what the router already refused
+
+    private static RequestParameterInformation PathToken(string type = "Int32") =>
+        new(TypeDefinition.Get("System", type), "id", true, null, ParameterBindType.Path, "id", 0);
+
+    private static JsonElement Responses(RequestHandlerModel handler) =>
+        Write(handler)
+            .GetProperty("paths").GetProperty("/todos/{id}").GetProperty("get")
+            .GetProperty("responses");
+
+    /// <summary>
+    /// The router decides before the binder, so a value the converter would have refused is a 404
+    /// and never reaches binding. Both writers used to run: the 404 explained the refusal and the
+    /// 400 claimed one the same operation could not produce.
+    /// </summary>
+    [Fact]
+    public void AConstrainedTokenGuaranteeingTheConversionDeclaresNoFourHundred() {
+        var responses = Responses(Handler(PathToken(), path: "/todos/{id:int}"));
+
+        Assert.False(responses.TryGetProperty("400", out _));
+        Assert.True(responses.TryGetProperty("404", out _));
+    }
+
+    /// <summary>The same handler with nothing guarding the token: the 400 is real.</summary>
+    [Fact]
+    public void AnUnconstrainedTokenStillDeclaresTheFourHundred() {
+        Assert.True(Responses(Handler(PathToken())).TryGetProperty("400", out _));
+    }
+
+    /// <summary>
+    /// A constraint wider than the type still lets a refusal through - <c>{id:long}</c> admits
+    /// 99999999999, which an <c>int</c> parameter refuses - so the 400 stays.
+    /// </summary>
+    [Fact]
+    public void AConstraintWiderThanTheTypeStillDeclaresTheFourHundred() {
+        Assert.True(
+            Responses(Handler(PathToken(), path: "/todos/{id:long}")).TryGetProperty("400", out _));
+    }
+
+    /// <summary>
+    /// Two 404s reach the wire and a document can write one, so the one it writes says the other
+    /// exists. A client author reading the declared body schema is otherwise told nothing about the
+    /// empty body they will also be sent.
+    /// </summary>
+    [Fact]
+    public void ADeclaredNotFoundSaysARouteConstraintAnswersItToo() {
+        var handler = Handler(
+            responses: [new ResponseSchemaModel(404, "No such todo", Schema("Problem"))],
+            path: "/todos/{id:int}");
+
+        Assert.Equal(
+            "No such todo. A token that fails its route constraint answers this status too, " +
+            "before the handler and with no body.",
+            Responses(handler).GetProperty("404").GetProperty("description").GetString());
+    }
+
+    /// <summary>The note is for the operations a route constraint can refuse, and no others.</summary>
+    [Fact]
+    public void ADeclaredNotFoundOnAnUnconstrainedRouteIsLeftAlone() {
+        var handler = Handler(responses: [new ResponseSchemaModel(404, "No such todo", Schema("Problem"))]);
+
+        Assert.Equal(
+            "No such todo", Responses(handler).GetProperty("404").GetProperty("description").GetString());
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/RouteConstraintFactsTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/RouteConstraintFactsTests.cs
@@ -202,6 +202,53 @@ public class RouteConstraintFactsTests {
         Assert.Null(RouteConstraintFacts.Call(term));
     }
 
+    /// <summary>
+    /// What the document writer asks: can the converter still refuse a value this constraint let
+    /// through. Every arm is pinned, because a wrong <c>true</c> here deletes a 400 a caller can
+    /// still be sent.
+    /// </summary>
+    [Theory]
+    [InlineData("int", "Int32", true)]
+    [InlineData("int", "int", true)]
+    [InlineData("int", "Int64", true)]
+    [InlineData("int", "Decimal", true)]
+    [InlineData("int", "Double", true)]
+    [InlineData("int", "Single", true)]
+    [InlineData("long", "Int64", true)]
+    [InlineData("long", "Double", true)]
+    [InlineData("decimal", "Decimal", true)]
+    [InlineData("decimal", "Double", true)]
+    [InlineData("bool", "Boolean", true)]
+    [InlineData("guid", "Guid", true)]
+    [InlineData("date", "DateOnly", true)]
+    [InlineData("date", "DateTime", true)]
+    [InlineData("datetime", "DateTimeOffset", true)]
+    [InlineData("range(1,100)", "Int32", true)]
+    [InlineData("int:min(1)", "Int32", true)]
+    // A wider constraint admits values a narrower type refuses, so the refusal stays reachable.
+    [InlineData("long", "Int32", false)]
+    [InlineData("decimal", "Int32", false)]
+    [InlineData("min(1)", "Int32", false)]
+    [InlineData("max(100)", "Int32", false)]
+    // Every numeric constraint admits a leading minus, so none of them guarantees an unsigned parse.
+    [InlineData("int", "UInt32", false)]
+    [InlineData("int", "Int16", false)]
+    // A time of day is what DateOnly refuses.
+    [InlineData("datetime", "DateOnly", false)]
+    [InlineData("date", "Guid", false)]
+    // Constraints that say nothing about a type.
+    [InlineData("alpha", "Int32", false)]
+    [InlineData("hex", "Int32", false)]
+    [InlineData("slug", "Guid", false)]
+    [InlineData("length(6)", "Int32", false)]
+    // A constraint the application declared: nothing is known about what it tests.
+    [InlineData("isbn", "Int32", false)]
+    [InlineData("", "Int32", false)]
+    public void AConstraintGuaranteesTheConversionsItsOwnTestMakes(
+        string chain, string csType, bool guaranteed) {
+        Assert.Equal(guaranteed, RouteConstraintFacts.GuaranteesConversion(chain, csType));
+    }
+
     /// <summary>Alphabetical, because this list is read by a person in an error message.</summary>
     [Fact]
     public void NamesAreListedInOrder() {

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/RouteTemplateTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/RouteTemplateTests.cs
@@ -1,0 +1,51 @@
+using Hardened.SourceGenerator.Web.Routing;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Web;
+
+/// <summary>
+/// A route read by something that is not the router: the document's path template, the constraint
+/// guarding one token, and whether there is any constraint at all.
+/// </summary>
+public class RouteTemplateTests {
+
+    [Theory]
+    [InlineData("/todos", "/todos")]
+    [InlineData("/todos/{id}", "/todos/{id}")]
+    [InlineData("/todos/{id:int}", "/todos/{id}")]
+    [InlineData("/todos/{id:int:min(1)}", "/todos/{id}")]
+    [InlineData("/files/{*path}", "/files/{path}")]
+    [InlineData("/files/{*path:slug}", "/files/{path}")]
+    [InlineData("/a/{x:int}/b/{y:guid}/c", "/a/{x}/b/{y}/c")]
+    // Malformed templates are the route token diagnostics' to report, not this one's to repair.
+    [InlineData("/todos/{id", "/todos/{id")]
+    public void NamesOnlyKeepsTheNameAndNothingElse(string path, string template) {
+        Assert.Equal(template, RouteTemplate.NamesOnly(path));
+    }
+
+    [Theory]
+    [InlineData("/todos/{id:int}", "id", "int")]
+    [InlineData("/todos/{id:int:min(1)}", "id", "int:min(1)")]
+    [InlineData("/todos/{id}", "id", "")]
+    [InlineData("/files/{*path:slug}", "path", "slug")]
+    [InlineData("/a/{x:int}/b/{y:guid}", "y", "guid")]
+    // A parameter that binds from the query or a header is not in the route, and nothing guards it.
+    [InlineData("/todos/{id:int}", "limit", "")]
+    // By whole name: a prefix is a different token, and reading its constraint as this one's would
+    // delete a 400 the shorter token can still answer.
+    [InlineData("/todos/{identifier:int}", "id", "")]
+    [InlineData("/todos/{id}/{identifier:int}", "id", "")]
+    public void ConstraintOnAnswersForOneToken(string path, string token, string chain) {
+        Assert.Equal(chain, RouteTemplate.ConstraintOn(path, token));
+    }
+
+    [Theory]
+    [InlineData("/todos", false)]
+    [InlineData("/todos/{id}", false)]
+    [InlineData("/todos/{id:int}", true)]
+    [InlineData("/a/{x}/b/{y:guid}", true)]
+    [InlineData("/todos/{id", false)]
+    public void HasConstraintAsksTheWholeRoute(string path, bool constrained) {
+        Assert.Equal(constrained, RouteTemplate.HasConstraint(path));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -6,6 +6,7 @@ using Hardened.Generation.Models;
 using Hardened.SourceGenerator.Models.Request;
 using Hardened.SourceGenerator.Requests;
 using Hardened.SourceGenerator.Shared;
+using Hardened.SourceGenerator.Web.Routing;
 
 namespace Hardened.SourceGenerator.OpenApiDocument;
 
@@ -92,13 +93,13 @@ public static class OpenApiDocumentGenerator {
         // Grouped by path, because a document keys operations under one path entry rather than
         // repeating the path per verb.
         // Grouped by the template, which is what the document keys on - not by the route, which is
-        // what the router keys on. The two differ wherever a token carries a constraint: ToTemplate
-        // strips it, so /pets/{petId:guid} and /pets/{petId} are one path item in a document and two
-        // routes in a table. Grouping on the route emitted the same key twice, and every parser
-        // keeps the last - so a GET declared beside a constrained DELETE vanished from the document
-        // while continuing to serve.
+        // what the router keys on. The two differ wherever a token carries a constraint:
+        // RouteTemplate strips it, so /pets/{petId:guid} and /pets/{petId} are one path item in a
+        // document and two routes in a table. Grouping on the route emitted the same key twice, and
+        // every parser keeps the last - so a GET declared beside a constrained DELETE vanished from
+        // the document while continuing to serve.
         var byPath = handlers
-            .GroupBy(handler => ToTemplate(RoutePath.Combine(basePath, handler.Name.Path)))
+            .GroupBy(handler => RouteTemplate.NamesOnly(RoutePath.Combine(basePath, handler.Name.Path)))
             .OrderBy(group => group.Key, System.StringComparer.Ordinal);
 
         var firstPath = true;
@@ -398,8 +399,7 @@ public static class OpenApiDocumentGenerator {
         // under one name is a document no generator can read.
         var declared = handler.DeclaredHeaderParameters
             .Where(header => !bound.Any(parameter => string.Equals(
-                string.IsNullOrEmpty(parameter.BindingName) ? parameter.Name : parameter.BindingName,
-                header.Name, System.StringComparison.OrdinalIgnoreCase)))
+                BoundName(parameter), header.Name, System.StringComparison.OrdinalIgnoreCase)))
             .ToList();
 
         if (bound.Count == 0 && declared.Count == 0) {
@@ -415,9 +415,7 @@ public static class OpenApiDocumentGenerator {
                 builder.Append(',');
             }
 
-            var name = string.IsNullOrEmpty(parameter.BindingName)
-                ? parameter.Name
-                : parameter.BindingName;
+            var name = BoundName(parameter);
 
             // A parameter carrying a default is one the caller may omit - the binder answers
             // with the default rather than a 400 - so publishing it required documents a demand
@@ -766,8 +764,14 @@ public static class OpenApiDocumentGenerator {
         var successContentType = ContentType(handler);
 
         foreach (var group in byStatus) {
+            var description = group.First().Description;
+
+            if (group.Key == 404 && RouteTemplate.HasConstraint(handler.Name.Path)) {
+                description = Sentence(description) + ConstrainedPathNote;
+            }
+
             var builder = new StringBuilder("{\"description\":\"")
-                .Append(JsonSchemaWriter.Escape(group.First().Description))
+                .Append(JsonSchemaWriter.Escape(description))
                 .Append('"');
 
             WriteResponseHeaders(builder, group);
@@ -923,6 +927,14 @@ public static class OpenApiDocumentGenerator {
     /// non-string value, whether or not a validator was generated for it - the gate that required
     /// one is why a documented 400 depended on the operation happening to declare a constraint.
     /// A string binds as itself and cannot fail conversion.
+    ///
+    /// <para>
+    /// A route constraint that guarantees the conversion is the other way a parameter cannot refuse.
+    /// The router decides first, so a value the converter would have rejected is a 404 and never
+    /// reaches binding at all - which is what <c>{id:int}</c> is written for. Reading the path here
+    /// is what stops this writer publishing a 400 the 404 writer in the same file has already
+    /// explained away.
+    /// </para>
     /// </remarks>
     private static bool HasBindingRefusals(RequestHandlerModel handler) {
         foreach (var parameter in handler.RequestParameterInformationList) {
@@ -933,13 +945,25 @@ public static class OpenApiDocumentGenerator {
 
             var name = parameter.ParameterType.Name.TrimEnd('?');
 
-            if (name is not ("String" or "string" or "Object" or "object")) {
-                return true;
+            if (name is "String" or "string" or "Object" or "object") {
+                continue;
             }
+
+            if (parameter.BindingType == ParameterBindType.Path &&
+                RouteConstraintFacts.GuaranteesConversion(
+                    RouteTemplate.ConstraintOn(handler.Name.Path, BoundName(parameter)), name)) {
+                continue;
+            }
+
+            return true;
         }
 
         return false;
     }
+
+    /// <summary>The name the caller uses for a parameter, which is the route token's name.</summary>
+    private static string BoundName(RequestParameterInformation parameter) =>
+        string.IsNullOrEmpty(parameter.BindingName) ? parameter.Name : parameter.BindingName;
 
     /// <summary>Whether the handler already declares <paramref name="status"/> itself.</summary>
     private static bool DeclaresStatus(RequestHandlerModel handler, int status) {
@@ -1001,11 +1025,18 @@ public static class OpenApiDocumentGenerator {
     /// the router's 404 - deliberately bodyless, before binding and before the handler. The
     /// constraint itself is stripped from the path template, because a template expression is a
     /// name and nothing else, which left the document with no trace of the refusal at all.
-    /// Skipped where the operation declares its own 404, whose description then wins.
+    ///
+    /// <para>
+    /// Where the operation declares a 404 of its own, that description wins and
+    /// <see cref="ConstrainedPathNote"/> is added to it by <see cref="WriteDeclaredResponses"/>
+    /// instead. Two 404s reach the wire and only one can be written down, so the one that is
+    /// written says the other exists: a client author reading a declared body schema is otherwise
+    /// told nothing about the empty body they will also be sent.
+    /// </para>
     /// </remarks>
     private static void WriteConstrainedPathResponse(
         SortedDictionary<int, string> responses, RequestHandlerModel handler) {
-        if (!HasConstrainedPathToken(handler.Name.Path)) {
+        if (!RouteTemplate.HasConstraint(handler.Name.Path)) {
             return;
         }
 
@@ -1017,27 +1048,22 @@ public static class OpenApiDocumentGenerator {
                          "\"The path did not name a resource: a token failed its route constraint.\"}";
     }
 
-    private static bool HasConstrainedPathToken(string path) {
-        var open = path.IndexOf('{');
+    /// <summary>
+    /// <paramref name="text"/> punctuated as a sentence, so a second one can follow it.
+    /// </summary>
+    /// <remarks>
+    /// A description written in a contract usually has no full stop - <c>No pet with that id</c> -
+    /// and appending to it produced one run-on sentence.
+    /// </remarks>
+    private static string Sentence(string text) =>
+        text.Length == 0 || text[text.Length - 1] is '.' or '!' or '?' ? text : text + ".";
 
-        while (open >= 0) {
-            var close = path.IndexOf('}', open);
-
-            if (close < 0) {
-                return false;
-            }
-
-            var colon = path.IndexOf(':', open);
-
-            if (colon > open && colon < close) {
-                return true;
-            }
-
-            open = path.IndexOf('{', close);
-        }
-
-        return false;
-    }
+    /// <summary>
+    /// What a declared 404 gains where a route constraint answers the same status.
+    /// </summary>
+    private const string ConstrainedPathNote =
+        " A token that fails its route constraint answers this status too, before the handler and " +
+        "with no body.";
 
     /// <summary>
     /// The media type a success goes out as: <c>[RawResponse]</c>'s, else the contract's declared
@@ -1211,72 +1237,6 @@ public static class OpenApiDocumentGenerator {
 
     private static string Pascal(string value) =>
         value.Length == 0 ? value : char.ToUpperInvariant(value[0]) + value.Substring(1);
-
-    /// <summary>
-    /// The route as a document writes it.
-    ///
-    /// <para>
-    /// Hardened's own form matches except for the catch-all marker: <c>/files/{*path}</c> is a
-    /// Hardened route, and <c>{*path}</c> is not a valid OpenAPI path template — a template
-    /// expression is a name, and the name has to match a declared parameter. The marker says how
-    /// much of the path the token takes, which is a routing concern the document has no way to
-    /// express, so it is dropped and the parameter is written under its own name.
-    /// </para>
-    ///
-    /// <para>
-    /// That does lose something: a specification round-tripped back through
-    /// <c>Hardened.OpenApi.BuildTask</c> gives a single-segment token where the source route had a
-    /// catch-all. Worth knowing, and better than emitting a document no OpenAPI reader accepts.
-    /// </para>
-    /// </summary>
-    private static string ToTemplate(string path) {
-        if (path.IndexOf('{') < 0) {
-            return path;
-        }
-
-        var builder = new StringBuilder(path.Length);
-        var index = 0;
-
-        while (index < path.Length) {
-            var open = path.IndexOf('{', index);
-
-            if (open < 0) {
-                builder.Append(path, index, path.Length - index);
-                break;
-            }
-
-            var close = path.IndexOf('}', open);
-
-            if (close < 0) {
-                builder.Append(path, index, path.Length - index);
-                break;
-            }
-
-            builder.Append(path, index, open - index).Append('{');
-
-            var start = open + 1;
-
-            // The catch-all marker: how much of the path the token takes, which a document cannot
-            // express.
-            if (start < close && path[start] == '*') {
-                start++;
-            }
-
-            // The constraint: what the token has to look like to match. A template expression is a
-            // parameter name and nothing else, so ":int" is not a shorter spelling of a schema - it
-            // is a syntax error that happens to parse. Left in, it made the name in the template
-            // disagree with the name in "parameters", which Spectral reports as path-params and a
-            // generated client turns into a request for /boards/%7BboardId:guid%7D.
-            var name = path.IndexOf(':', start);
-            var end = name >= 0 && name < close ? name : close;
-
-            builder.Append(path, start, end - start).Append('}');
-
-            index = close + 1;
-        }
-
-        return builder.ToString();
-    }
 
     /// <summary>
     /// The vocabulary schema for a code-first enum parameter, or null when the type is not one.

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteConstraintFacts.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteConstraintFacts.cs
@@ -208,6 +208,74 @@ public static class RouteConstraintFacts {
         };
 
     /// <summary>
+    /// Whether a token guarded by <paramref name="chain"/> always converts to <paramref name="csType"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A constraint runs before binding, so a value it rejects never reaches the converter: the
+    /// route did not match, and the answer is the router's 404. Where the constraint makes the same
+    /// test the converter would make, the converter cannot refuse — which is what lets the document
+    /// stop declaring a 400 for an operation no request can produce one from.
+    /// </para>
+    /// <para>
+    /// The guarantees are the ones <c>StringConverterService</c> makes good on, and they run one
+    /// way only. A value that passed <see cref="RouteConstraints.IsInt"/> parses again as a wider
+    /// integral or as any fractional type; <c>{id:long}</c> admits <c>99999999999</c>, which an
+    /// <c>int</c> parameter still refuses, so nothing is claimed there. Unsigned types are claimed
+    /// by nothing at all, because every numeric constraint here admits a leading minus.
+    /// </para>
+    /// <para>
+    /// A name this does not know guarantees nothing. A <c>[RouteConstraint]</c> the application
+    /// declared tests whatever its author wrote, and reading that as a type guarantee would drop a
+    /// 400 a caller can still be sent.
+    /// </para>
+    /// </remarks>
+    public static bool GuaranteesConversion(string chain, string csType) {
+        if (Terms(chain) is not { } terms) {
+            return false;
+        }
+
+        foreach (var term in terms) {
+            if (Guarantees(term, csType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <remarks>
+    /// Arity is part of the lookup for the reason <see cref="Call"/> gives. <c>min</c> and
+    /// <c>max</c> parse as a <c>long</c> and bound one end, so neither narrows to <c>int</c>;
+    /// <c>range</c> bounds both ends with integer literals, so its value is inside <c>int</c>'s
+    /// range as well as <c>long</c>'s.
+    /// </remarks>
+    private static bool Guarantees(Term term, string csType) =>
+        (term.Name, term.Arguments.Count) switch {
+            ("int", 0) => AtLeastInt32(csType) || Fractional(csType),
+            ("range", 2) => AtLeastInt32(csType) || Fractional(csType),
+            ("long", 0) => AtLeastInt64(csType) || Fractional(csType),
+            ("min", 1) => AtLeastInt64(csType) || Fractional(csType),
+            ("max", 1) => AtLeastInt64(csType) || Fractional(csType),
+            ("decimal", 0) => Fractional(csType),
+            ("bool", 0) => csType is "Boolean" or "bool",
+            ("guid", 0) => csType is "Guid",
+            ("date", 0) => csType is "DateOnly" or "DateTime" or "DateTimeOffset",
+            // Not DateOnly: the accepted formats include a time of day, which DateOnly refuses.
+            ("datetime", 0) => csType is "DateTime" or "DateTimeOffset",
+            _ => false
+        };
+
+    private static bool AtLeastInt32(string csType) =>
+        csType is "Int32" or "int" || AtLeastInt64(csType);
+
+    private static bool AtLeastInt64(string csType) =>
+        csType is "Int64" or "long";
+
+    private static bool Fractional(string csType) =>
+        csType is "Decimal" or "decimal" or "Double" or "double" or "Single" or "float";
+
+    /// <summary>
     /// The argument counts a parameterised name accepts, for the diagnostic that has to say so.
     /// Empty when the name takes none.
     /// </summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTemplate.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTemplate.cs
@@ -1,0 +1,148 @@
+using System.Text;
+
+namespace Hardened.SourceGenerator.Web.Routing;
+
+/// <summary>
+/// A Hardened route read as something other than a route: as a document's path template, as a log
+/// line an operator reads, and as the constraint on one token.
+/// </summary>
+/// <remarks>
+/// Routing syntax inside a token - the catch-all marker and the constraint chain - is how the
+/// router decides what matches. Nothing outside the router wants it: a document that carried it
+/// disagreed with its own parameter list, and a warning that carried it named a route the operator
+/// cannot find in their own source, because <c>spec_p_588343bc</c> is a hash this build invented.
+/// </remarks>
+internal static class RouteTemplate {
+
+    /// <summary>
+    /// The route with every token reduced to its name.
+    ///
+    /// <para>
+    /// Hardened's own form matches an OpenAPI path template except for the catch-all marker:
+    /// <c>/files/{*path}</c> is a Hardened route, and <c>{*path}</c> is not a valid template
+    /// expression — an expression is a name, and the name has to match a declared parameter. The
+    /// marker says how much of the path the token takes, which is a routing concern the document has
+    /// no way to express, so it is dropped and the parameter is written under its own name.
+    /// </para>
+    ///
+    /// <para>
+    /// That does lose something: a specification round-tripped back through
+    /// <c>Hardened.OpenApi.BuildTask</c> gives a single-segment token where the source route had a
+    /// catch-all. Worth knowing, and better than emitting a document no OpenAPI reader accepts.
+    /// </para>
+    /// </summary>
+    public static string NamesOnly(string path) {
+        if (path.IndexOf('{') < 0) {
+            return path;
+        }
+
+        var builder = new StringBuilder(path.Length);
+        var index = 0;
+
+        while (index < path.Length) {
+            var open = path.IndexOf('{', index);
+
+            if (open < 0) {
+                builder.Append(path, index, path.Length - index);
+                break;
+            }
+
+            var close = path.IndexOf('}', open);
+
+            if (close < 0) {
+                builder.Append(path, index, path.Length - index);
+                break;
+            }
+
+            builder.Append(path, index, open - index).Append('{');
+
+            var start = TokenStart(path, open, close);
+
+            // The constraint: what the token has to look like to match. A template expression is a
+            // parameter name and nothing else, so ":int" is not a shorter spelling of a schema - it
+            // is a syntax error that happens to parse. Left in, it made the name in the template
+            // disagree with the name in "parameters", which Spectral reports as path-params and a
+            // generated client turns into a request for /boards/%7BboardId:guid%7D.
+            var colon = path.IndexOf(':', start);
+            var end = colon >= 0 && colon < close ? colon : close;
+
+            builder.Append(path, start, end - start).Append('}');
+
+            index = close + 1;
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// The constraint chain written on <paramref name="token"/> - <c>int:min(1)</c> for
+    /// <c>{id:int:min(1)}</c> - or an empty string where the token carries none or is not in the
+    /// route at all.
+    /// </summary>
+    /// <remarks>
+    /// By token name rather than by position, because the caller has a bound parameter and wants
+    /// the constraint guarding it. A parameter that binds from the query or a header is not in the
+    /// route, and an empty chain is the truthful answer for it: nothing guards the value.
+    /// </remarks>
+    public static string ConstraintOn(string path, string token) {
+        var open = path.IndexOf('{');
+
+        while (open >= 0) {
+            var close = path.IndexOf('}', open);
+
+            if (close < 0) {
+                return "";
+            }
+
+            var start = TokenStart(path, open, close);
+            var colon = path.IndexOf(':', start);
+            var nameEnd = colon >= 0 && colon < close ? colon : close;
+
+            if (nameEnd - start == token.Length &&
+                string.CompareOrdinal(path, start, token, 0, token.Length) == 0) {
+                return nameEnd == close ? "" : path.Substring(colon + 1, close - colon - 1);
+            }
+
+            open = path.IndexOf('{', close);
+        }
+
+        return "";
+    }
+
+    /// <summary>Whether any token in <paramref name="path"/> carries a constraint.</summary>
+    /// <remarks>
+    /// The question the document writer asks before it says anything about a route constraint at
+    /// all, and the reason it can say nothing for the overwhelming majority of routes.
+    /// </remarks>
+    public static bool HasConstraint(string path) {
+        var open = path.IndexOf('{');
+
+        while (open >= 0) {
+            var close = path.IndexOf('}', open);
+
+            if (close < 0) {
+                return false;
+            }
+
+            var colon = path.IndexOf(':', open);
+
+            if (colon > open && colon < close) {
+                return true;
+            }
+
+            open = path.IndexOf('{', close);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Where the token's name starts: past the opening brace, and past the catch-all marker where
+    /// there is one.
+    /// </summary>
+    private static int TokenStart(string path, int open, int close) {
+        var start = open + 1;
+
+        return start < close && path[start] == '*' ? start + 1 : start;
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/ServerSentEventManifestEmitter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/ServerSentEventManifestEmitter.cs
@@ -4,6 +4,7 @@ using CSharpAuthor;
 using Hardened.SourceGenerator.Models.Request;
 using Hardened.SourceGenerator.Shared;
 using Hardened.SourceGenerator.Requests;
+using Hardened.SourceGenerator.Web.Routing;
 
 namespace Hardened.SourceGenerator.Web;
 
@@ -39,14 +40,22 @@ internal static class ServerSentEventManifestEmitter {
     /// The handlers framed as events, as the verb and path an operator reads off a log line.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Ordered and deduplicated so the emitted list does not move between builds over nothing,
     /// which would dirty the incremental cache and the fixtures with it.
+    /// </para>
+    /// <para>
+    /// Token names only. A route constraint is how the router decides what matches, and one a
+    /// specification declared is named after a hash of the pattern - so the warning named
+    /// <c>/devices/{deviceId:spec_p_588343bc}</c>, a route the operator cannot find in their own
+    /// contract.
+    /// </para>
     /// </remarks>
     public static IReadOnlyList<string> Collect(IReadOnlyList<RequestHandlerModel> handlers) =>
         handlers
             .Where(handler =>
                 handler.ResponseInformation.StreamFraming == StreamFramingNames.ServerSentEvents)
-            .Select(handler => handler.Name.Method + " " + handler.Name.Path)
+            .Select(handler => handler.Name.Method + " " + RouteTemplate.NamesOnly(handler.Name.Path))
             .Distinct()
             .OrderBy(name => name, System.StringComparer.Ordinal)
             .ToList();

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Hardened.Web.SourceGenerator.Tests.csproj
@@ -130,5 +130,15 @@
                  Link="SpecBridge/%(Filename)%(Extension)"/>
         <Compile Include="../Hardened.SourceGenerator.Tests/OpenApiDocument/XmlDocumentationTests.cs"
                  Link="SpecBridge/XmlDocumentationTests.cs"/>
+        <!--
+            And the route-template and constraint-fact suites, for the reason their own remarks
+            give: both files are source-linked into several generator assemblies, coverage is
+            measured per assembly, and a test in one assembly covers that assembly's copy and
+            nothing else.
+        -->
+        <Compile Include="../Hardened.SourceGenerator.Tests/Web/RouteConstraintFactsTests.cs"
+                 Link="Routing/RouteConstraintFactsTests.cs"/>
+        <Compile Include="../Hardened.SourceGenerator.Tests/Web/RouteTemplateTests.cs"
+                 Link="Routing/RouteTemplateTests.cs"/>
     </ItemGroup>
 </Project>

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ResponseSetDocumentTests.cs
@@ -328,19 +328,29 @@ public class ResponseSetDocumentTests {
     /// A value that violates a route constraint means the route did not match, and the answer is
     /// the router's bodyless 404. The constraint is stripped from the path template, so this entry
     /// is the one trace of it the document carries.
+    ///
+    /// <para>
+    /// And no 400 beside it: <c>:int</c> is the same test the converter would make, so the value
+    /// that would have failed to bind was refused a step earlier. The same handler with a bare
+    /// <c>{id}</c> is <see cref="ABindingRefusalPublishesTheFourHundred"/>.
+    /// </para>
     /// </summary>
     [Fact]
-    public void AConstrainedPathTokenPublishesTheFourOhFour() {
+    public void AConstrainedPathTokenPublishesTheFourOhFourAndNoFourHundred() {
         var responses = Responses(Document("""
                 [Get("/todos/{id:int}")]
                 public Todo ById(int id) => new Todo(id, "t");
             """), "/todos/{id}", "get");
 
-        Assert.Equal(new[] { "200", "400", "404" }, Statuses(responses));
+        Assert.Equal(new[] { "200", "404" }, Statuses(responses));
         Assert.False(responses.GetProperty("404").TryGetProperty("content", out _));
     }
 
-    /// <summary>An operation that declares its own 404 keeps its own description.</summary>
+    /// <summary>
+    /// An operation that declares its own 404 keeps its own description, and gains a sentence: the
+    /// router answers the same status with no body, which is the other 404 a caller can be sent and
+    /// the one a document cannot key separately.
+    /// </summary>
     [Fact]
     public void ADeclaredFourOhFourIsNotOverwritten() {
         var responses = Responses(Document("""
@@ -348,8 +358,14 @@ public class ResponseSetDocumentTests {
                 public Response<Todo, NotFound> ById(int id) => new Todo(id, "t");
             """), "/todos/{id}", "get");
 
-        Assert.Equal(new[] { "200", "400", "404" }, Statuses(responses));
-        Assert.True(responses.GetProperty("404").TryGetProperty("content", out _));
+        Assert.Equal(new[] { "200", "404" }, Statuses(responses));
+
+        var notFound = responses.GetProperty("404");
+
+        Assert.True(notFound.TryGetProperty("content", out _));
+        Assert.Contains(
+            "A token that fails its route constraint answers this status too",
+            notFound.GetProperty("description").GetString());
     }
 
     #endregion


### PR DESCRIPTION
From the 0.32 template trial: **A-01 ≡ B-05** (found independently by two arms), **B-06**, **C-06** and **C-07**. One cause, four symptoms — a constraint on a path token is the router's business, and four writers treated it as a validator's.

A route constraint runs before binding. A value it rejects means the route did not match, so the answer is the router's bodyless 404 and the binder never sees one. Four places did not know that:

| | Was | Now |
|---|---|---|
| `{id:int}` binding an `int` | 404 **and** an unreachable 400 | 404 |
| a spec `pattern` on a path token | a route constraint **and** a `[Pattern]` on every request | the route constraint |
| `required` on a path token | a validator for a check that cannot fail, and its 400 | nothing |
| a declared 404 | said nothing about the router's bodyless one | says it |

## What changed

- `RouteConstraintFacts.GuaranteesConversion` is the new fact: can the converter still refuse a value this constraint let through. `{id:int}` binding an `int` cannot, so no 400. `{id:long}` binding an `int` admits `99999999999` and **keeps** its 400. Nothing is claimed for a `[RouteConstraint]` the application declared, or for an unsigned type — every numeric constraint admits a leading minus.
- A path parameter's pattern compiled into the route contributes no `[Pattern]`. That drops a regex match from every request that got through, as well as the false 400. `RouteConstraintEmitter` now runs before the validation interfaces are built, because it decides what they are for.
- `required` on a path parameter emits no `[Required]`: a request that reached the handler matched the template, and an absent or empty segment matched nothing and was answered 404. The same unfailable-check reasoning `HRDV003` already gives for a value type.
- Where an operation declares its own 404, its description gains: *"A token that fails its route constraint answers this status too, before the handler and with no body."* Two 404s reach the wire and a document can key one, so the one it keys says the other exists.
- `RouteTemplate` collects the three ways a route is read as something other than a route. The SSE buffered-mode warning uses it — it was naming `/devices/{deviceId:spec_p_588343bc}`, a route that appears in nobody's source, because the constraint name is a hash of a contract's pattern (C-07).

## The wire is unchanged

Every removed 400 was a status no request could produce. Nothing about routing, binding or validation answers differently; a `pattern` on a path token was already refused by the router before this.

## Evidence

Six unreachable 400s leave this repository's own three exported documents:

```
Application.json     GET    /binding/path-constrained/{count}  [200,400,404,504] -> [200,404,504]
OpenApiTestApp.json  GET    /pets/{petId}                      [200,400,404,429] -> [200,404,429]
OpenApiTestApp.json  DELETE /pets/{petId}                      [204,400]         -> [204]
OpenApiTestApp.json  GET    /pets/{petId}/events               [200,400]         -> [200]
OpenApiTestApp.json  GET    /secured/owned/{ownerId}           [200,400,401,403] -> [200,401,403]
SmithyTestApp.json   GET    /pets/{petId}/events               [200,400]         -> [200]
```

And the controls that prove the change is narrow, all unchanged:

- `/binding/path-typed/{count}` — the same `int count` with a bare `{count}`. The 400 is real.
- `/constraints/page/{count:int}` — `[Range(1,100)]` on top of the constraint. `/page/0` is a 400 and stays published.
- `/pets/{petId}/label` — a patterned path token plus an `integer` query parameter. Its 400 is real.
- `PUT`/`PATCH /pets/{petId}` — a body validates. Unchanged.

Two existing tests asserted the old behaviour from a second direction (`AConstrainedPathTokenPublishesTheFourOhFour`, `ADeclaredFourOhFourIsNotOverwritten`) and are updated to the new expectation, next to the unchanged `ABindingRefusalPublishesTheFourHundred`.

New: `RouteTemplateTests`, `GuaranteesConversion` pinned arm by arm (a wrong `true` deletes a reachable 400), the document writer's four branches, `OperationParameters`' path-token cases, and an end-to-end assertion that the SSE manifest lists `GET /orders/{id}/live` for a route written `/orders/{id:int}/live`.

## Documentation

`validation.md` gains the table of which declaration is refused by the router, the validator or the binder, and what each publishes — which is also the answer to C-06, where an arm found `@pattern` and `@range` on one token answering differently and could not tell whether that was deliberate. It is. `routing.md` says what a constraint does to the document.

## Verification

- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — clean apart from the standing local `HSMT011` (Smithy CLI 1.56.0 here against the 1.73.0 pin).
- `dotnet test Hardened.slnx` — 74 test projects, 0 failures.
- `npm run build` in `docs/` — no dead links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)