### PR TITLE
Compare the scaffold's document to the server, and document the container per request

### DIFF
--- a/docs/guide/testing-hosts.md
+++ b/docs/guide/testing-hosts.md
@@ -81,9 +81,82 @@ needs it rather than on the assembly.
 | `TestWebResponse.Headers` | what the pipeline wrote | what Kestrel sent | what Kestrel sent |
 | `TestWebResponse.Failure` | the handler's exception | null | null |
 | An unmatched path | 404 | 404 | whatever `Program.cs` put behind `UseHardened()`, then ASP.NET Core's 404 |
+| Requests per container | one | every request in the test | every request in the test |
 | Cost per test | none | one Kestrel bind | one `WebApplication` build and bind |
 
 Credentials are two headers, so they travel. See [Credentials](/guide/testing-credentials).
+
+## A container per request
+
+`ITestHost.ContainerPolicy` says whether a host builds a container per request or serves every
+request from one:
+
+| Host | `ContainerPolicy` |
+|---|---|
+| The pipeline, and `[PipelineHost]` | `PerInvocation` |
+| The Lambda web host | `PerInvocation` |
+| Every other host, `[KestrelRuntime]`, `[AspNetCoreRuntime]` and the Azure Functions host among them | `Reused` |
+
+On a `PerInvocation` host, two requests in one test do not share a `[SingletonService]`:
+
+```csharp
+[HardenedTest]
+public async Task ATodoOneRequestCreatesIsGoneByTheNext(ITestWebApp app) {
+    await app.Post(new NewTodo("Write a test"), "/todos");
+
+    var todos = (await app.Get("/todos")).Deserialize<List<Todo>>();
+
+    Assert.Equal([1, 2], todos.Select(todo => todo.Id));
+}
+```
+
+That is the deployment model rather than a harness choice. An execution environment is not promised
+between invocations of one function, and two handlers deployed as two functions are two processes,
+so a handler leaning on what a previous request left in a singleton fails here rather than
+intermittently in production. A trigger façade does the same thing for the same reason: each send
+is one delivery and one container, and a batch is one delivery.
+
+`Reused` is not the mirror claim. A socket host answers it because the test holds an `HttpClient`
+bound to the loopback port the kernel picked, so restarting the server per request would leave
+every client the harness handed out addressing a closed socket. It is a limit on what those hosts
+can check, not a statement that sharing is safe on them. A service behind a load balancer is many
+instances too. Run the same handlers under `[PipelineHost]` for that check.
+
+What crosses the boundary is what the test holds. A test parameter is one instance for the whole
+test, a `[Mock]` and a plain application service the handler writes to alike, because it was handed
+over to be asserted on. The exceptions are the parameters the harness supplies to drive the
+application with, `ITestWebApp`, an `HttpClient`, a generated client and a trigger façade. Those are
+rebuilt, because rebuilding them is the point.
+
+A registration nothing holds is per container. Four harness services are pinned by name, because
+isolation has no reading for them: the test's cancellation token, the environment, the configuration
+package and `ITestContext`. `ILoggerProvider` is not one, because one per container is harmless, and
+neither is `IApplicationRoot`, which has to be per container because it wraps whichever provider
+built it.
+
+### Sending every request to one container
+
+`[Shared]` on the parameter is the escape hatch:
+
+```csharp
+[HardenedTest]
+public async Task SharedSendsEveryRequestToOneContainer([Shared] ITestWebApp app) {
+    await app.Post(new NewTodo("Write a test"), "/todos");
+
+    var todos = (await app.Get("/todos")).Deserialize<List<Todo>>();
+
+    Assert.Equal([1, 2, 3], todos.Select(todo => todo.Id));
+}
+```
+
+It marks the way the parameter is built rather than the object the test holds. Pinning the object
+alone would change nothing about which container its requests reach, because the host decides that.
+It reads on `ITestWebApp`, on an `HttpClient` and on any generated client, and a host that reuses
+anyway ignores it.
+
+Reach for it when the reuse is the subject: a response cache serving a second read, one retry budget
+across attempts, a filter registered on `IGlobalFilterRegistry` that has to reach a later request.
+It is not the way to make an ordinary test pass.
 
 ## The ASP.NET Core composition
 

--- a/docs/guide/testing-mocks.md
+++ b/docs/guide/testing-mocks.md
@@ -42,8 +42,9 @@ With Moq, a parameter typed `Mock<T>` is the mock to configure and the container
 
 ## Behind a route
 
-A handler resolves from the same container, so a mock reaches it through `ITestWebApp` and
-through a typed client alike:
+A mock is a test parameter, so it is one object for the whole test even where each request runs
+against a container of its own. It reaches the handler through `ITestWebApp` and through a typed
+client alike:
 
 ```csharp
 [HardenedTest]
@@ -57,7 +58,8 @@ public async Task CreateTodo_StoresTheTodo(TodosClient client, [Mock] ITodoStore
 }
 ```
 
-The id came from the mock, so the handler used it.
+The id came from the mock, so the handler used it. What else survives a rebuilt container is
+in [A container per request](/guide/testing-hosts#a-container-per-request).
 
 ## A fake instead of a mock
 

--- a/docs/guide/testing-web.md
+++ b/docs/guide/testing-web.md
@@ -126,8 +126,8 @@ Anything else is an `Assert.Equal` against `StatusCode`.
 
 ## A mock behind a route
 
-`[Mock]` composes with `ITestWebApp`. The handler resolves from the container the mock was
-registered in:
+`[Mock]` composes with `ITestWebApp`. A mock is a test parameter, so it is one object for the whole
+test and every container a request runs against resolves that one:
 
 ```csharp
 using NSubstitute;
@@ -143,7 +143,9 @@ public async Task UsesTheMockedService(ITestWebApp app, [Mock] IMathService<int>
 }
 ```
 
-[Substituting services](/guide/testing-mocks) has the rest.
+[Substituting services](/guide/testing-mocks) has the rest, and
+[A container per request](/guide/testing-hosts#a-container-per-request) has what else
+survives a rebuild.
 
 ## What runs
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -50,7 +50,10 @@ public class MathServiceTests {
 }
 ```
 
-The application is built for each test and disposed when the test ends.
+The application is built for each test and disposed when the test ends. On the pipeline, and on
+the Lambda web host, each request the test sends is then run against a container of its own, so two
+requests in one test do not share a `[SingletonService]`. See
+[A container per request](/guide/testing-hosts#a-container-per-request).
 
 ## Setting up a project
 
@@ -98,6 +101,7 @@ A web application adds `[assembly: WebTesting]` from `Hardened.Web.Testing`; see
 |---|---|
 | Any registered service | The application's own registration, resolved from the test's container |
 | `[Mock] T` | A mock of `T` from the library the test project names, NSubstitute, Moq or FakeItEasy, registered over the application's registration. [Substituting services](/guide/testing-mocks) |
+| `[Shared] T` | The same, sending every request that parameter makes to one container. Valid on `ITestWebApp`, an `HttpClient` and a client type. [A container per request](/guide/testing-hosts#a-container-per-request) |
 | `ITestContext` | Named steps, a retry engine, a logger and the test's cancellation token. [Steps and retries](/guide/testing-steps) |
 | `ITestWebApp` | Sends requests through the pipeline. [Sending requests](/guide/testing-web) |
 | A client type | A Kiota client, a Refit interface or any class taking one `HttpClient`, built over the pipeline. [Typed clients](/guide/testing-clients) |
@@ -140,7 +144,7 @@ Kestrel, ASP.NET Core or Lambda. A test that needs the host names one; see
 - [Credentials](/guide/testing-credentials): who a request is sent as
 - [Typed clients](/guide/testing-clients): a generated client as a parameter
 - [Asserting a response](/guide/testing-responses): `Returns<T>()`, `ReturnsStatus<T>()` and `LastResponse`
-- [Test hosts](/guide/testing-hosts): the same tests on Kestrel or ASP.NET Core
+- [Test hosts](/guide/testing-hosts): the same tests on Kestrel or ASP.NET Core, and which hosts rebuild the container
 - [Steps and retries](/guide/testing-steps): `ITestContext`
 - [Writing a test attribute](/guide/testing-attributes): setup shared by many tests
 - [Testing AWS handlers](/aws/testing): Lambda functions, SQS batches, stream records, DynamoDB Local

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -180,10 +180,10 @@ it cannot fall out of step.
 #endif
 
 Every route is in the published document, and `tests/Hardened1.Tests/DocumentStatusTests.cs` holds
-the document to the statuses this suite exercises, operation by operation. Adding a route fails
-that test until its `Expected` table names the new operation and the statuses a test drives - which
-is the point: a status the document declares and nothing answers is the defect a reference page
-cannot show.
+the document to what this application answers, operation by operation. Adding a route fails that
+test until its `Probes` table carries a request per status the new operation can answer - which is
+the point: a status the document declares and nothing answers is the defect a reference page cannot
+show.
 #if (specFirst)
 
 #if (openapi)
@@ -330,7 +330,19 @@ route; `tests/Hardened1.Tests/TodoStoreMockTests.cs` does. The fake is FakeItEas
 #endif
 
 Every declared status has a test, not only the happy one - a response set exercised only at 200 is
-indistinguishable from having none.
+indistinguishable from having none. `tests/Hardened1.Tests/DocumentStatusTests.cs` is what holds
+the suite to that. It sends a request per status, records what came back, and fails when the
+published document declares a status nothing answered or the application answers one the document
+never mentions. Its table is requests rather than status codes, so a status cannot be claimed
+there without a request that produces it.
+
+Each request runs against a container of its own. A todo one request creates is gone by the next,
+because the next request built its own container and its own `[SingletonService]` store. That is
+the deployment model rather than a harness detail: an execution environment is not promised
+between invocations, so a handler leaning on what the last request left behind fails in a test
+here rather than intermittently in production.
+`tests/Hardened1.Tests/ContainerIsolationTests.cs` shows both sides. Mark a parameter `[Shared]`
+to send every request to one container, for a test whose subject is the reuse itself.
 
 #if (hasClient)
 ## Clients

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/ContainerIsolationTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/ContainerIsolationTests.cs
@@ -1,0 +1,61 @@
+namespace Hardened1.Tests;
+
+/// <summary>
+/// Two requests in one test do not share a container.
+/// </summary>
+/// <remarks>
+/// TodoStore is a [SingletonService] holding its todos in a field, so "singleton" is exactly the
+/// question these two tests answer. A todo one request creates is gone by the next, because the
+/// next request built a container of its own and a store of its own with it.
+///
+/// That is the deployment model rather than a harness detail. An execution environment is not
+/// promised between invocations - two queue handlers deployed as two functions are two processes,
+/// and a service behind a load balancer is many instances - so a handler leaning on what the last
+/// request left behind fails here rather than intermittently in production.
+///
+/// [PipelineHost] because this is the check the pipeline can make. A socket host hands the test an
+/// HttpClient bound to one port, so it reuses one container and reports ContainerPolicy.Reused;
+/// the same handlers run here for the isolation check. See "Testing" in README.md.
+/// </remarks>
+[PipelineHost]
+public class ContainerIsolationTests {
+
+    private record TodoResponse(int Id, string Title, bool Done);
+
+    private record NewTodoRequest(string Title);
+
+    [HardenedTest]
+    public async Task ATodoOneRequestCreatesIsGoneByTheNext(ITestWebApp app) {
+        (await app.Post(new NewTodoRequest("Write a test"), "/todos")).Assert.Ok();
+
+        var todos = (await app.Get("/todos")).Deserialize<List<TodoResponse>>();
+
+#if (xunit)
+        Assert.Equal([1, 2], todos.Select(todo => todo.Id));
+#else
+        Assert.That(todos.Select(todo => todo.Id), Is.EqualTo(new[] { 1, 2 }));
+#endif
+    }
+
+    /// <summary>
+    /// [Shared] is the escape hatch, and it belongs on a test whose subject is the reuse itself.
+    /// </summary>
+    /// <remarks>
+    /// It marks the way the parameter is built rather than the object the test holds: pinning the
+    /// object alone would change nothing about which container its requests reach, because the
+    /// host decides that. Reach for it for a cache serving a second read or one budget across
+    /// several attempts, and not to make an ordinary test pass.
+    /// </remarks>
+    [HardenedTest]
+    public async Task SharedSendsEveryRequestToOneContainer([Shared] ITestWebApp app) {
+        (await app.Post(new NewTodoRequest("Write a test"), "/todos")).Assert.Ok();
+
+        var todos = (await app.Get("/todos")).Deserialize<List<TodoResponse>>();
+
+#if (xunit)
+        Assert.Equal([1, 2, 3], todos.Select(todo => todo.Id));
+#else
+        Assert.That(todos.Select(todo => todo.Id), Is.EqualTo(new[] { 1, 2, 3 }));
+#endif
+    }
+}

--- a/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/tests/Hardened1.Tests/DocumentStatusTests.cs
@@ -1,45 +1,138 @@
+using System.Globalization;
 using System.IO.Compression;
 using System.Text.Json;
 
 namespace Hardened1.Tests;
 
 /// <summary>
-/// The published document's status set, operation by operation, against what this suite
-/// exercises.
+/// The published document's status set, operation by operation, against the statuses this
+/// application answers when it is asked.
 /// </summary>
 /// <remarks>
 /// A declared status nothing answers - or an answered status the document never mentions - is the
-/// defect class a reference page cannot reveal, because the page renders either way. The sets
-/// below are the contract's declared statuses plus what the framework synthesizes and answers
-/// itself: a 400 wherever generated validation or a non-string bound parameter can refuse a
-/// request. Each listed status is driven by a test in this project, so the document, the
-/// application and the suite have to agree or this fails naming the operation.
+/// defect class a reference page cannot reveal, because the page renders either way. So the table
+/// below holds requests rather than status codes. Every probe is sent, what came back is what
+/// counts as answered, and the document is compared against that. A status cannot be claimed here
+/// without a request that produces it, and a probe that stops producing the status it was written
+/// for is reported beside the comparison rather than quietly changing what this test asserts.
+///
+/// Each request runs against a container of its own, so the probes need no ordering and one cannot
+/// set up or spoil another. See "Testing" in README.md.
 /// </remarks>
 public class DocumentStatusTests {
 
-    private static readonly Dictionary<string, string[]> Expected = new() {
+    /// <summary>
+    /// One request, and the status it exists to provoke.
+    /// </summary>
+    /// <param name="Operation">
+    /// The document's own key for the route: the method, then the templated path.
+    /// </param>
+    private sealed record Probe(
+        string Operation,
+        int Status,
+        Func<ITestWebApp, Task<TestWebResponse>> Send);
+
+    private record NewTodoRequest(string Title);
+
+    /// <summary>
+    /// A request per status this application can answer.
+    /// </summary>
+    /// <remarks>
+    /// The success statuses differ by response model, and that difference is the model's point
+    /// rather than an inconsistency: throws mode names one success type per handler and has
+    /// nowhere to put a status beside it, so a created todo comes back at 200. Every other model,
+    /// and both contract languages, carry the status in the declaration.
+    /// </remarks>
+    private static readonly Probe[] Probes = [
+        new("GET /todos", 200, app => app.Get("/todos")),
+
+        new("GET /todos/{id}", 200, app => app.Get("/todos/1")),
+        new("GET /todos/{id}", 400, app => app.Get("/todos/0")),
+        new("GET /todos/{id}", 404, app => app.Get("/todos/9999")),
+
 #if (codeFirst && throwsMode)
-        // Throws mode documents what the signature declares plus what [Throws<T>] adds: the 404
-        // and the 409 are thrown, and the attribute is what puts them in the document. The 400s
-        // stay: the id and the title are constrained, so binding either can refuse.
-        ["GET /todos"] = ["200"],
-        ["GET /todos/{id}"] = ["200", "400", "404"],
-        ["POST /todos"] = ["200", "400", "409"],
-        ["DELETE /todos/{id}"] = ["200", "400", "404"],
+        new("POST /todos", 200, app => app.Post(new NewTodoRequest("Write a test"), "/todos")),
 #else
-        // The declared statuses, plus the 400 the generated validation answers: the id and the
-        // title are constrained, so every operation binding either can refuse.
-        ["GET /todos"] = ["200"],
-        ["GET /todos/{id}"] = ["200", "400", "404"],
-        ["POST /todos"] = ["201", "400", "409"],
-        ["DELETE /todos/{id}"] = ["204", "400", "404"],
+        new("POST /todos", 201, app => app.Post(new NewTodoRequest("Write a test"), "/todos")),
 #endif
-    };
+        new("POST /todos", 400, app => app.Post(new NewTodoRequest(new string('x', 100)), "/todos")),
+        new("POST /todos", 409, app => app.Post(new NewTodoRequest("Add an endpoint"), "/todos")),
+
+#if (codeFirst && throwsMode)
+        new("DELETE /todos/{id}", 200, app => app.Delete("/todos/1")),
+#else
+        new("DELETE /todos/{id}", 204, app => app.Delete("/todos/1")),
+#endif
+        new("DELETE /todos/{id}", 400, app => app.Delete("/todos/0")),
+        new("DELETE /todos/{id}", 404, app => app.Delete("/todos/9999"))
+    ];
 
     [HardenedTest]
-    public async Task EveryOperationDeclaresExactlyTheStatusesThisSuiteExercises(ITestWebApp app) {
-        var document = await Document(app);
-        var declared = new Dictionary<string, string[]>();
+    public async Task TheDocumentDeclaresExactlyWhatTheApplicationAnswers(ITestWebApp app) {
+        var faults = new List<string>();
+        var answered = new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+
+        foreach (var probe in Probes) {
+            var status = (await probe.Send(app)).StatusCode;
+
+            if (status != probe.Status) {
+                faults.Add(
+                    $"{probe.Operation}: the probe written for {probe.Status} answered {status}.");
+            }
+
+            if (!answered.TryGetValue(probe.Operation, out var statuses)) {
+                answered[probe.Operation] = statuses = new SortedSet<string>(StringComparer.Ordinal);
+            }
+
+            // What came back, not what the probe hoped for. A wrong probe is reported above and
+            // still contributes the truth here, so one mistake reads as one fault rather than two.
+            statuses.Add(status.ToString(CultureInfo.InvariantCulture));
+        }
+
+        var declared = Declared(await Document(app));
+
+        foreach (var operation in declared.Keys.Union(answered.Keys).Order(StringComparer.Ordinal)) {
+            var inDocument = declared.TryGetValue(operation, out var published)
+                ? published
+                : new SortedSet<string>(StringComparer.Ordinal);
+
+            var onTheWire = answered.TryGetValue(operation, out var observed)
+                ? observed
+                : new SortedSet<string>(StringComparer.Ordinal);
+
+            if (inDocument.Count == 0) {
+                faults.Add($"{operation}: answered here and absent from the document.");
+                continue;
+            }
+
+            if (onTheWire.Count == 0) {
+                faults.Add($"{operation}: in the document and reached by no probe in this file.");
+                continue;
+            }
+
+            foreach (var status in inDocument.Except(onTheWire)) {
+                faults.Add($"{operation}: declares {status} and no request here answered it.");
+            }
+
+            foreach (var status in onTheWire.Except(inDocument)) {
+                faults.Add($"{operation}: answered {status}, which the document does not declare.");
+            }
+        }
+
+        var report = string.Join(Environment.NewLine, faults);
+
+#if (xunit)
+        Assert.True(faults.Count == 0, report);
+#else
+        Assert.That(faults, Is.Empty, report);
+#endif
+    }
+
+    /// <summary>
+    /// The status set the served document declares, keyed the way <see cref="Probe"/> keys one.
+    /// </summary>
+    private static Dictionary<string, SortedSet<string>> Declared(JsonElement document) {
+        var declared = new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
 
         foreach (var path in document.GetProperty("paths").EnumerateObject()) {
             foreach (var operation in path.Value.EnumerateObject()) {
@@ -47,31 +140,13 @@ public class DocumentStatusTests {
                     continue;
                 }
 
-                declared[$"{operation.Name.ToUpperInvariant()} {path.Name}"] = responses
-                    .EnumerateObject()
-                    .Select(response => response.Name)
-                    .OrderBy(status => status, StringComparer.Ordinal)
-                    .ToArray();
+                declared[$"{operation.Name.ToUpperInvariant()} {path.Name}"] = new SortedSet<string>(
+                    responses.EnumerateObject().Select(response => response.Name),
+                    StringComparer.Ordinal);
             }
         }
 
-#if (xunit)
-        Assert.Equal(
-            Expected.Keys.OrderBy(key => key, StringComparer.Ordinal),
-            declared.Keys.OrderBy(key => key, StringComparer.Ordinal));
-
-        foreach (var operation in Expected) {
-            Assert.Equal(operation.Value, declared[operation.Key]);
-        }
-#else
-        Assert.That(
-            declared.Keys.OrderBy(key => key, StringComparer.Ordinal),
-            Is.EqualTo(Expected.Keys.OrderBy(key => key, StringComparer.Ordinal)));
-
-        foreach (var operation in Expected) {
-            Assert.That(declared[operation.Key], Is.EqualTo(operation.Value));
-        }
-#endif
+        return declared;
     }
 
     /// <summary>The served document, which is stored and answered gzipped.</summary>


### PR DESCRIPTION
From the 0.32 trial: items **1** and **2** on its own remediation list. They are one subject seen twice - the scaffold's test suite is what a new user reads to learn what a test in this framework asserts, and it was making two claims it could not back.

## The document was compared against a table

`DocumentStatusTests` exists to prove that "a status the document declares and nothing answers is the defect a reference page cannot show". It compared the published document against a hand-written list of status codes, so both halves could be wrong together. In the trial they were: it passed on both applications while eleven discrepancies between document and server stood in them.

Its table is requests now.

```csharp
new("GET /todos/{id}", 400, app => app.Get("/todos/0")),
new("POST /todos",     409, app => app.Post(new NewTodoRequest("Add an endpoint"), "/todos")),
```

Every probe is sent, the status that came back is what counts as answered, and the document is compared against that. Two things follow. A status cannot be claimed in that file without a request that produces it, and a probe that stops producing the status it was written for is named rather than quietly changing what the test asserts:

```
GET /todos/{id}: the probe written for 400 answered 404.
GET /todos/{id}: declares 400 and no request here answered it.
POST /todos: answered 409, which the document does not declare.
```

The table is not gone so much as inverted. It used to say what the document should contain; it says how to make the server answer.

The success statuses are still the one thing that forks on the response model, for the reason they always did: throws mode names one success type per handler and has nowhere to put a status beside it, so a created todo comes back at 200. `codeFirst && throwsMode` is the fork, which is the condition the old table used and not the `throwsMode` the sample tests use - a contract carries the code in both languages, so spec-first throws answers 201 and 204.

## Nothing said the container is rebuilt

#315 made each request run against a container of its own on the hosts that can, and no page said so. `ContainerPolicy`, `[Shared]` and "container of its own" returned zero hits across `docs/` and the templates, and `testing.md` still ended the section with "the application is built for each test and disposed when the test ends", which is now half of it.

- **`testing-hosts.md`** gains *A container per request*: which host answers which policy, why `PerInvocation` is a claim about a deployment while `Reused` is a limit on what a host can check, what crosses the boundary, and `[Shared]`.
- **`testing.md`** corrects that sentence, adds the `[Shared]` row to the parameter table and links across.
- **`testing-web.md` and `testing-mocks.md`** both explained a mock reaching a handler by "the same container", which describes the model before #315. A mock reaches the handler because it is a *parameter*, and that is what they say now.
- The generated **`README.md`** says both, beside the sentence about every declared status having a test. It also named an `Expected` table that this PR removes.

## The scaffold shows it

`ContainerIsolationTests` is the test the trial asked for. The scaffold's suite never crossed two mutating requests in one test, so nothing in it revealed the change.

```csharp
[HardenedTest]
public async Task ATodoOneRequestCreatesIsGoneByTheNext(ITestWebApp app) {
    (await app.Post(new NewTodoRequest("Write a test"), "/todos")).Assert.Ok();

    var todos = (await app.Get("/todos")).Deserialize<List<TodoResponse>>();

    Assert.Equal([1, 2], todos.Select(todo => todo.Id));
}
```

`SharedSendsEveryRequestToOneContainer` is the same test with `[Shared]` on the parameter and `[1, 2, 3]` at the end.

`[PipelineHost]` on the class, because this is the check the pipeline can make. The `azure-functions` scaffold declares a host at the assembly, and that host reuses one container; the same handlers run here for the isolation check, which is what `ITestHost.ContainerPolicy`'s own remarks tell a reader to do.

## Verification

- `scripts/verify-templates.sh` with the pinned Smithy CLI on `PATH` - every combination, no failures. Eighteen web configurations go from 15 tests to 17, including both Smithy rows, both union rows, the NUnit, Moq and FakeItEasy rows, and `azure-functions` at 16 because it scaffolds no socket test. One further single-row run after the `README` edit, which the full run predated.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` - 0 warnings, 0 errors.
- `npm run build` in `docs/` - no dead links.

No framework source changed, so nothing here alters what a deployed application does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
