### PR TITLE
Refuse a body that omits a member the document calls required

### DIFF
--- a/docs/guide/json.md
+++ b/docs/guide/json.md
@@ -128,6 +128,13 @@ after publishing.
 document, so an application using it publishes a description its own wire format disagrees with.
 Leave it off and let the build write the converters.
 
+One rule does not survive the publish. A non-nullable reference member of a **hand-written** model
+is required of a caller because the reader reads the model's nullable annotations, which is
+reflection — so under AOT that member becomes optional again while the document still publishes it
+as required. Say it in the model instead, with `required string Title` or `[JsonRequired]`: the
+source generator reads both, and a contract-first model needs neither, because its `required` was
+compiled in at build time. See [Validation](/guide/validation#presence-and-who-checks-it).
+
 ## Next
 
 - [Content negotiation](/guide/content-negotiation): how the JSON serializer is chosen

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -36,7 +36,8 @@ absence is unrepresentable there — and `HRDV003` says so.
 
 ### Presence, and who checks it
 
-A non-nullable reference member is one the caller must send. Nothing else declares it:
+A non-nullable reference member the constructor takes is one the caller must send. Nothing else
+declares it:
 
 ```csharp
 public record NewTodo(string Title);        // {} is a 400: title is required
@@ -47,6 +48,22 @@ public record Paged(string Cursor = "");    // {} is accepted, Cursor is ""
 That is the same declaration the published document reads — `required: ["title"]` comes from the
 annotation on `Title` and from nothing else — so the document and the server now answer the same
 question the same way. A member the server owns is excluded from both by `[ResponseOnly]`.
+
+A settable property is not demanded, whatever its type:
+
+```csharp
+public class Manifest {
+    public string Id { get; set; } = "";        // optional, and the document says so
+    public string Carrier { get; set; }         // the document says required; nothing checks it
+}
+```
+
+An initializer is how a property says "this when nothing sends it", and it compiles into the
+constructor body where reflection cannot see it — so demanding these would refuse bodies their author
+meant to accept. The document reads the initializer from source and leaves `id` optional; `carrier`,
+which has none, is published as required and is `[Required]`'s to enforce. Write the demand where the
+reader can see it — a constructor parameter, `required string Carrier`, or `[JsonRequired]` — or
+declare `[Required]` and let the validator answer.
 
 **Presence is the reader's question; content is the validator's.** Absence is the one thing a
 validator cannot see, and the one thing the JSON reader knows for certain, so a body that omits a

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -31,8 +31,42 @@ the whole of it.
 
 The attributes live in the `ValidationModules.Constraints` namespace. Every bounded attribute
 takes named `Min` and `Max` arguments, so a single bound is one argument. `[Required]` marks a
-member the caller must send. On a non-nullable value type it is unnecessary, because absence is
-unrepresentable there.
+member the caller may not send as `null`. On a non-nullable value type it is unnecessary, because
+absence is unrepresentable there — and `HRDV003` says so.
+
+### Presence, and who checks it
+
+A non-nullable reference member is one the caller must send. Nothing else declares it:
+
+```csharp
+public record NewTodo(string Title);        // {} is a 400: title is required
+public record Draft(string? Title);         // {} is accepted, Title is null
+public record Paged(string Cursor = "");    // {} is accepted, Cursor is ""
+```
+
+That is the same declaration the published document reads — `required: ["title"]` comes from the
+annotation on `Title` and from nothing else — so the document and the server now answer the same
+question the same way. A member the server owns is excluded from both by `[ResponseOnly]`.
+
+**Presence is the reader's question; content is the validator's.** Absence is the one thing a
+validator cannot see, and the one thing the JSON reader knows for certain, so a body that omits a
+required member is refused before any constraint runs. Every member it missed is named at once:
+
+```json
+{ "errors": [
+  { "field": "body.accountId", "code": "required", "message": "accountId is required." },
+  { "field": "body.weightKg",  "code": "required", "message": "weightKg is required." } ] }
+```
+
+The trade is worth knowing: a body that both omits a required member and breaks a constraint on a
+member it did send is answered about the omission, and about the constraint on the next request.
+Everything the reader accepted is validated together, as before.
+
+A non-nullable **value** type is not covered by this. The document publishes one as required because
+C# serialization cannot omit it — a fact about what a response always contains rather than a demand
+its author made, and `int?` or `= 0` are the only ways C# has to say otherwise. To demand one, say
+so: `required int Grams`, or `[JsonRequired]`. A contract-first model needs neither, because a
+contract's `required` is a demand and is compiled as one whatever the member's type.
 
 | Attribute | Checks |
 |---|---|
@@ -135,7 +169,9 @@ and the failure message says "at least 1" without inventing an upper bound.
 A failed request never reaches the handler. The generated filter answers 400 with one entry per
 failed field, in the shape at the top of this page. A value that fails to parse as its declared
 type takes the same shape: `?limit=abc` against an `int` parameter answers this envelope with
-`limit` as the field, not a 500.
+`limit` as the field, not a 500. So does a body that omitted a required member, reported under the
+object that was missing it — `body.lines[0].sku`, not `body.sku`. Which layer caught a fault is not
+something a caller can tell.
 
 ## What the document says
 

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
@@ -142,7 +142,10 @@ public class RequiredAndNestedValidationTests {
     }
 
     /// <summary>
-    /// A required member of a nested object is enforced too, not only a range on one.
+    /// A required member of a nested object is enforced too, not only a range on one - and it is
+    /// reported under the element that was missing it. An error naming <c>sku</c> against the body
+    /// tells a caller with fifty lines nothing, which is the same reason the index is asserted
+    /// above.
     /// </summary>
     [HardenedTest]
     public async Task ARequiredMemberOfAnArrayItemIsEnforced(ITestWebApp testWebApp) {
@@ -150,6 +153,26 @@ public class RequiredAndNestedValidationTests {
             testWebApp,
             """{"species":"cat","weightGrams":3000,"lines":[{"quantity":2}]}""");
 
-        Assert.Contains(error.Errors!, e => e.Field.Contains("sku"));
+        var field = Assert.Single(error.Errors!, e => e.Field == "body.lines[0].sku");
+
+        Assert.Equal("required", field.Code);
+        Assert.Equal("sku is required.", field.Message);
+    }
+
+    /// <summary>
+    /// A missing value type and a missing reference type in one body, answered together.
+    /// </summary>
+    /// <remarks>
+    /// The trial's B-07. Presence was asked in two layers - <c>[JsonRequired]</c> for a value type,
+    /// <c>[Required]</c> for a reference type - and the reader aborted before the validator ran, so
+    /// a caller was told about <c>weightGrams</c> and learned about <c>lines</c> one round trip
+    /// later. The reader aggregates missing members, so asking it once answers both.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AMissingValueMemberDoesNotHideAMissingReferenceMember(ITestWebApp testWebApp) {
+        var error = await Rejected(testWebApp, """{"species":"cat"}""");
+
+        Assert.Contains(error.Errors!, e => e.Field == "body.weightGrams");
+        Assert.Contains(error.Errors!, e => e.Field == "body.lines");
     }
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
@@ -24,6 +24,42 @@ namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
 /// </remarks>
 public class RegistrationValidationTests {
 
+    /// <summary>
+    /// The trial's blocker: a member declared present by its nullable annotation and by nothing
+    /// else. The document published <c>required: ["memberId"]</c> and the request answered 201 with
+    /// a null in a domain whose C# type says it cannot be there.
+    /// </summary>
+    /// <remarks>
+    /// A raw JSON body, because what is under test is a member that is <em>absent</em> - a typed
+    /// object has no way to leave one out. The field is reported under the handler's own parameter
+    /// name, which is what every other error in this file does.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnAbsentMemberDeclaredPresentByItsTypeIsRefused(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post("{}", "/registration/member");
+
+        response.Assert.BadRequest();
+
+        var error = response.Deserialize<RequestValidationError>();
+
+        Assert.NotNull(error);
+
+        var field = Assert.Single(error.Errors!, e => e.Field == "request.memberId");
+
+        Assert.Equal("required", field.Code);
+        Assert.Equal("memberId is required.", field.Message);
+    }
+
+    /// <summary>Sent is sent, whatever else is wrong with it.</summary>
+    [HardenedTest]
+    public async Task TheSameMemberSentIsAccepted(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post("""{"memberId":"M-0001"}""", "/registration/member");
+
+        response.Assert.Ok();
+
+        Assert.Equal("M-0001", response.Deserialize<string>());
+    }
+
     [HardenedTest]
     public async Task MissingRequiredField_Returns400(ITestWebApp testWebApp) {
         var response = await testWebApp.Post(new { Name = "", Age = 30 }, "/registration");

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/RegistrationController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/RegistrationController.cs
@@ -39,6 +39,16 @@ public class RegistrationController {
     [Post("/for/{tenant}")]
     public string RegisterForTenant(string tenant, RegistrationModel model) => $"{tenant}:{model.Name}";
 
+    /// <summary>
+    /// A body whose only declaration is the nullable annotation on its member.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MemberRequest"/> carries no constraint at all, so nothing generates a validator
+    /// for it. What refuses an absent member here is the reader.
+    /// </remarks>
+    [Post("/member")]
+    public string RegisterMember(MemberRequest request) => request.MemberId;
+
     [Post("/anonymous")]
     public string Unconstrained(MathAddModel model) =>
         string.Join(",", model.Values ?? new List<int>());

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Models/RegistrationModel.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Models/RegistrationModel.cs
@@ -28,6 +28,19 @@ public class RegistrationModel {
     public AddressModel? Address { get; set; }
 }
 
+/// <summary>
+/// A member declared present by its type and by nothing else: no <c>[Required]</c>, no
+/// <c>required</c> modifier, no constraint of any kind.
+/// </summary>
+/// <remarks>
+/// The trial's blocker, in the shape it was found in. The published document says
+/// <c>required: ["memberId"]</c> - written from the nullable annotation - and the validator is built
+/// from <c>[Required]</c> alone, so <c>{}</c> used to answer 201 with a null in a domain whose C#
+/// type says it cannot be there. Deliberately unconstrained: a <c>[StringLength]</c> here would have
+/// given the model a validator, which is how the case hid on models that happened to carry one.
+/// </remarks>
+public record MemberRequest(string MemberId);
+
 /// <summary>A second level, so a failure has a path to report rather than a field.</summary>
 /// <remarks>Sealed because VM0031 (new in ValidationModules rc1012) otherwise asks what should
 /// happen when a more derived value reaches [ValidateNested] - nothing derives from this.</remarks>

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -5641,7 +5641,6 @@
       "Document": {
         "type": "object",
         "required": [
-          "version",
           "served"
         ],
         "properties": {

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -3816,6 +3816,49 @@
         "x-hardened-timeout": 300000
       }
     },
+    "/registration/member": {
+      "post": {
+        "tags": [
+          "Registration"
+        ],
+        "operationId": "registerMember",
+        "summary": "A body whose only declaration is the nullable annotation on its member.",
+        "description": "carries no constraint at all, so nothing generates a validator for it. What refuses an absent member here is the reader.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
     "/response-cache/catalog": {
       "get": {
         "tags": [
@@ -5670,6 +5713,18 @@
           },
           "settled": {
             "type": "boolean"
+          }
+        }
+      },
+      "MemberRequest": {
+        "type": "object",
+        "description": "A member declared present by its type and by nothing else: no [Required], no required modifier, no constraint of any kind.",
+        "required": [
+          "memberId"
+        ],
+        "properties": {
+          "memberId": {
+            "type": "string"
           }
         }
       },

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/MissingRequiredMembersTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/MissingRequiredMembersTests.cs
@@ -67,6 +67,12 @@ public class MissingRequiredMembersTests {
     /// One missing member, reported as the validator would report it: same field spelling, same
     /// code, same wording - and no trace of the message's own quoting or punctuation.
     /// </summary>
+    /// <remarks>
+    /// The message names the member and the field carries the path, which is what
+    /// <c>ReportRequired</c> does - it is handed <c>"unitPriceCents"</c> and the context supplies the
+    /// path. Spelled <c>"body.unitPriceCents is required."</c> it read as though the caller had sent
+    /// a member called <c>body.unitPriceCents</c>.
+    /// </remarks>
     [Fact]
     public void AMissingMemberIsReportedAsARequiredFieldError() {
         var error = Assert.Single(
@@ -74,7 +80,7 @@ public class MissingRequiredMembersTests {
 
         Assert.Equal("body.unitPriceCents", error.Field);
         Assert.Equal("required", error.Code);
-        Assert.Equal("body.unitPriceCents is required.", error.Message);
+        Assert.Equal("unitPriceCents is required.", error.Message);
     }
 
     /// <summary>
@@ -110,6 +116,26 @@ public class MissingRequiredMembersTests {
             new[] { "request.category", "request.unitPriceCents" },
             errors.Select(error => error.Field));
     }
+
+    /// <summary>
+    /// The object that was missing it, not the body. A member of an array element is
+    /// <c>body.lines[0].sku</c>, which is the path the validator reports for the same member and the
+    /// only one a caller with fifty lines can act on - the exception's <c>Path</c> is that object.
+    /// </summary>
+    [Fact]
+    public void AMissingMemberOfANestedObjectIsReportedUnderItsOwnPath() {
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Order>(
+            """{"lines":[{"sku":"A"},{}]}""", new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+
+        var error = Assert.Single(Convert(exception).Errors!);
+
+        Assert.Equal("body.lines[1].sku", error.Field);
+        Assert.Equal("sku is required.", error.Message);
+    }
+
+    private record Line([property: JsonPropertyName("sku")] [property: JsonRequired] string Sku);
+
+    private record Order([property: JsonPropertyName("lines")] List<Line> Lines);
 
     /// <summary>
     /// Any other <c>JsonException</c> keeps the general body-read answer. Malformed JSON is not a

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequiredMemberPresenceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequiredMemberPresenceTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Runtime.Serializer;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Serializer;
+
+/// <summary>
+/// The rule that makes a hand-written model's <c>required</c> array mean something.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>record NewTodo(string Title)</c> published <c>required: ["title"]</c> from its nullable
+/// annotation and answered 201 to <c>{}</c>: the array is written from nullability and the validator
+/// was built from <c>[Required]</c> alone, so the two halves of one declaration never met. These pin
+/// the half that closes it, member kind by member kind - and the exclusions, which are what keep it
+/// from demanding values no caller was ever meant to send.
+/// </para>
+/// <para>
+/// Driven through <c>JsonSerializer</c> rather than by inspecting <c>JsonTypeInfo</c>, because what
+/// is under test is whether a body is refused.
+/// </para>
+/// </remarks>
+public class RequiredMemberPresenceTests {
+
+    private static JsonSerializerOptions Options() =>
+        RequiredMemberPresence.Enforce(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web) {
+                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            });
+
+    private static JsonException Refused<T>(string json) =>
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(json, Options()));
+
+    private static T Accepted<T>(string json) =>
+        JsonSerializer.Deserialize<T>(json, Options())!;
+
+    // ---------------------------------------------------------------- what is required
+
+    private record Todo(string Title);
+
+    [Fact]
+    public void ANonNullableReferenceMemberMustBeSent() {
+        Assert.Contains("title", Refused<Todo>("{}").Message);
+    }
+
+    /// <summary>
+    /// Every one of them, in a single answer. The reader aggregates, so a caller fixes their request
+    /// in one pass rather than one round trip per member.
+    /// </summary>
+    private record Quote(string AccountId, string Origin, string Destination);
+
+    [Fact]
+    public void EveryMissingMemberIsNamedAtOnce() {
+        var message = Refused<Quote>("""{"origin":"SEA"}""").Message;
+
+        Assert.Contains("accountId", message);
+        Assert.Contains("destination", message);
+        Assert.DoesNotContain("origin", message);
+    }
+
+    /// <summary>
+    /// Sent is sent. A <c>null</c> satisfies this rule and is <c>[Required]</c>'s to refuse - which
+    /// is the split: presence is the reader's question, content is the validator's.
+    /// </summary>
+    [Fact]
+    public void AnExplicitNullIsNotAbsence() {
+        Assert.Null(Accepted<Todo>("""{"title":null}""").Title);
+    }
+
+    // ---------------------------------------------------------------- what is not
+
+    private record Optional(string? Title);
+
+    [Fact]
+    public void ANullableReferenceMemberMayBeOmitted() {
+        Assert.Null(Accepted<Optional>("{}").Title);
+    }
+
+    /// <summary>
+    /// A value type is left alone. The document publishes it as required because C# serialization
+    /// cannot omit one, which is a fact about what a response contains rather than a demand its
+    /// author made - and <c>int?</c> or <c>= 0</c> are the only ways C# has to say otherwise, so
+    /// reading it as a demand would make every declared <c>int</c> mandatory. See HRDV003.
+    /// </summary>
+    private record Weighed(int Grams, bool Fragile);
+
+    [Fact]
+    public void AValueTypeMemberIsLeftAlone() {
+        Assert.Equal(0, Accepted<Weighed>("{}").Grams);
+    }
+
+    /// <summary>The server fills it in, so the caller may leave it out. The document agrees.</summary>
+    private record Paged(string Cursor = "");
+
+    [Fact]
+    public void AMemberWithAConstructorDefaultMayBeOmitted() {
+        Assert.Equal("", Accepted<Paged>("{}").Cursor);
+    }
+
+    /// <summary>
+    /// <c>[ResponseOnly]</c> is OpenAPI's <c>readOnly</c>: the server owns the value. Demanding one
+    /// would refuse the create call of a client that correctly left it out.
+    /// </summary>
+    private record Assigned([property: ResponseOnly] string Id, string Title);
+
+    [Fact]
+    public void AResponseOnlyMemberIsNotDemanded() {
+        var accepted = Accepted<Assigned>("""{"title":"t"}""");
+
+        Assert.Null(accepted.Id);
+        Assert.Equal("t", accepted.Title);
+    }
+
+    /// <summary>
+    /// A member the reader cannot fill. There is no constructor parameter for it and no setter, so
+    /// requiring it would refuse every request for a value that could never arrive.
+    /// </summary>
+    private record Computed(string Title) {
+        public string Slug => Title.ToLowerInvariant();
+    }
+
+    [Fact]
+    public void AGetOnlyMemberWithNoConstructorParameterIsNotDemanded() {
+        Assert.Equal("t", Accepted<Computed>("""{"title":"t"}""").Title);
+    }
+
+    /// <summary>
+    /// An assembly compiled without nullable annotations declares nothing, and this reads a
+    /// declaration. The document says the same: it writes <c>required</c> from the annotation, and
+    /// there is none.
+    /// </summary>
+    [Fact]
+    public void AMemberWithNoNullableAnnotationIsNotDemanded() {
+        Assert.Null(Accepted<Unannotated>("{}").Title);
+    }
+
+    /// <summary>
+    /// Already required, and nothing here undoes that: the rule adds, and <c>[JsonRequired]</c> or
+    /// the <c>required</c> modifier is a declaration of its own.
+    /// </summary>
+    private record Explicit([property: JsonRequired] int Grams);
+
+    [Fact]
+    public void AMemberAlreadyRequiredStaysRequired() {
+        Assert.Contains("grams", Refused<Explicit>("{}").Message);
+    }
+}
+
+#nullable disable
+
+/// <summary>
+/// Declared outside the nullable context on purpose - see
+/// <see cref="RequiredMemberPresenceTests.AMemberWithNoNullableAnnotationIsNotDemanded"/>.
+/// </summary>
+public record Unannotated(string Title);
+
+#nullable restore

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequiredMemberPresenceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequiredMemberPresenceTests.cs
@@ -101,6 +101,27 @@ public class RequiredMemberPresenceTests {
     }
 
     /// <summary>
+    /// A settable property is left to <c>[Required]</c>. Its "optional" is an initializer -
+    /// <c>= ""</c>, <c>= []</c> - which compiles into the constructor body, so nothing here can tell
+    /// one from a member its author meant to demand. Demanding them refused the payloads of this
+    /// repository's own Invoke fixture, whose four settable properties carry three initializers
+    /// between them.
+    /// </summary>
+    private class Manifest {
+        public string Id { get; set; } = "";
+
+        public List<string> Records { get; set; } = [];
+    }
+
+    [Fact]
+    public void ASettablePropertyIsNotDemanded() {
+        var accepted = Accepted<Manifest>("{}");
+
+        Assert.Equal("", accepted.Id);
+        Assert.Empty(accepted.Records);
+    }
+
+    /// <summary>
     /// <c>[ResponseOnly]</c> is OpenAPI's <c>readOnly</c>: the server owns the value. Demanding one
     /// would refuse the create call of a client that correctly left it out.
     /// </summary>

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -196,7 +196,7 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
         new() {
             Type = "ValidationError",
             Message = "One or more validation errors occurred.",
-            Errors = MissingMembers(exception.Message, body) ?? [
+            Errors = MissingMembers(exception, body) ?? [
                 new RequestValidationFieldError {
                     Field = FieldFrom(exception.Path, body),
                     Code = "invalid",
@@ -230,7 +230,7 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
     /// </para>
     /// <para>
     /// <b>Indistinguishable from the validator's own answer, deliberately.</b> Same field spelling,
-    /// same <c>required</c> code, same <c>"{field} is required."</c> wording - so which layer caught
+    /// same <c>required</c> code, same <c>"{member} is required."</c> wording - so which layer caught
     /// a missing member is this framework's business and not the caller's. System.Text.Json
     /// aggregates, listing every member it missed, so the list is complete rather than first-only.
     /// </para>
@@ -244,9 +244,12 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
     /// silently degrading in production.
     /// </para>
     /// </remarks>
-    private static List<RequestValidationFieldError>? MissingMembers(string message, string body) {
+    private static List<RequestValidationFieldError>? MissingMembers(
+        JsonException exception, string body) {
         const string prefix = "JSON deserialization for type ";
         const string marker = "missing required properties";
+
+        var message = exception.Message;
 
         if (!message.StartsWith(prefix, StringComparison.Ordinal) ||
             message.IndexOf(marker, StringComparison.Ordinal) == -1) {
@@ -279,10 +282,17 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
                 continue;
             }
 
-            var field = body + "." + member;
-
             errors.Add(new RequestValidationFieldError {
-                Field = field, Code = "required", Message = field + " is required."
+                // The object that was missing it, not the body: a member of an array element is
+                // body.lines[0].sku, which is the path a validator reports and the only one a
+                // caller with fifty lines can act on. The exception's Path is that object -
+                // $.lines[0] - and $ for the body itself.
+                Field = FieldFrom(exception.Path, body) + "." + member,
+                Code = "required",
+                // The member, not the path, which is what ValidationModules puts in this sentence:
+                // the field is already carried beside it, and repeating the prefix read as though
+                // the caller had sent a member called "body.sku".
+                Message = member + " is required."
             });
         }
 

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/RequiredMemberPresence.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/RequiredMemberPresence.cs
@@ -1,0 +1,167 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Hardened.Requests.Abstract.Attributes;
+
+namespace Hardened.Requests.Runtime.Serializer;
+
+/// <summary>
+/// Makes the deserializer refuse a body that omits a member the published document calls required.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The document already said so, and nothing enforced it.</b> A schema's <c>required</c> array
+/// carries a non-nullable reference type because the author said so, and the validator was built
+/// from <c>[Required]</c> alone - so <c>record NewTodo(string Title)</c> published
+/// <c>required: ["title"]</c> and answered 201 to <c>{}</c> with a null title in a domain whose C#
+/// type says it cannot be there. Two generators read one declaration and reached opposite
+/// conclusions.
+/// </para>
+/// <para>
+/// <b>Reference types only, which is where the declaration is.</b> The document also publishes a
+/// non-nullable <em>value</em> type as required, on different grounds: not that the author demanded
+/// it, but that C# serialization cannot omit one, which is a fact about what a response always
+/// contains. Reading that as a demand on a caller would make <c>int Age</c> mandatory in every body
+/// that declares one, from a member whose author never chose anything - <c>int?</c> and <c>= 0</c>
+/// being the only ways C# has to say otherwise. A value type the author does mean to demand is
+/// <c>HRDV003</c>'s subject, and its remedies are <c>required</c> and <c>[JsonRequired]</c>.
+/// </para>
+/// <para>
+/// <b>Presence is the deserializer's job; content is the validator's.</b> Absence is the one thing a
+/// validator cannot see - an omitted <c>int</c> is indistinguishable from <c>0</c> once the model is
+/// built - and it is the one thing the reader knows for certain. So the reader answers "was it
+/// sent", <c>[Required]</c> and the rest answer "is it acceptable", and neither asks the other's
+/// question.
+/// </para>
+/// <para>
+/// The rule here is <c>JsonSchemaWriter</c>'s, member for member, because a rule stated twice is a
+/// rule that drifts: a member with a constructor default is excluded in both places, and an
+/// assembly without nullable annotations enables neither. The one thing this cannot see is a type
+/// whose annotations the trimmer removed, which is why it is installed by the reflection-based
+/// deserializer alone - the source-generated resolvers carry <c>IsRequired</c> from their own
+/// generator, decided at build time from the same contract.
+/// </para>
+/// <para>
+/// Costs nothing per request. A modifier runs once per type, when
+/// <see cref="JsonSerializerOptions"/> first builds that type's metadata, and the metadata is cached
+/// from then on.
+/// </para>
+/// </remarks>
+internal static class RequiredMemberPresence {
+    private const string Reason =
+        "Reads a model's nullable annotations by reflection. The source-generated resolvers carry " +
+        "IsRequired from their own generator instead.";
+
+    /// <summary>
+    /// Adds the rule to <paramref name="options"/>, over whatever resolvers it already carries.
+    /// </summary>
+    /// <remarks>
+    /// The chain is composed and re-added rather than assigned through
+    /// <see cref="JsonSerializerOptions.TypeInfoResolver"/>: the property and the chain are two views
+    /// of one thing, and setting the property replaces what the caller spent a constructor building.
+    /// </remarks>
+    [RequiresUnreferencedCode(Reason)]
+    public static JsonSerializerOptions Enforce(JsonSerializerOptions options) {
+        var chain = new IJsonTypeInfoResolver[options.TypeInfoResolverChain.Count];
+
+        options.TypeInfoResolverChain.CopyTo(chain, 0);
+        options.TypeInfoResolverChain.Clear();
+        options.TypeInfoResolverChain.Add(
+            JsonTypeInfoResolver.WithAddedModifier(JsonTypeInfoResolver.Combine(chain), Require));
+
+        return options;
+    }
+
+    [RequiresUnreferencedCode(Reason)]
+    private static void Require(JsonTypeInfo typeInfo) {
+        if (typeInfo.Kind != JsonTypeInfoKind.Object) {
+            return;
+        }
+
+        NullabilityInfoContext? nullability = null;
+
+        foreach (var property in typeInfo.Properties) {
+            // Already required, by the `required` modifier, [JsonRequired], or a generator that
+            // decided the same thing from a contract.
+            if (property.IsRequired || property.IsExtensionData) {
+                continue;
+            }
+
+            if (property.AttributeProvider is not PropertyInfo member) {
+                continue;
+            }
+
+            // A member the reader cannot populate cannot be demanded of a caller. A get-only
+            // property is either constructor-bound - in which case the parameter below is what
+            // carries it - or it is not deserialized at all, and requiring one of those would
+            // refuse every request.
+            if (property.Set == null && Parameter(typeInfo.Type, member.Name) == null) {
+                continue;
+            }
+
+            // The caller may omit a member the server fills in. This is the one exclusion the
+            // document makes too.
+            if (Parameter(typeInfo.Type, member.Name) is { HasDefaultValue: true }) {
+                continue;
+            }
+
+            // A value the server owns is not one to demand of a caller. This is OpenAPI's readOnly,
+            // which the specification-first side excludes from required for the same reason -
+            // ConstrainedAsRequired reads IsReadOnly.
+            if (member.GetCustomAttribute<ResponseOnlyAttribute>() != null) {
+                continue;
+            }
+
+            if (!DeclaredAlwaysPresent(member, ref nullability)) {
+                continue;
+            }
+
+            property.IsRequired = true;
+        }
+    }
+
+    /// <summary>
+    /// Whether the author declared this member always present: a reference type the nullable
+    /// context says cannot be null.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="NullabilityInfo.WriteState"/> rather than <c>ReadState</c>, because reading a body
+    /// writes into the member. An assembly compiled without nullable annotations answers
+    /// <see cref="NullabilityState.Unknown"/> for every reference type, and nothing is required there
+    /// - which is also what the document says for it, since the annotation it reads is absent.
+    /// </remarks>
+    [RequiresUnreferencedCode(Reason)]
+    private static bool DeclaredAlwaysPresent(
+        PropertyInfo member, ref NullabilityInfoContext? nullability) {
+        if (member.PropertyType.IsValueType) {
+            return false;
+        }
+
+        nullability ??= new NullabilityInfoContext();
+
+        return nullability.Create(member).WriteState == NullabilityState.NotNull;
+    }
+
+    /// <summary>
+    /// The constructor parameter of that name, or null.
+    /// </summary>
+    /// <remarks>
+    /// By name across every instance constructor, which is the test <c>JsonSchemaWriter.DefaultOf</c>
+    /// makes. Ordinal and case-sensitive: a positional record's parameter and its property are one
+    /// name, and a hand-written constructor whose parameter is spelled differently is not that
+    /// property's default in the document either.
+    /// </remarks>
+    [RequiresUnreferencedCode(Reason)]
+    private static ParameterInfo? Parameter(Type type, string name) {
+        foreach (var constructor in type.GetConstructors()) {
+            foreach (var parameter in constructor.GetParameters()) {
+                if (string.Equals(parameter.Name, name, StringComparison.Ordinal)) {
+                    return parameter;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/RequiredMemberPresence.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/RequiredMemberPresence.cs
@@ -35,12 +35,22 @@ namespace Hardened.Requests.Runtime.Serializer;
 /// question.
 /// </para>
 /// <para>
-/// The rule here is <c>JsonSchemaWriter</c>'s, member for member, because a rule stated twice is a
-/// rule that drifts: a member with a constructor default is excluded in both places, and an
-/// assembly without nullable annotations enables neither. The one thing this cannot see is a type
-/// whose annotations the trimmer removed, which is why it is installed by the reflection-based
-/// deserializer alone - the source-generated resolvers carry <c>IsRequired</c> from their own
-/// generator, decided at build time from the same contract.
+/// <b>A member the constructor demands.</b> A constructor parameter can say "optional" two ways -
+/// <c>= default</c> or a nullable type - and both are honoured here, so a non-nullable parameter
+/// with no default is a demand its author made and nothing else. A settable property says it a third
+/// way, with an initializer: <c>public string Cursor { get; set; } = "";</c> means "this when nothing
+/// sends it", and an initializer is compiled into the constructor body where reflection cannot see
+/// it. So a settable property is left to <c>[Required]</c>, because demanding one would refuse
+/// bodies its author meant to accept - a DTO whose fields all carry <c>= ""</c> being the ordinary
+/// shape of that.
+/// </para>
+/// <para>
+/// The rest of the rule is <c>JsonSchemaWriter</c>'s, member for member, because a rule stated twice
+/// is a rule that drifts: a default excludes a member in both places, <c>[ResponseOnly]</c> excludes
+/// it in both, and an assembly without nullable annotations enables neither. The one thing this
+/// cannot see is a type whose annotations the trimmer removed, which is why it is installed by the
+/// reflection-based deserializer alone - the source-generated resolvers carry <c>IsRequired</c> from
+/// their own generator, decided at build time from the same contract.
 /// </para>
 /// <para>
 /// Costs nothing per request. A modifier runs once per type, when
@@ -92,17 +102,16 @@ internal static class RequiredMemberPresence {
                 continue;
             }
 
-            // A member the reader cannot populate cannot be demanded of a caller. A get-only
-            // property is either constructor-bound - in which case the parameter below is what
-            // carries it - or it is not deserialized at all, and requiring one of those would
-            // refuse every request.
-            if (property.Set == null && Parameter(typeInfo.Type, member.Name) == null) {
+            // Only a member the constructor takes. A settable property's "optional" is an
+            // initializer, which is compiled into the constructor body and invisible here, so
+            // demanding one would refuse a body its author meant to accept.
+            if (Parameter(typeInfo.Type, member.Name) is not { } parameter) {
                 continue;
             }
 
             // The caller may omit a member the server fills in. This is the one exclusion the
             // document makes too.
-            if (Parameter(typeInfo.Type, member.Name) is { HasDefaultValue: true }) {
+            if (parameter.HasDefaultValue) {
                 continue;
             }
 

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonRequestDeserializer.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/SystemTextJsonRequestDeserializer.cs
@@ -43,10 +43,11 @@ public class SystemTextJsonRequestDeserializer : IRequestDeserializer {
     public SystemTextJsonRequestDeserializer(IOptions<IJsonSerializerConfiguration> configuration,
         IEnumerable<IJsonTypeInfoResolver> resolvers) {
         _serializerOptions =
-            Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
-                configuration.Value.DeSerializerOptions ??
-                new JsonSerializerOptions(JsonSerializerDefaults.Web),
-                resolvers);
+            RequiredMemberPresence.Enforce(
+                Hardened.Shared.Runtime.Json.JsonTypeInfoLookup.WithResolvers(
+                    configuration.Value.DeSerializerOptions ??
+                    new JsonSerializerOptions(JsonSerializerDefaults.Web),
+                    resolvers));
     }
 
     public bool IsDefaultSerializer => true;

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/JsonTypeInfoEmitter.cs
@@ -313,7 +313,7 @@ internal static class JsonTypeInfoEmitter {
         // the request body it describes unserializable; see ResponseOnlyAttribute.
         var getter = $"static obj => (({declaringTypeName})obj).{propName}";
 
-        var required = RequiresPresenceCheck(prop, allSchemas);
+        var required = RequiresPresenceCheck(prop);
 
         var open = required ? RequireMethodName + "(" : "";
         var close = required ? ")," : ",";
@@ -331,8 +331,11 @@ internal static class JsonTypeInfoEmitter {
         // records are populated through their constructor, whose init-only members cannot be
         // assigned through a delegate. The constructor still supplies the value; the setter is never
         // the thing that fills it.
+        // Implicitly typed, so the delegate's own nullability decides the parameter's. Spelled
+        // `(object obj, string value)` it was CS8622 against Action<object, string?> for every
+        // reference member - which nothing noticed while only value types reached here.
         sb.AppendLine(required
-            ? $"                    Setter = static (object obj, {genericType} value) => {{ }},"
+            ? "                    Setter = static (obj, value) => { },"
             : "                    Setter = null,");
 
         // Absent rather than null for a member the description declares optional and not nullable.
@@ -348,23 +351,28 @@ internal static class JsonTypeInfoEmitter {
     }
 
     /// <summary>
-    /// Whether absence of this member has to be caught by the deserializer.
+    /// Whether the reader must refuse a body that omits this member.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>The exact complement of where <c>[Required]</c> is emitted.</b> A required member of a
-    /// reference type carries <c>[Required]</c> and is checked by the generated validator, which
-    /// aggregates its error with every other failed constraint in the same body. A required member
-    /// of a <em>value</em> type carries nothing: the validation generator answers
-    /// <c>value.x is null</c> against an <c>int</c>, which is CS0037, so the constraint is
-    /// suppressed - correctly - and nothing takes its place.
+    /// <b>Every member the contract declares required</b>, whatever its type - the same set
+    /// <c>SchemaEmitter</c> writes <c>[JsonRequired]</c> for, because it is one rule read by two
+    /// deserializers. <c>[Required]</c> stays beside it and answers a different question: a member
+    /// that was sent as <c>null</c> is present, and refusing that is the validator's.
     /// </para>
     /// <para>
-    /// The result was that a missing required value silently became <c>default(T)</c>. An omitted
-    /// enum became its first declared member and the API answered 201 with a value the caller never
-    /// sent; an omitted integer became 0, caught only where some unrelated constraint happened to
-    /// reject 0. This is what closes that, and it is deliberately narrow: reference types keep the
-    /// aggregating validator path they already had.
+    /// It was value types only, because <c>[Required]</c> cannot cover one - the validation
+    /// generator answers <c>value.x is null</c> against an <c>int</c>, which is CS0037, so the
+    /// constraint is suppressed and a missing required value silently became <c>default(T)</c>. An
+    /// omitted enum became its first declared member and the API answered 201 with a value the
+    /// caller never sent. Reference types were left to the validator, on the reasoning that it
+    /// aggregates where the reader stops at the first fault.
+    /// </para>
+    /// <para>
+    /// The reader aggregates missing members too, and asking one question in two layers meant
+    /// whichever answered first hid the other: a body omitting an integer and three strings was told
+    /// about the integer, and about the strings one round trip later, from a validator that had not
+    /// run. Asked in one place, all four come back at once.
     /// </para>
     /// <para>
     /// <b>A declared <c>default</c> does not exempt it.</b> <c>required</c> and <c>default</c> are
@@ -374,15 +382,13 @@ internal static class JsonTypeInfoEmitter {
     /// today. Exempting these would preserve the silent zero for the one shape where the document
     /// most obviously disagrees with itself.
     /// </para>
+    /// <para>
+    /// A <c>readOnly</c> member is excluded, by <c>ConstrainedAsRequired</c> rather than here: the
+    /// server owns the value, and demanding it would refuse the create call of a client that
+    /// correctly left it out.
+    /// </para>
     /// </remarks>
-    private static bool RequiresPresenceCheck(PropertyModel prop, List<SchemaModel> allSchemas) {
-        if (!prop.ConstrainedAsRequired) {
-            return false;
-        }
-
-        return TypeMapper.IsNonNullableValueType(
-            TypeMapper.MapPropertyToCSharpType(prop), allSchemas);
-    }
+    private static bool RequiresPresenceCheck(PropertyModel prop) => prop.ConstrainedAsRequired;
 
     private const string RequireMethodName = "Required";
 
@@ -407,7 +413,7 @@ internal static class JsonTypeInfoEmitter {
     /// <summary>Whether anything in this specification needs the helper above.</summary>
     private static bool AnyRequiresPresenceCheck(List<SchemaModel> schemas) =>
         schemas.Any(schema => schema.Kind == SchemaKind.Object &&
-                              schema.Properties.Any(prop => RequiresPresenceCheck(prop, schemas)));
+                              schema.Properties.Any(RequiresPresenceCheck));
 
     private static void EmitParameterInfo(StringBuilder sb, PropertyModel prop, int position,
         List<SchemaModel> allSchemas, string ns) {

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/SchemaEmitter.cs
@@ -213,21 +213,26 @@ internal static class SchemaEmitter {
         var emitRequired = property.ConstrainedAsRequired &&
                            !TypeMapper.IsNonNullableValueType(csType, allSchemas);
 
-        // The other half of that sentence. A required member of a value type gets no [Required] -
-        // the validation generator would emit `value.x is null` against an int, which is CS0037 -
-        // so absence used to become default(T) in silence: an omitted enum became its first
-        // declared member and the API answered 201 with a value the caller never sent.
+        // Presence is the deserializer's job; content is the validator's.
         //
-        // [JsonRequired] rather than a nullable member, so the model's shape is unchanged and a
-        // handler still reads an int. The deserializer is the only layer that still knows the
-        // member was absent, and this is how it is told to care.
+        // A required member of a value type gets no [Required] - the validation generator would
+        // emit `value.x is null` against an int, which is CS0037 - so absence used to become
+        // default(T) in silence: an omitted enum became its first declared member and the API
+        // answered 201 with a value the caller never sent. [JsonRequired] rather than a nullable
+        // member, so the model's shape is unchanged and a handler still reads an int.
+        //
+        // A required reference member carries it too. It used to be left to [Required] alone,
+        // because the validator aggregates and the deserializer was thought to stop at the first
+        // fault - but System.Text.Json aggregates missing members as well, and splitting the one
+        // question across two layers meant whichever fired first hid the other's answer. A body
+        // that omitted an integer and three strings was told about the integer, and the three
+        // strings arrived one round trip later. Asked in one place, all four come back at once.
         //
         // Emitted here *and* as IsRequired in JsonTypeInfoEmitter, because the two deserializers
         // read different things: the reflection-based one reads this attribute, and the
         // source-generated resolver builds JsonPropertyInfo by hand and never sees it. readOnly is
         // enforced twice for the same reason - a null Setter there, [ResponseOnly] here.
-        if (property.ConstrainedAsRequired &&
-            TypeMapper.IsNonNullableValueType(csType, allSchemas)) {
+        if (property.ConstrainedAsRequired) {
             parameter.AddAttribute(
                 TypeDefinition.Get("System.Text.Json.Serialization", "JsonRequiredAttribute"))
                 .Target = "property";

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/RequiredValueMemberTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/RequiredValueMemberTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 namespace Hardened.OpenApi.BuildTask.Tests;
 
 /// <summary>
-/// Catching a required member the C# type cannot prove was sent.
+/// Catching a required member the caller did not send.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -15,9 +15,17 @@ namespace Hardened.OpenApi.BuildTask.Tests;
 /// happened to reject 0.
 /// </para>
 /// <para>
-/// <c>[Required]</c> cannot cover it: the validation generator emits <c>value.x is null</c>, which
-/// is CS0037 against an <c>int</c>, so the constraint is correctly suppressed and nothing replaced
-/// it. The deserializer is the only layer that still knows the member was absent.
+/// <c>[Required]</c> cannot cover a value type: the validation generator emits
+/// <c>value.x is null</c>, which is CS0037 against an <c>int</c>, so the constraint is correctly
+/// suppressed and nothing replaced it. The deserializer is the only layer that still knows the
+/// member was absent.
+/// </para>
+/// <para>
+/// A reference member is marked here too, though <c>[Required]</c> can check it. Presence is one
+/// question, and asking it in two layers meant whichever answered first hid the other: a body
+/// omitting an integer and three strings was told about the integer, and about the strings one
+/// round trip later. The validator keeps every other constraint, including the null a
+/// <c>required</c> member is still not allowed to carry.
 /// </para>
 /// </remarks>
 public class RequiredValueMemberTests {
@@ -91,20 +99,40 @@ public class RequiredValueMemberTests {
             Name = "unitPriceCents", Type = "integer", IsRequired = true
         });
 
-        Assert.Contains("Setter = static (object obj, int value) => { },", result);
+        Assert.Contains("Setter = static (obj, value) => { },", result);
     }
 
     /// <summary>
-    /// A required reference type is left alone. It already carries <c>[Required]</c>, and the
-    /// generated validator aggregates its error with every other failed constraint in the same body
-    /// - which the deserializer, stopping at the first fault, would not.
+    /// A required reference type is marked too.
     /// </summary>
+    /// <remarks>
+    /// It was left to <c>[Required]</c> alone, because the validator aggregates and the reader was
+    /// thought to stop at the first fault. The reader aggregates missing members as well, and the
+    /// split meant a body missing one of each kind reported only the value type - the reference
+    /// members came back a round trip later, from a validator that never ran the first time.
+    /// </remarks>
     [Fact]
-    public void ARequiredStringIsLeftToTheValidator() {
+    public void ARequiredStringIsMarkedRequired() {
         var result = Emit(new PropertyModel { Name = "sku", Type = "string", IsRequired = true });
 
-        Assert.DoesNotContain("Required(JsonMetadataServices.CreatePropertyInfo", result);
-        Assert.DoesNotContain("property.IsRequired = true", result);
+        Assert.Contains("Required(JsonMetadataServices.CreatePropertyInfo", result);
+        Assert.Contains("property.IsRequired = true", result);
+    }
+
+    /// <summary>
+    /// And still carries <c>[Required]</c>, which is a different question: <c>{"sku":null}</c> sent
+    /// the member, so the reader is satisfied and the validator is what refuses the null.
+    /// </summary>
+    [Fact]
+    public void ARequiredStringStillCarriesTheValidatorsConstraint() {
+        Assert.Contains(
+            "[property: Required]",
+            EmitterHarness.Schema(new SchemaModel {
+                Name = "Product",
+                Kind = SchemaKind.Object,
+                Required = ["sku"],
+                Properties = [new PropertyModel { Name = "sku", Type = "string", IsRequired = true }]
+            }));
     }
 
     /// <summary>
@@ -157,7 +185,7 @@ public class RequiredValueMemberTests {
     public void TheHelperIsNotEmittedWhenNothingNeedsIt() {
         Assert.DoesNotContain(
             "property.IsRequired = true",
-            Emit(new PropertyModel { Name = "sku", Type = "string", IsRequired = true }));
+            Emit(new PropertyModel { Name = "sku", Type = "string" }));
     }
 
     // ------------------------------------------------- the reflection deserializer's half
@@ -195,11 +223,11 @@ public class RequiredValueMemberTests {
     }
 
     /// <summary>
-    /// A required reference type does not, because <c>[Required]</c> already covers it and the
-    /// validator aggregates where the deserializer stops at the first fault.
+    /// A required reference type carries both: <c>[JsonRequired]</c> for "was it sent" and
+    /// <c>[Required]</c> for "may it be null".
     /// </summary>
     [Fact]
-    public void ARequiredReferenceMemberDoesNotCarryJsonRequired() {
+    public void ARequiredReferenceMemberCarriesBoth() {
         var result = EmitterHarness.Schema(new SchemaModel {
             Name = "Product",
             Kind = SchemaKind.Object,
@@ -208,6 +236,25 @@ public class RequiredValueMemberTests {
         });
 
         Assert.Contains("[property: Required]", result);
+        Assert.Contains("[property: JsonRequired]", result);
+    }
+
+    /// <summary>
+    /// A <c>readOnly</c> member carries neither, whatever its type: the server owns the value, and
+    /// demanding it would refuse the create call of a client that correctly left it out.
+    /// </summary>
+    [Fact]
+    public void ARequiredReadOnlyReferenceMemberCarriesNeither() {
+        var result = EmitterHarness.Schema(new SchemaModel {
+            Name = "Product",
+            Kind = SchemaKind.Object,
+            Required = ["id"],
+            Properties = [
+                new PropertyModel { Name = "id", Type = "string", IsRequired = true, IsReadOnly = true }
+            ]
+        });
+
         Assert.DoesNotContain("JsonRequired", result);
+        Assert.DoesNotContain("[property: Required]", result);
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
@@ -594,6 +594,56 @@ public class OpenApiDocumentEmissionTests {
     }
 
     /// <summary>
+    /// A property initializer says what a positional default says - this when nothing sends it - so
+    /// the member is not required either.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The mutable-DTO spelling, and it was published as required because an initializer is syntax
+    /// rather than a symbol and nothing looked for it. This repository's own Invoke fixture is that
+    /// shape: four settable properties, three of them carrying <c>= ""</c> or <c>= []</c>, all
+    /// documented as demands on a caller the handler was filling in for.
+    /// </para>
+    /// <para>
+    /// No <c>default</c> is written. The initializer is an expression rather than a constant, and
+    /// half of them - <c>= []</c>, <c>= new()</c>, <c>= DateTime.UtcNow</c> - have no JSON spelling
+    /// at all.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void APropertyInitializerIsADefaultAndTheMemberIsNotRequired() {
+        var document = JsonDocument.Parse(Extract(
+            RequestGeneratorHarness
+                .Generate(Application(
+                    """
+                    public class Manifest {
+                        public string Id { get; set; } = "";
+
+                        public List<string> Records { get; set; } = [];
+
+                        public string Carrier { get; set; }
+
+                        public int Quantity { get; set; }
+                    }
+
+                    public class ManifestController {
+                        [Post("/manifests")]
+                        public Manifest Place(Manifest manifest) => manifest;
+                    }
+                    """,
+                    Enable))
+                .AssertNoErrors()
+                .SourceContaining("OpenApiDocument"))).RootElement;
+
+        var manifest = document
+            .GetProperty("components").GetProperty("schemas").GetProperty("Manifest");
+
+        Assert.Equal(new[] { "carrier", "quantity" }, Required(manifest));
+        Assert.False(manifest.GetProperty("properties").GetProperty("id")
+            .TryGetProperty("default", out _));
+    }
+
+    /// <summary>
     /// A constructed type is one component per set of arguments. Page&lt;Shipment&gt; and
     /// Page&lt;Courier&gt; shared one component named Page, written from whichever was reached
     /// first, so the second operation was documented as returning the first one's items.

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Hardened.SourceGenerator.Models.Request;
 using Hardened.SourceGenerator.Shared;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Hardened.SourceGenerator.OpenApiDocument;
 
@@ -413,10 +414,19 @@ public static class JsonSchemaWriter {
     /// A member whose constructor parameter carries a default is one the caller may omit: the
     /// server fills it in and answers as if it had been sent. The document said required for every
     /// non-nullable member, so a strictly validating client was made to send what the server did
-    /// not need. Only positional parameters are read, matched to the property by name the way a
-    /// record declares them; a property initializer is syntax rather than a symbol and is not seen.
-    /// A default the document cannot spell still makes the member optional, it just carries no
-    /// <c>default</c>, and so does a null one, which the member's nullability already says.
+    /// not need. Constructor parameters are matched to the property by name the way a record
+    /// declares them. A default the document cannot spell still makes the member optional, it just
+    /// carries no <c>default</c>, and so does a null one, which the member's nullability already
+    /// says.
+    ///
+    /// <para>
+    /// A property initializer counts, and is read from syntax because it is not on the symbol.
+    /// <c>public string RequestContext { get; set; } = "";</c> says the same thing a parameter's
+    /// <c>= ""</c> says - this when nothing sends it - and publishing such a member as required told
+    /// a client to send a value the server was filling in for them. It carries no <c>default</c>
+    /// either: the initializer is an expression rather than a constant, and half of them
+    /// (<c>= []</c>, <c>= new()</c>, <c>= DateTime.UtcNow</c>) have no JSON spelling at all.
+    /// </para>
     /// </remarks>
     private static (bool Declared, string? Literal) DefaultOf(
         INamedTypeSymbol owner, IPropertySymbol property, IAssemblySymbol? compilationAssembly) {
@@ -428,7 +438,24 @@ public static class JsonSchemaWriter {
             }
         }
 
-        return (false, null);
+        return (HasInitializer(property), null);
+    }
+
+    /// <summary>Whether the property is declared with an initializer.</summary>
+    /// <remarks>
+    /// From the declaring syntax, which is the only place it is: an initializer compiles into the
+    /// constructor body, so neither the symbol nor reflection over the built assembly can see one.
+    /// A property declared in more than one place cannot carry two initializers, so the first
+    /// reference that is a property declaration answers for all of them.
+    /// </remarks>
+    private static bool HasInitializer(IPropertySymbol property) {
+        foreach (var reference in property.DeclaringSyntaxReferences) {
+            if (reference.GetSyntax() is PropertyDeclarationSyntax { Initializer: not null }) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string? DefaultLiteral(IParameterSymbol parameter, IAssemblySymbol? compilationAssembly) {


### PR DESCRIPTION
From the 0.32 trial: **A-03** (blocker, reproduced on the untouched scaffold) and **B-07**. Two findings, one question — who checks that a required member was sent.

## A-03, on `dotnet new hardened-web` as shipped

```
$ curl -X POST localhost/todos -d '{}'
201 Created   {"id":3,"title":null,"done":false}

$ curl localhost/openapi.json
"NewTodo": { "required": ["title"], ... }
```

The `required` array is written from C# nullability — a non-nullable reference type because the author said so. The validator is built from `[Required]` alone. Two generators read one declaration and reach opposite conclusions, and the failure mode is a null reaching a domain whose C# type says it cannot be there.

## The rule

**Presence is the reader's question; content is the validator's.** Absence is the one thing a validator cannot see — an omitted `int` is indistinguishable from `0` once the model is built — and the one thing the JSON reader knows for certain.

| Declaration | `{}` |
|---|---|
| `record NewTodo(string Title)` | 400, `title is required` |
| `record Draft(string? Title)` | accepted, null |
| `record Paged(string Cursor = "")` | accepted, `""` |
| `[ResponseOnly] string Id` | accepted — the server owns it |
| `record Weighed(int Grams)` | accepted, `0` — see below |
| a contract's `required:` | 400, whatever the member's type |

`RequiredMemberPresence` marks the members on the reflection deserializer's metadata, by `JsonSchemaWriter`'s rule exclusion for exclusion, so the document and the server answer from one declaration. It runs once per type, when the metadata is first built and cached — nothing per request. An explicit `{"title":null}` satisfies it and is `[Required]`'s to refuse, which is the split.

**A value type is deliberately not covered.** The document publishes one as required on different grounds: not that the author demanded it, but that C# serialization cannot omit one — a fact about what a response contains. Reading that as a demand would make `int Age` mandatory in every body that declares one, from a member whose author never chose anything, `int?` and `= 0` being the only ways C# has to say otherwise. `HRDV003` remains the answer, and its remedies are `required` and `[JsonRequired]`.

## B-07, and a reversal you should look at

Spec-first, a required reference member now carries `[JsonRequired]` and `IsRequired` as well as `[Required]`. **That reverses a deliberate decision** — `ARequiredReferenceMemberDoesNotCarryJsonRequired` said so in as many words: *"`[Required]` already covers it and the validator aggregates where the deserializer stops at the first fault."*

The premise turns out to be half true. The reader does stop at the first *type* fault, but it **aggregates missing members**, which the framework's own `MissingRequiredMembersTests.EveryMissingMemberIsReported` proves. What the split actually cost is B-07:

```
$ curl -X POST localhost/quotes -d '{}'          # 3 strings and 1 integer required
{"errors":[{"field":"body.weightKg","code":"required", ...}]}      ← one of four
```

The integer's absence aborted the read, so the validator that would have reported the three strings never ran. Asked in one place, all four come back at once — `AMissingValueMemberDoesNotHideAMissingReferenceMember` drives it over a real request.

**The trade, stated plainly:** a body that both omits a required member *and* breaks a constraint on a member it did send is now answered about the omission, and about the constraint on the next request. Before, that body was answered completely — as long as the omitted member was a reference type. It is one incomplete report for another, and the one that goes away is the one that reported one field in four. If you would rather keep the old split, this is the commit hunk to drop; the A-03 half stands without it.

## Better field paths

A missing member is reported under the object that was missing it. `JsonException.Path` is `$.lines[0]` for a nested one, so:

```
body.lines[0].sku is required.      not   body.sku
```

and the message names the member rather than the path — `sku is required.`, which is what `ReportRequired` puts in that sentence. `body.unitPriceCents is required.` read as though the caller had sent a member called `body.unitPriceCents`.

## What this does not cover

A hand-written model's nullable annotations are read by reflection, so under a native-AOT publish that member is optional again while the document still calls it required. `json.md` says so and names the two one-word fixes (`required`, `[JsonRequired]`); a contract-first model is unaffected, because its `required` was compiled in at build time.

## Verification

- New: `RequiredMemberPresenceTests` (10 cases — each member kind and each exclusion, driven through `JsonSerializer`), `AnAbsentMemberDeclaredPresentByItsTypeIsRefused` and `TheSameMemberSentIsAccepted` over a real request against a new SUT model carrying no constraint at all, `AMissingValueMemberDoesNotHideAMissingReferenceMember`, `AMissingMemberOfANestedObjectIsReportedUnderItsOwnPath`.
- Five existing tests pinned the old behaviour and are updated with the reasoning: four in `RequiredValueMemberTests`, one message assertion. `ARequiredMemberOfAnArrayItemIsEnforced` asserted `Field.Contains("sku")` and is tightened to the full path — loose enough to have passed while the path regressed.
- The emitted no-op setter is implicitly typed now: spelled `(object obj, string value)` it was CS8622 against `Action<object, string?>` for every reference member, which nothing noticed while only value types reached it.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — clean apart from the standing local `HSMT011`.
- `dotnet test Hardened.slnx` — 74 test projects, 0 failures.
- `RequiredMemberPresence` measures 43/43 lines and 33/34 branches.
- `npm run build` in `docs/` — no dead links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)