### PR TITLE
Install and publish a filter declared on a module class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,5 +299,6 @@ function runtimes do not reference it.
 - `docs/design/response-caching.md` — `[CacheResponse<T>]`, the store package, who a stored answer is for, invalidating by tag, revalidating with a 304
 - `docs/design/request-timeouts.md` — `[Timeout]`, the four rungs it resolves through, `x-hardened-timeout` and the Smithy `@timeout` trait, tighten-only conventions, why the token is put back
 - `docs/design/client-testing.md` — `Returns<T>()` in `Hardened.Web.Testing`, the route and reader seam it reads through, `[assembly: KiotaTesting]` and `[assembly: RefitTesting]`, why there is a package per generator
+- `docs/design/filter-rungs.md` — proposed: a filter declared on the entry point or the assembly, collected once and read by the document as well as the pipeline. Not built yet
 - `docs/` — the published site. `npm run build` there fails on a dead internal link
 - Full user documentation: <https://ipjohnson.github.io/Hardened.Framework>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,6 @@ function runtimes do not reference it.
 - `docs/design/response-caching.md` — `[CacheResponse<T>]`, the store package, who a stored answer is for, invalidating by tag, revalidating with a 304
 - `docs/design/request-timeouts.md` — `[Timeout]`, the four rungs it resolves through, `x-hardened-timeout` and the Smithy `@timeout` trait, tighten-only conventions, why the token is put back
 - `docs/design/client-testing.md` — `Returns<T>()` in `Hardened.Web.Testing`, the route and reader seam it reads through, `[assembly: KiotaTesting]` and `[assembly: RefitTesting]`, why there is a package per generator
-- `docs/design/filter-rungs.md` — proposed: a filter declared on the entry point or the assembly, collected once and read by the document as well as the pipeline. Not built yet
+- `docs/design/filter-rungs.md` — a filter declared on a `[HardenedModule]` class, collected once and read by the document as well as the pipeline; the entry-point rung is built, the assembly rung is not
 - `docs/` — the published site. `npm run build` there fails on a dead internal link
 - Full user documentation: <https://ipjohnson.github.io/Hardened.Framework>

--- a/docs/design/filter-rungs.md
+++ b/docs/design/filter-rungs.md
@@ -1,0 +1,204 @@
+# Filters at the entry point and the assembly
+
+A filter can be declared on a handler method and on its controller class. It cannot be declared for
+a whole application without leaving the compilation, and the route that does leave it —
+`[Enable<T>]` and a DI-registered global provider — is invisible to the document generator. This
+note is about closing that: two more rungs, collected once, emitted once, and read by both halves.
+
+## What happens today
+
+Three separate mechanisms put a filter in a chain.
+
+**Attributes on a handler.** `BaseRequestModelGenerator.GetFilters` collects attributes implementing
+`IRequestFilterProvider` from the method and from its containing class — two rungs, no more.
+`HandlerInfoCodeGenerator` writes them into a `_metadata` array per generated handler class, and
+`ExecutionHelper.GetFilterInfo(_metadata)` hands the ones that are filter providers to
+`CreateFilterArray`:
+
+```csharp
+private static readonly object[] _metadata = new object[] { new ConditionalGetAttribute() };
+```
+
+The array is also what `IExecutionRequestHandlerInfo.Metadata` exposes, so a filter can ask what
+else was declared on the handler it is being installed on.
+
+**The global registry.** `IGlobalFilterRegistry` holds every `IRequestFilterProvider` registered as
+a service, and `CreateFilterArray` asks it for filters for each handler as the chain is built.
+`AddGlobalFilter(provider, when:)` wraps the provider in a `ConditionalFilterProvider` whose
+predicate is read once per handler.
+
+**`[Enable<T>]`.** A `[DependencyModule]` whose `ConfigureServices` calls `AddGlobalFilter`.
+`ConditionalGet` is exactly this and nothing more:
+
+```csharp
+services.AddGlobalFilter(
+    new ConditionalGetAttribute(),
+    when: handlerInfo =>
+        !ConditionalGetAttribute.Declares(handlerInfo) && !handlerInfo.StreamsResponse);
+```
+
+The document is written from a fourth thing: `FilterResponseSelector.Declarations` scans the
+method, its class, and the assembly, and reads the `[AnswersStatus]` / `[AnswersHeader]` /
+`[ReadsHeader]` facets off whatever it finds.
+
+## What that costs
+
+The rungs do not line up. Filters install from two, facets are read from three, and neither reads
+the entry point — so:
+
+- `[ConditionalGet]` on a module class compiles (its `AttributeUsage` allows `Class`) and installs
+  nothing.
+- `[assembly: ConditionalGet]` does not compile at all; the usage is `Method | Class`. The
+  document side would have read it.
+- `[Enable<ConditionalGet>]` installs the filter on every GET and publishes it on none. That is the
+  0.32 trial's A-04: four GETs answer 304 over the wire, one operation declares it in the document,
+  and the template's own generated Kiota client throws `no error factory is registered for this
+  code: 304` on exactly the request the feature exists to make cheap.
+
+The runtime half of A-04 is not a defect — 304 everywhere is what the flag promises. The document
+half cannot be fixed where it stands, because the predicate that decides which handlers are covered
+is a `Func<IExecutionRequestHandlerInfo, bool>` evaluated at startup, and the document is written at
+build time.
+
+## The proposal
+
+**Collect the entry point's and the assembly's filter declarations once, emit them once, and let
+every handler in that compilation reference them.**
+
+The entry point is already in hand where it is needed. `RoutingTableGenerator` runs on
+`(EntryPointSelector.Model, ImmutableArray<RequestHandlerModel>)` — the module class and every
+handler, combined, in one compilation — and `EntryPointSelector.Model.AttributeModels` is the same
+list `[Server]`, `[OpenApiInfo]` and `[Enable<T>]` are read from. The assembly's attributes are in
+that compilation too.
+
+### Emit once, not per handler
+
+The obvious implementation is to append the entry point's filters to each `RequestHandlerModel` and
+let `_metadata` carry them. Do not do that. Three reasons, in order of weight:
+
+1. **Incrementality.** A handler model is a Roslyn cache key. Folding the entry point's attributes
+   into every handler makes one edit to the module class invalidate every handler in the
+   application. `EnabledFeatureSelector`'s own remarks make this argument about feature detection;
+   it applies here with more force, because handlers are the expensive half.
+2. **One construction site.** `new AuditAttribute() { Category = "x" }` written into forty
+   `_metadata` arrays is forty places for the arguments to be spelled, and forty copies in the
+   assembly.
+3. **It reads as what it is.** A declaration that covers the application should appear once in the
+   generated source, next to the routing table it covers.
+
+So: a nested static on the routing class, the way `ServerSentEventManifestEmitter` already puts one
+there.
+
+```csharp
+public partial class Application {
+    private static class ApplicationFilters {
+        internal static readonly object[] Declared = new object[] { new ConditionalGetAttribute() };
+    }
+}
+```
+
+Every generated handler in the compilation gets that array as a second source alongside its own
+`_metadata`. Two ways to wire it, and this is the first open question:
+
+- **Through the handler constructor.** `GetFilterInfo(_metadata)` becomes
+  `GetFilterInfo(_metadata, Application.ApplicationFilters.Declared)`. Explicit, but every handler
+  names its entry point, which handlers currently do not do.
+- **Through the registry, at startup.** The routing table registers `ApplicationFilters.Declared`
+  into `IGlobalFilterRegistry` once. Nothing changes in the handlers at all, the composition seam
+  already exists, and it stays a *compile-time declaration* even though it is applied at run time —
+  which is the part that matters, because the document can then read the same declaration.
+
+The second is smaller and keeps `CreateFilterArray` as it is. It also means the entry-point rung and
+the `[Enable<T>]` rung end up in the same place at run time, which is where they belong.
+
+### Rules that have to be written down
+
+**Nearest rung wins.** `ConditionalGet` spells this today as
+`!ConditionalGetAttribute.Declares(handlerInfo)` — a runtime scan of the handler's metadata for the
+same attribute type. As a general rule it should not be each filter's job: a rung-declared provider
+should stand down for a handler that declares the same provider type nearer. `Metadata` already
+carries what the test needs. A filter that genuinely wants to install twice says so.
+
+**Applicability.** `[ConditionalGet]` installs on GET and HEAD, and not on a streaming handler.
+`GetFilters` enforces that at run time and the facets repeat it for the document —
+`Methods = "GET,HEAD", NotWhenStreaming = true`. That pairing is the model to follow: the condition
+belongs in metadata a generator can read, not only in a predicate.
+
+**Order and ties.** `CreateFilterArray` sorts by `RequestFilterInfo.Order` and breaks ties on
+insertion order: registry first, then timeout, IO, invoke, instance, then the handler's own
+providers. If entry-point filters arrive through the registry they tie *ahead* of a handler's own
+filters at the same order. That is probably right — the wider declaration was registered first — but
+it is a decision, not an accident, and it should be stated.
+
+**Equality.** `ConditionalGet` overrides `Equals`/`GetHashCode` so that enabling it twice registers
+one default. Any rung-declared filter needs the same treatment or the same guarantee from the
+collection site.
+
+### The document reads the same rungs
+
+`FilterResponseSelector.Declarations` gains the entry-point rung, so the facets follow the
+declaration wherever it is written. The assembly rung is already there. After that, one declaration
+on the module class both installs the filter and publishes the 304, the `ETag` on both statuses, and
+`If-None-Match` / `If-Modified-Since` as parameters — on exactly the operations `Methods` and
+`NotWhenStreaming` say it covers.
+
+Note what this does *not* fix: `[Enable<ConditionalGet>]` on a **host** entry point still cannot
+reach the document of a **library** compiled earlier. That is not a gap to close but a fact about
+separate compilations — the template says the same thing twice, about `[ApiGatewayModule]` and
+about why `[Enable<OpenApiDocumentPublishing>]` belongs on the library module. It is the argument
+for making the library-module and assembly rungs the ones an application reaches for, and leaving
+the host flag as the deployment switch it really is.
+
+## What `[Enable<T>]` keeps
+
+It is not replaced. It earns its place for two things a compile-time rung cannot do:
+
+- **Registering services.** A `[DependencyModule]` can bring a store, options, a hosted service. A
+  filter that needs any of those needs the module — response caching and rate limiting do.
+  `ConditionalGet` does not: its whole `ConfigureServices` is one `AddGlobalFilter` call, which is
+  why it is the feature that shows the gap most plainly.
+- **A host switching on a library's handlers.** Only a startup-time registration reaches handlers
+  compiled in an assembly the host merely references.
+
+The convention in `docs/design/` — an attribute plus `[Enable<Feature>]`, with the default standing
+down for an explicit declaration — stays. What changes is that the attribute gains two rungs, so the
+common case (my application, my handlers, one declaration) no longer has to leave the compilation to
+say "all of them".
+
+## Specification-first
+
+The same rungs apply. A described operation's filters come from `x-filters` in the contract and
+reach the model through `RequestModelBuilder`'s `WithFilters`; an entry-point or assembly
+declaration is orthogonal to that and composes the same way. `AGENTS.md` says a spec-first
+application has nowhere to put a route attribute — this is one of the few attributes it *can* put
+somewhere, because the module class is ordinary C# in the same compilation.
+
+## Migration
+
+Nothing breaks. `[Enable<ConditionalGet>]` keeps working and keeps installing the same filter;
+handlers with their own `[ConditionalGet]` keep their own. What is new is that
+
+```csharp
+[HardenedModule]
+[HardenedWebModule]
+[ConditionalGet]
+public partial class TodoLibrary { }
+```
+
+installs on every GET in that library *and* says so in the document. `ConditionalGetAttribute`'s
+`AttributeUsage` gains `Assembly` if the assembly rung is wanted for it specifically; the collection
+change is what makes any filter attribute work there.
+
+## Open questions
+
+1. Constructor argument or registry registration for the shared array — the two wirings above.
+2. Should the entry-point rung be *inherited by imported library modules*? A host module composes
+   library modules by attribute; a filter declared on the host today reaches only the host's own
+   handlers. Compile-time inheritance across that seam is not possible; the registry route makes it
+   automatic. Those are different answers and only one can be the default.
+3. Does `[Enable<T>]`'s type argument also contribute facets to the document — i.e. is A-04's
+   flag-on-the-host form worth publishing when the entry point and the handlers *are* in one
+   compilation? It is cheap where they are and impossible where they are not, which argues for
+   documenting the limit rather than half-closing it.
+4. Which existing global filters move to a rung. `[Enable<HardenedCompression>]` is the next one
+   with the same shape.

--- a/docs/design/filter-rungs.md
+++ b/docs/design/filter-rungs.md
@@ -3,7 +3,8 @@
 A filter can be declared on a handler method and on its controller class. It cannot be declared for
 a whole application without leaving the compilation, and the route that does leave it —
 `[Enable<T>]` and a DI-registered global provider — is invisible to the document generator. This
-note is about closing that: two more rungs, collected once, emitted once, and read by both halves.
+note is about closing that: four rungs walked for every handler, the wide two collected once, and
+one merged metadata list that everything downstream reads.
 
 ## What happens today
 
@@ -11,8 +12,8 @@ Three separate mechanisms put a filter in a chain.
 
 **Attributes on a handler.** `BaseRequestModelGenerator.GetFilters` collects attributes implementing
 `IRequestFilterProvider` from the method and from its containing class — two rungs, no more.
-`HandlerInfoCodeGenerator` writes them into a `_metadata` array per generated handler class, and
-`ExecutionHelper.GetFilterInfo(_metadata)` hands the ones that are filter providers to
+`HandlerInfoCodeGenerator` writes them into a `_metadata` array per generated handler class, method
+first, and `ExecutionHelper.GetFilterInfo(_metadata)` hands the ones that are filter providers to
 `CreateFilterArray`:
 
 ```csharp
@@ -60,118 +61,168 @@ half cannot be fixed where it stands, because the predicate that decides which h
 is a `Func<IExecutionRequestHandlerInfo, bool>` evaluated at startup, and the document is written at
 build time.
 
+## The four-rung walk already exists
+
+`TimeoutResolver` resolves a deadline through the operation, its class, the handler's assembly and
+the entry point's default, and its remarks settle two things this design needs.
+
+**Most specific wins, and nothing is combined.** *"Unlike a requirement, two budgets do not compose
+into a third, so the nearest declaration to the handler is the answer and the rest are fallbacks."*
+The contrast is the point: `RequirementFrom(Metadata)` conjoins every authorization attribute it
+finds, so the framework already has both policies side by side, plus a third — a timeout convention
+may only tighten.
+
+**The assembly beats the entry point.** *"A `[WebLibrary]` project writing `[assembly:
+Timeout(Milliseconds = 2000)]` is saying something specific about its own handlers; an entry point
+writing `[Enable<RequestTimeouts>]` is stating a blanket fallback for handlers that said nothing.
+Read the other way round, a host would silently loosen a bound a library deliberately set."* That
+ordering is the shared walk's ordering, not one resolver's private rule.
+
+So the walk is not new. What is new is doing it once, for filters as well as budgets, and building
+one list everything reads.
+
 ## The proposal
 
-**Collect the entry point's and the assembly's filter declarations once, emit them once, and let
-every handler in that compilation reference them.**
+**Walk all four rungs for every handler, merge them into `Metadata`, and collect the wide two once.**
 
-The entry point is already in hand where it is needed. `RoutingTableGenerator` runs on
-`(EntryPointSelector.Model, ImmutableArray<RequestHandlerModel>)` — the module class and every
-handler, combined, in one compilation — and `EntryPointSelector.Model.AttributeModels` is the same
-list `[Server]`, `[OpenApiInfo]` and `[Enable<T>]` are read from. The assembly's attributes are in
-that compilation too.
+Uniqueness lands at two levels, in different places, and separating them is most of the design.
 
-### Emit once, not per handler
+### Between the assembly and the entry point — at build time, once
 
-The obvious implementation is to append the entry point's filters to each `RequestHandlerModel` and
-let `_metadata` carry them. Do not do that. Three reasons, in order of weight:
-
-1. **Incrementality.** A handler model is a Roslyn cache key. Folding the entry point's attributes
-   into every handler makes one edit to the module class invalidate every handler in the
-   application. `EnabledFeatureSelector`'s own remarks make this argument about feature detection;
-   it applies here with more force, because handlers are the expensive half.
-2. **One construction site.** `new AuditAttribute() { Category = "x" }` written into forty
-   `_metadata` arrays is forty places for the arguments to be spelled, and forty copies in the
-   assembly.
-3. **It reads as what it is.** A declaration that covers the application should appear once in the
-   generated source, next to the routing table it covers.
-
-So: a nested static on the routing class, the way `ServerSentEventManifestEmitter` already puts one
-there.
+The generator has both lists as `AttributeModel`s and already keys on `TypeDefinition`, which is
+what `HandlerInfoCodeGenerator` constructs the instances from. Emit the assembly's items first, then
+only the entry-point items whose closed type is not already present, into one array beside the
+routing table — the way `ServerSentEventManifestEmitter` already puts a nested class there:
 
 ```csharp
 public partial class Application {
     private static class ApplicationFilters {
-        internal static readonly object[] Declared = new object[] { new ConditionalGetAttribute() };
+        // assembly rung, then entry-point items whose type is not already here
+        internal static readonly object[] Wider =
+            new object[] { new AuditAttribute { Category = "quotes" }, new ConditionalGetAttribute() };
     }
 }
 ```
 
-Every generated handler in the compilation gets that array as a second source alongside its own
-`_metadata`. Two ways to wire it, and this is the first open question:
+Unique before it ships, at no run-time cost, and one place where the arguments are spelled.
 
-- **Through the handler constructor.** `GetFilterInfo(_metadata)` becomes
-  `GetFilterInfo(_metadata, Application.ApplicationFilters.Declared)`. Explicit, but every handler
-  names its entry point, which handlers currently do not do.
-- **Through the registry, at startup.** The routing table registers `ApplicationFilters.Declared`
-  into `IGlobalFilterRegistry` once. Nothing changes in the handlers at all, the composition seam
-  already exists, and it stays a *compile-time declaration* even though it is applied at run time —
-  which is the part that matters, because the document can then read the same declaration.
+If the generator emits the assembly rung as well as the entry point's, there is no reflection
+anywhere: the generator's compilation *is* the handler's assembly, so `GetCustomAttributes()` leaves
+the startup path entirely and `TimeoutResolver`'s per-assembly `ConcurrentDictionary` goes with it.
+That is also the AOT-friendly shape.
 
-The second is smaller and keeps `CreateFilterArray` as it is. It also means the entry-point rung and
-the `[Enable<T>]` rung end up in the same place at run time, which is where they belong.
+### Against the handler's own two rungs — per handler, as the chain is built
 
-### Rules that have to be written down
+This is the part no shared array can precompute, because the answer differs per handler. One pass,
+once per handler, not per request. `CreateFilterArray` already replaces `handlerInfo` twice on that
+line — `ApplyConventions`, then `WithTimeout` — so a third sits in the same seam:
 
-**Nearest rung wins.** `ConditionalGet` spells this today as
-`!ConditionalGetAttribute.Declares(handlerInfo)` — a runtime scan of the handler's metadata for the
-same attribute type. As a general rule it should not be each filter's job: a rung-declared provider
-should stand down for a handler that declares the same provider type nearer. `Metadata` already
-carries what the test needs. A filter that genuinely wants to install twice says so.
+```csharp
+handlerInfo = handlerInfo.WithWiderRungs(ApplicationFilters.Wider);
+// method + class, as emitted; then each wider item whose closed type is absent,
+// unless its AttributeUsage says AllowMultiple
+```
 
-**Applicability.** `[ConditionalGet]` installs on GET and HEAD, and not on a streaming handler.
-`GetFilters` enforces that at run time and the facets repeat it for the document —
-`Methods = "GET,HEAD", NotWhenStreaming = true`. That pairing is the model to follow: the condition
-belongs in metadata a generator can read, not only in a predicate.
+**The key is the closed attribute type, and `AttributeUsage.AllowMultiple` decides replace against
+compose.** `false` means nearest wins and the wider declaration is dropped; `true` means every rung
+contributes. The author already had to declare it in C#, so this needs no new vocabulary, and it is
+cacheable per attribute type. It also falls out correctly for generics: `Authorize<BearerAuth>` and
+`Authorize<PetsOAuth>` are different closed types and compose without special-casing.
 
-**Order and ties.** `CreateFilterArray` sorts by `RequestFilterInfo.Order` and breaks ties on
-insertion order: registry first, then timeout, IO, invoke, instance, then the handler's own
-providers. If entry-point filters arrive through the registry they tie *ahead* of a handler's own
-filters at the same order. That is probably right — the wider declaration was registered first — but
-it is a decision, not an accident, and it should be stated.
+### Merge into `Metadata`, not into a side list
 
-**Equality.** `ConditionalGet` overrides `Equals`/`GetHashCode` so that enabling it twice registers
-one default. Any rung-declared filter needs the same treatment or the same guarantee from the
-collection site.
+If the walk produces `IExecutionRequestHandlerInfo.Metadata` itself, every existing reader inherits
+the four-rung view: `RequirementFrom(Metadata)`, `TimeoutFrom`, `StreamsResponse`, and
+`ConditionalGetAttribute.Declares` — which then stops needing to exist, because the merge has
+already applied the rule it was hand-rolling.
 
-### The document reads the same rungs
+One thing to get right: **the suppression has to be applied while the list is built, not after.**
+Merge first and filter later and `Declares` sees the module's own instance, and the module stands
+itself down.
 
-`FilterResponseSelector.Declarations` gains the entry-point rung, so the facets follow the
-declaration wherever it is written. The assembly rung is already there. After that, one declaration
-on the module class both installs the filter and publishes the 304, the `ETag` on both statuses, and
-`If-None-Match` / `If-Modified-Since` as parameters — on exactly the operations `Methods` and
-`NotWhenStreaming` say it covers.
+## From "apply here" to "apply where applicable"
 
-Note what this does *not* fix: `[Enable<ConditionalGet>]` on a **host** entry point still cannot
-reach the document of a **library** compiled earlier. That is not a gap to close but a fact about
-separate compilations — the template says the same thing twice, about `[ApiGatewayModule]` and
-about why `[Enable<OpenApiDocumentPublishing>]` belongs on the library module. It is the argument
-for making the library-module and assembly rungs the ones an application reaches for, and leaving
-the host flag as the deployment switch it really is.
+A declaration's meaning changes with its rung. On a method it says *install on this handler*. On the
+entry point or the assembly it says *install where you apply*, and applicability stops being a
+footnote and becomes the whole content of the declaration.
+
+`IRequestFilterProvider.GetFilters(handlerInfo)` already expresses both — it is handed the handler
+and returns zero or more filters, so `yield break` is "not here". `ConditionalGetAttribute` already
+does it, because a class-level declaration on a controller that also writes had to install nothing
+on the writes.
+
+What is wrong is that the rule is stated **six times** on that one attribute: `Methods = Reads,
+NotWhenStreaming = true` on each of five facets, plus the `if` at the top of `GetFilters`. The
+`Reads` constant exists to stop it being spelled five times, and its own comment says why — *"a
+document claiming a 304 on an operation the filter stood down on is the defect the declarations were
+added to close."*
+
+**So hoist applicability to one declaration on the attribute type, and have both halves read it.**
+The provider stops re-implementing the rule; the facets stop repeating it; the document generator
+reads the same statement the pipeline obeys. Two diagnostics then fall out, and both are the defect
+class this whole trial kept finding — a declaration that reads as a commitment and does nothing:
+
+- **A filter attribute at a wide rung that declares no applicability means every handler.** That
+  should be something an author wrote deliberately, not a default they backed into. `[Retry]` on an
+  entry point retrying every write is the shape to worry about.
+- **A filter at a nearer rung on a handler it does not apply to installs nothing, silently.**
+  `[ConditionalGet]` on a POST today. It should name both the declaration and the handler and stop
+  the build, the way `HRDT001` does for a thrown type that declares no status.
+
+That is also the honest boundary on "one standard method": the *walk* and the *dedup* are standard —
+four rungs, closed-type keys, `AllowMultiple` — while applicability is per-attribute data, declared
+once and read by two halves. Nothing about a rung can infer whether a filter belongs on a POST.
+
+## What this settles, and what it changes
+
+`[ConditionalGet]` on a module class installs on every GET in that compilation and publishes the
+304, the `ETag` on both statuses and both conditional request headers — from one declaration,
+because `FilterResponseSelector.Declarations` gains the same entry-point rung and the facets follow
+the attribute wherever it is written. The applicability conditions are already in metadata a
+generator can read: `Methods = "GET,HEAD", NotWhenStreaming = true`.
+
+The behaviour change that needs its own test rather than arriving as a side effect: once `Metadata`
+is the merged list, `[assembly: AuthorizeGrants("admin")]` starts composing into the requirement of
+every handler in that assembly. That is very likely what whoever writes it expects — it is what
+`RequirementFrom` does with the rungs it can already see — but it is a change, not a refactor.
+
+**Ties still break on insertion order.** `CreateFilterArray` sorts by `RequestFilterInfo.Order` and
+breaks ties on insertion: registry first, then timeout, IO, invoke, instance, then the handler's own
+providers. A wider-rung filter at the same order as a handler's own therefore runs first. That is
+probably right — the wider declaration was there first — but it is a decision, and it should be
+stated rather than discovered.
+
+**Equality still matters at the registration site.** `ConditionalGet` overrides `Equals` and
+`GetHashCode` so that enabling it twice registers one default. The build-time dedup above covers the
+two wide rungs; a module registered twice through DI is still the module's problem.
 
 ## What `[Enable<T>]` keeps
 
 It is not replaced. It earns its place for two things a compile-time rung cannot do:
 
-- **Registering services.** A `[DependencyModule]` can bring a store, options, a hosted service. A
-  filter that needs any of those needs the module — response caching and rate limiting do.
-  `ConditionalGet` does not: its whole `ConfigureServices` is one `AddGlobalFilter` call, which is
-  why it is the feature that shows the gap most plainly.
-- **A host switching on a library's handlers.** Only a startup-time registration reaches handlers
+- **Registering services.** A `[DependencyModule]` can bring a store, options, a hosted service.
+  Response caching and rate limiting need that. `ConditionalGet` does not: its whole
+  `ConfigureServices` is one `AddGlobalFilter` call, which is why it is the feature that shows the
+  gap most plainly.
+- **A host switching on a library's handlers.** Only a startup registration reaches handlers
   compiled in an assembly the host merely references.
 
-The convention in `docs/design/` — an attribute plus `[Enable<Feature>]`, with the default standing
-down for an explicit declaration — stays. What changes is that the attribute gains two rungs, so the
-common case (my application, my handlers, one declaration) no longer has to leave the compilation to
-say "all of them".
+### The limit that stays
+
+`[Enable<ConditionalGet>]` on a **host** entry point can never publish into a **library's**
+document. They are separate compilations, and the template says as much twice: once about
+`[ApiGatewayModule]`, once about why `[Enable<OpenApiDocumentPublishing>]` belongs on the library
+module and emits `"paths": {}` on the host. That is the argument for making the library-module and
+assembly rungs the ones an application reaches for, and leaving the host flag as the deployment
+switch it is.
 
 ## Specification-first
 
 The same rungs apply. A described operation's filters come from `x-filters` in the contract and
 reach the model through `RequestModelBuilder`'s `WithFilters`; an entry-point or assembly
-declaration is orthogonal to that and composes the same way. `AGENTS.md` says a spec-first
-application has nowhere to put a route attribute — this is one of the few attributes it *can* put
-somewhere, because the module class is ordinary C# in the same compilation.
+declaration is orthogonal and merges the same way. `AGENTS.md` says a spec-first application has
+nowhere to put a route attribute — this is one of the few it *can* put somewhere, because the module
+class is ordinary C# in the same compilation.
 
 ## Migration
 
@@ -185,20 +236,21 @@ handlers with their own `[ConditionalGet]` keep their own. What is new is that
 public partial class TodoLibrary { }
 ```
 
-installs on every GET in that library *and* says so in the document. `ConditionalGetAttribute`'s
-`AttributeUsage` gains `Assembly` if the assembly rung is wanted for it specifically; the collection
-change is what makes any filter attribute work there.
+installs on every GET in that library *and* says so in the document.
+`ConditionalGetAttribute`'s `AttributeUsage` gains `Assembly` if the assembly rung is wanted for it
+specifically; the collection change is what makes any filter attribute work there.
 
 ## Open questions
 
-1. Constructor argument or registry registration for the shared array — the two wirings above.
-2. Should the entry-point rung be *inherited by imported library modules*? A host module composes
-   library modules by attribute; a filter declared on the host today reaches only the host's own
-   handlers. Compile-time inheritance across that seam is not possible; the registry route makes it
-   automatic. Those are different answers and only one can be the default.
-3. Does `[Enable<T>]`'s type argument also contribute facets to the document — i.e. is A-04's
-   flag-on-the-host form worth publishing when the entry point and the handlers *are* in one
-   compilation? It is cheap where they are and impossible where they are not, which argues for
+1. **Does a wider rung reach a referenced library's handlers?** Compile-time collection cannot cross
+   that seam; a DI registration does it automatically. Two different answers, and only one can be
+   the default. The walk above chooses compile-time, which means a host's declaration covers the
+   host's own handlers — the same answer `TimeoutResolver` already gives for `[assembly: Timeout]`.
+2. **Does `[Enable<T>]`'s type argument also contribute facets to the document?** Cheap where the
+   entry point and the handlers share a compilation, impossible where they do not — which argues for
    documenting the limit rather than half-closing it.
-4. Which existing global filters move to a rung. `[Enable<HardenedCompression>]` is the next one
-   with the same shape.
+3. **Which existing global filters move to a rung.** `[Enable<HardenedCompression>]` is next with the
+   same shape.
+4. **Does `TimeoutResolver` fold into the shared walk in the same change, or after it?** Its assembly
+   rung and cache are exactly what the walk subsumes, but it also carries the tighten-only convention
+   pass, which nothing else has.

--- a/docs/design/filter-rungs.md
+++ b/docs/design/filter-rungs.md
@@ -1,10 +1,12 @@
 # Filters at the entry point and the assembly
 
-A filter can be declared on a handler method and on its controller class. It cannot be declared for
-a whole application without leaving the compilation, and the route that does leave it —
+A filter could be declared on a handler method and on its controller class. It could not be declared
+for a whole application without leaving the compilation, and the route that does leave it —
 `[Enable<T>]` and a DI-registered global provider — is invisible to the document generator. This
 note is about closing that: four rungs walked for every handler, the wide two collected once, and
-one merged metadata list that everything downstream reads.
+one merged metadata list that everything downstream reads. The entry-point rung is built and the
+assembly rung is not, so what follows is half history and half proposal — the next section says
+which is which.
 
 ## What is built
 
@@ -39,9 +41,11 @@ answered the way `TimeoutResolver` already answers it for `[assembly: Timeout]`.
   `TimeoutPolicy` service taking the tightest, not an attribute, so subsuming it changes what the
   rung means rather than where it is read.
 
-## What happens today
+## What the gap was
 
-Three separate mechanisms put a filter in a chain.
+Three separate mechanisms put a filter in a chain, and this section describes them as they stood
+before the entry-point rung existed. The three are all still there; what changed is that a fourth
+now sits beside them.
 
 **Attributes on a handler.** `BaseRequestModelGenerator.GetFilters` collects attributes implementing
 `IRequestFilterProvider` from the method and from its containing class — two rungs, no more.
@@ -75,19 +79,20 @@ The document is written from a fourth thing: `FilterResponseSelector.Declaration
 method, its class, and the assembly, and reads the `[AnswersStatus]` / `[AnswersHeader]` /
 `[ReadsHeader]` facets off whatever it finds.
 
-## What that costs
+## What that cost
 
-The rungs do not line up. Filters install from two, facets are read from three, and neither reads
+The rungs did not line up. Filters installed from two, facets were read from three, and neither read
 the entry point — so:
 
-- `[ConditionalGet]` on a module class compiles (its `AttributeUsage` allows `Class`) and installs
-  nothing.
+- `[ConditionalGet]` on a module class compiled — its `AttributeUsage` allows `Class` — and
+  installed nothing. That is the rung this note closed.
 - `[assembly: ConditionalGet]` does not compile at all; the usage is `Method | Class`. The
-  document side would have read it.
+  document side would have read it. That rung is still open.
 - `[Enable<ConditionalGet>]` installs the filter on every GET and publishes it on none. That is the
   0.32 trial's A-04: four GETs answer 304 over the wire, one operation declares it in the document,
   and the template's own generated Kiota client throws `no error factory is registered for this
-  code: 304` on exactly the request the feature exists to make cheap.
+  code: 304` on exactly the request the feature exists to make cheap. It still behaves that way,
+  and is now what a host writes for handlers it only references.
 
 The runtime half of A-04 is not a defect — 304 everywhere is what the flag promises. The document
 half cannot be fixed where it stands, because the predicate that decides which handlers are covered

--- a/docs/design/filter-rungs.md
+++ b/docs/design/filter-rungs.md
@@ -6,6 +6,39 @@ a whole application without leaving the compilation, and the route that does lea
 note is about closing that: four rungs walked for every handler, the wide two collected once, and
 one merged metadata list that everything downstream reads.
 
+## What is built
+
+**The entry-point rung, both halves.** A filter attribute on a `[HardenedModule]` class is collected
+by the generator into one array beside the routing table, registered as
+`IApplicationFilterDeclarations`, and merged into each handler's `Metadata` by `ExecutionHelper` as
+its chain is built — dropped for a handler that declares the same closed type nearer. The same
+declarations' facets ride on `EntryPointSelector.Model` and are narrowed per operation by
+`OpenApiDocumentGenerator`, so the document publishes what the pipeline installs. Both front ends
+arrive through those two functions, so a described application gets it too.
+
+Scoped to the compilation it was written in: `IApplicationFilterDeclarations.DeclaringAssembly` is
+matched against `handlerInfo.HandlerType.Assembly`, so a process composing several modules gives
+each one's declarations to that module's own handlers and no others. That is open question 1,
+answered the way `TimeoutResolver` already answers it for `[assembly: Timeout]`.
+
+**What is not built**, and why each is its own change:
+
+- *The assembly rung.* `FilterResponseSelector` already reads it for the document and nothing
+  installs from it, so the asymmetry in the table below stands. Collecting it at build time needs an
+  incremental provider `EntryPointSelector.Model` does not carry, and `AttributeTargets.Assembly` is
+  on no filter attribute this framework ships except `[Timeout]` — so it is a vocabulary decision
+  across the whole attribute set rather than one generator change.
+- *`AttributeUsage.AllowMultiple` as the replace-or-compose switch.* `CacheResponseAttribute`'s own
+  remarks are the counterexample: it carries `AllowMultiple = true` because the compiler dedupes a
+  generic attribute on its unbound form, not because two declarations compose. The rule built here
+  is nearest-wins on the closed type, full stop; a generic attribute a handler closes differently
+  still stacks, and the merge's remarks say so.
+- *The applicability hoist and its two diagnostics.* `[ConditionalGet]` still states its reach six
+  times, and the two halves still agree by inspection rather than by construction.
+- *`TimeoutResolver` folding into the shared walk.* Its entry-point rung is a registered
+  `TimeoutPolicy` service taking the tightest, not an attribute, so subsuming it changes what the
+  rung means rather than where it is read.
+
 ## What happens today
 
 Three separate mechanisms put a filter in a chain.
@@ -242,15 +275,18 @@ specifically; the collection change is what makes any filter attribute work ther
 
 ## Open questions
 
-1. **Does a wider rung reach a referenced library's handlers?** Compile-time collection cannot cross
-   that seam; a DI registration does it automatically. Two different answers, and only one can be
-   the default. The walk above chooses compile-time, which means a host's declaration covers the
-   host's own handlers — the same answer `TimeoutResolver` already gives for `[assembly: Timeout]`.
+1. ~~**Does a wider rung reach a referenced library's handlers?**~~ Settled: no. The declarations
+   carry the assembly they were written in and reach only handlers from it.
 2. **Does `[Enable<T>]`'s type argument also contribute facets to the document?** Cheap where the
    entry point and the handlers share a compilation, impossible where they do not — which argues for
-   documenting the limit rather than half-closing it.
-3. **Which existing global filters move to a rung.** `[Enable<HardenedCompression>]` is next with the
-   same shape.
-4. **Does `TimeoutResolver` fold into the shared walk in the same change, or after it?** Its assembly
-   rung and cache are exactly what the walk subsumes, but it also carries the tighten-only convention
-   pass, which nothing else has.
+   documenting the limit rather than half-closing it. Documented, not built.
+3. **Which existing global filters move to a rung.** `[Enable<ResponseCompression>]` is next with the
+   same shape: `[Compress]` is already a filter attribute allowing `Class`, so it needs no runtime
+   change at all.
+4. **Does `TimeoutResolver` fold into the shared walk?** Its assembly rung and cache are what the
+   walk would subsume, but its entry-point rung is a registered policy rather than an attribute, and
+   it carries the tighten-only convention pass. Neither half is a refactor.
+5. **Where does an attribute say whether a nearer declaration replaces it or composes with it?** The
+   merge keys on the closed type and drops the wider one, which is right for every filter attribute
+   shipped today and wrong the moment a generic one is declared at two rungs with different
+   arguments. It belongs on the attribute type, beside the applicability the hoist wants there.

--- a/docs/guide/conditional-requests.md
+++ b/docs/guide/conditional-requests.md
@@ -24,17 +24,36 @@ ETag: "OybX3FuqNfSKoSm+h1FJqQ=="
 
 ## Turning it on
 
-The attribute goes on an operation or on a class. For every GET handler in the application:
+The attribute goes on an operation, on a class, or on a module. For every GET handler compiled with
+that module:
 
 ```csharp
 [HardenedModule]
-[Enable<ConditionalGet>]
-[KestrelRuntime]
-public partial class Application { }
+[HardenedWebModule]
+[ConditionalGet]
+public partial class Catalog { }
 ```
 
 The module-wide form stands down for any handler carrying `[ConditionalGet]` itself, so explicit
 beats convention.
+
+Write it there rather than as `[Enable<ConditionalGet>]`, which does the same thing at run time and
+publishes nothing:
+
+```csharp
+GET /library/books                    ['200', '400']
+GET /library/books/{id}               ['200', '304', '400', '404']   ← the one with [ConditionalGet]
+```
+
+Every one of those answers a 304 over the wire. Only the operation that spelled the attribute says
+so, because `[Enable<T>]` registers the filter at startup and the document is written at build time
+- so a generated client has no branch for the answer it will actually be sent. A declaration on the
+module class stays inside the compilation, and the document publishes the 304, the `ETag` on both
+statuses and both conditional request headers on every read the filter covers.
+
+`[Enable<ConditionalGet>]` still works, and is still what a **host** writes to switch the feature on
+for handlers it only references. It cannot publish into a library's document: they are separate
+compilations, and the library's was written first.
 
 GET handlers only, in both forms. The routing table sends a HEAD to the GET leaf, and on any
 other method the conditional headers mean a 412, which this does not answer. A class-level

--- a/docs/guide/execution-pipeline.md
+++ b/docs/guide/execution-pipeline.md
@@ -175,6 +175,37 @@ The handler instance is created once, at `HandlerCreation`, and every attempt sh
 that keeps mutable per-request state on itself cannot be retried.
 :::
 
+## Attaching a filter to a module
+
+The same attribute goes on a `[HardenedModule]` class, where it covers every handler compiled with
+it:
+
+```csharp
+[HardenedModule]
+[HardenedWebModule]
+[ConditionalGet]
+public partial class Catalog { }
+```
+
+Three things follow from the declaration being inside the compilation rather than outside it.
+
+**The document says so too.** A filter reaching an operation is a fact about that operation, and the
+generator writing `openapi.json` reads the declaration off the module class the same way it reads
+one off a controller. A registration made at startup cannot be read at build time, so a filter
+attached that way answers a status the document never mentions.
+
+**Nearest wins.** A handler or a controller declaring the same attribute keeps its own, and the
+module's is dropped for that handler. Nothing is installed twice.
+
+**It reaches the handlers it was compiled with, and no others.** A module that a host references
+covers its own handlers; the host's declaration covers the host's. That is the same rung
+`[assembly: Timeout]` resolves through, and for the same reason - a referenced library was compiled,
+and described, before the host existed.
+
+A declaration decides for itself which handlers it applies to, and installs nothing on the rest.
+`[ConditionalGet]` on a module covers the reads and leaves the writes alone, in the document as well
+as in the chain.
+
 ## Attaching a filter to everything
 
 `IGlobalFilterRegistry` registers across all handlers. Do it from an `IStartupService`:

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -145,7 +145,7 @@ See [Authorization](/guide/authorization).
 
 | Attribute | Target | Purpose |
 |---|---|---|
-| `[ConditionalGet]` | Class, method | Answers a caller holding the response with a [304](/guide/conditional-requests). GET handlers only |
+| `[ConditionalGet]` | Module, class, method | Answers a caller holding the response with a [304](/guide/conditional-requests). GET handlers only |
 
 Both features are off until the application asks for them, and both can be turned on for every
 handler from the module instead:
@@ -160,6 +160,12 @@ handler from the module instead:
 Each stands down for a handler carrying its own `[Compress]` or `[ConditionalGet]`, so explicit beats
 convention. A budget resolves the same way, over four levels: the operation, its class, the
 handler's assembly, then the entry point.
+
+`[Enable<ConditionalGet>]` registers its filter at startup, so the document cannot see it: every GET
+answers a 304 and only the operations that spelled the attribute say so. Writing `[ConditionalGet]`
+on the module class instead keeps the declaration inside the compilation, so the document publishes
+it on every read the filter covers. The `[Enable<T>]` form is what a host writes to switch the
+feature on for handlers it only references.
 
 The verb attributes also declare `SuccessStatus`, the status a successful response answers with
 and the document publishes; unset means 200. The `NullReturnStatus`, `ValidationErrorStatus` and

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.Web.SUT/WebLibrary.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.Web.SUT/WebLibrary.cs
@@ -1,12 +1,22 @@
 ﻿using Hardened.Shared.Runtime.Attributes;
 using Hardened.Web.Runtime.Attributes;
+using Hardened.Web.Runtime.Conditional;
 using Hardened.Web.Runtime.DependencyInjection;
 
 namespace Hardened.IntegrationTests.Web.SUT;
 
+/// <summary>
+/// A library module that declares a filter for every handler compiled with it.
+/// </summary>
+/// <remarks>
+/// <c>[ConditionalGet]</c> here rather than in the host, because the rung is the compilation: this
+/// covers <c>SomeController</c> and reaches none of the host's own handlers, which is what
+/// <c>ModuleDeclaredFilterTests</c> asserts from both sides.
+/// </remarks>
 [HardenedModule]
 [BasePath("/web-library")]
 [HardenedWebModule]
+[ConditionalGet]
 public partial class WebLibrary {
     public string Test { get; set; } = "Default";
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/ModuleDeclaredFilterTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/ModuleDeclaredFilterTests.cs
@@ -1,0 +1,69 @@
+using DependencyModules.Testing.Attributes;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Testing;
+using Microsoft.Extensions.Primitives;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
+
+/// <summary>
+/// A filter declared on a module class, through a built application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>WebLibrary</c> carries <c>[ConditionalGet]</c> and <c>SomeController</c>, compiled with it,
+/// carries nothing. So the tag on the library's read and the 304 it answers came from the module's
+/// declaration and from nowhere else.
+/// </para>
+/// <para>
+/// The host is the other half of the same assertion. It references the library and composes its
+/// module, and its own handlers still answer without a tag - because a declaration covers the
+/// compilation it was written in, and the host was compiled after the library's document was
+/// written.
+/// </para>
+/// </remarks>
+public class ModuleDeclaredFilterTests {
+
+    private const string InTheLibrary = "/web-library/string-methods/concat/hello/world";
+
+    private const string InTheHost = "/binding/path/17";
+
+    private static Action<TestWebRequest> Plain(Action<TestWebRequest>? also = null) =>
+        request => {
+            request.Headers[KnownHeaders.AcceptEncoding] = new StringValues("identity");
+            also?.Invoke(request);
+        };
+
+    [HardenedTest]
+    public async Task AHandlerCompiledWithTheModuleAnswersWithATag(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(InTheLibrary, Plain());
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.True(response.Headers.ContainsKey(KnownHeaders.ETag),
+            "The module's declaration should have tagged the read it covers.");
+    }
+
+    [HardenedTest]
+    public async Task ACallerHoldingThatTagIsAnsweredNotModified(ITestWebApp testWebApp) {
+        var first = await testWebApp.Get(InTheLibrary, Plain());
+
+        var tag = first.Headers[KnownHeaders.ETag].ToString();
+
+        var second = await testWebApp.Get(InTheLibrary, Plain(
+            request => request.Headers[KnownHeaders.IfNoneMatch] = new StringValues(tag)));
+
+        Assert.Equal(304, second.StatusCode);
+        Assert.Equal(0, second.Body.Length);
+    }
+
+    /// <summary>
+    /// And the host's own reads are untouched, which is the seam a compile-time rung cannot cross.
+    /// </summary>
+    [HardenedTest]
+    public async Task AHandlerInTheHostIsLeftAlone(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(InTheHost, Plain());
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.False(response.Headers.ContainsKey(KnownHeaders.ETag),
+            "A library module's declaration must not reach the host's handlers.");
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -716,6 +716,11 @@ namespace Hardened.Requests.Abstract.RequestFilter
         public const int Serialization = 7000;
         public const int Validation = 8000;
     }
+    public interface IApplicationFilterDeclarations
+    {
+        System.Collections.Generic.IReadOnlyList<object> Declared { get; }
+        System.Reflection.Assembly DeclaringAssembly { get; }
+    }
     public interface IGlobalFilterRegistry
     {
         System.Collections.Generic.List<Hardened.Requests.Abstract.RequestFilter.RequestFilterInfo> GetFilters(Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo requestHandlerInfo);

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Runtime.approved.txt
@@ -327,6 +327,7 @@ namespace Hardened.Requests.Runtime.Execution
     {
         public static Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo WithRequirement(this Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Abstract.Authorization.Requirement? requirement) { }
         public static Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo WithTimeout(this Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, Hardened.Requests.Abstract.Timeouts.TimeoutPolicy? timeout) { }
+        public static Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo WithWiderRungs(this Hardened.Requests.Abstract.Execution.IExecutionRequestHandlerInfo handlerInfo, System.Collections.Generic.IReadOnlyList<object> rungs) { }
     }
     public class ExecutionRequestParameter : Hardened.Requests.Abstract.Execution.IExecutionRequestParameter
     {

--- a/src/Requests/Hardened.Requests.Abstract/RequestFilter/IApplicationFilterDeclarations.cs
+++ b/src/Requests/Hardened.Requests.Abstract/RequestFilter/IApplicationFilterDeclarations.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+
+namespace Hardened.Requests.Abstract.RequestFilter;
+
+/// <summary>
+/// The filter declarations written on an application's entry point, known at startup.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A filter can be declared on a handler method and on its containing class, and the generator
+/// reads both into that handler's <see cref="Execution.IExecutionRequestHandlerInfo.Metadata"/>.
+/// A declaration covering the whole application has no handler to sit on, so it is collected once
+/// from the entry point's own attribute list and emitted beside the routing table. This is how it
+/// reaches the pipeline.
+/// </para>
+/// <para>
+/// <b>A rung rather than a registration, so the document can read it too.</b>
+/// <c>[Enable&lt;ConditionalGet&gt;]</c> reaches every handler through
+/// <see cref="IGlobalFilterRegistry"/>, and what decides which handlers it covers is a predicate
+/// evaluated at startup - which the generator writing the OpenAPI document cannot evaluate,
+/// because the document is written at build time. A declaration read inside the compilation is
+/// visible to both halves.
+/// </para>
+/// <para>
+/// Every entry is an attribute instance, constructed once for the application. It reaches a
+/// handler through the same merge that decides whether it applies at all: an entry whose type the
+/// handler already declares nearer is dropped, and the rest are appended to that handler's
+/// metadata as its filter chain is built. See
+/// <c>ExecutionRequestHandlerInfoExtensions.WithWiderRungs</c>.
+/// </para>
+/// <para>
+/// Nothing is registered for an entry point that declares no filter, which is almost every
+/// application. A process that composes several modules carries one of these per module that does,
+/// each covering its own compilation - see <see cref="DeclaringAssembly"/>.
+/// </para>
+/// </remarks>
+public interface IApplicationFilterDeclarations {
+    /// <summary>
+    /// The declarations, in the order they were written on the entry point.
+    /// </summary>
+    IReadOnlyList<object> Declared { get; }
+
+    /// <summary>
+    /// The compilation these were declared in, whose handlers they cover.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A process composes as many modules as it references and each brings its own, so what makes
+    /// one declaration a fact about one set of handlers is the assembly it was written in. A host
+    /// that references a library cannot declare a filter for that library's handlers: the library
+    /// was compiled first, and its document was written then. <c>TimeoutResolver</c> answers the
+    /// same rung the same way, and says so - the assembly rung is the <em>handler's</em> assembly.
+    /// </para>
+    /// <para>
+    /// Defaulted to the implementation's own assembly, which is the answer for the class the
+    /// routing generator emits and for anything written by hand beside the handlers it covers.
+    /// </para>
+    /// </remarks>
+    Assembly DeclaringAssembly => GetType().Assembly;
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Execution/ApplicationFilterRungTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Execution/ApplicationFilterRungTests.cs
@@ -1,0 +1,286 @@
+using System.Reflection;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.RequestFilter;
+using Hardened.Requests.Runtime.Execution;
+using Hardened.Requests.Runtime.Filters;
+using Hardened.Requests.Runtime.Tests.Support;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Execution;
+
+/// <summary>
+/// A filter declared on the entry point, as every handler's chain is built.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generator emits the declarations once beside the routing table and registers them as
+/// <see cref="IApplicationFilterDeclarations"/>. What happens next is here: each is dropped for a
+/// handler that declares the same type nearer, and the rest are merged into that handler's metadata
+/// and asked for their filters.
+/// </para>
+/// <para>
+/// Driven through <c>ExecutionHelper</c> and run, as <c>FilterOrderingTests</c> is, because the
+/// merge and the installation are two halves of one answer and asserting the merged list alone
+/// would not show that anything ran.
+/// </para>
+/// </remarks>
+public class ApplicationFilterRungTests {
+
+    private const string Instance = "instance";
+    private const string Io = "io";
+    private const string Invoke = "invoke";
+
+    private class Controller { }
+
+    /// <summary>
+    /// A filter attribute of the shape an application declares on its module class: it decides for
+    /// itself which handlers it applies to, and installs nothing on the rest.
+    /// </summary>
+    private sealed class RecordingAttribute : Attribute, IRequestFilterProvider {
+        private readonly List<string> _log;
+        private readonly string _name;
+        private readonly int? _order;
+        private readonly string? _method;
+
+        public RecordingAttribute(
+            List<string> log, string name, int? order = null, string? method = null) {
+            _log = log;
+            _name = name;
+            _order = order;
+            _method = method;
+        }
+
+        public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
+            if (_method != null && !string.Equals(handlerInfo.Method, _method, StringComparison.Ordinal)) {
+                yield break;
+            }
+
+            yield return new RequestFilterInfo(_ => new Pipeline.Recording(_log, _name), _order, _name);
+        }
+    }
+
+    /// <summary>A second type, so a declaration can be suppressed by one and not by the other.</summary>
+    private sealed class OtherRecordingAttribute : Attribute, IRequestFilterProvider {
+        private readonly List<string> _log;
+
+        public OtherRecordingAttribute(List<string> log) {
+            _log = log;
+        }
+
+        public IEnumerable<RequestFilterInfo> GetFilters(IExecutionRequestHandlerInfo handlerInfo) {
+            yield return new RequestFilterInfo(
+                _ => new Pipeline.Recording(_log, "other"), FilterOrder.Before, "other");
+        }
+    }
+
+    private sealed class Declarations : IApplicationFilterDeclarations {
+        public Declarations(params object[] declared) {
+            Declared = declared;
+        }
+
+        public IReadOnlyList<object> Declared { get; }
+    }
+
+    /// <summary>Declarations written in a compilation the handler does not belong to.</summary>
+    private sealed class ForeignDeclarations : IApplicationFilterDeclarations {
+        public ForeignDeclarations(params object[] declared) {
+            Declared = declared;
+        }
+
+        public IReadOnlyList<object> Declared { get; }
+
+        public Assembly DeclaringAssembly => typeof(string).Assembly;
+    }
+
+    /// <summary>
+    /// Composes and runs a handler's chain the way the generated code does, returning the names of
+    /// the filters that executed in the order they ran.
+    /// </summary>
+    private static async Task<(List<string> Ran, IExecutionRequestHandlerInfo Composed)> Run(
+        List<string> log,
+        IApplicationFilterDeclarations[]? declarations,
+        object[]? metadata = null,
+        string method = "GET",
+        IRequestFilterProvider[]? handlerProviders = null) {
+        var ioProvider = Substitute.For<IIOFilterProvider>();
+
+        ioProvider.ProvideFilter(
+                Arg.Any<IExecutionRequestHandlerInfo>(),
+                Arg.Any<Func<IExecutionContext, Task<IExecutionRequestParameters>>>())
+            .Returns(new Pipeline.Recording(log, Io));
+
+        var instanceProvider = Substitute.For<IInstanceFilterProvider>();
+
+        instanceProvider.ProvideFilter<Controller>(Arg.Any<IServiceProvider>())
+            .Returns(new Pipeline.Recording(log, Instance));
+
+        var context = Pipeline.Context(method: method, configureServices: services => {
+            services.AddSingleton<IGlobalFilterRegistry>(
+                new GlobalFilterRegistry(Array.Empty<IRequestFilterProvider>()));
+            services.AddSingleton(ioProvider);
+            services.AddSingleton(instanceProvider);
+
+            foreach (var module in declarations ?? Array.Empty<IApplicationFilterDeclarations>()) {
+                services.AddSingleton(module);
+            }
+        });
+
+        context.HandlerInstance = new Controller();
+
+        var handlerInfo = new ExecutionRequestHandlerInfo(
+            "/books", method, typeof(Controller), nameof(Run), metadata: metadata);
+
+        var setup = ExecutionHelper.StandardFilterEmptyParameters<Controller>(
+            context.RequestServices,
+            handlerInfo,
+            (_, _) => log.Add(Invoke),
+            handlerProviders ?? Array.Empty<IRequestFilterProvider>());
+
+        await new ExecutionChain(setup.Filters, context).Next();
+
+        return (log, setup.HandlerInfo);
+    }
+
+    /// <summary>
+    /// The declaration installs on a handler that carries none of its own, which is the whole
+    /// point: one attribute on the module class covers the application.
+    /// </summary>
+    [Fact]
+    public async Task ADeclarationReachesAHandlerThatCarriesNone() {
+        var log = new List<string>();
+
+        var (ran, _) = await Run(log, [new Declarations(new RecordingAttribute(log, "wide"))]);
+
+        Assert.Contains("wide", ran);
+    }
+
+    /// <summary>
+    /// And is merged into the handler's own metadata, which is what lets a filter ask what else was
+    /// declared on the handler it is being installed on - the question
+    /// <c>ConditionalGetAttribute.Declares</c> asks.
+    /// </summary>
+    [Fact]
+    public async Task ADeclarationThatReachesAHandlerIsInItsMetadata() {
+        var log = new List<string>();
+        var declared = new RecordingAttribute(log, "wide");
+
+        var (_, composed) = await Run(log, [new Declarations(declared)]);
+
+        Assert.Contains(declared, composed.Metadata);
+    }
+
+    /// <summary>
+    /// Nearest wins. A handler declaring the same type keeps its own and the wider one is dropped,
+    /// so the filter is installed once rather than twice.
+    /// </summary>
+    [Fact]
+    public async Task AHandlerDeclaringTheSameTypeSuppressesTheWiderOne() {
+        var log = new List<string>();
+        var own = new RecordingAttribute(log, "own");
+        var wide = new RecordingAttribute(log, "wide");
+
+        var (ran, composed) = await Run(
+            log, [new Declarations(wide)], metadata: [own], handlerProviders: [own]);
+
+        Assert.Contains("own", ran);
+        Assert.DoesNotContain("wide", ran);
+        Assert.DoesNotContain(wide, composed.Metadata);
+    }
+
+    /// <summary>
+    /// Keyed on the type rather than on the fact that something was declared, so an unrelated
+    /// declaration on the handler suppresses nothing.
+    /// </summary>
+    [Fact]
+    public async Task ADeclarationOfAnotherTypeSuppressesNothing() {
+        var log = new List<string>();
+        var other = new OtherRecordingAttribute(log);
+        var wide = new RecordingAttribute(log, "wide");
+
+        var (ran, _) = await Run(
+            log, [new Declarations(wide)], metadata: [other], handlerProviders: [other]);
+
+        Assert.Contains("wide", ran);
+        Assert.Contains("other", ran);
+    }
+
+    /// <summary>
+    /// A declaration decides for itself which handlers it applies to, and installs nothing on the
+    /// rest. <c>[ConditionalGet]</c> on a module class is this: it covers the reads and leaves the
+    /// writes alone.
+    /// </summary>
+    [Fact]
+    public async Task ADeclarationInstallsNothingOnAHandlerItDoesNotApplyTo() {
+        var log = new List<string>();
+
+        var (ran, _) = await Run(
+            log,
+            [new Declarations(new RecordingAttribute(log, "wide", method: "GET"))],
+            method: "POST");
+
+        Assert.DoesNotContain("wide", ran);
+    }
+
+    /// <summary>
+    /// Ties break on insertion order, and a declaration covering the application is inserted with
+    /// the registry's - ahead of a handler's own asking for the same position. The wider
+    /// declaration was written first.
+    /// </summary>
+    [Fact]
+    public async Task AWiderDeclarationRunsAheadOfTheHandlersOwnAtTheSameOrder() {
+        var log = new List<string>();
+        var own = new RecordingAttribute(log, "own", FilterOrder.Before);
+        var wide = new OtherRecordingAttribute(log);
+
+        var (ran, _) = await Run(log, [new Declarations(wide)], handlerProviders: [own]);
+
+        Assert.Equal(["other", "own"], ran.Where(name => name is "other" or "own").ToArray());
+    }
+
+    /// <summary>
+    /// Every module in the handler's own compilation contributes, rather than whichever registered
+    /// last. A process composes as many modules as it references.
+    /// </summary>
+    [Fact]
+    public async Task EveryModuleThatDeclaresSomethingContributes() {
+        var log = new List<string>();
+
+        var (ran, _) = await Run(log, [
+            new Declarations(new RecordingAttribute(log, "first")),
+            new Declarations(new OtherRecordingAttribute(log))
+        ]);
+
+        Assert.Contains("first", ran);
+        Assert.Contains("other", ran);
+    }
+
+    /// <summary>
+    /// A module declares filters for the handlers it was compiled with and no others. Compile-time
+    /// collection cannot cross that seam, and a referenced library's handlers were described in a
+    /// document written before this application existed.
+    /// </summary>
+    [Fact]
+    public async Task DeclarationsFromAnotherCompilationReachNothing() {
+        var log = new List<string>();
+
+        var (ran, composed) =
+            await Run(log, [new ForeignDeclarations(new RecordingAttribute(log, "wide"))]);
+
+        Assert.DoesNotContain("wide", ran);
+        Assert.Empty(composed.Metadata);
+    }
+
+    /// <summary>
+    /// An application whose entry point declares no filter registers nothing, and composes exactly
+    /// the chain it composed before this existed.
+    /// </summary>
+    [Fact]
+    public async Task NothingRegisteredChangesNothing() {
+        var (ran, composed) = await Run(new List<string>(), declarations: null);
+
+        Assert.Equal([Instance, Io, Invoke], ran);
+        Assert.Empty(composed.Metadata);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionHelper.cs
@@ -231,11 +231,25 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
         IExecutionFilter ioFilter,
         IExecutionFilter invokeFilter,
         IExecutionFilter instanceFilter) {
+        // First, because everything below reads the handler: a convention reads its requirement,
+        // the resolver reads its metadata for a deadline, and the registry's predicates ask what it
+        // declares - and a declaration on the entry point is one of the things it declares.
+        var wider = WiderRungs(serviceProvider, handlerInfo);
+
+        handlerInfo = handlerInfo.WithWiderRungs(wider);
         handlerInfo = ApplyConventions(serviceProvider, handlerInfo);
         handlerInfo = handlerInfo.WithTimeout(TimeoutResolver.Resolve(serviceProvider, handlerInfo));
 
         var filterList =
             serviceProvider.GetRequiredService<IGlobalFilterRegistry>().GetFilters(handlerInfo);
+
+        // Beside the registry's rather than with the handler's own, which is the position
+        // [Enable<T>] already gives them: ties break on insertion order, so a declaration covering
+        // the application runs ahead of one on a handler that asked for the same place. The wider
+        // declaration was written first.
+        foreach (var provider in GetFilterInfo(wider)) {
+            filterList.AddRange(provider.GetFilters(handlerInfo));
+        }
 
         AddTimeoutFilter(filterList, handlerInfo);
 
@@ -346,6 +360,72 @@ AsyncEnumerableFilterEmptyParameters<TController, TItem>(
             _ => filter,
             FilterOrder.Before + FilterOrder.Serialization,
             nameof(TimeoutFilter)));
+    }
+
+    /// <summary>
+    /// The entry point's filter declarations that reach this handler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Nearest wins.</b> A declaration whose type the handler already carries on its method or
+    /// its class is dropped here, so the nearer one is the only one installed - which is the rule
+    /// <c>ConditionalGetAttribute.Declares</c> hand-rolls today for the one filter that had an
+    /// application-wide form.
+    /// </para>
+    /// <para>
+    /// <b>Keyed on the closed type</b>, which is what makes a generic filter attribute behave:
+    /// <c>Authorize&lt;BearerAuth&gt;</c> and <c>Authorize&lt;PetsOAuth&gt;</c> are two types and
+    /// compose, while two <c>[ConditionalGet]</c> are one. The consequence to know is that a
+    /// generic attribute a handler closes differently does not suppress the wider one -
+    /// <c>[CacheResponse&lt;VaryByRoute&gt;]</c> on the entry point beside
+    /// <c>[CacheResponse&lt;VaryByQuery&gt;]</c> on a handler is two declarations, and two that
+    /// disagree about a duration fail as the chain is built. Which of the two a nearer declaration
+    /// means is the attribute's to say, and it has nowhere to say it yet.
+    /// </para>
+    /// <para>
+    /// Asked once per handler, as its chain is built. An application whose entry point declares no
+    /// filter registers nothing, so this is one failed service lookup per handler and no walk at
+    /// all.
+    /// </para>
+    /// </remarks>
+    private static object[] WiderRungs(
+        IServiceProvider serviceProvider, IExecutionRequestHandlerInfo handlerInfo) {
+        // GetService rather than GetServices, for the reason ApplyConventions gives: the
+        // convenience overload resolves IEnumerable<T> as required, and Hardened's container does
+        // not synthesise an empty one.
+        var registered = serviceProvider.GetService<IEnumerable<IApplicationFilterDeclarations>>();
+
+        if (registered == null) {
+            return Array.Empty<object>();
+        }
+
+        List<object>? reaching = null;
+
+        foreach (var declarations in registered) {
+            // One per module that declares anything, so the handler's own assembly is what picks
+            // out the declarations that are about it.
+            if (!Equals(declarations.DeclaringAssembly, handlerInfo.HandlerType.Assembly)) {
+                continue;
+            }
+
+            foreach (var declaration in declarations.Declared) {
+                if (!DeclaredNearer(handlerInfo.Metadata, declaration.GetType())) {
+                    (reaching ??= new List<object>()).Add(declaration);
+                }
+            }
+        }
+
+        return reaching == null ? Array.Empty<object>() : reaching.ToArray();
+    }
+
+    private static bool DeclaredNearer(IReadOnlyList<object> metadata, Type declaration) {
+        foreach (var item in metadata) {
+            if (item.GetType() == declaration) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Execution/ExecutionRequestHandlerInfo.cs
@@ -60,21 +60,25 @@ public class ExecutionRequestHandlerInfo : IExecutionRequestHandlerInfo {
     /// </para>
     /// <para>
     /// A null override keeps what the source carried. <see cref="Requirement"/> falls back to the
-    /// primary constructor's derivation from metadata, which is the same answer the source reached.
+    /// primary constructor's derivation from metadata, which is the same answer the source reached
+    /// - unless <paramref name="metadata"/> replaced the list it was derived from, which is why
+    /// <see cref="ExecutionRequestHandlerInfoExtensions.WithWiderRungs"/> states the requirement
+    /// rather than leaving it null.
     /// </para>
     /// </remarks>
     internal ExecutionRequestHandlerInfo(
         IExecutionRequestHandlerInfo source,
         string? path,
         Requirement? requirement,
-        TimeoutPolicy? timeout = null)
+        TimeoutPolicy? timeout = null,
+        IReadOnlyList<object>? metadata = null)
         : this(
             path ?? source.Path,
             source.Method,
             source.HandlerType,
             source.InvokeMethod,
             source.Parameters,
-            source.Metadata,
+            metadata ?? source.Metadata,
             requirement ?? source.Requirement,
             source.SuccessStatus,
             source.NullResponseBody,
@@ -211,4 +215,66 @@ public static class ExecutionRequestHandlerInfoExtensions {
         timeout is null || Equals(timeout, handlerInfo.Timeout)
             ? handlerInfo
             : new ExecutionRequestHandlerInfo(handlerInfo, path: null, requirement: null, timeout);
+
+    /// <summary>
+    /// The same handler, also carrying the declarations written on a rung wider than itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Merged into <see cref="IExecutionRequestHandlerInfo.Metadata"/> rather than kept in a
+    /// list beside it</b>, so every existing reader inherits the wider view rather than each one
+    /// growing a second lookup: <c>RequirementFrom</c>, <c>TimeoutFrom</c> and a filter asking what
+    /// else was declared on the handler it is being installed on all read that one list.
+    /// <c>ConditionalGetAttribute.Declares</c> is the last of those, and it is what makes
+    /// <c>[Enable&lt;ConditionalGet&gt;]</c> stand down for a handler already covered by a rung.
+    /// </para>
+    /// <para>
+    /// <b>Appended, because nearest-first is load-bearing.</b> The generator emits a method's own
+    /// attributes ahead of its class's and <c>TimeoutFrom</c> takes the first, so a rung wider than
+    /// both belongs after both. <c>HandlerMetadataOrderTests</c> pins the half of that ordering the
+    /// generator writes.
+    /// </para>
+    /// <para>
+    /// <b>The requirement is stated rather than re-derived.</b> A handler can carry one that no
+    /// attribute in its metadata expresses - a described operation's <c>security:</c>, or a
+    /// convention - so recomputing from the merged list would drop it. What a wider rung
+    /// contributes is conjoined onto what the handler already required, which is what
+    /// <c>RequirementFrom</c> does with the rungs it can already see.
+    /// </para>
+    /// <para>
+    /// Returns the handler unchanged where no declaration reached it, which is every handler in an
+    /// application whose entry point declares no filter.
+    /// </para>
+    /// </remarks>
+    public static IExecutionRequestHandlerInfo WithWiderRungs(
+        this IExecutionRequestHandlerInfo handlerInfo, IReadOnlyList<object> rungs) {
+        if (rungs.Count == 0) {
+            return handlerInfo;
+        }
+
+        var merged = new List<object>(handlerInfo.Metadata.Count + rungs.Count);
+
+        merged.AddRange(handlerInfo.Metadata);
+        merged.AddRange(rungs);
+
+        return new ExecutionRequestHandlerInfo(
+            handlerInfo,
+            path: null,
+            requirement: Conjoined(handlerInfo.Requirement, rungs),
+            timeout: null,
+            metadata: merged);
+    }
+
+    /// <summary>
+    /// What the handler already required, and what the wider rungs require of it.
+    /// </summary>
+    private static Requirement? Conjoined(Requirement? required, IReadOnlyList<object> rungs) {
+        var wider = IExecutionRequestHandlerInfo.RequirementFrom(rungs);
+
+        if (wider == null) {
+            return required;
+        }
+
+        return required == null ? wider : Requirement.AllOf([required, wider]);
+    }
 }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
@@ -99,6 +99,9 @@
         <Compile Include="../Hardened.SourceGenerator/Web/ServerSentEventManifestEmitter.cs">
             <Link>Web/%(FileName)%(Extension)</Link>
         </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Web/ApplicationFilterEmitter.cs">
+            <Link>Web/%(FileName)%(Extension)</Link>
+        </Compile>
         <Compile Include="../Hardened.SourceGenerator/Validation/ParameterValidatorRegistration.cs">
             <Link>Validation/%(FileName)%(Extension)</Link>
         </Compile>

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstEntryPointFilterTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstEntryPointFilterTests.cs
@@ -1,0 +1,119 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Hardened.SourceGeneration.Testing;
+using Xunit;
+
+namespace Hardened.OpenApi.SourceGenerator.Tests;
+
+/// <summary>
+/// A filter declared on the module class of a specification-first application.
+/// </summary>
+/// <remarks>
+/// The rung is the same rung. A described application has nowhere to put a route attribute, but its
+/// module class is ordinary C# in the same compilation - and both front ends reach the pipeline
+/// through <c>RoutingTableGenerator.GenerateCSharpRouteFile</c> and the document through
+/// <c>OpenApiDocumentGenerator.Write</c>, so neither has a copy of this to drift from.
+/// </remarks>
+public class SpecFirstEntryPointFilterTests {
+
+    private const string Spec =
+        """
+        openapi: "3.0.0"
+        info: { title: Pets, version: "1.0" }
+        paths:
+          /pets:
+            get:
+              operationId: listPets
+              responses:
+                '200':
+                  description: The pets
+                  content:
+                    application/json:
+                      schema: { type: array, items: { $ref: '#/components/schemas/Pet' } }
+            post:
+              operationId: addPet
+              requestBody:
+                content:
+                  application/json:
+                    schema: { $ref: '#/components/schemas/Pet' }
+              responses:
+                '201':
+                  description: Added
+        components:
+          schemas:
+            Pet:
+              type: object
+              required: [id]
+              properties:
+                id: { type: string }
+        """;
+
+    private const string EntryPointWithRung =
+        """
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Conditional;
+
+        namespace TestNamespace;
+
+        [HardenedModule]
+        [ConditionalGet]
+        public partial class TestApp {
+        }
+        """;
+
+    private static GeneratorResult Generated() {
+        var result = OpenApiGenerator.Run(Spec, EntryPointWithRung);
+
+        Assert.Empty(result.Errors);
+
+        return result;
+    }
+
+    private static JsonElement Document(GeneratorResult result) {
+        var source = result.GeneratedSources
+            .First(pair => pair.Key.Contains("OpenApiDocument")).Value;
+
+        var match = Regex.Match(
+            source, @"new byte\[\]\s*\{(.*?)\}\s*;", RegexOptions.Singleline);
+
+        Assert.True(match.Success, "No document byte array in the generated source.");
+
+        var bytes = match.Groups[1].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(byte.Parse)
+            .ToArray();
+
+        using var compressed = new MemoryStream(bytes, writable: false);
+        using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
+        using var inflated = new MemoryStream();
+
+        gzip.CopyTo(inflated);
+
+        return JsonDocument.Parse(Encoding.UTF8.GetString(inflated.ToArray())).RootElement.Clone();
+    }
+
+    private static string[] Statuses(JsonElement document, string method) =>
+        document.GetProperty("paths").GetProperty("/pets").GetProperty(method)
+            .GetProperty("responses").EnumerateObject()
+            .Select(response => response.Name)
+            .OrderBy(status => status, StringComparer.Ordinal)
+            .ToArray();
+
+    [Fact]
+    public void TheDescribedReadPublishesWhatTheModuleDeclares() {
+        var document = Document(Generated());
+
+        Assert.Contains("304", Statuses(document, "get"));
+        Assert.DoesNotContain("304", Statuses(document, "post"));
+    }
+
+    [Fact]
+    public void TheDeclarationReachesTheDescribedRoutingTable() {
+        var routing = Generated().SourceContaining("SpecRouting");
+
+        Assert.Contains("ApplicationFilters", routing);
+        Assert.Contains("IApplicationFilterDeclarations", routing);
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -42,6 +42,11 @@ public static class OpenApiDocumentGenerator {
         OpenApiVersion version = OpenApiVersionFacts.Default, DocumentIdentity? identity = null) {
         var builder = new StringBuilder();
 
+        // Before anything reads a handler, because the entry point's rung says something about
+        // every one of them. Both front ends arrive here, so a described application publishes what
+        // its module declares on the same terms an attribute-routed one does.
+        handlers = WithEntryPointRung(appModel, handlers);
+
         // Identity, in preference order: the contract's own (specification-first), an
         // [OpenApiInfo] on the entry point (code-first), then the fallbacks every application got
         // before either existed - the entry point's class name and "1.0.0". The fallbacks renamed
@@ -192,6 +197,97 @@ public static class OpenApiDocumentGenerator {
         }
 
         return builder.Append('}').ToString();
+    }
+
+    /// <summary>
+    /// <paramref name="handlers"/> with what the entry point declares folded into each one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A filter declared on the entry point installs on every handler in the compilation that it
+    /// applies to, so what it answers belongs on those operations. Read once for the application
+    /// and narrowed per handler here, because whether a declaration reaches an operation depends on
+    /// that operation's verb and on whether it streams - the same
+    /// <c>Methods</c>/<c>NotWhenStreaming</c> narrowing a declaration on a controller gets.
+    /// </para>
+    /// <para>
+    /// Copied rather than amended in place. A handler model is a Roslyn cache key and the same
+    /// instance is handed to the routing table, so writing the document must not change what the
+    /// table reads.
+    /// </para>
+    /// </remarks>
+    private static IReadOnlyList<RequestHandlerModel> WithEntryPointRung(
+        EntryPointSelector.Model appModel, IReadOnlyList<RequestHandlerModel> handlers) {
+        if (appModel.FilterFacts is not DeclaredOperationFacts facts || facts.IsEmpty) {
+            return handlers;
+        }
+
+        var merged = new List<RequestHandlerModel>(handlers.Count);
+
+        foreach (var handler in handlers) {
+            merged.Add(Merged(
+                handler,
+                facts.For(handler.Name.Method, handler.ResponseInformation.IsAsyncEnumerable)));
+        }
+
+        return merged;
+    }
+
+    private static RequestHandlerModel Merged(
+        RequestHandlerModel handler, OperationDeclarations reaching) {
+        if (reaching.Refusals.Count == 0 && reaching.ResponseHeaders.Count == 0 &&
+            reaching.RequestHeaders.Count == 0) {
+            return handler;
+        }
+
+        // The rung's responses go last, so a status the handler declared itself keeps the shape the
+        // handler gave it - the order Compose puts a declaration's own refusals in.
+        var merged = handler.WithFilters(
+            handler.Filters,
+            responseSchemas: reaching.WithHeaders(
+                handler.ResponseSchemas.Concat(reaching.Refusals).ToList()));
+
+        // A refusal names what can be answered instead of the handler and says nothing about what
+        // the handler answers when it runs, so the return type is still the only source of the
+        // success. The same rule [Throws<T>] follows.
+        if (reaching.Refusals.Count > 0 && handler.ResponseInformation.UnionCases == null) {
+            merged.DeclaredResponsesAreComplete = false;
+        }
+
+        merged.DeclaredHeaderParameters =
+            Combined(handler.DeclaredHeaderParameters, reaching.HeaderParameters());
+
+        // Headers() answers null where it merged nothing in, which is every handler the rung
+        // declares no header for.
+        merged.SingleResponseHeaders =
+            reaching.Headers(
+                handler.ResponseInformation.DefaultStatusCode ?? 200,
+                handler.SingleResponseHeaders ?? System.Array.Empty<ResponseHeaderModel>())
+            ?? handler.SingleResponseHeaders;
+
+        return merged;
+    }
+
+    /// <summary>
+    /// The handler's own header parameters, then the rung's that it does not already name.
+    /// </summary>
+    private static IReadOnlyList<DeclaredHeaderParameterModel> Combined(
+        IReadOnlyList<DeclaredHeaderParameterModel> declared,
+        IReadOnlyList<DeclaredHeaderParameterModel> wider) {
+        if (wider.Count == 0) {
+            return declared;
+        }
+
+        var result = new List<DeclaredHeaderParameterModel>(declared);
+
+        foreach (var header in wider) {
+            if (!result.Exists(existing =>
+                    string.Equals(existing.Name, header.Name, System.StringComparison.OrdinalIgnoreCase))) {
+                result.Add(header);
+            }
+        }
+
+        return result;
     }
 
     private static void WriteOperation(

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/DeclaredOperationFacts.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/DeclaredOperationFacts.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Hardened.Generation.Models;
 using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Shared;
 
 namespace Hardened.SourceGenerator.Requests;
 
@@ -23,7 +24,7 @@ namespace Hardened.SourceGenerator.Requests;
 /// not have.
 /// </para>
 /// </remarks>
-internal sealed class DeclaredOperationFacts : IEquatable<DeclaredOperationFacts> {
+internal sealed class DeclaredOperationFacts : IEquatable<DeclaredOperationFacts>, IEntryPointFilterFacts {
 
     public static readonly DeclaredOperationFacts Empty = new(
         Array.Empty<ScopedRefusal>(),

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/EntryPointFilterRung.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/EntryPointFilterRung.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using Hardened.SourceGenerator.Requests;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// The filters an entry point declares for every handler in its compilation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A filter attribute on a handler method or on its controller is read by
+/// <c>BaseRequestModelGenerator.GetFilters</c> into that handler's metadata array. One covering the
+/// whole application has no handler to sit on, and the route that leaves the compilation -
+/// <c>[Enable&lt;T&gt;]</c> and a global registration - is invisible to the generator that writes
+/// the document. Read here instead, while the entry point's symbols are in reach, so both halves
+/// see the same declaration.
+/// </para>
+/// <para>
+/// <b>Whatever implements <c>IRequestFilterProvider</c>, and nothing else.</b> The handler rungs
+/// take a denylist - anything that is not a route or a response declaration is a filter - which is
+/// safe on a handler and not on an entry point, where <c>[HardenedModule]</c>, a runtime marker and
+/// every <c>[Enable&lt;T&gt;]</c> sit in the same list. It also keeps the two halves reading one
+/// set: the document publishes what the pipeline installs, rather than a status from an attribute
+/// that contributes no filter.
+/// </para>
+/// <para>
+/// The facets are read from the same declarations for that reason, through
+/// <see cref="FilterResponseSelector.ReadDeclarations"/> and unnarrowed. Which operations one
+/// reaches is decided per handler, where the verb and the response shape are known.
+/// </para>
+/// </remarks>
+public static partial class EntryPointSelector {
+
+    private const string FilterProvider = "IRequestFilterProvider";
+
+    private const string FilterProviderNamespace = "Hardened.Requests.Abstract.RequestFilter";
+
+    static partial void ReadFilterRung(
+        GeneratorSyntaxContext context,
+        ClassDeclarationSyntax entryPoint,
+        Model model,
+        CancellationToken cancellationToken) {
+        List<AttributeSyntax>? declarations = null;
+
+        foreach (var list in entryPoint.AttributeLists) {
+            foreach (var attribute in list.Attributes) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (IsFilterProvider(context, attribute)) {
+                    (declarations ??= new List<AttributeSyntax>()).Add(attribute);
+                }
+            }
+        }
+
+        if (declarations == null) {
+            return;
+        }
+
+        var models = new List<AttributeModel>(declarations.Count);
+
+        foreach (var declaration in declarations) {
+            if (AttributeModelHelper.GetAttribute(context, declaration) is { } attributeModel) {
+                models.Add(attributeModel);
+            }
+        }
+
+        model.FilterDeclarations = models;
+        model.FilterFacts =
+            FilterResponseSelector.ReadDeclarations(context, declarations, cancellationToken);
+    }
+
+    /// <summary>
+    /// Whether this attribute's own type provides a filter.
+    /// </summary>
+    /// <remarks>
+    /// By interface rather than by name, so an application's own filter attribute is declarable at
+    /// the entry point on the same terms as one this framework ships. Matched on the interface's
+    /// namespace as well as its name, because a name alone is something any assembly can spell.
+    /// </remarks>
+    private static bool IsFilterProvider(GeneratorSyntaxContext context, AttributeSyntax attribute) {
+        if (context.SemanticModel.GetSymbolInfo(attribute).Symbol?.ContainingType is not { } type) {
+            return false;
+        }
+
+        foreach (var contract in type.AllInterfaces) {
+            if (contract.Name == FilterProvider &&
+                contract.ContainingNamespace?.ToDisplayString() == FilterProviderNamespace) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/FilterResponseSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/FilterResponseSelector.cs
@@ -75,6 +75,44 @@ public static class FilterResponseSelector {
     internal static DeclaredOperationFacts Read(
         GeneratorSyntaxContext context,
         MethodDeclarationSyntax method,
+        CancellationToken cancellationToken) =>
+        Collect(
+            context,
+            Declarations(context, method),
+            Written(context, method),
+            cancellationToken);
+
+    /// <summary>
+    /// The same reading, over declarations that are not on a handler at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The entry point's rung. A filter declared there covers every handler in the compilation, so
+    /// what it answers belongs on every operation the same declaration installs on - narrowed by
+    /// the same <see cref="DeclaredScope"/>, since a declaration that reaches only the reads
+    /// publishes only on the reads.
+    /// </para>
+    /// <para>
+    /// No <see cref="Written"/> rung. That one reads <c>[AnswersHeader]</c> and
+    /// <c>[ReadsHeader]</c> written directly beside a handler, where the operation is the subject.
+    /// An entry point is not an operation, and a header declared there would describe every route
+    /// in the application without a filter behind it to write one.
+    /// </para>
+    /// </remarks>
+    internal static DeclaredOperationFacts ReadDeclarations(
+        GeneratorSyntaxContext context,
+        IEnumerable<AttributeSyntax> declarations,
+        CancellationToken cancellationToken) =>
+        Collect(
+            context,
+            declarations.Select(attribute => Declaration.FromSyntax(context, attribute)),
+            Enumerable.Empty<(ISymbol, AttributeData)>(),
+            cancellationToken);
+
+    private static DeclaredOperationFacts Collect(
+        GeneratorSyntaxContext context,
+        IEnumerable<Declaration> declarations,
+        IEnumerable<(ISymbol Carrier, AttributeData Facet)> written,
         CancellationToken cancellationToken) {
         Dictionary<int, ScopedRefusal>? byStatus = null;
         List<ScopedResponseHeader>? responseHeaders = null;
@@ -86,7 +124,7 @@ public static class FilterResponseSelector {
         // and the further one add a 504 the operation can never answer.
         HashSet<string>? spoken = null;
 
-        foreach (var declaration in Declarations(context, method)) {
+        foreach (var declaration in declarations) {
             cancellationToken.ThrowIfCancellationRequested();
 
             if (declaration.Type == null) {
@@ -136,7 +174,7 @@ public static class FilterResponseSelector {
         // it carries a Location - and those are read off the symbol rather than through
         // Declarations, because Declarations carries an attribute's type and this needs the
         // arguments the attribute was written with.
-        foreach (var (carrier, facet) in Written(context, method)) {
+        foreach (var (carrier, facet) in written) {
             if (Is(facet, AnswersHeader)) {
                 AddResponseHeader(carrier, facet, ref spoken, ref responseHeaders);
             }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/EntryPointSelector.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/EntryPointSelector.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Hardened.SourceGenerator.Shared;
 
-public static class EntryPointSelector {
+public static partial class EntryPointSelector {
     public class Model {
         public ITypeDefinition EntryPointType { get; set; } = default!;
 
@@ -43,6 +43,19 @@ public static class EntryPointSelector {
         /// <see cref="Shared.ImportedCachedHandlers.ImportsAStore"/>.
         /// </summary>
         public bool ImportsAStore { get; set; }
+
+        /// <summary>
+        /// The filters this entry point declares for every handler in its compilation, ready to
+        /// construct. See <see cref="ReadFilterRung"/>.
+        /// </summary>
+        public IReadOnlyList<AttributeModel> FilterDeclarations { get; set; } =
+            Array.Empty<AttributeModel>();
+
+        /// <summary>
+        /// What those declarations answer, unnarrowed, for the document writer to apply per
+        /// operation. Null where the entry point declares no filter.
+        /// </summary>
+        public IEntryPointFilterFacts? FilterFacts { get; set; }
     }
 
     public class Comparer : IEqualityComparer<Model> {
@@ -65,7 +78,9 @@ public static class EntryPointSelector {
                    x.EnabledFeatures.SequenceEqual(y.EnabledFeatures) &&
                    x.ImportedLinks.SequenceEqual(y.ImportedLinks) &&
                    x.ImportedCachedHandlers.SequenceEqual(y.ImportedCachedHandlers, StringComparer.Ordinal) &&
-                   x.ImportsAStore == y.ImportsAStore;
+                   x.ImportsAStore == y.ImportsAStore &&
+                   x.FilterDeclarations.SequenceEqual(y.FilterDeclarations) &&
+                   Equals(x.FilterFacts, y.FilterFacts);
         }
 
         private bool CompareProperties(Model x, Model y) {
@@ -123,6 +138,23 @@ public static class EntryPointSelector {
         }
     }
 
+    /// <summary>
+    /// Reads the filters this entry point declares for every handler in its compilation into
+    /// <paramref name="model"/>.
+    /// </summary>
+    /// <remarks>
+    /// A partial method for the reason <see cref="IEntryPointFilterFacts"/> is an interface: this
+    /// folder is the one every generator compiles, and what a declaration answers is built out of
+    /// response models that only the generators writing a document compile. Those implement this;
+    /// in the rest the call is erased and the two members stay empty, which is what they mean for a
+    /// generator that writes no document.
+    /// </remarks>
+    static partial void ReadFilterRung(
+        GeneratorSyntaxContext context,
+        ClassDeclarationSyntax entryPoint,
+        Model model,
+        CancellationToken cancellationToken);
+
     public static Func<SyntaxNode, CancellationToken, bool> UsingAttribute() {
         return (node, _) => node is ClassDeclarationSyntax && node.IsAttributed("HardenedModule");
     }
@@ -169,7 +201,7 @@ public static class EntryPointSelector {
                 importsAStore = ImportedCachedHandlers.ImportsAStore(syntaxContext, attributes);
             }
 
-            return new Model {
+            var model = new Model {
                 EntryPointType = ((ClassDeclarationSyntax)syntaxContext.Node).GetTypeDefinition(),
                 MethodDefinitions = GenerateMethodDefinitions(syntaxContext, methods),
                 RootEntryPoint = rootEntryPoint,
@@ -180,6 +212,15 @@ public static class EntryPointSelector {
                 ImportedCachedHandlers = importedCachedHandlers,
                 ImportsAStore = importsAStore
             };
+
+            // And once more, for the same reason as the three above: which of those attributes
+            // provide a filter, and what each of them answers. After the model rather than into its
+            // initializer, because the implementation lives in a generator this file cannot name.
+            if (syntaxContext.Node is ClassDeclarationSyntax entryPointClass) {
+                ReadFilterRung(syntaxContext, entryPointClass, model, token);
+            }
+
+            return model;
         };
     }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/IEntryPointFilterFacts.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/IEntryPointFilterFacts.cs
@@ -1,0 +1,23 @@
+namespace Hardened.SourceGenerator.Shared;
+
+/// <summary>
+/// What the filters an entry point declares answer, for the generator writing the document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An interface with one member, and that is the whole point of it. <c>Shared</c> is the folder
+/// every generator compiles - the validation generator compiles this and one other file and nothing
+/// else - so a type declared here may not reach into the response models, which only the generators
+/// that write a document compile. <see cref="EntryPointSelector.Model"/> has to carry the facts
+/// across that line, so it carries them as this.
+/// </para>
+/// <para>
+/// <c>DeclaredOperationFacts</c> is the implementation and the only one. A generator that writes a
+/// document names it directly to narrow the facts per operation; one that does not can still
+/// compare two models and see that nothing changed.
+/// </para>
+/// </remarks>
+public interface IEntryPointFilterFacts {
+    /// <summary>Whether the entry point's declarations say anything about a document at all.</summary>
+    bool IsEmpty { get; }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Shared/KnownTypes.cs
@@ -77,6 +77,8 @@ public static class KnownTypes {
 
                     public const string Outputs = "Hardened.Requests.Abstract.Outputs";
 
+                    public const string RequestFilter = "Hardened.Requests.Abstract.RequestFilter";
+
                 }
 
                 public static class Runtime {
@@ -285,6 +287,11 @@ public static class KnownTypes {
         public static readonly ITypeDefinition IServerSentEventManifest =
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Serializer,
                 "IServerSentEventManifest");
+
+        /// <summary>The filters an entry point declares for every handler in its compilation.</summary>
+        public static readonly ITypeDefinition IApplicationFilterDeclarations =
+            TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition,
+                Namespace.Hardened.Requests.Abstract.RequestFilter, "IApplicationFilterDeclarations");
 
         public static readonly ITypeDefinition IExecutionRequestParameter =
             TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace.Hardened.Requests.Abstract.Execution,

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/ApplicationFilterEmitter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/ApplicationFilterEmitter.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using CSharpAuthor;
+using static CSharpAuthor.SyntaxHelpers;
+using Hardened.SourceGenerator.Shared;
+
+namespace Hardened.SourceGenerator.Web;
+
+/// <summary>
+/// The filters an application declares once, for every handler in its compilation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One array beside the routing table rather than a copy appended to every handler's own metadata.
+/// Three reasons, in order of weight. A handler model is a Roslyn cache key, so folding the entry
+/// point's attributes into each one would make an edit to the module class invalidate every handler
+/// in the application. <c>new AuditAttribute { Category = "x" }</c> written into forty metadata
+/// arrays is forty places for the arguments to be spelled and forty instances in the assembly. And
+/// a declaration that covers the application should appear once in the generated source, next to
+/// the routing table it covers.
+/// </para>
+/// <para>
+/// Registered as <c>IApplicationFilterDeclarations</c> and read once per handler by
+/// <c>ExecutionHelper</c>, which drops any entry the handler declares nearer and merges the rest
+/// into its metadata. Nothing is emitted for an entry point that declares no filter, which keeps
+/// this out of the checked-in routing fixtures and off the AOT trimming surface of every
+/// application that does not use it.
+/// </para>
+/// </remarks>
+internal static class ApplicationFilterEmitter {
+
+    public const string ContainerName = "ApplicationFilters";
+
+    private const string DeclaredField = "_declared";
+
+    public static void Emit(ClassDefinition appClass, IReadOnlyList<AttributeModel> declarations) {
+        if (declarations.Count == 0) {
+            return;
+        }
+
+        var container = appClass.AddClass(ContainerName);
+
+        container.Modifiers |= ComponentModifier.Private | ComponentModifier.Sealed;
+        container.AddBaseType(KnownTypes.Requests.IApplicationFilterDeclarations);
+        container.Comment =
+            "The filters this application declares for every handler in this compilation. " +
+            "Merged into each handler's metadata as its chain is built; see " +
+            "IApplicationFilterDeclarations.";
+
+        var field = container.AddField(typeof(object).MakeArrayType(), DeclaredField);
+
+        field.Modifiers |=
+            ComponentModifier.Private | ComponentModifier.Static | ComponentModifier.Readonly;
+        field.InitializeValue = Declared(declarations);
+
+        var property = container.AddProperty(
+            new GenericTypeDefinition(
+                TypeDefinitionEnum.InterfaceDefinition,
+                "System.Collections.Generic",
+                "IReadOnlyList",
+                new[] { TypeDefinition.Get(typeof(object)) }),
+            "Declared");
+
+        property.Modifiers |= ComponentModifier.Public;
+        property.Set = null;
+        property.Get.LambdaSyntax = true;
+        property.Get.AddCode(DeclaredField + ";");
+    }
+
+    /// <summary>
+    /// The declarations as written, constructed once.
+    /// </summary>
+    /// <remarks>
+    /// The same spelling <c>HandlerInfoCodeGenerator</c> emits a handler's own metadata array with,
+    /// from the same <see cref="AttributeModel"/>: the constructor arguments and the property
+    /// initializer an attribute was written with, already qualified.
+    /// </remarks>
+    private static IOutputComponent Declared(IReadOnlyList<AttributeModel> declarations) {
+        var instances = new List<object>(declarations.Count);
+
+        foreach (var declaration in declarations) {
+            var instance = New(
+                (ITypeDefinition)declaration.TypeDefinition,
+                new CodeOutputComponent(declaration.Arguments) { Indented = false });
+
+            if (!string.IsNullOrEmpty(declaration.PropertyAssignment)) {
+                instance.AddInitValue(declaration.PropertyAssignment);
+            }
+
+            instances.Add(instance);
+        }
+
+        return NewArray(typeof(object), instances.ToArray());
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -259,6 +259,8 @@ public static class RoutingTableGenerator {
 
         ServerSentEventManifestEmitter.Emit(appClass, eventStreams);
 
+        ApplicationFilterEmitter.Emit(appClass, appModel.FilterDeclarations);
+
         GenerateDependencyInjection(
             appClass, routingType, appModel, endPointModels, enums, eventStreams, cancellationToken,
             options);
@@ -298,6 +300,19 @@ public static class RoutingTableGenerator {
 
         diMethod.AddIndentedStatement(serviceCollection.InvokeGeneric("AddSingleton",
             new[] { KnownTypes.Web.IWebExecutionRequestHandlerProvider, routingTableType }));
+
+        // Only where the entry point declares a filter. Registered rather than handed to each
+        // handler, because ExecutionHelper composes every chain and a handler class is generated
+        // from its own declarations and cannot name its entry point.
+        if (applicationModel.FilterDeclarations.Count > 0) {
+            diMethod.AddIndentedStatement(serviceCollection.InvokeGeneric("AddSingleton",
+                new[] {
+                    KnownTypes.Requests.IApplicationFilterDeclarations,
+                    TypeDefinition.Get(applicationModel.EntryPointType.Namespace,
+                        applicationModel.EntryPointType.Name + "." +
+                        ApplicationFilterEmitter.ContainerName)
+                }));
+        }
 
         // Only where a handler is framed as events, so an application with none generates exactly
         // what it generated before this existed.

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/EntryPointFilterRungTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/EntryPointFilterRungTests.cs
@@ -1,0 +1,218 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Runtime.Authorization;
+using Hardened.Shared.Runtime.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Hardened.Web.Runtime.Conditional;
+using Hardened.Web.Runtime.OpenApi;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests;
+
+/// <summary>
+/// A filter declared on the entry point, in the generated source and in the served document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The 0.32 trial's A-04: <c>[Enable&lt;ConditionalGet&gt;]</c> installs the filter on every GET
+/// and publishes it on none, because what decides which handlers are covered is a predicate
+/// evaluated at startup and the document is written at build time. A declaration on the module
+/// class stays inside the compilation, so both halves read it.
+/// </para>
+/// <para>
+/// Both halves are asserted here rather than only the document: the array the pipeline reads and
+/// the statuses the document publishes come from one declaration, and a test that watched only one
+/// of them would pass on exactly the disagreement this closes.
+/// </para>
+/// </remarks>
+public class EntryPointFilterRungTests {
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),                 // Hardened.Web.Runtime
+        typeof(FromBodyAttribute),            // Hardened.Requests.Abstract
+        typeof(AuthorizeGrantsAttribute),     // Hardened.Requests.Runtime
+        typeof(EnableAttribute<>),            // Hardened.Shared.Runtime
+        typeof(ConditionalGetAttribute),      // the declaration
+        typeof(OpenApiDocumentPublishing)     // the marker
+    ];
+
+    private const string Usings = """
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Hardened.Shared.Runtime.Attributes;
+        using Hardened.Web.Runtime.Attributes;
+        using Hardened.Web.Runtime.Conditional;
+        using Hardened.Web.Runtime.OpenApi;
+
+        """;
+
+    private const string Controllers = """
+        public class LibraryController {
+            [Get("/books")]
+            public string List() => "";
+
+            [Get("/books/{id}")]
+            public string Read(string id) => "";
+
+            [Post("/books")]
+            public string Add(string title) => "";
+        }
+
+        """;
+
+    private static GeneratorResult Generate(string entryPointAttributes, string controllers) {
+        var source = Usings + """
+            namespace TestApp;
+
+            [HardenedModule]
+            [Enable<OpenApiDocumentPublishing>]
+            """ + entryPointAttributes + """
+
+            public partial class Application { }
+
+            """ + controllers;
+
+        return GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Test.cs"] = source },
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors).AssertNoErrors();
+    }
+
+    private static JsonElement Document(GeneratorResult result) {
+        var match = Regex.Match(
+            result.SourceContaining("OpenApiDocument"),
+            @"new byte\[\]\s*\{(.*?)\}\s*;", RegexOptions.Singleline);
+
+        Assert.True(match.Success, "No document byte array in the generated source.");
+
+        var bytes = match.Groups[1].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(byte.Parse)
+            .ToArray();
+
+        using var source = new MemoryStream(bytes, writable: false);
+        using var gzip = new GZipStream(source, CompressionMode.Decompress);
+        using var inflated = new MemoryStream();
+
+        gzip.CopyTo(inflated);
+
+        return JsonDocument.Parse(inflated.ToArray()).RootElement.Clone();
+    }
+
+    private static JsonElement Operation(JsonElement document, string path, string method) =>
+        document.GetProperty("paths").GetProperty(path).GetProperty(method);
+
+    private static string[] Statuses(JsonElement document, string path, string method = "get") =>
+        Operation(document, path, method).GetProperty("responses").EnumerateObject()
+            .Select(response => response.Name)
+            .OrderBy(status => status, StringComparer.Ordinal)
+            .ToArray();
+
+    private static string[] Headers(JsonElement document, string path, string status) =>
+        Operation(document, path, "get").GetProperty("responses").GetProperty(status)
+            .TryGetProperty("headers", out var headers)
+            ? headers.EnumerateObject().Select(header => header.Name).ToArray()
+            : [];
+
+    private static string[] Parameters(JsonElement document, string path, string method = "get") =>
+        Operation(document, path, method).TryGetProperty("parameters", out var parameters)
+            ? parameters.EnumerateArray().Select(p => p.GetProperty("name").GetString()!).ToArray()
+            : [];
+
+    /// <summary>
+    /// The declaration reaches the pipeline as an array beside the routing table, registered for
+    /// <c>ExecutionHelper</c> to merge into each handler as its chain is built.
+    /// </summary>
+    [Fact]
+    public void TheDeclarationIsEmittedOnceAndRegistered() {
+        var routing = Generate("[ConditionalGet]", Controllers).SourceContaining("Routing");
+
+        Assert.Contains("class ApplicationFilters", routing);
+        Assert.Contains("new ConditionalGetAttribute()", routing);
+        Assert.Contains("IApplicationFilterDeclarations", routing);
+
+        // Once for the application, rather than once per handler - which is the reason it is here
+        // and not folded into each handler's own metadata array.
+        Assert.Single(Regex.Matches(routing, @"new ConditionalGetAttribute\(\)"));
+    }
+
+    /// <summary>
+    /// An entry point declaring no filter generates what it generated before this existed.
+    /// </summary>
+    [Fact]
+    public void AnEntryPointDeclaringNoFilterEmitsNothing() {
+        var routing = Generate("", Controllers).SourceContaining("Routing");
+
+        Assert.DoesNotContain("ApplicationFilters", routing);
+        Assert.DoesNotContain("IApplicationFilterDeclarations", routing);
+    }
+
+    /// <summary>
+    /// A-04 itself: every read publishes the 304 the filter answers, and the write publishes
+    /// nothing, because the declaration says it reaches GET and HEAD.
+    /// </summary>
+    [Fact]
+    public void EveryReadPublishesTheStatusTheDeclarationAnswers() {
+        var document = Document(Generate("[ConditionalGet]", Controllers));
+
+        Assert.Equal(["200", "304"], Statuses(document, "/books"));
+        Assert.Equal(["200", "304"], Statuses(document, "/books/{id}"));
+        Assert.Equal(["200"], Statuses(document, "/books", "post"));
+    }
+
+    /// <summary>
+    /// And the rest of what a caller needs to make the request: the tag on both statuses, and the
+    /// header to send it back in.
+    /// </summary>
+    [Fact]
+    public void EveryReadPublishesTheHeadersTheDeclarationReadsAndWrites() {
+        var document = Document(Generate("[ConditionalGet]", Controllers));
+
+        Assert.Equal(["ETag"], Headers(document, "/books", "200"));
+        Assert.Equal(["ETag"], Headers(document, "/books", "304"));
+        Assert.Contains("If-None-Match", Parameters(document, "/books"));
+        Assert.Contains("If-Modified-Since", Parameters(document, "/books"));
+
+        Assert.Empty(Parameters(document, "/books", "post"));
+    }
+
+    /// <summary>
+    /// A handler that streams is left alone by both halves. The filter stands down because tagging
+    /// a response means holding it back to hash it, and the document says so because the
+    /// declaration states <c>NotWhenStreaming</c>.
+    /// </summary>
+    [Fact]
+    public void AStreamedReadPublishesNothingFromTheRung() {
+        var document = Document(Generate("[ConditionalGet]", """
+            public class FeedController {
+                [Get("/feed")]
+                public async IAsyncEnumerable<string> Live() { yield return ""; await Task.CompletedTask; }
+            }
+            """));
+
+        Assert.Equal(["200"], Statuses(document, "/feed"));
+    }
+
+    /// <summary>
+    /// A handler declaring it itself is published once rather than twice, which is the document's
+    /// half of nearest-rung-wins.
+    /// </summary>
+    [Fact]
+    public void AHandlerDeclaringItItselfPublishesOneOfEach() {
+        var document = Document(Generate("[ConditionalGet]", """
+            public class RateController {
+                [Get("/rates")]
+                [ConditionalGet]
+                public string Read() => "";
+            }
+            """));
+
+        Assert.Equal(["200", "304"], Statuses(document, "/rates"));
+        Assert.Equal(["ETag"], Headers(document, "/rates", "200"));
+        Assert.Single(Parameters(document, "/rates"), name => name == "If-None-Match");
+    }
+}


### PR DESCRIPTION
Closes the 0.32 trial's A-04: `[Enable<ConditionalGet>]` installs the filter on every GET and publishes the 304 on none, so the generated Kiota client throws `no error factory is registered for this code: 304` on exactly the request the feature exists to make cheap. The predicate deciding which handlers are covered is evaluated at startup and the document is written at build time, so the document half cannot be fixed where it stands.

The entry point becomes a rung both halves read.

```csharp
[HardenedModule]
[HardenedWebModule]
[ConditionalGet]
public partial class Catalog { }
```

installs on every read in that compilation **and** publishes the 304, the `ETag` on both statuses and both conditional request headers — on exactly the operations the declaration says it reaches.

## What it does

- `EntryPointSelector` collects the attributes on a `[HardenedModule]` class that implement `IRequestFilterProvider`, by interface rather than by the handler rungs' denylist, because a module's attribute list is mostly markers. It carries both the declarations and their `[AnswersStatus]`/`[AnswersHeader]`/`[ReadsHeader]` facets.
- `RoutingTableGenerator` emits them once as a nested `ApplicationFilters` class beside the routing table and registers it as `IApplicationFilterDeclarations`. Nothing is emitted for an entry point that declares no filter.
- `ExecutionHelper` merges them into each handler's `Metadata` as its chain is built, dropping any whose closed type the handler declares nearer, and asks the survivors for their filters beside the registry's — the position `[Enable<T>]` already gives them.
- `OpenApiDocumentGenerator` narrows the facets per operation through the same `Methods`/`NotWhenStreaming` scoping a declaration on a controller already gets.

Both front ends compose through `RoutingTableGenerator.GenerateCSharpRouteFile` and `OpenApiDocumentGenerator.Write`, so a described application gets this with no second implementation.

## Scoped to its own compilation

`IApplicationFilterDeclarations.DeclaringAssembly` is matched against `handlerInfo.HandlerType.Assembly`. A process composes as many modules as it references, so without it a library's declaration would reach a host's handlers, whose document was written before the host existed. That is the same answer `TimeoutResolver` already gives for `[assembly: Timeout]`, and it settles open question 1 in the design note.

`[Enable<ConditionalGet>]` is unchanged and still works; it is what a host writes to switch the feature on for handlers it only references.

## What is not built

Each is its own change, and the design note says what each would take.

- **The assembly rung.** `AttributeTargets.Assembly` is on no filter attribute this framework ships except `[Timeout]`, so it is a vocabulary decision across the whole attribute set rather than one generator change.
- **`AttributeUsage.AllowMultiple` as the replace-or-compose switch.** `CacheResponseAttribute` carries `AllowMultiple = true` because the compiler dedupes a generic attribute on its unbound form, not because two declarations compose. The rule here is nearest-wins on the closed type; a generic attribute a handler closes differently still stacks, and `WiderRungs`'s remarks say so.
- **The applicability hoist and its two diagnostics.** `[ConditionalGet]` still states its reach six times.
- **`TimeoutResolver` folding into the shared walk.** Its entry-point rung is a registered `TimeoutPolicy` taking the tightest, not an attribute.

## Verification

- `dotnet test Hardened.slnx` — 74 assemblies green.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — clean apart from the standing local-only `HSMT011` (this machine's Smithy CLI is 1.56.0 against the 1.73.0 pin).
- `Hardened.Simulators.slnx` built and tested green.
- `npm run build` in `docs/` green.
- Public API re-approved: `IApplicationFilterDeclarations` and `WithWiderRungs`.

New tests: `EntryPointFilterRungTests` (the emitted array, the registration, the document on reads and not on writes or streams, a handler declaring it itself), `SpecFirstEntryPointFilterTests` (the same through the described front end), `ApplicationFilterRungTests` (the merge, nearest-wins, ties, several modules, another compilation), and `ModuleDeclaredFilterTests` — a built application where `WebLibrary` declares `[ConditionalGet]`, its handler answers 304 over the pipeline, and the host's own reads carry no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)