### PR TITLE
Cover the entry-point rung where its assembly is measured

### DIFF
--- a/docs/guide/compression.md
+++ b/docs/guide/compression.md
@@ -20,7 +20,21 @@ Vary: Accept-Encoding
 
 ## Turning it on
 
-For one operation or one class, `[Compress]` as above. For the whole application:
+For one operation or one class, `[Compress]` as above. For every handler compiled with a module,
+the same attribute on the module class:
+
+```csharp
+[HardenedModule]
+[HardenedWebModule]
+[Compress]
+public partial class Catalog { }
+```
+
+An operation carrying `[Compress]` itself keeps its own, so the nearer declaration is the one that
+applies.
+
+`[Enable<ResponseCompression>]` does the same at run time and is what a host writes for handlers it
+only references:
 
 ```csharp
 [HardenedModule]
@@ -29,9 +43,7 @@ For one operation or one class, `[Compress]` as above. For the whole application
 public partial class Application { }
 ```
 
-An operation carrying `[Compress]` is left alone by the application-wide default, so the
-declaration on the operation is the one that applies. Nothing is compressed until one of the two
-is written.
+Nothing is compressed until one of these is written.
 
 gzip is offered first and Brotli behind it, both at the fastest level. The coding is negotiated
 from the client's `Accept-Encoding` when the filter is entered. Whether the body is compressed at

--- a/docs/guide/rate-limiting.md
+++ b/docs/guide/rate-limiting.md
@@ -34,6 +34,18 @@ registered for you, so a handler carrying `[RateLimit]` is limited with nothing 
 A handler with no store registered is not limited: the filter resolves `IRateLimitStore` per
 request and passes the request straight through when there is none.
 
+It goes on a `[HardenedModule]` class as well, where it caps every handler compiled with it and
+publishes the 429 on each of them:
+
+```csharp
+[HardenedModule]
+[HardenedWebModule]
+[RateLimit(PermitLimit = 100, WindowSeconds = 60)]
+public partial class Catalog { }
+```
+
+A handler carrying its own `[RateLimit]` keeps that one instead.
+
 ::: danger Each instance counts separately
 Two replicas behind a load balancer allow twice the configured limit between them. On Lambda
 every execution environment has its own count, and the number of environments is what you do

--- a/docs/guide/response-caching.md
+++ b/docs/guide/response-caching.md
@@ -176,6 +176,29 @@ filled the cache, so the key has to include whatever the response varies on. Add
 
 ## Apply it everywhere
 
+The attribute goes on a `[HardenedModule]` class, where it covers every handler compiled with it:
+
+```csharp
+[HardenedModule]
+[HardenedWebModule]
+[CacheResponse<VaryByRoute>(Duration = 60)]
+public partial class Catalog { }
+```
+
+A handler declaring `[CacheResponse<VaryByRoute>]` itself keeps its own and the module's is dropped
+for that handler, so explicit beats convention.
+
+::: warning Two strategies do not replace each other
+The dedup is on the closed type, which is what lets
+[two strategies compose on one handler](#composing-two). So a handler declaring
+`[CacheResponse<VaryByQuery>]` beside a module's `[CacheResponse<VaryByRoute>]` gets **both**, and
+two that disagree about a `Duration` or a `Scope` fail as the chain is built. Close the module's
+declaration over the same strategy the handlers vary from, or declare per handler.
+:::
+
+`AddGlobalFilter` does the same at run time, and is what a host writes for handlers it only
+references:
+
 ```csharp
 services.AddGlobalFilter(
     new CacheResponseAttribute<VaryByRoute> { Duration = 60 },
@@ -183,7 +206,7 @@ services.AddGlobalFilter(
 ```
 
 A globally registered instance stands down on any handler that declares `[CacheResponse]`
-itself, so explicit beats convention.
+itself, on the same terms.
 
 ## Configuration
 

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -65,20 +65,20 @@ All take `As` to narrow the service type, and `Using` to choose the registration
 
 | Attribute | Target | Purpose |
 |---|---|---|
-| `[Retry]` | Class, method | Re-runs the handler after a failure. `Attempts` (3), `SleepTime` (500 ms), `TotalBudget` (10 s), `AllowNonIdempotent`. Declines client errors, and non-idempotent verbs unless told otherwise |
+| `[Retry]` | Module, class, method | Re-runs the handler after a failure. `Attempts` (3), `SleepTime` (500 ms), `TotalBudget` (10 s), `AllowNonIdempotent`. Declines client errors, and non-idempotent verbs unless told otherwise |
 | `[Timeout]` | Class, method, assembly | [Bounds how long the operation may take](/guide/request-timeouts). `Milliseconds` (30 s), `Status` (504), `RetryAfterSeconds`. The nearest declaration wins, and nothing is bounded until one is written |
 
 `Hardened.Requests.Runtime.RateLimiting`
 
 | Attribute | Target | Purpose |
 |---|---|---|
-| `[RateLimit]` | Class, method | [Caps how often the operation may be called](/guide/rate-limiting). `PermitLimit` (100), `WindowSeconds` (60). Publishes the 429 |
+| `[RateLimit]` | Module, class, method | [Caps how often the operation may be called](/guide/rate-limiting). `PermitLimit` (100), `WindowSeconds` (60). Publishes the 429 |
 
 `Hardened.Requests.Runtime.Caching`
 
 | Attribute | Target | Purpose |
 |---|---|---|
-| `[CacheResponse<T>(values, …)]` | Class, method | [Stores the response](/guide/response-caching) and serves it without running the handler. `Duration`, `Scope`, `Tags`. `AllowMultiple`, and the parts compose into one key |
+| `[CacheResponse<T>(values, …)]` | Module, class, method | [Stores the response](/guide/response-caching) and serves it without running the handler. `Duration`, `Scope`, `Tags`. `AllowMultiple`, and the parts compose into one key |
 
 `Hardened.Requests.Caching.Memory`
 
@@ -138,8 +138,8 @@ See [Authorization](/guide/authorization).
 
 | Attribute | Target | Purpose |
 |---|---|---|
-| `[Compress]` | Class, method | [Compresses this operation's responses](/guide/compression) under the configured media-type rule. `Favor` picks a coding |
-| `[Compress<TPredicate>(args)]` | Class, method | The same, decided by a predicate over the value the handler returned |
+| `[Compress]` | Module, class, method | [Compresses this operation's responses](/guide/compression) under the configured media-type rule. `Favor` picks a coding |
+| `[Compress<TPredicate>(args)]` | Module, class, method | The same, decided by a predicate over the value the handler returned |
 
 `Hardened.Web.Runtime.Conditional`
 
@@ -147,8 +147,12 @@ See [Authorization](/guide/authorization).
 |---|---|---|
 | `[ConditionalGet]` | Module, class, method | Answers a caller holding the response with a [304](/guide/conditional-requests). GET handlers only |
 
-Both features are off until the application asks for them, and both can be turned on for every
-handler from the module instead:
+Every filter attribute above goes on a `[HardenedModule]` class as well, where it covers each
+handler compiled with it. That is the form to reach for: the declaration stays inside the
+compilation, so the [document publishes what the pipeline installs](/guide/execution-pipeline#attaching-a-filter-to-a-module).
+
+The `[Enable<T>]` forms below do the same at run time, and are what a host writes for handlers it
+only references:
 
 | Attribute | Target | Purpose |
 |---|---|---|

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/EntryPointRungDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/EntryPointRungDocumentTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.OpenApiDocument;
+using Hardened.SourceGenerator.Requests;
+using Hardened.SourceGenerator.Shared;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.OpenApiDocument;
+
+/// <summary>
+/// What a filter declared on the entry point publishes, per operation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The facts are read once for the application and narrowed here, because whether a declaration
+/// reaches an operation depends on that operation's verb and on whether it streams - the same
+/// narrowing a declaration on a controller gets. Driven over hand-built facts rather than through a
+/// generator, so the merge is exercised on shapes a real declaration reaches only in combination:
+/// a status the handler already declares, a header it already binds, an operation whose responses
+/// were complete.
+/// </para>
+/// <para>
+/// The pipeline half of the same declaration is <c>ApplicationFilterEmitterTests</c>. A document
+/// that publishes what nothing installs is the defect this rung closed, so neither half is a test
+/// of the other.
+/// </para>
+/// </remarks>
+public class EntryPointRungDocumentTests {
+
+    private static ITypeDefinition Type(string name) => TypeDefinition.Get("TestApp", name);
+
+    private static DeclaredScope Reads => new("GET,HEAD", notWhenStreaming: true);
+
+    private static DeclaredOperationFacts NotModified(DeclaredScope? scope = null) {
+        var reach = scope ?? Reads;
+
+        return new DeclaredOperationFacts(
+            [new ScopedRefusal(new ResponseSchemaModel(304, "Nothing is sent.", null), reach)],
+            [
+                new ScopedResponseHeader(304, "ETag", "The tag, repeated.", reach),
+                new ScopedResponseHeader(200, "ETag", "A tag for this response.", reach)
+            ],
+            [new ScopedRequestHeader("If-None-Match", "A tag a previous response carried.", reach)]);
+    }
+
+    private static EntryPointSelector.Model App(DeclaredOperationFacts? facts) =>
+        new() {
+            EntryPointType = Type("Application"),
+            AttributeModels = Array.Empty<AttributeModel>(),
+            FilterFacts = facts
+        };
+
+    private static RequestHandlerModel Handler(
+        string httpMethod = "GET",
+        bool streams = false,
+        IReadOnlyList<ResponseSchemaModel>? responses = null,
+        RequestParameterInformation? parameter = null) =>
+        new(new RequestHandlerNameModel("/books", httpMethod),
+            Type("BookController"),
+            "List",
+            TypeDefinition.Get("TestApp.Generated", "BookController_List"),
+            parameter == null ? [] : [parameter],
+            new ResponseInformationModel { ReturnType = Type("Book"), IsAsyncEnumerable = streams },
+            []) {
+            ResponseSchemas = responses ?? Array.Empty<ResponseSchemaModel>()
+        };
+
+    private static JsonElement Operation(DeclaredOperationFacts? facts, RequestHandlerModel handler) =>
+        JsonDocument
+            .Parse(OpenApiDocumentGenerator.Write(App(facts), [handler], ""))
+            .RootElement
+            .GetProperty("paths").GetProperty("/books")
+            .GetProperty(handler.Name.Method.ToLowerInvariant());
+
+    private static string[] Statuses(JsonElement operation) =>
+        operation.GetProperty("responses").EnumerateObject()
+            .Select(response => response.Name)
+            .OrderBy(status => status, StringComparer.Ordinal)
+            .ToArray();
+
+    private static string[] Parameters(JsonElement operation) =>
+        operation.TryGetProperty("parameters", out var parameters)
+            ? parameters.EnumerateArray().Select(p => p.GetProperty("name").GetString()!).ToArray()
+            : [];
+
+    /// <summary>
+    /// The success survives. A refusal names what can be answered instead of the handler and says
+    /// nothing about what the handler answers when it runs, so it cannot be the whole set.
+    /// </summary>
+    [Fact]
+    public void ADeclaredRefusalJoinsTheOperationsOwnSuccess() {
+        var operation = Operation(NotModified(), Handler());
+
+        Assert.Equal(["200", "304"], Statuses(operation));
+    }
+
+    [Fact]
+    public void TheHeadersTheDeclarationWritesLandOnTheStatusesItNames() {
+        var operation = Operation(NotModified(), Handler());
+
+        Assert.Equal(
+            ["ETag"],
+            operation.GetProperty("responses").GetProperty("304")
+                .GetProperty("headers").EnumerateObject().Select(header => header.Name));
+
+        Assert.Contains("If-None-Match", Parameters(operation));
+    }
+
+    /// <summary>
+    /// And nothing reaches an operation the declaration stood down on, in either direction - a
+    /// status published where the filter installs nothing is the lie the scoping exists to stop.
+    /// </summary>
+    [Theory]
+    [InlineData("POST", false)]
+    [InlineData("GET", true)]
+    public void AnOperationTheDeclarationDoesNotReachPublishesNothingFromIt(
+        string httpMethod, bool streams) {
+        var operation = Operation(NotModified(), Handler(httpMethod, streams));
+
+        Assert.DoesNotContain("304", Statuses(operation));
+        Assert.Empty(Parameters(operation));
+    }
+
+    /// <summary>
+    /// A status the operation declares itself keeps the shape the operation gave it. The rung's
+    /// entries go last for that reason.
+    /// </summary>
+    [Fact]
+    public void AStatusTheOperationAlreadyDeclaresKeepsItsOwnDescription() {
+        var operation = Operation(
+            NotModified(),
+            Handler(responses: [new ResponseSchemaModel(304, "The handler's own wording.", null)]));
+
+        Assert.Equal(
+            "The handler's own wording.",
+            operation.GetProperty("responses").GetProperty("304")
+                .GetProperty("description").GetString());
+    }
+
+    /// <summary>
+    /// A header the operation binds as a parameter wins: it carries a type and a description of its
+    /// own, and two entries under one name is a document no generator can read.
+    /// </summary>
+    [Fact]
+    public void AHeaderTheOperationBindsIsNotPublishedTwice() {
+        var operation = Operation(
+            NotModified(),
+            Handler(parameter: new RequestParameterInformation(
+                Type("String"), "ifNoneMatch", false, null,
+                ParameterBindType.Header, "If-None-Match", 0)));
+
+        Assert.Single(Parameters(operation), name => name == "If-None-Match");
+    }
+
+    /// <summary>
+    /// A declaration that states no reach covers every operation, which is what any filter without
+    /// a verb restriction means.
+    /// </summary>
+    [Fact]
+    public void ADeclarationStatingNoReachCoversEveryOperation() {
+        var facts = NotModified(new DeclaredScope(null, notWhenStreaming: false));
+
+        Assert.Contains("304", Statuses(Operation(facts, Handler("POST"))));
+        Assert.Contains("304", Statuses(Operation(facts, Handler(streams: true))));
+    }
+
+    /// <summary>
+    /// An entry point declaring no filter writes the document it wrote before this existed.
+    /// </summary>
+    [Fact]
+    public void AnEntryPointDeclaringNoFilterChangesNothing() {
+        var handler = Handler();
+
+        Assert.Equal(
+            OpenApiDocumentGenerator.Write(App(null), [handler], ""),
+            OpenApiDocumentGenerator.Write(
+                App(DeclaredOperationFacts.Empty), [handler], ""));
+
+        Assert.Equal(["200"], Statuses(Operation(null, handler)));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Shared/EntryPointFilterRungTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Shared/EntryPointFilterRungTests.cs
@@ -1,0 +1,171 @@
+using Hardened.SourceGenerator.Requests;
+using Hardened.SourceGenerator.Shared;
+using Hardened.SourceGenerator.Tests.Infrastructure;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Shared;
+
+/// <summary>
+/// The filters a <c>[HardenedModule]</c> class declares, as the transform reads them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two members of one model, and they have to agree: <c>FilterDeclarations</c> is what the routing
+/// table constructs and <c>FilterFacts</c> is what the document publishes. A declaration reaching
+/// one and not the other is the disagreement the rung exists to close, so both are asserted from
+/// the same capture.
+/// </para>
+/// <para>
+/// Selected by interface rather than by the denylist the handler rungs use. An entry point's
+/// attribute list is mostly markers - <c>[HardenedModule]</c> itself, a runtime, every
+/// <c>[Enable&lt;T&gt;]</c> - and a denylist there would construct all of them into the filter
+/// chain.
+/// </para>
+/// </remarks>
+public class EntryPointFilterRungTests {
+
+    private const string ConditionalGet = "[Hardened.Web.Runtime.Conditional.ConditionalGet]";
+
+    private static EntryPointSelector.Model Model(string attributes) =>
+        EntryPointCapture.Single(EntryPointCapture.Application(attributes: attributes));
+
+    private static DeclaredOperationFacts Facts(EntryPointSelector.Model model) =>
+        Assert.IsType<DeclaredOperationFacts>(model.FilterFacts);
+
+    [Fact]
+    public void AFilterAttributeReachesTheModelReadyToConstruct() {
+        var model = Model(ConditionalGet);
+
+        var declaration = Assert.Single(model.FilterDeclarations);
+
+        Assert.Equal("ConditionalGetAttribute", declaration.TypeDefinition.Name);
+        Assert.Equal("Hardened.Web.Runtime.Conditional", declaration.TypeDefinition.Namespace);
+    }
+
+    /// <summary>
+    /// And carries what it answers, unnarrowed. Which operations it reaches depends on their verb
+    /// and response shape, which this pass does not know.
+    /// </summary>
+    [Fact]
+    public void TheSameDeclarationCarriesWhatItAnswers() {
+        var facts = Facts(Model(ConditionalGet));
+
+        Assert.False(facts.IsEmpty);
+        Assert.Contains(facts.Refusals, refusal => refusal.Response.Status == 304);
+        Assert.Contains(facts.ResponseHeaders, header => header.Name == "ETag");
+        Assert.Contains(facts.RequestHeaders, header => header.Name == "If-None-Match");
+    }
+
+    /// <summary>
+    /// Narrowed per operation by the scope the declaration stated for itself, which is how the same
+    /// facts publish a 304 on a read and nothing on a write.
+    /// </summary>
+    [Theory]
+    [InlineData("GET", false, true)]
+    [InlineData("HEAD", false, true)]
+    [InlineData("POST", false, false)]
+    [InlineData("GET", true, false)]
+    public void WhatItAnswersIsNarrowedByVerbAndResponseShape(
+        string httpMethod, bool streams, bool reaches) {
+        var reaching = Facts(Model(ConditionalGet)).For(httpMethod, streams);
+
+        Assert.Equal(reaches, reaching.Refusals.Any(refusal => refusal.Status == 304));
+        Assert.Equal(reaches, reaching.HeaderParameters().Count > 0);
+    }
+
+    /// <summary>
+    /// An entry point declaring no filter carries none, which is almost every application and is
+    /// what keeps the routing table it generates unchanged.
+    /// </summary>
+    [Fact]
+    public void AnEntryPointDeclaringNoFilterCarriesNone() {
+        var model = Model("");
+
+        Assert.Empty(model.FilterDeclarations);
+        Assert.Null(model.FilterFacts);
+    }
+
+    /// <summary>
+    /// The markers around it are not filters. <c>[HardenedModule]</c> is on every entry point and
+    /// <c>[Enable&lt;T&gt;]</c> names a module rather than providing a filter itself, so a denylist
+    /// would have constructed both.
+    /// </summary>
+    [Fact]
+    public void AMarkerOnTheEntryPointIsNotAFilter() {
+        var model = Model(
+            "[Enable<Hardened.Web.Runtime.OpenApi.OpenApiDocumentPublishing>]\n" + ConditionalGet);
+
+        var declaration = Assert.Single(model.FilterDeclarations);
+
+        Assert.Equal("ConditionalGetAttribute", declaration.TypeDefinition.Name);
+    }
+
+    /// <summary>
+    /// Two declarations both reach the model, in the order they were written - which is the order
+    /// they are merged into a handler's metadata and therefore the order they break ties in.
+    /// </summary>
+    [Fact]
+    public void EveryFilterDeclaredOnTheEntryPointReachesTheModelInOrder() {
+        var model = Model(
+            "[Hardened.Requests.Runtime.Filters.Retry]\n" + ConditionalGet);
+
+        Assert.Equal(
+            ["RetryAttribute", "ConditionalGetAttribute"],
+            model.FilterDeclarations.Select(declaration => declaration.TypeDefinition.Name));
+    }
+
+    /// <summary>
+    /// The arguments come with it. A declaration covering an application is written once, so this
+    /// is the only place its arguments are spelled.
+    /// </summary>
+    [Fact]
+    public void TheArgumentsADeclarationWasWrittenWithComeWithIt() {
+        var model = Model("[Hardened.Requests.Runtime.Filters.Retry(Attempts = 5)]");
+
+        var declaration = Assert.Single(model.FilterDeclarations);
+
+        Assert.Equal("Attempts = 5", declaration.PropertyAssignment);
+    }
+
+    /// <summary>
+    /// Every filter attribute this framework ships is declarable there, which is what the reference
+    /// table and the feature guides say. Selected by the interface, so an application's own is too.
+    /// </summary>
+    [Theory]
+    [InlineData("[Hardened.Web.Runtime.Conditional.ConditionalGet]", "ConditionalGetAttribute")]
+    [InlineData("[Hardened.Web.Runtime.Compression.Compress]", "CompressAttribute")]
+    [InlineData("[Hardened.Requests.Runtime.Filters.Retry]", "RetryAttribute")]
+    [InlineData("[Hardened.Requests.Runtime.RateLimiting.RateLimit]", "RateLimitAttribute")]
+    [InlineData(
+        "[Hardened.Requests.Runtime.Caching.CacheResponse<Hardened.Web.Runtime.Caching.VaryByRoute>(Duration = 60)]",
+        "CacheResponseAttribute")]
+    public void EveryShippedFilterAttributeIsDeclarableOnTheEntryPoint(
+        string attribute, string expected) {
+        var declaration = Assert.Single(Model(attribute).FilterDeclarations);
+
+        Assert.Equal(expected, declaration.TypeDefinition.Name);
+    }
+
+    /// <summary>
+    /// And one that declares a status publishes it from there. <c>[RateLimit]</c> on a module caps
+    /// every handler compiled with it, so every one of them can answer the 429.
+    /// </summary>
+    [Fact]
+    public void AFilterThatDeclaresAStatusPublishesItFromTheEntryPoint() {
+        var facts = Facts(Model("[Hardened.Requests.Runtime.RateLimiting.RateLimit]"));
+
+        Assert.Contains(facts.For("GET", streams: false).Refusals, refusal => refusal.Status == 429);
+    }
+
+    /// <summary>
+    /// Two models with the same declarations compare equal, so an edit elsewhere in the entry point
+    /// does not invalidate every routing table in the compilation.
+    /// </summary>
+    [Fact]
+    public void TwoEntryPointsDeclaringTheSameFilterCompareEqual() {
+        var comparer = new EntryPointSelector.Comparer();
+
+        Assert.True(comparer.Equals(Model(ConditionalGet), Model(ConditionalGet)));
+        Assert.False(comparer.Equals(Model(ConditionalGet), Model("")));
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/ApplicationFilterEmitterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Web/ApplicationFilterEmitterTests.cs
@@ -1,0 +1,103 @@
+using CSharpAuthor;
+using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Shared;
+using Hardened.SourceGenerator.Web;
+using Xunit;
+
+namespace Hardened.SourceGenerator.Tests.Web;
+
+/// <summary>
+/// The array a routing table carries for the filters its entry point declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One array beside the table rather than a copy in every handler's metadata: a handler model is a
+/// Roslyn cache key, so folding the entry point's attributes into each one would make an edit to
+/// the module class invalidate every handler in the application, and the arguments would be spelled
+/// once per handler in the emitted assembly.
+/// </para>
+/// <para>
+/// Asserted on the emitted C# because that is where the two halves of this meet - the nested class
+/// and the registration that hands it to <c>ExecutionHelper</c> - and a table that emits one
+/// without the other compiles and installs nothing.
+/// </para>
+/// </remarks>
+public class ApplicationFilterEmitterTests {
+
+    private static AttributeModel Declaration(
+        string @namespace, string name, string arguments = "", string properties = "") =>
+        new(TypeDefinition.Get(@namespace, name), arguments, properties);
+
+    private static EntryPointSelector.Model App(params AttributeModel[] filters) =>
+        new() {
+            EntryPointType = TypeDefinition.Get("Test.Api", "TestApp"),
+            AttributeModels = Array.Empty<AttributeModel>(),
+            RootEntryPoint = true,
+            MethodDefinitions = Array.Empty<HardenedMethodDefinition>(),
+            FilterDeclarations = filters
+        };
+
+    private static RequestHandlerModel Handler() =>
+        new(new RequestHandlerNameModel("/books", "GET"),
+            TypeDefinition.Get("Test.Api.Services", "IBookService"),
+            "List",
+            TypeDefinition.Get("Test.Api.Generated", "BookController_List"),
+            Array.Empty<RequestParameterInformation>(),
+            new ResponseInformationModel { IsAsync = true },
+            Array.Empty<AttributeModel>());
+
+    private static string Emit(params AttributeModel[] filters) =>
+        RoutingTableGenerator.GenerateCSharpRouteFile(
+            App(filters), [Handler()], CancellationToken.None);
+
+    [Fact]
+    public void ADeclaredFilterIsConstructedOnceAndRegistered() {
+        var generated = Emit(Declaration("Hardened.Web.Runtime.Conditional", "ConditionalGetAttribute"));
+
+        Assert.Contains("class ApplicationFilters", generated);
+        Assert.Contains("new ConditionalGetAttribute()", generated);
+        Assert.Contains("IApplicationFilterDeclarations", generated);
+        Assert.Contains("TestApp.ApplicationFilters", generated);
+    }
+
+    /// <summary>
+    /// With whatever it was written with. The array is the one place an application-wide
+    /// declaration's arguments are spelled.
+    /// </summary>
+    [Fact]
+    public void TheArgumentsAndInitializersAreEmittedWithIt() {
+        var generated = Emit(
+            Declaration("Test.Api.Filters", "AuditAttribute", "\"quotes\"", "Level = 2"));
+
+        Assert.Contains("new AuditAttribute(\"quotes\"){ Level = 2 }", generated);
+    }
+
+    /// <summary>
+    /// Several declarations keep the order they were written in, which is the order they are merged
+    /// into a handler's metadata and therefore the order they break ties in.
+    /// </summary>
+    [Fact]
+    public void SeveralDeclarationsKeepTheOrderTheyWereWrittenIn() {
+        var generated = Emit(
+            Declaration("Hardened.Requests.Runtime.Filters", "RetryAttribute"),
+            Declaration("Hardened.Web.Runtime.Conditional", "ConditionalGetAttribute"));
+
+        Assert.True(
+            generated.IndexOf("new RetryAttribute()", StringComparison.Ordinal) <
+            generated.IndexOf("new ConditionalGetAttribute()", StringComparison.Ordinal),
+            "The emitted array should read in declaration order.");
+    }
+
+    /// <summary>
+    /// An entry point declaring no filter emits neither the class nor the registration, so a table
+    /// that does not use this generates exactly what it generated before it existed - which is what
+    /// keeps the checked-in routing fixtures unmoved.
+    /// </summary>
+    [Fact]
+    public void AnEntryPointDeclaringNoFilterEmitsNothing() {
+        var generated = Emit();
+
+        Assert.DoesNotContain("ApplicationFilters", generated);
+        Assert.DoesNotContain("IApplicationFilterDeclarations", generated);
+    }
+}


### PR DESCRIPTION
Fixes the red `build-package` on `main`. #325 passed every test and failed the coverage gate: `Hardened.SourceGenerator` line coverage fell to 69.7% against its 70.4% baseline.

## Why it fell

The rung's generator code lives in `Hardened.SourceGenerator`, and every suite that exercised it — `Hardened.Web.SourceGenerator.Tests` and `Hardened.OpenApi.SourceGenerator.Tests` — compiles that source into its own assembly. Their coverage counted against `Hardened.Web.SourceGenerator` (65.4% → 66.7%) and `Hardened.Idl.SourceGenerator` (61.8% → 62.9%), both of which the gate reported as improved. Nothing exercised the new paths in the assembly the gate was reading.

## The tests

Twenty, in `Hardened.SourceGenerator.Tests`, which references that assembly rather than compiling its source:

- `Shared/EntryPointFilterRungTests` — the transform through `EntryPointCapture`: what reaches `FilterDeclarations` and `FilterFacts`, that the markers around it are not filters, the narrowing per verb and response shape, the arguments a declaration was written with, and model equality.
- `Web/ApplicationFilterEmitterTests` — the emitted array and its registration through `GenerateCSharpRouteFile`, declaration order, and that an entry point declaring no filter emits neither.
- `OpenApiDocument/EntryPointRungDocumentTests` — the per-operation merge through `OpenApiDocumentGenerator.Write`: the success surviving, headers landing on the statuses they name, an operation the declaration stood down on publishing nothing, a status the operation already declares keeping its own wording, and a header the operation binds not being published twice.

Measured locally at **71.56% line / 56.7% branch**, from **69.77% / 54.8%** with the three files removed. That "before" figure is the 69.7% the CI run reported, so the local measurement tracks the one the gate reads. The baseline is left at 70.4 — raising a floor is its own deliberate commit.

## The documentation

#325 documented the rung in terms of `[ConditionalGet]`, and it is every filter attribute: `[Compress]`, `[Retry]`, `[RateLimit]` and `[CacheResponse<T>]` all reach it too.

- `docs/reference/attributes.md` — the target column on those five rows, and one paragraph saying the module form is the one to reach for and the `[Enable<T>]` form is what a host writes for handlers it only references.
- `docs/guide/compression.md`, `docs/guide/rate-limiting.md`, `docs/guide/response-caching.md` — the module form beside the application-wide one each already had.
- A theory in `EntryPointFilterRungTests` pins the list, so the claim and the selection cannot drift apart, and asserts `[RateLimit]` publishes its 429 from the entry point.

**Response caching gets a warning the others do not need.** The dedup keys on the closed type, which is what lets [two strategies compose on one handler](https://github.com/ipjohnson/Hardened.Framework/blob/main/docs/guide/response-caching.md). So a module's `[CacheResponse<VaryByRoute>]` does not stand down for a handler's `[CacheResponse<VaryByQuery>]` — they stack, and two that disagree about a `Duration` or a `Scope` fail as the chain is built. That is the `AllowMultiple` objection from the design note, in the one place it currently bites a user.

## Verification

- `dotnet test Hardened.slnx` — 74 assemblies green.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — clean apart from the standing local-only `HSMT011`.
- `npm run build` in `docs/` green, which is also the dead-internal-link check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)