### PR TITLE
Answer a body the reader cannot use as a fact about the body

### DIFF
--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -190,6 +190,20 @@ type takes the same shape: `?limit=abc` against an `int` parameter answers this 
 object that was missing it — `body.lines[0].sku`, not `body.sku`. Which layer caught a fault is not
 something a caller can tell.
 
+A body the reader could not use at all is answered as a fact about the body:
+
+| Sent | Field | Code |
+|---|---|---|
+| nothing, or an empty body | `body` | `required` |
+| `null` | `body` | `required` |
+| `{"weightKg":` — a document that does not parse | `body` | `invalid` |
+| `{"weightKg":"heavy"}` — a value that would not convert | `body.weightKg` | `invalid` |
+
+The field is the handler's own body parameter identifier, so a handler taking `MemberRequest request`
+reports `request`. Only the last row names a member: a malformed document has a reader path too, and
+it means wherever the text ran out rather than what is wrong — `{"accountId":` was answered
+`body.accountId`, about a member that is present and correct as far as it goes.
+
 ## What the document says
 
 The published OpenAPI document repeats every declared constraint as the facet it came from, so the

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT.Tests/RequiredAndNestedValidationTests.cs
@@ -160,6 +160,24 @@ public class RequiredAndNestedValidationTests {
     }
 
     /// <summary>
+    /// A literal <c>null</c> body against a <c>requestBody: required: true</c>.
+    /// </summary>
+    /// <remarks>
+    /// The trial's B-01, found spec-first: the generated binder ended in a null-forgiving <c>!</c>,
+    /// so the null reached the handler and the first dereference was a 500. The contract says the
+    /// body is required, which makes this the one refusal the document had already promised.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ANullBodyIsRefusedRatherThanDereferenced(ITestWebApp testWebApp) {
+        var error = await Rejected(testWebApp, "null");
+
+        var field = Assert.Single(error.Errors!);
+
+        Assert.Equal("body", field.Field);
+        Assert.Equal("required", field.Code);
+    }
+
+    /// <summary>
     /// A missing value type and a missing reference type in one body, answered together.
     /// </summary>
     /// <remarks>

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/RegistrationValidationTests.cs
@@ -50,6 +50,66 @@ public class RegistrationValidationTests {
         Assert.Equal("memberId is required.", field.Message);
     }
 
+    /// <summary>
+    /// A literal <c>null</c> body: the four bytes that are a valid JSON document and carry no value.
+    /// </summary>
+    /// <remarks>
+    /// The trial's B-01, and a 500 until now. The generated binder ended in a null-forgiving
+    /// <c>!</c>, so the null reached the handler and the first dereference threw - the one malformed
+    /// payload of the set that was not a 400, where <c>5</c>, <c>"text"</c>, <c>[]</c>, a truncated
+    /// object and an absent body were all refused properly.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ANullBodyIsRefusedRatherThanDereferenced(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post("null", "/registration/member");
+
+        response.Assert.BadRequest();
+
+        var field = Assert.Single(
+            response.Deserialize<RequestValidationError>()!.Errors!, e => e.Field == "request");
+
+        Assert.Equal("required", field.Code);
+        Assert.Equal("request is required.", field.Message);
+    }
+
+    /// <summary>
+    /// An empty body is the same thing said a different way, and answers the same.
+    /// </summary>
+    /// <remarks>
+    /// It used to hand the caller the reader's own diagnostics - <c>"The input does not contain any
+    /// JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is
+    /// true."</c> - which describes the framework's parser rather than the caller's mistake.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnEmptyBodyIsRefusedTheSameWay(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post("", "/registration/member");
+
+        response.Assert.BadRequest();
+
+        var field = Assert.Single(
+            response.Deserialize<RequestValidationError>()!.Errors!, e => e.Field == "request");
+
+        Assert.Equal("required", field.Code);
+        Assert.Equal("request is required.", field.Message);
+    }
+
+    /// <summary>
+    /// A body that does not parse is the body's fault. It was reported against whichever member the
+    /// reader had reached when the text ran out - <c>request.memberId</c> here, a member that is
+    /// present and correct as far as it goes.
+    /// </summary>
+    [HardenedTest]
+    public async Task AMalformedBodyIsRefusedAgainstTheBody(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post("""{"memberId":""", "/registration/member");
+
+        response.Assert.BadRequest();
+
+        var field = Assert.Single(response.Deserialize<RequestValidationError>()!.Errors!);
+
+        Assert.Equal("request", field.Field);
+        Assert.Equal("invalid", field.Code);
+    }
+
     /// <summary>Sent is sent, whatever else is wrong with it.</summary>
     [HardenedTest]
     public async Task TheSameMemberSentIsAccepted(ITestWebApp testWebApp) {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -890,6 +890,10 @@ namespace Hardened.Requests.Runtime.Streaming
 }
 namespace Hardened.Requests.Runtime.Validation
 {
+    public static class RequestBody
+    {
+        public static T Required<T>(T? value, string field) { }
+    }
     public class RequestValidationError
     {
         public RequestValidationError() { }

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Errors/MalformedBodyTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Errors/MalformedBodyTests.cs
@@ -1,0 +1,188 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Hardened.Requests.Abstract.Errors;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Runtime.Errors;
+using Hardened.Requests.Runtime.Validation;
+using Microsoft.Extensions.Primitives;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Errors;
+
+/// <summary>
+/// What a caller is told about a body the reader could not use, and whose name is on it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The trial's B-08: <c>{"accountId":</c> was answered <c>body.accountId is invalid</c>, and
+/// <c>accountId</c> is not at fault - the caller's JSON is. A truncated document has a path like
+/// any other failure, and it means something different: wherever the reader had reached when the
+/// text ran out, which is whichever member happens to be last.
+/// </para>
+/// <para>
+/// Real deserialization failures throughout, never a hand-written <c>JsonException</c>. A
+/// fabricated one carries no inner exception, which is the signal being read.
+/// </para>
+/// </remarks>
+public class MalformedBodyTests {
+
+    private static readonly ExceptionToModelConverter Converter = new();
+
+    private record Quote(
+        [property: JsonPropertyName("accountId")] string AccountId,
+        [property: JsonPropertyName("weightKg")] int WeightKg);
+
+    private static IExecutionContext Context() {
+        var response = Substitute.For<IExecutionResponse>();
+        response.Headers.Returns(new Dictionary<string, StringValues>());
+
+        var context = Substitute.For<IExecutionContext>();
+        context.Response.Returns(response);
+
+        return context;
+    }
+
+    private static RequestValidationFieldError Refused(string json) {
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Quote>(
+            json, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+
+        var (status, model) = Converter.ConvertExceptionToModel(Context(), exception);
+
+        Assert.Equal(400, status);
+
+        return Assert.Single(Assert.IsType<RequestValidationError>(model).Errors!);
+    }
+
+    /// <summary>
+    /// A document that does not parse is the body's fault, whatever the reader's path says. The
+    /// path here is <c>$.accountId</c>, which is where the text ran out.
+    /// </summary>
+    [Theory]
+    [InlineData("""{"accountId":""")]
+    [InlineData("""{"accountId":"A""")]
+    [InlineData("""{"accountId":"A","weightKg":1""")]
+    [InlineData("x")]
+    public void AMalformedDocumentIsReportedAgainstTheBody(string json) {
+        var error = Refused(json);
+
+        Assert.Equal("body", error.Field);
+        Assert.Equal("invalid", error.Code);
+    }
+
+    /// <summary>
+    /// A value the reader understood and could not convert keeps its own name: that path is the
+    /// field at fault, and naming it is the whole use of the answer.
+    /// </summary>
+    [Fact]
+    public void AValueOfTheWrongTypeIsReportedAgainstItsOwnMember() {
+        var error = Refused("""{"accountId":"A","weightKg":"heavy"}""");
+
+        Assert.Equal("body.weightKg", error.Field);
+        Assert.Equal("invalid", error.Code);
+    }
+
+    /// <summary>
+    /// An empty payload is not malformed JSON, it is the absence of one - the same thing a literal
+    /// <c>null</c> body is, which the binder refuses with this error's twin. A caller was being
+    /// handed the reader's diagnostics instead: <c>"The input does not contain any JSON tokens.
+    /// Expected the input to start with a valid JSON token, when isFinalBlock is true."</c>
+    /// </summary>
+    [Fact]
+    public void AnEmptyBodyIsReportedAsMissingRatherThanMalformed() {
+        var error = Refused("");
+
+        Assert.Equal("body", error.Field);
+        Assert.Equal("required", error.Code);
+        Assert.Equal("body is required.", error.Message);
+    }
+
+    /// <summary>The prefix is the handler's own body parameter identifier wherever it appears.</summary>
+    [Fact]
+    public void TheFieldIsTheHandlersBodyParameter() {
+        var context = Context();
+
+        context.HandlerInfo.Returns(new Hardened.Requests.Runtime.Execution.ExecutionRequestHandlerInfo(
+            "/quotes", "POST", typeof(object), "Create", bodyParameterName: "request"));
+
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Quote>(
+            """{"accountId":""", new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+
+        var (_, model) = Converter.ConvertExceptionToModel(context, exception);
+
+        Assert.Equal(
+            "request",
+            Assert.Single(Assert.IsType<RequestValidationError>(model).Errors!).Field);
+    }
+}
+
+/// <summary>
+/// The binder's half of the same answer.
+/// </summary>
+/// <remarks>
+/// A JSON <c>null</c> deserializes without complaint, so no exception reaches the converter and the
+/// refusal has to be made where the value lands. Same field, same code, same sentence an empty body
+/// gets - see <c>MalformedBodyTests.AnEmptyBodyIsReportedAsMissingRatherThanMalformed</c>.
+/// </remarks>
+public class RequestBodyTests {
+
+    [Fact]
+    public void ANullBodyIsRefusedAsRequired() {
+        var exception = Assert.Throws<ValidationException>(
+            () => RequestBody.Required<string>(null, "request"));
+
+        var error = Assert.Single(exception.ValidationResult.Errors);
+
+        Assert.Equal("request", error.Field);
+        Assert.Equal("required", error.Code);
+        Assert.Equal("request is required.", error.Message);
+    }
+
+    [Fact]
+    public void ABodyThatArrivedIsHandedBack() {
+        Assert.Equal("sent", RequestBody.Required("sent", "request"));
+    }
+}
+
+/// <summary>
+/// A canary over System.Text.Json's own behaviour, in the shape
+/// <c>MissingRequiredMembersMessageTests</c> established.
+/// </summary>
+/// <remarks>
+/// Telling a malformed document from a value that would not convert is read off the inner
+/// exception's type name, because there is no public type for it and the prose is worse to depend
+/// on. An SDK that stops wrapping reader failures that way fails here, naming the reason, rather
+/// than quietly putting a member's name on the caller's syntax error again.
+/// </remarks>
+public class MalformedBodyMessageTests {
+
+    private record Quote(
+        [property: JsonPropertyName("accountId")] string AccountId,
+        [property: JsonPropertyName("weightKg")] int WeightKg);
+
+    private static JsonException Deserialize(string json) =>
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Quote>(
+            json, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+
+    [Theory]
+    [InlineData("""{"accountId":""")]
+    [InlineData("x")]
+    [InlineData("")]
+    public void AReaderFailureIsStillWrappedInAJsonReaderException(string json) {
+        Assert.Equal("JsonReaderException", Deserialize(json).InnerException?.GetType().Name);
+    }
+
+    /// <summary>A conversion failure is not, which is what makes the type a signal.</summary>
+    [Fact]
+    public void AConversionFailureIsStillNotAReaderException() {
+        Assert.NotEqual(
+            "JsonReaderException",
+            Deserialize("""{"accountId":"A","weightKg":"heavy"}""").InnerException?.GetType().Name);
+    }
+
+    /// <summary>The sentence an empty payload is still told apart by.</summary>
+    [Fact]
+    public void AnEmptyPayloadStillSaysItCarriesNoTokens() {
+        Assert.StartsWith("The input does not contain any JSON tokens", Deserialize("").Message);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Errors/ExceptionToModelConverter.cs
@@ -197,13 +197,56 @@ public class ExceptionToModelConverter : IExceptionToModelConverter {
             Type = "ValidationError",
             Message = "One or more validation errors occurred.",
             Errors = MissingMembers(exception, body) ?? [
-                new RequestValidationFieldError {
-                    Field = FieldFrom(exception.Path, body),
-                    Code = "invalid",
-                    Message = WithoutPositionSuffix(exception.Message)
-                }
+                EmptyBody(exception)
+                    ? new RequestValidationFieldError {
+                        Field = body, Code = "required", Message = body + " is required."
+                    }
+                    : new RequestValidationFieldError {
+                        Field = NotWellFormed(exception) ? body : FieldFrom(exception.Path, body),
+                        Code = "invalid",
+                        Message = WithoutPositionSuffix(exception.Message)
+                    }
             ]
         };
+
+    /// <summary>
+    /// Whether the payload is not JSON at all, as opposed to JSON the model could not take.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The difference decides whose name goes on the error. A value the reader understood and could
+    /// not convert has a path that <em>is</em> the field at fault - <c>$.weightKg</c> for
+    /// <c>"heavy"</c> against an <c>int</c> - and naming it is the whole use of the answer. A
+    /// document that does not parse has a path too, and it means something else entirely: wherever
+    /// the reader had got to when the text ran out. <c>{"accountId":</c> reported
+    /// <c>body.accountId</c>, and <c>accountId</c> is not at fault - the caller's JSON is.
+    /// </para>
+    /// <para>
+    /// Read off the inner exception rather than the message. System.Text.Json wraps a reader
+    /// failure in its own <c>JsonReaderException</c> and a converter failure in a
+    /// <c>FormatException</c> or nothing at all, so the type is the signal and the prose is not. It
+    /// is still a dependency on an internal name, which is what
+    /// <c>MalformedBodyMessageTests</c> is for: an SDK that changes it fails a test here rather
+    /// than silently mis-naming a field in production.
+    /// </para>
+    /// </remarks>
+    private static bool NotWellFormed(JsonException exception) =>
+        exception.InnerException?.GetType().Name == "JsonReaderException";
+
+    /// <summary>
+    /// Whether the caller sent no body at all.
+    /// </summary>
+    /// <remarks>
+    /// An empty payload is not malformed JSON, it is the absence of one, and a caller told
+    /// <c>"The input does not contain any JSON tokens. Expected the input to start with a valid
+    /// JSON token, when isFinalBlock is true."</c> has been handed the reader's diagnostics rather
+    /// than an answer. It is the same thing a literal <c>null</c> body is - see
+    /// <c>RequestBody.Required</c>, which produces this error's twin from the binder - so it is
+    /// reported the same way.
+    /// </remarks>
+    private static bool EmptyBody(JsonException exception) =>
+        NotWellFormed(exception) &&
+        exception.Message.StartsWith("The input does not contain any JSON tokens", StringComparison.Ordinal);
 
     /// <summary>
     /// The prefix a body field is reported under: the handler's own parameter identifier, which is

--- a/src/Requests/Hardened.Requests.Runtime/Validation/RequestBody.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Validation/RequestBody.cs
@@ -1,0 +1,47 @@
+using ValidationModules;
+
+namespace Hardened.Requests.Runtime.Validation;
+
+/// <summary>
+/// What a generated binder does with a body the handler declared it cannot do without.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The binder used to end in a null-forgiving <c>!</c> and nothing else -
+/// <c>parameters.body = (await …DeserializeRequestBody&lt;Quote&gt;(context))!;</c> - which is a
+/// promise to the compiler rather than a check. <c>null</c> is a valid JSON document, so a caller
+/// sending the four bytes <c>null</c> deserialized to null, the null reached the handler, and the
+/// first dereference was a <c>NullReferenceException</c>: a 500 for a request the contract already
+/// says is invalid. Every other malformed payload - <c>5</c>, <c>"text"</c>, <c>[]</c>, a truncated
+/// object, no body at all - was a 400. <c>null</c> was the only one that was not.
+/// </para>
+/// <para>
+/// Reported as <c>required</c> against the body rather than as a server fault, because that is what
+/// a caller who sent no value has done, and it is the answer the same request gets when the body is
+/// empty. <see cref="ValidationException"/> so the envelope is the one every other refusal
+/// produces - the caller cannot tell which layer refused them, which is the point.
+/// </para>
+/// </remarks>
+public static class RequestBody {
+
+    /// <summary>
+    /// <paramref name="value"/>, or a 400 naming <paramref name="field"/>.
+    /// </summary>
+    /// <param name="field">
+    /// The handler's own body parameter identifier, which is what the generated validators and the
+    /// deserializer's own errors are pathed under. Not the literal word "body": a handler that calls
+    /// its parameter <c>request</c> reports <c>request</c> everywhere else.
+    /// </param>
+    /// <remarks>
+    /// Emitted only for a parameter the handler declared non-nullable. A handler taking
+    /// <c>Quote?</c> has said a null body is a case it handles, and gets the null.
+    /// </remarks>
+    public static T Required<T>(T? value, string field) {
+        if (value is null) {
+            throw new ValidationException(ValidationResult.FromErrors(
+                new[] { new ValidationError(field, ValidationCodes.Required, $"{field} is required.") }));
+        }
+
+        return value;
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionParameterBindingTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Function/FunctionParameterBindingTests.cs
@@ -29,8 +29,27 @@ public class FunctionParameterBindingTests {
             .SourceContaining("Process.FunctionHandler");
 
         Assert.Contains(
-            "parameters.model = (await contentSerializationService.DeserializeRequestBody<global::TestApp.DataModel>(context))!;",
+            "parameters.model = global::Hardened.Requests.Runtime.Validation.RequestBody.Required(",
             source);
+        Assert.Contains(
+            "await contentSerializationService.DeserializeRequestBody<global::TestApp.DataModel>(context)",
+            source);
+    }
+
+    /// <summary>
+    /// A payload the function declared nullable is bound as it arrives: the handler has said a null
+    /// payload is a case it handles, so nothing refuses one on its behalf.
+    /// </summary>
+    [Fact]
+    public void ANullableModelParameterIsNotGuarded() {
+        var source = FunctionGeneratorHarness.Generate(FunctionGeneratorHarness.Application("""
+                [HardenedFunction]
+                public void Process(DataModel? model) { }
+            """, FunctionGeneratorHarness.SupportTypes))
+            .AssertNoErrors()
+            .SourceContaining("Process.FunctionHandler");
+
+        Assert.DoesNotContain("RequestBody.Required", source);
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/Fixtures/WebPipeline/body-post/OrderController_Place_554.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/Fixtures/WebPipeline/body-post/OrderController_Place_554.cs
@@ -46,7 +46,10 @@ namespace TestApp.Generated
         {
             var parameters = new global::TestApp.Generated.OrderController_Place_554.Parameters();
             var contentSerializationService = context.KnownServices.ContextSerializationService;
-            parameters.body = (await contentSerializationService.DeserializeRequestBody<global::TestApp.Order>(context))!;
+            parameters.body = global::Hardened.Requests.Runtime.Validation.RequestBody.Required(
+                await contentSerializationService.DeserializeRequestBody<global::TestApp.Order>(context),
+                "body"
+            );
             return parameters;
         }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BindRequestParametersMethodGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BindRequestParametersMethodGenerator.cs
@@ -328,7 +328,17 @@ public static class BindRequestParametersMethodGenerator {
                 parameterInformation.ParameterType
             }, context));
 
-        invokeMethod.Assign(Bang(Parenthesis(deserializeStatement)))
-            .To(parametersVar.Property(parameterInformation.MemberName));
+        // A null-forgiving `!` is a promise to the compiler, not a check. `null` is a valid JSON
+        // document, so a caller sending those four bytes deserialized to null, the null reached the
+        // handler, and the first dereference was a 500 - the one malformed payload that was not a
+        // 400. Where the handler declared the parameter nullable it has said it handles that case,
+        // and gets the null.
+        IOutputComponent bound = parameterInformation.ParameterType.IsNullable
+            ? Parenthesis(deserializeStatement)
+            : Invoke(
+                KnownTypes.Requests.RequestBody, "Required",
+                deserializeStatement, QuoteString(parameterInformation.Name));
+
+        invokeMethod.Assign(bound).To(parametersVar.Property(parameterInformation.MemberName));
     }
 }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
@@ -89,6 +89,8 @@ public static class KnownTypes {
                     public const string Serializer = "Hardened.Requests.Runtime.Serializer";
 
                     public const string PathTokens = "Hardened.Requests.Runtime.PathTokens";
+
+                    public const string Validation = "Hardened.Requests.Runtime.Validation";
                 }
             }
 
@@ -195,6 +197,10 @@ public static class KnownTypes {
         public static readonly ITypeDefinition IExecutionResponse =
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Execution,
                 "IExecutionResponse");
+
+        /// <summary>The binder's refusal of a null body - see <c>RequestBody.Required</c>.</summary>
+        public static readonly ITypeDefinition RequestBody =
+            TypeDefinition.Get(Namespace.Hardened.Requests.Runtime.Validation, "RequestBody");
 
         public static ITypeDefinition DefaultOutputFunc =
             TypeDefinition.Get(Namespace.Hardened.Requests.Abstract.Execution, "DefaultOutputFunc");


### PR DESCRIPTION
From the 0.32 trial: **B-01** (blocker) and **B-08**. Three ways of sending a body nothing can read, three different answers, one of them a 500.

## B-01 — the one payload that was not a 400

```
$ curl -X POST localhost/quotes -H 'Content-Type: application/json' -d 'null'
500 Internal Server Error   {"type":"ServerError", ...}

$ curl -X POST localhost/quotes -H 'Content-Type: application/json' -d '{}'      ← control
400 Bad Request
```

`null` is a valid JSON document. The generated binder ended in a null-forgiving `!` and nothing else —

```csharp
parameters.body = (await contentSerializationService.DeserializeRequestBody<Quote>(context))!;
```

— which is a promise to the compiler, not a check. Those four bytes deserialized to null, the null reached the handler, and the first dereference threw. `5`, `"text"`, `[]`, a truncated object and an absent body were all refused properly; `null` alone was the server admitting a fault of its own, for a request the contract already calls invalid.

The binder now emits `RequestBody.Required(await …, "request")`, and **only where the handler declared the parameter non-nullable** — a handler taking `Quote?` has said a null body is a case it handles, and gets the null. Both front ends emit it, and both hosts: the function binder is the same code path.

## B-08 — whose name goes on a syntax error

```
$ curl -X POST localhost/quotes -H 'Content-Type: application/json' -d '{"accountId":'
{"errors":[{"field":"body.accountId","code":"invalid", ...}]}
```

`accountId` is not at fault. A malformed document carries a reader path like any other failure, and it means something else entirely: wherever the reader had reached when the text ran out, which is whichever member happens to be last. A value the reader *understood* and could not convert is the opposite case — there the path **is** the field at fault, and naming it is the whole use of the answer.

Told apart by the inner exception's type rather than the message: System.Text.Json wraps a reader failure in its own `JsonReaderException` and a converter failure in a `FormatException` or nothing at all. It is still a dependency on an internal name, so `MalformedBodyMessageTests` pins it in the shape `MissingRequiredMembersMessageTests` established — an SDK that changes it fails a test here rather than quietly mis-naming a field in production.

## And the empty body, which nobody reported

It was handing the caller the reader's diagnostics: *"The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true."* An empty payload is not malformed JSON, it is the absence of one — which is exactly what `null` is. Left alone it would have read wrong beside the other two, so it gets the same answer.

| Sent | Field | Code |
|---|---|---|
| nothing, or an empty body | `body` | `required` |
| `null` | `body` | `required` |
| `{"weightKg":` — does not parse | `body` | `invalid` |
| `{"weightKg":"heavy"}` — would not convert | `body.weightKg` | `invalid` |

The field is the handler's own body parameter identifier throughout, so a handler taking `MemberRequest request` reports `request` — the spelling the generated validators already use.

## C-12 is deliberately not here

Refusing a body whose `Content-Type` nobody claims needs a notion of what an operation *consumes*, and nothing carries one: `[SupportedContentTypes]` is about responses, and `SerializationLocatorService.FindRequestDeserializer` falls back to the default deserializer for any content type no deserializer claims — which is why a form-urlencoded body that happens to be JSON is accepted. That is a 415 policy, the request-side mirror of the 406 content negotiation already answers, and it belongs with **B-13** (406 answered by every operation and declared in no document) rather than bolted onto a bug fix.

## Verification

- New: `MalformedBodyTests` (7 cases over real deserialization failures), `RequestBodyTests`, `MalformedBodyMessageTests` (the canary), `ANullBodyIsRefusedRatherThanDereferenced` over a real request in **both** front ends, plus `AnEmptyBodyIsRefusedTheSameWay` and `AMalformedBodyIsRefusedAgainstTheBody`, and `ANullableModelParameterIsNotGuarded` for the parameter the guard skips.
- One golden fixture re-recorded (`body-post`) and one function-binding assertion updated to the new emission.
- `RequestBody` is a new public type, because generated code names it; the approved surface is updated from a Debug build and the diff is three lines.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — clean apart from the standing local `HSMT011`.
- `dotnet test Hardened.slnx` — 74 test projects, 0 failures.
- `dotnet test Hardened.Simulators.slnx` — 10 projects, 0 failures. Run this time, after #323 failed CI on it.
- `npm run build` in `docs/` — no dead links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)