### PR TITLE
Publish the servers a contract declares, and name the declarations that do nothing

### DIFF
--- a/docs/design/generator-diagnostics.md
+++ b/docs/design/generator-diagnostics.md
@@ -56,8 +56,8 @@ only when *no* entry matches a described service.
 
 ### HOAG032 — declaration is not read on a described handler
 
-A `[Handler]` method carries a declaration the described path never reads, so it compiles, reads as
-a commitment, and changes nothing.
+A `[Handler]` class or one of its methods carries a declaration the described path never reads, so
+it compiles, reads as a commitment, and changes nothing.
 
 ```
 'ReportServiceImpl.Export' carries [RawResponse], which is read from a handler's own syntax and a
@@ -66,9 +66,22 @@ nothing. Remove it: the content type a described response commits to comes from 
 media type.
 ```
 
-`[RawResponse]` is the only one today. The generator reads it off the handler's own syntax, and a
-described operation has none — its signature is generated from the contract, which says the same
-thing with the response's media type.
+Four today, on the two rungs a handler has:
+
+| Declaration | Where | The contract says it with |
+|---|---|---|
+| `[RawResponse]` | method | the response's media type |
+| `[Throws<T>]` | method | the operation's `responses` |
+| `[Tag]` | class | the operation's `tags` |
+| `[Server]` | class | a `servers` block |
+
+The generator reads each off the handler's own syntax, and a described operation has none: its
+signature is generated from the contract.
+
+Both rungs are walked, because the attributes divide across them. `[Tag]` and `[Server]` are
+`AttributeTargets.Class`. The walk over methods this rule started as would have taken a table entry
+for either and reported nothing: a diagnostic that looks configured and is not, which is the shape
+of the defect the rule exists to catch.
 
 A warning, so a project that wants to keep the attribute for its own reasons can say
 `<NoWarn>$(NoWarn);HOAG032</NoWarn>`.

--- a/docs/guide/openapi-document.md
+++ b/docs/guide/openapi-document.md
@@ -195,7 +195,7 @@ document and the wire cannot disagree.
 | Attribute | Effect |
 |---|---|
 | [`[Tag(name)]`](/reference/attributes) | the tag an operation groups under. Defaults to the class name minus `Controller` |
-| [`[Server(url, description?)]`](/reference/attributes) | a base URL listed under `servers`. Repeatable, and valid on the assembly |
+| [`[Server(url, description?)]`](/reference/attributes) | a base URL listed under `servers`. Repeatable, and read off the `[HardenedModule]` class in the compilation that writes the document - which is the library rather than the host wherever the two are separate projects. The assembly target compiles and publishes nothing |
 
 A handler's XML documentation comment carries into the operation: `<summary>` becomes `summary`
 and `<remarks>` becomes `description`.

--- a/docs/guide/openapi.md
+++ b/docs/guide/openapi.md
@@ -242,11 +242,16 @@ two 2xx statuses always gets a response container.
 A `[Handler]` class implements a generated interface, and attributes go on its methods as they
 would anywhere. Which of them mean anything depends on when they are read:
 
-| | Read at | On a `[Handler]` method |
+| | Read at | On the implementation |
 |---|---|---|
-| `[Retry]`, `[RateLimit]`, `[CacheResponse<T>]`, `[Compress]`, `[ConditionalGet]`, `[Timeout]`, your own `IRequestFilterProvider` | run time, off the handler's metadata | Honoured. This is where a per-operation filter goes in a spec-first project |
+| `[Retry]`, `[RateLimit]`, `[CacheResponse<T>]`, `[Compress]`, `[ConditionalGet]`, `[Timeout]`, your own `IRequestFilterProvider` | run time, off the handler's metadata | Honoured on a method. This is where a per-operation filter goes in a spec-first project |
 | `[AuthorizeGrants]`, `[Authorize<TAuth>]`, `[AllowAnonymous]`, an `IAuthorizationConvention` | run time, into the handler's `Requirement` | Honoured, and can only narrow what the contract admits |
-| `[Throws<T>]`, `[Tag]`, `[Server]` | build time, into the document | Inert. The build task writes the document from the contract before the compiler runs, so it never sees them |
+| `[Throws<T>]` and `[RawResponse]` on a method, `[Tag]` and `[Server]` on the class | build time, into the document | Inert, and `HOAG032` says so. The build task writes the document from the contract before the compiler runs, so it never sees them |
+
+The contract is where each of those four is spelled instead: `responses` for the statuses, the
+response's media type for the content type, the operation's `tags` for the group, and a `servers`
+block for the base URLs. A `servers` block is published as written, and wins over a `[Server]` on
+the module class where an application has both.
 
 Anything shaping the document has to be in the description. Anything shaping the pipeline can be
 on the implementation:

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -130,7 +130,7 @@ See [Authorization](/guide/authorization).
 | `[WebLibrary]` | Class | Marks a web library entry point |
 | `[Tag(name)]` | Class | The [OpenAPI tag](/guide/openapi-document) this controller's operations group under. Defaults to the class name minus `Controller` |
 | `[Operation(id)]` | Method | The [`operationId`](/guide/openapi-document) the handler publishes, which a generated client names its method after. Defaults to the method name in camelCase. Two handlers declaring one id is `HRDOA004` |
-| `[Server(url, description?)]` | Class, assembly | A base URL the generated document lists under `servers` |
+| `[Server(url, description?)]` | Class | A base URL the generated document lists under `servers`. Read off the `[HardenedModule]` class in the compilation that writes the document. The assembly target compiles and publishes nothing, and a described contract's own `servers` block wins over it |
 | `[CaseInsensitiveRoutes]` | Class | Matches this module's routes [without regard to case](/guide/routing#case-and-trailing-slashes) |
 | `[RouteConstraint(name)]` | Method | Declares a [route constraint](/guide/routing#declaring-your-own-constraint). `static bool(ReadOnlySpan<char>)` |
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -49,7 +49,7 @@ front end only leaves a gap in the other.
 | `HOAG020` | error | An operation declares a markup content type and names no view to render it |
 | `HOAG030` | warning | A described service has no `[Handler]`. Its routes exist and fail at request time. `NoWarn` it in a project that ships contracts without implementations |
 | `HOAG031` | warning | A `[Handler]` class names no described service in its base list. Usually a spelling mismatch. A base class beside the interface is fine |
-| `HOAG032` | warning | A described handler carries a declaration read from a handler's own syntax, such as `[RawResponse]`. A described operation's signature is generated, so it compiles, reads as a commitment, and changes nothing. The contract says the same thing with the response's media type |
+| `HOAG032` | warning | A described handler carries a declaration read from a handler's own syntax: `[RawResponse]` or `[Throws<T>]` on a method, `[Tag]` or `[Server]` on the class. A described operation's signature is generated, so each compiles, reads as a commitment, and changes nothing. The message names what the contract says instead |
 
 ## Routing
 

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/Specs/petstore.yaml
@@ -5,6 +5,14 @@ openapi: "3.0.0"
 info:
   title: Petstore API
   version: "1.0.0"
+# Where the service is served, which the published document used to drop: this block was read for
+# its path component and nothing else, so a client generated from the document had every path and
+# no host to send one to. No path here on purpose - these routes are served at the root, and a
+# document that said otherwise would be wrong in the direction that is hardest to notice.
+servers:
+  - url: https://petstore.example.invalid
+    description: production
+  - url: https://staging.petstore.example.invalid
 # The group's own prose, which used to be parsed to nothing: the published document's tags
 # carried the name alone.
 tags:

--- a/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
+++ b/src/IntegrationTests/OpenApi/Hardened.IntegrationTests.OpenApi.SUT/openapi/OpenApiTestApp.json
@@ -4,6 +4,15 @@
     "title": "Petstore API",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "https://petstore.example.invalid",
+      "description": "production"
+    },
+    {
+      "url": "https://staging.petstore.example.invalid"
+    }
+  ],
   "tags": [
     {
       "name": "Pet",

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ServerModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ServerModel.cs
@@ -1,0 +1,31 @@
+namespace Hardened.Generation.Models;
+
+/// <summary>
+/// A base URL the contract says the service is served from, for the published document's
+/// <c>servers</c> list.
+/// </summary>
+/// <remarks>
+/// Where the application is deployed is the one thing a generated document cannot derive from the
+/// code, and a contract is one of the two places an author can say it - <c>[Server]</c> on the
+/// entry point is the other. A contract's <c>servers</c> block was read for its path component and
+/// otherwise dropped, so a specification-first document published no <c>servers</c> at all and a
+/// client generated from it had a set of paths and nowhere to send them.
+/// </remarks>
+internal class ServerModel : IEquatable<ServerModel> {
+
+    /// <summary>The URL as the contract wrote it, less any base path the build already applied.</summary>
+    public string Url { get; set; } = "";
+
+    public string? Description { get; set; }
+
+    public bool Equals(ServerModel? other) =>
+        other is not null && Url == other.Url && Description == other.Description;
+
+    public override bool Equals(object? obj) => Equals(obj as ServerModel);
+
+    public override int GetHashCode() {
+        unchecked {
+            return (Url.GetHashCode() * 397) ^ (Description?.GetHashCode() ?? 0);
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/ServiceSpecModel.cs
@@ -70,6 +70,14 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     /// <summary>The schemes the contract declares, for the published document.</summary>
     public List<SecuritySchemeModel> SecuritySchemes { get; set; } = new();
 
+    /// <summary>The servers the contract declares, for the published document.</summary>
+    /// <remarks>
+    /// Their path component is already removed where <c>HardenedOpenApiApplyServerBasePath</c> put
+    /// it on every route instead, so a client joining a server URL to a path cannot apply it twice.
+    /// See <see cref="ServerModel"/>.
+    /// </remarks>
+    public List<ServerModel> Servers { get; set; } = new();
+
     /// <summary>
     /// What the build task emitted for validation, per operation. Empty when nothing is constrained.
     /// </summary>
@@ -167,6 +175,25 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
         if (UiUrl != other.UiUrl) return false;
         if (SourceUrl != other.SourceUrl) return false;
         if (UiEnvironments != other.UiEnvironments) return false;
+
+        // The identity the contract declares about itself. Absent here, a contract that only
+        // renamed itself or only changed where it is served produced a model this compared equal,
+        // and the provider carrying it downstream never recomputed - so the published document
+        // kept the previous title, or published no servers after they were added.
+        if (Title != other.Title) return false;
+        if (Version != other.Version) return false;
+        if (InfoDescription != other.InfoDescription) return false;
+        if (SecuritySchemes.Count != other.SecuritySchemes.Count) return false;
+        if (Servers.Count != other.Servers.Count) return false;
+
+        for (var i = 0; i < SecuritySchemes.Count; i++) {
+            if (!SecuritySchemes[i].Equals(other.SecuritySchemes[i])) return false;
+        }
+
+        for (var i = 0; i < Servers.Count; i++) {
+            if (!Servers[i].Equals(other.Servers[i])) return false;
+        }
+
         if (Schemas.Count != other.Schemas.Count) return false;
         if (Services.Count != other.Services.Count) return false;
         if (FilterTypes.Count != other.FilterTypes.Count) return false;
@@ -196,6 +223,9 @@ internal class ServiceSpecModel : IEquatable<ServiceSpecModel> {
     public override int GetHashCode() {
         unchecked {
             var hash = FileName.GetHashCode();
+            hash = (hash * 397) ^ (Title?.GetHashCode() ?? 0);
+            hash = (hash * 397) ^ (Version?.GetHashCode() ?? 0);
+            foreach (var s in Servers) hash = (hash * 397) ^ s.GetHashCode();
             foreach (var s in Schemas) hash = (hash * 397) ^ s.GetHashCode();
             foreach (var s in Services) hash = (hash * 397) ^ s.GetHashCode();
             foreach (var f in FilterTypes) hash = (hash * 397) ^ f.GetHashCode();

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -61,7 +61,12 @@ internal static class SpecModelSerializer {
     /// reader handed a 6 file would find no name and re-derive the colliding one, which is the
     /// silent half of the defect the allocation exists to close.
     /// </remarks>
-    private const string Header = "#hardened-openapi-model 6";
+    /// <remarks>
+    /// 7 adds the <c>server</c> records carrying the contract's own <c>servers</c>. Bumped for the
+    /// new record tag, same reasoning as 4: a 6 reader handed a 7 file throws on the tag rather
+    /// than skipping it.
+    /// </remarks>
+    private const string Header = "#hardened-openapi-model 7";
 
     private const char FieldSeparator = '\t';
 
@@ -88,6 +93,16 @@ internal static class SpecModelSerializer {
             var record = new Record("secscheme");
             record.Add("Name", scheme.Name);
             record.Add("Json", scheme.Json);
+            record.WriteTo(builder);
+        }
+
+        // In the order the contract wrote them. A document's servers list is ordered - a reader
+        // and a generated client take the first as the default - so sorting these the way the
+        // schemes are sorted would choose a different default than the author did.
+        foreach (var server in model.Servers) {
+            var record = new Record("server");
+            record.Add("Url", server.Url);
+            record.Add("Description", server.Description);
             record.WriteTo(builder);
         }
 
@@ -167,6 +182,13 @@ internal static class SpecModelSerializer {
                     model.SecuritySchemes.Add(new SecuritySchemeModel {
                         Name = record.String("Name") ?? "",
                         Json = record.String("Json") ?? ""
+                    });
+                    break;
+
+                case "server":
+                    model.Servers.Add(new ServerModel {
+                        Url = record.String("Url") ?? "",
+                        Description = record.String("Description")
                     });
                     break;
 

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerBindingDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/HandlerBindingDiagnostics.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Hardened.SourceGenerator.Models.Request;
+using Hardened.SourceGenerator.Shared;
 using Microsoft.CodeAnalysis;
 
 namespace Hardened.Idl.SourceGenerator;
@@ -11,7 +12,7 @@ namespace Hardened.Idl.SourceGenerator;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Both are warnings rather than errors, and deliberately. Generating the interfaces without
+/// All three are warnings rather than errors, and deliberately. Generating the interfaces without
 /// implementing them is a supported thing to do - a package that carries a contract for a client to
 /// consume, or one project describing a service another implements - so an error would make a
 /// legitimate target impossible to build.
@@ -19,7 +20,7 @@ namespace Hardened.Idl.SourceGenerator;
 /// <para>
 /// <c>TreatWarningsAsErrors</c> is set for continuous-integration builds, so a project that means to
 /// ship interfaces alone silences these in its own csproj:
-/// <c>&lt;NoWarn&gt;$(NoWarn);HOAG030;HOAG031&lt;/NoWarn&gt;</c>. That is the escape hatch, and it
+/// <c>&lt;NoWarn&gt;$(NoWarn);HOAG030;HOAG031;HOAG032&lt;/NoWarn&gt;</c>. That is the escape hatch, and it
 /// is deliberate that it has to be written down rather than inferred.
 /// </para>
 /// </remarks>
@@ -31,22 +32,36 @@ internal static class HandlerBindingDiagnostics {
     /// <summary>A handler whose base list names no described service.</summary>
     public const string NoServiceInterfaceId = "HOAG031";
 
-    /// <summary>A declaration the described path does not read, written on a handler method.</summary>
+    /// <summary>A declaration the described path does not read, on a handler class or method.</summary>
     public const string InertDeclarationId = "HOAG032";
 
     /// <summary>
     /// The declarations that are code-first syntax only, by attribute name.
     /// </summary>
     /// <remarks>
-    /// <c>[RawResponse]</c> commits a response to a content type, and the generator reads it off
-    /// the handler's own syntax. A described operation's signature is generated, so there is no
-    /// syntax to read it from: the attribute compiles on the implementation, reads as a commitment
-    /// in review, and changes nothing. A contract says the same thing with the response's media
-    /// type.
+    /// <para>
+    /// Each of these is read off a handler's own syntax by the attribute-routed generator. A
+    /// described operation's signature is generated instead, so there is no syntax to read it from:
+    /// the attribute compiles on the implementation, reads as a commitment in review, and changes
+    /// nothing. Every one of them has a spelling in the contract, which is what the message names.
+    /// </para>
+    /// <para>
+    /// A generic attribute keys on its simple name here. <c>AttributeModelHelper</c> puts the type
+    /// arguments in the type definition rather than in <c>Name</c>, so <c>[Throws&lt;Gone&gt;]</c>
+    /// arrives as <c>ThrowsAttribute</c> and an exact lookup finds it.
+    /// </para>
     /// </remarks>
     private static readonly Dictionary<string, string> InertDeclarations = new(StringComparer.Ordinal) {
         ["RawResponseAttribute"] =
-            "the content type a described response commits to comes from the contract's media type"
+            "the content type a described response commits to comes from the contract's media type",
+        ["ThrowsAttribute"] =
+            "a described operation answers the statuses its contract declares, and the generated " +
+            "signature carries them",
+        ["TagAttribute"] =
+            "a described operation is grouped by the tag its contract gives it",
+        ["ServerAttribute"] =
+            "write a servers block in the contract, or declare [Server] on the [HardenedModule] " +
+            "class whose compilation writes the document"
     };
 
     /// <summary>
@@ -68,9 +83,9 @@ internal static class HandlerBindingDiagnostics {
         id: InertDeclarationId,
         title: "Declaration is not read on a described handler",
         messageFormat:
-        "'{0}.{1}' carries [{2}], which is read from a handler's own syntax and a described " +
+        "'{0}' carries [{1}], which is read from a handler's own syntax and a described " +
         "operation's signature is generated - so it compiles, reads as a commitment, and changes " +
-        "nothing. Remove it: {3}.",
+        "nothing. Remove it: {2}.",
         category: "Hardened.Generation",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
@@ -158,28 +173,48 @@ internal static class HandlerBindingDiagnostics {
     }
 
     /// <summary>
-    /// Every declaration on this handler's methods that the described path does not read.
+    /// Every declaration on this handler that the described path does not read.
     /// </summary>
     /// <remarks>
-    /// Read off the filters <c>HandlerSelector</c> already collected rather than from a walk of
-    /// its own, so an attribute added to <see cref="InertDeclarations"/> is one line. The location
-    /// is the class's, which is what <c>HandlerInfo</c> carries; the message names the method.
+    /// <para>
+    /// Read off what <c>HandlerSelector</c> already collected rather than from a walk of its own,
+    /// so an attribute added to <see cref="InertDeclarations"/> costs a table entry and nothing
+    /// else. The location is the class's, which is what <c>HandlerInfo</c> carries; the message
+    /// names the method where there is one.
+    /// </para>
+    /// <para>
+    /// Both rungs, because the attributes divide across them. <c>[RawResponse]</c> and
+    /// <c>[Throws&lt;T&gt;]</c> are written on a method and <c>[Tag]</c> and <c>[Server]</c> are
+    /// <c>AttributeTargets.Class</c>, so a walk over methods alone would take a table entry for
+    /// either of the last two and report nothing - a diagnostic that looks configured and is not,
+    /// which is the shape of the defect this whole file exists to catch.
+    /// </para>
     /// </remarks>
     private static void ReportInertDeclarations(HandlerInfo handler, List<Diagnostic> diagnostics) {
+        foreach (var filter in handler.ClassFilters) {
+            Report(handler, filter, handler.ImplementationType.Name, diagnostics);
+        }
+
         foreach (var method in handler.MethodFilters) {
             foreach (var filter in method.Filters) {
-                if (!InertDeclarations.TryGetValue(filter.TypeDefinition.Name, out var instead)) {
-                    continue;
-                }
-
-                diagnostics.Add(Diagnostic.Create(
-                    InertDeclarationDescriptor(),
-                    handler.Location ?? Location.None,
-                    handler.ImplementationType.Name,
-                    method.MethodName,
-                    filter.TypeDefinition.Name.Replace("Attribute", ""),
-                    instead));
+                Report(
+                    handler, filter,
+                    handler.ImplementationType.Name + "." + method.MethodName, diagnostics);
             }
         }
+    }
+
+    private static void Report(
+        HandlerInfo handler, AttributeModel declaration, string where, List<Diagnostic> diagnostics) {
+        if (!InertDeclarations.TryGetValue(declaration.TypeDefinition.Name, out var instead)) {
+            return;
+        }
+
+        diagnostics.Add(Diagnostic.Create(
+            InertDeclarationDescriptor(),
+            handler.Location ?? Location.None,
+            where,
+            declaration.TypeDefinition.Name.Replace("Attribute", ""),
+            instead));
     }
 }

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/SpecSourceGenerator.cs
@@ -244,15 +244,17 @@ public class SpecSourceGenerator : IIncrementalGenerator {
         });
 
         // The document's identity, merged across every spec the project declares: first
-        // non-empty title, version and description win, schemes union by name. Its own provider,
-        // so editing a handler does not recompute it and editing the contract's info block
-        // invalidates exactly the document.
+        // non-empty title, version and description win, schemes union by name, servers union by
+        // URL in the order they were written. Its own provider, so editing a handler does not
+        // recompute it and editing the contract's info block invalidates exactly the document.
         var identityProvider = openApiFiles.Collect().Select((specs, _) => {
             string? title = null;
             string? version = null;
             string? description = null;
             var schemes = new List<(string Name, string Json)>();
             var schemeNames = new HashSet<string>(StringComparer.Ordinal);
+            var servers = new List<(string Url, string? Description)>();
+            var serverUrls = new HashSet<string>(StringComparer.Ordinal);
 
             foreach (var spec in specs) {
                 if (spec == null) {
@@ -268,11 +270,20 @@ public class SpecSourceGenerator : IIncrementalGenerator {
                         schemes.Add((scheme.Name, scheme.Json));
                     }
                 }
+
+                foreach (var server in spec.Servers) {
+                    if (serverUrls.Add(server.Url)) {
+                        servers.Add((server.Url, server.Description));
+                    }
+                }
             }
 
             schemes.Sort((left, right) => string.CompareOrdinal(left.Name, right.Name));
 
-            return new DocumentIdentity(title, version, description, schemes);
+            // Deliberately not sorted, unlike the schemes. A scheme is addressed by name and its
+            // order is nothing; servers are a list whose first entry is the default a client takes,
+            // so the author's order is the answer.
+            return new DocumentIdentity(title, version, description, schemes, servers);
         });
 
         // Find entry points for routing table generation

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ServersTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/ServersTests.cs
@@ -1,0 +1,148 @@
+using System.Threading;
+using Hardened.Generation.Models;
+using Hardened.OpenApi.SourceGenerator;
+using Xunit;
+
+namespace Hardened.OpenApi.BuildTask.Tests;
+
+/// <summary>
+/// What a contract's <c>servers</c> block reaches the model as.
+/// </summary>
+/// <remarks>
+/// It was read for its path component and otherwise dropped, so a specification-first document
+/// published no <c>servers</c> at all: every path and no host to send one to, with <c>[Server]</c>
+/// read off the entry point rather than the contract and so no way to say it from here either.
+/// </remarks>
+public class ServersTests {
+
+    private static ServiceSpecModel Parse(string yaml, bool applyServerBasePath = false) {
+        var model = OpenApiSpecParser.Parse(
+            yaml, "spec", CancellationToken.None, applyServerBasePath);
+
+        Assert.NotNull(model);
+
+        return model!;
+    }
+
+    private const string Paths = @"
+paths:
+  /todos:
+    get:
+      operationId: listTodos
+      responses:
+        '200':
+          description: The todos.
+";
+
+    private static string Spec(string servers) =>
+        "openapi: \"3.0.0\"\ninfo:\n  title: T\n  version: \"1.0.0\"\n" + servers + Paths;
+
+    [Fact]
+    public void EveryServerReachesTheModelInTheOrderItWasWritten() {
+        var model = Parse(Spec(@"
+servers:
+  - url: https://api.example.com
+    description: production
+  - url: https://staging.example.com
+"));
+
+        Assert.Equal(2, model.Servers.Count);
+        Assert.Equal("https://api.example.com", model.Servers[0].Url);
+        Assert.Equal("production", model.Servers[0].Description);
+        Assert.Equal("https://staging.example.com", model.Servers[1].Url);
+        Assert.Null(model.Servers[1].Description);
+    }
+
+    [Fact]
+    public void AContractThatDeclaresNoServersCarriesNone() {
+        Assert.Empty(Parse(Spec("")).Servers);
+    }
+
+    /// <summary>A trailing slash is not part of the URL a path is joined to.</summary>
+    [Fact]
+    public void ATrailingSlashIsRemoved() {
+        var model = Parse(Spec(@"
+servers:
+  - url: https://api.example.com/
+"));
+
+        Assert.Equal("https://api.example.com", Assert.Single(model.Servers).Url);
+    }
+
+    /// <summary>
+    /// The doubling the base path option would otherwise cause.
+    /// </summary>
+    /// <remarks>
+    /// With the option on, every route is written under <c>/v1</c> already. Publishing the URL as
+    /// the contract wrote it would have a client join <c>https://api.example.com/v1</c> to
+    /// <c>/v1/todos</c>, which is the mistake <c>ServerBasePath</c>'s own remarks give as the
+    /// reason the option is opt-in in the first place.
+    /// </remarks>
+    [Fact]
+    public void AnAppliedBasePathIsRemovedFromTheServerThatCarriedIt() {
+        const string spec = @"
+servers:
+  - url: https://api.example.com/v1
+";
+
+        Assert.Equal(
+            "https://api.example.com",
+            Assert.Single(Parse(Spec(spec), applyServerBasePath: true).Servers).Url);
+
+        // And with the option off the path is still the server's, because nothing moved it.
+        Assert.Equal(
+            "https://api.example.com/v1",
+            Assert.Single(Parse(Spec(spec)).Servers).Url);
+    }
+
+    /// <summary>
+    /// Only the suffix that was applied, and only where it is the suffix.
+    /// </summary>
+    /// <remarks>
+    /// The base path comes from the first server alone, so a second server with a path of its own
+    /// was never the one written onto the routes. Stripping it too would be a second wrong answer
+    /// rather than a fix.
+    /// </remarks>
+    [Fact]
+    public void ASecondServerWithADifferentPathIsLeftAlone() {
+        var model = Parse(Spec(@"
+servers:
+  - url: https://api.example.com/v1
+  - url: https://staging.example.com/v2
+"), applyServerBasePath: true);
+
+        Assert.Equal("https://api.example.com", model.Servers[0].Url);
+        Assert.Equal("https://staging.example.com/v2", model.Servers[1].Url);
+    }
+
+    /// <summary>A server that is nothing but the applied base path has nothing left to publish.</summary>
+    [Fact]
+    public void AServerThatIsOnlyTheBasePathIsDropped() {
+        Assert.Empty(Parse(Spec(@"
+servers:
+  - url: /v1
+"), applyServerBasePath: true).Servers);
+    }
+
+    /// <summary>
+    /// A variable reaches the document as written.
+    /// </summary>
+    /// <remarks>
+    /// <c>ServerBasePath</c> refuses an unresolved <c>{variable}</c> because the route tree
+    /// compiles a path into character comparisons and cannot match a brace. A document reader has
+    /// no such problem: server variables are part of the specification, so publishing one is
+    /// republishing what the author wrote.
+    /// </remarks>
+    [Fact]
+    public void AServerVariableIsPublishedAsWritten() {
+        var model = Parse(Spec(@"
+servers:
+  - url: https://{region}.example.com
+    variables:
+      region:
+        default: eu
+"));
+
+        Assert.Equal("https://{region}.example.com", Assert.Single(model.Servers).Url);
+    }
+}

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask.Tests/SpecModelSerializerTests.cs
@@ -407,6 +407,21 @@ public class SpecModelSerializerTests {
                 },
             },
             Services = { new ServiceModel { Tag = "Pet", TagDescription = "Everything about pets.", Operations = { operation } } },
+            // The document's own identity. Absent here for as long as it has existed, so the round
+            // trip for every one of these was written and never proven - which is the hole this
+            // file's reflection comparer exists to close, left open by the model it compares.
+            Title = "Petstore API",
+            Version = "2.1.0",
+            InfoDescription = "Everything about the pets in the store.",
+            SecuritySchemes = {
+                new SecuritySchemeModel { Name = "bearer", Json = "{\"type\":\"http\",\"scheme\":\"bearer\"}" },
+            },
+            // Two, because the list is ordered and one entry cannot show that. The second carries
+            // no description, which is the member that has to stay null rather than becoming "".
+            Servers = {
+                new ServerModel { Url = "https://api.example.com", Description = "production" },
+                new ServerModel { Url = "https://staging.example.com" },
+            },
             FilterTypes = {
                 new FilterTypeModel {
                     Name = "rateLimit",

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -181,6 +181,8 @@ internal static class OpenApiSpecParser {
 
         var basePath = applyServerBasePath ? ServerBasePath(document) : "";
 
+        ReadServers(document, basePath, model);
+
         if (document.Paths != null) {
             foreach (var pathKvp in document.Paths) {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -509,6 +511,57 @@ internal static class OpenApiSpecParser {
                     operation.ResponseIsArray = false;
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// The contract's <c>servers</c>, for the published document to repeat.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Read for <see cref="ServerBasePath"/> and otherwise dropped, which left a
+    /// specification-first document with no <c>servers</c> at all: a generated client had every
+    /// path and no host to send one to, and <c>[Server]</c> is read off the entry point rather than
+    /// the contract so there was no in-framework way to say it either.
+    /// </para>
+    /// <para>
+    /// <paramref name="basePath"/> is removed from the end of a URL that carries it, because the
+    /// build has already put it on every route. Publishing both would have a client join
+    /// <c>https://api.example.com/v1</c> to <c>/v1/todos</c>, which is the doubling
+    /// <c>ServerBasePath</c>'s own remarks give as the reason it is opt-in. Only that exact suffix
+    /// goes: a second server whose path differs from the first was never the one applied, and
+    /// guessing at it here would be a second wrong answer rather than a fix.
+    /// </para>
+    /// <para>
+    /// A URL with an unresolved <c>{variable}</c> is published as written. A document reader knows
+    /// what a server variable is; only the route tree does not, which is why
+    /// <see cref="ServerBasePath"/> refuses one and this does not.
+    /// </para>
+    /// </remarks>
+    private static void ReadServers(OpenApiDocument document, string basePath, ServiceSpecModel model) {
+        if (document.Servers == null) {
+            return;
+        }
+
+        foreach (var server in document.Servers) {
+            if (server?.Url is not { } url || string.IsNullOrWhiteSpace(url)) {
+                continue;
+            }
+
+            url = url.TrimEnd('/');
+
+            if (basePath.Length > 0 && url.EndsWith(basePath, StringComparison.Ordinal)) {
+                url = url.Substring(0, url.Length - basePath.Length);
+            }
+
+            if (url.Length == 0) {
+                continue;
+            }
+
+            model.Servers.Add(new ServerModel {
+                Url = url,
+                Description = FirstNonEmpty(server.Description)
+            });
         }
     }
 

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/HandlerBindingDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/HandlerBindingDiagnosticsTests.cs
@@ -129,19 +129,21 @@ public class HandlerBindingDiagnosticsTests {
             Assert.Equal(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning, d.Severity));
     }
 
+    private static AttributeModel Declaration(string attributeName) =>
+        new(TypeDefinition.Get("Hardened.Requests.Abstract.Attributes", attributeName), "", "");
+
     private static HandlerInfo HandlerDeclaring(string method, string attributeName) =>
         new(TypeDefinition.Get("Test.Api", "PetServiceImpl"),
             new[] { (ITypeDefinition)TypeDefinition.Get("Test.Api", "IPetService") },
             Array.Empty<AttributeModel>(),
-            new[] {
-                new HandlerMethodFilterInfo(
-                    method,
-                    new[] {
-                        new AttributeModel(
-                            TypeDefinition.Get("Hardened.Requests.Abstract.Attributes", attributeName),
-                            "", "")
-                    })
-            });
+            new[] { new HandlerMethodFilterInfo(method, new[] { Declaration(attributeName) }) });
+
+    /// <summary>The same handler with the declaration on the class rather than on a method.</summary>
+    private static HandlerInfo HandlerClassDeclaring(string attributeName) =>
+        new(TypeDefinition.Get("Test.Api", "PetServiceImpl"),
+            new[] { (ITypeDefinition)TypeDefinition.Get("Test.Api", "IPetService") },
+            new[] { Declaration(attributeName) },
+            Array.Empty<HandlerMethodFilterInfo>());
 
     /// <summary>
     /// <c>[RawResponse]</c> on a described handler, which the generator reads from a handler's own
@@ -179,6 +181,56 @@ public class HandlerBindingDiagnosticsTests {
             Assert.Single(Report(
                 new[] { Operation("IPetService", "/pets") },
                 new[] { HandlerDeclaring("ListPets", "RawResponseAttribute") })).Severity);
+
+    /// <summary>
+    /// <c>[Throws&lt;T&gt;]</c>, which is how a code-first handler puts a status in the document.
+    /// </summary>
+    /// <remarks>
+    /// A described operation answers the statuses its contract declares, so the attribute changed
+    /// nothing and nothing said so - while the same declaration is <c>HRDT001</c>, a build error,
+    /// code-first when the thrown type states no status. The generic keys on its simple name here:
+    /// <c>AttributeModelHelper</c> puts the type arguments in the type definition rather than in
+    /// <c>Name</c>.
+    /// </remarks>
+    [Fact]
+    public void AThrowsDeclarationIsReported() {
+        var message = Assert.Single(Report(
+            new[] { Operation("IPetService", "/pets") },
+            new[] { HandlerDeclaring("ListPets", "ThrowsAttribute") })).GetMessage();
+
+        Assert.Contains("PetServiceImpl.ListPets", message);
+        Assert.Contains("[Throws]", message);
+        Assert.Contains("contract declares", message);
+    }
+
+    /// <summary>
+    /// <c>[Tag]</c> and <c>[Server]</c>, which are <c>AttributeTargets.Class</c>.
+    /// </summary>
+    /// <remarks>
+    /// The rung that had no reader. A walk over methods alone would take the table entry for either
+    /// of these and report nothing - a diagnostic that looks configured and is not, which is the
+    /// defect this rule exists to catch, one level up.
+    /// </remarks>
+    [Theory]
+    [InlineData("TagAttribute", "[Tag]", "grouped by the tag")]
+    [InlineData("ServerAttribute", "[Server]", "servers block")]
+    public void AClassLevelDeclarationIsReported(string attribute, string named, string instead) {
+        var message = Assert.Single(Report(
+            new[] { Operation("IPetService", "/pets") },
+            new[] { HandlerClassDeclaring(attribute) })).GetMessage();
+
+        // The class alone, because there is no method to name.
+        Assert.Contains("'PetServiceImpl'", message);
+        Assert.Contains(named, message);
+        Assert.Contains(instead, message);
+    }
+
+    /// <summary>A class declaration the described path does read is left alone, as a method's is.</summary>
+    [Fact]
+    public void AClassLevelDeclarationTheDescribedPathReadsIsNotReported() =>
+        Assert.Empty(Report(
+            new[] { Operation("IPetService", "/pets") },
+            new[] { HandlerClassDeclaring("RateLimitAttribute") }));
 
     /// <summary>
     /// A declaration the described path does read is left alone. Without this the rule could pass

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/DocumentWriterTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocument/DocumentWriterTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using CSharpAuthor;
 using Hardened.Generation.Models;
@@ -63,6 +64,28 @@ public class DocumentWriterTests {
         JsonDocument.Parse(
             OpenApiDocumentGenerator.Write(EntryPoint(), [handler], "", version, identity))
             .RootElement;
+
+    /// <summary>The same, over an entry point carrying <c>[Server]</c> arguments as source text.</summary>
+    private static JsonElement WriteWithServerAttribute(string arguments, DocumentIdentity? identity = null) {
+        var appModel = new EntryPointSelector.Model {
+            EntryPointType = Type("Application"),
+            AttributeModels = [new AttributeModel(Type("ServerAttribute"), arguments, "")]
+        };
+
+        return JsonDocument.Parse(
+            OpenApiDocumentGenerator.Write(
+                appModel, [Handler()], "", OpenApiVersionFacts.Default, identity))
+            .RootElement;
+    }
+
+    private static (string Url, string? Description)[] Servers(JsonElement document) =>
+        document.GetProperty("servers").EnumerateArray()
+            .Select(server => (
+                server.GetProperty("url").GetString()!,
+                server.TryGetProperty("description", out var description)
+                    ? description.GetString()
+                    : null))
+            .ToArray();
 
     private static JsonElement LimitSchema(JsonElement document) {
         foreach (var parameter in document
@@ -184,6 +207,66 @@ public class DocumentWriterTests {
         var requirement = Assert.Single(operation.GetProperty("security").EnumerateArray());
 
         Assert.Equal(0, requirement.GetProperty("BearerAuth").GetArrayLength());
+    }
+
+    /// <summary>
+    /// A contract's own <c>servers</c>, which used to be read for a base path and dropped.
+    /// </summary>
+    /// <remarks>
+    /// Where the application is served is the one thing a document cannot derive from the code, so
+    /// dropping it left a generated client with every path and no host to send one to.
+    /// </remarks>
+    [Fact]
+    public void TheContractsServersArePublishedInTheOrderItWroteThem() {
+        var document = Write(
+            Handler(),
+            identity: new DocumentIdentity(
+                null, null, null, [],
+                [("https://api.example.com", "production"), ("https://staging.example.com", null)]));
+
+        Assert.Equal(
+            [("https://api.example.com", "production"), ("https://staging.example.com", null)],
+            Servers(document));
+    }
+
+    /// <summary>The attribute still answers for an application whose contract says nothing.</summary>
+    [Fact]
+    public void AServerAttributeIsPublishedWhenNoContractDeclaresOne() {
+        var document = WriteWithServerAttribute("\"https://api.example.com\", \"production\"");
+
+        Assert.Equal([("https://api.example.com", "production")], Servers(document));
+    }
+
+    /// <summary>
+    /// The contract wins, which is the precedence <c>info</c> already has.
+    /// </summary>
+    /// <remarks>
+    /// Either or rather than a union: an author who wrote both said one thing twice, and merging
+    /// them would put the same deployment in the list two ways.
+    /// </remarks>
+    [Fact]
+    public void TheContractsServersWinOverTheAttribute() {
+        var document = WriteWithServerAttribute(
+            "\"https://attribute.example.com\"",
+            new DocumentIdentity(null, null, null, [], [("https://contract.example.com", null)]));
+
+        Assert.Equal([("https://contract.example.com", null)], Servers(document));
+    }
+
+    /// <summary>
+    /// Nothing said, nothing written.
+    /// </summary>
+    /// <remarks>
+    /// An absent <c>servers</c> and an empty one are different documents: a reader takes the
+    /// absent case as the document's own location and the empty one as served from nowhere.
+    /// </remarks>
+    [Fact]
+    public void AnApplicationThatDeclaresNoServerWritesNoServersKey() {
+        Assert.False(Write(Handler()).TryGetProperty("servers", out _));
+
+        Assert.False(
+            Write(Handler(), identity: new DocumentIdentity(null, null, null, [], []))
+                .TryGetProperty("servers", out _));
     }
 
     [Fact]

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/DocumentIdentity.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/DocumentIdentity.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 namespace Hardened.SourceGenerator.OpenApiDocument;
 
 /// <summary>
-/// What the published document says about itself: <c>info</c> and the declared security schemes.
+/// What the published document says about itself: <c>info</c>, the servers it is reached at, and
+/// the declared security schemes.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -22,11 +23,13 @@ public sealed class DocumentIdentity : System.IEquatable<DocumentIdentity> {
 
     public DocumentIdentity(
         string? title, string? version, string? description,
-        IReadOnlyList<(string Name, string Json)> securitySchemes) {
+        IReadOnlyList<(string Name, string Json)> securitySchemes,
+        IReadOnlyList<(string Url, string? Description)>? servers = null) {
         Title = title;
         Version = version;
         Description = description;
         SecuritySchemes = securitySchemes;
+        Servers = servers ?? System.Array.Empty<(string Url, string? Description)>();
     }
 
     public string? Title { get; }
@@ -38,14 +41,31 @@ public sealed class DocumentIdentity : System.IEquatable<DocumentIdentity> {
     /// <summary>Each scheme's component name and its OpenAPI JSON, ordered by name.</summary>
     public IReadOnlyList<(string Name, string Json)> SecuritySchemes { get; }
 
+    /// <summary>
+    /// The servers the contract declares, in the order it wrote them.
+    /// </summary>
+    /// <remarks>
+    /// Ordered rather than sorted, because a document's <c>servers</c> list is ordered: a reader
+    /// and a generated client take the first as the default, so choosing a different one here
+    /// would override the author.
+    /// </remarks>
+    public IReadOnlyList<(string Url, string? Description)> Servers { get; }
+
     public bool Equals(DocumentIdentity? other) {
         if (other is null) {
             return false;
         }
 
         if (Title != other.Title || Version != other.Version || Description != other.Description ||
-            SecuritySchemes.Count != other.SecuritySchemes.Count) {
+            SecuritySchemes.Count != other.SecuritySchemes.Count ||
+            Servers.Count != other.Servers.Count) {
             return false;
+        }
+
+        for (var i = 0; i < Servers.Count; i++) {
+            if (Servers[i] != other.Servers[i]) {
+                return false;
+            }
         }
 
         for (var i = 0; i < SecuritySchemes.Count; i++) {
@@ -64,6 +84,7 @@ public sealed class DocumentIdentity : System.IEquatable<DocumentIdentity> {
             var hash = Title?.GetHashCode() ?? 0;
             hash = (hash * 397) ^ (Version?.GetHashCode() ?? 0);
             hash = (hash * 397) ^ SecuritySchemes.Count;
+            hash = (hash * 397) ^ Servers.Count;
             return hash;
         }
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -69,7 +69,7 @@ public static class OpenApiDocumentGenerator {
 
         builder.Append('}');
 
-        WriteServers(builder, appModel);
+        WriteServers(builder, appModel, identity);
         WriteTags(builder, handlers);
 
         builder.Append(",\"paths\":{");
@@ -387,7 +387,36 @@ public static class OpenApiDocumentGenerator {
         return (null, null, null);
     }
 
-    private static void WriteServers(StringBuilder builder, EntryPointSelector.Model appModel) {
+    /// <summary>
+    /// Where the application is served, from the contract when it says and from <c>[Server]</c>
+    /// otherwise.
+    /// </summary>
+    /// <remarks>
+    /// The same precedence <c>info</c> gets: what the contract declares about itself wins, and the
+    /// attribute is how a code-first application - or a described one whose contract says nothing -
+    /// answers the same question. Either or, rather than a union: an author who wrote both said one
+    /// thing twice, and publishing both would put the same host in the list two ways.
+    /// </remarks>
+    private static void WriteServers(
+        StringBuilder builder, EntryPointSelector.Model appModel, DocumentIdentity? identity) {
+        if (identity != null && identity.Servers.Count > 0) {
+            var firstDeclared = true;
+
+            foreach (var (url, description) in identity.Servers) {
+                if (url.Length == 0) {
+                    continue;
+                }
+
+                WriteServer(builder, url, description ?? "", ref firstDeclared);
+            }
+
+            if (!firstDeclared) {
+                builder.Append(']');
+            }
+
+            return;
+        }
+
         if (appModel.AttributeModels == null) {
             return;
         }
@@ -408,25 +437,28 @@ public static class OpenApiDocumentGenerator {
                 continue;
             }
 
-            builder.Append(first ? ",\"servers\":[" : ",");
-
-            builder.Append("{\"url\":\"").Append(JsonSchemaWriter.Escape(url)).Append('"');
-
-            var description = AttributeArguments.Text(parts, 1, "description");
-
-            if (description.Length > 0) {
-                builder.Append(",\"description\":\"")
-                    .Append(JsonSchemaWriter.Escape(description)).Append('"');
-            }
-
-            builder.Append('}');
-
-            first = false;
+            WriteServer(builder, url, AttributeArguments.Text(parts, 1, "description"), ref first);
         }
 
         if (!first) {
             builder.Append(']');
         }
+    }
+
+    private static void WriteServer(
+        StringBuilder builder, string url, string description, ref bool first) {
+        builder.Append(first ? ",\"servers\":[" : ",");
+
+        builder.Append("{\"url\":\"").Append(JsonSchemaWriter.Escape(url)).Append('"');
+
+        if (description.Length > 0) {
+            builder.Append(",\"description\":\"")
+                .Append(JsonSchemaWriter.Escape(description)).Append('"');
+        }
+
+        builder.Append('}');
+
+        first = false;
     }
 
     /// <summary>

--- a/src/Web/Hardened.Web.Runtime/Attributes/ServerAttribute.cs
+++ b/src/Web/Hardened.Web.Runtime/Attributes/ServerAttribute.cs
@@ -11,16 +11,38 @@ namespace Hardened.Web.Runtime.Attributes;
 /// </para>
 ///
 /// <para>
-/// Applied to the entry point, and more than once where an application is served from several
-/// places:
+/// Applied to the <c>[HardenedModule]</c> class in the compilation that writes the document, and
+/// more than once where an application is served from several places:
 /// </para>
 ///
 /// <code>
 /// [HardenedModule]
+/// [HardenedWebModule]
 /// [Server("https://api.example.com", "Production")]
 /// [Server("https://staging.example.com", "Staging")]
-/// public partial class Application { }
+/// public partial class Catalog { }
 /// </code>
+///
+/// <para>
+/// <b>Which class, when there are two.</b> The document is written where the routes are, which in
+/// the layout the templates ship is the library rather than the host: a project with a
+/// <c>Catalog</c> module and a <c>Catalog.Host</c> application publishes from the library, and the
+/// attribute on the host's <c>Application</c> reaches a compilation that writes no document. It is
+/// read off the module class's own attribute list, so a handler class is not a placement either -
+/// <c>HOAG032</c> says so on a described handler.
+/// </para>
+///
+/// <para>
+/// <b>The assembly target is not read.</b> <c>AttributeTargets.Assembly</c> is on the usage below
+/// and the document writer takes the entry point's class attributes only, so
+/// <c>[assembly: Server(...)]</c> compiles and publishes nothing.
+/// </para>
+///
+/// <para>
+/// A specification-first application says it in the contract instead. A <c>servers</c> block there
+/// is published as written, and wins over this attribute where both exist, which is the precedence
+/// <c>info</c> already has.
+/// </para>
 ///
 /// <para>
 /// Not the same thing as <c>[BasePath]</c>, and deliberately not derived from it. A base path is


### PR DESCRIPTION
From the 0.32 trial: what survived **B-03** after checking, its remediation item **3**, and **D-06**. One subject seen three times — where an application says it is served, and what tells an author a declaration is not being read.

## A contract's `servers` was dropped

```
$ python3 -c "import json; print(json.load(open('openapi/Freight.json')).get('servers'))"
None
```

The block was read for one thing, `OpenApiSpecParser.ServerBasePath`, and never carried onto the model. With `[Server]` read off the entry point rather than the contract, a specification-first application had no way to publish `servers` at all: every path and no host to send one to, and Kiota warning on every generation.

It rides `DocumentIdentity`, which already carries what a contract says about itself — `info` and the security schemes — so the path is the one that was already there: `OpenApiSpecParser` → `ServiceSpecModel.Servers` → the serializer → `SpecSourceGenerator`'s identity merge → `WriteServers`.

| | Publishes |
|---|---|
| a contract's `servers` block | as written, in the order written |
| `[Server]` on the `[HardenedModule]` class | unchanged |
| both | the contract, which is the precedence `info` already has |
| neither | no `servers` key, which is not the same as an empty one |

Either or rather than a union: an author who wrote both said one thing twice, and merging them would put the same deployment in the list two ways.

**The base path, which is the trap.** `HardenedOpenApiApplyServerBasePath` reads the first server's path and prefixes every route with it. Publishing the URL as written would then have a client join `https://api.example.com/v1` to `/v1/todos`, which is the doubling `ServerBasePath`'s own remarks give as the reason the option is opt-in. That suffix is removed from a published URL that carries it — only that exact suffix, because the base path comes from the first server alone and a second server with a path of its own was never the one applied. Guessing at it would be a second wrong answer rather than a fix.

**Evidence.** The petstore SUT contract declares two servers now, and its exported document carries them:

```json
"servers": [
  { "url": "https://petstore.example.invalid", "description": "production" },
  { "url": "https://staging.petstore.example.invalid" }
]
```

Description on the first only, so the member stays absent rather than becoming `""`.

## `HOAG032` named one declaration and could only ever name one

The trial asked for three attributes to be added to `InertDeclarations`, and the table's own remarks agreed it was one line each. It is one line for one of them. `ReportInertDeclarations` walked `handler.MethodFilters`, and of the three, `[Throws<T>]` is the only method-level attribute — `[Tag]` and `[Server]` are `AttributeTargets.Class` and land in `HandlerInfo.ClassFilters`, which the walk never visited. Adding their names would have compiled and reported nothing: a diagnostic that looks configured and is not, which is the shape of the defect this rule exists to catch.

Both rungs are walked now, and the message takes one "where" argument because a class-level declaration has no method to name.

| Declaration | Where | The contract says it with |
|---|---|---|
| `[RawResponse]` | method | the response's media type |
| `[Throws<T>]` | method | the operation's `responses` |
| `[Tag]` | class | the operation's `tags` |
| `[Server]` | class | a `servers` block |

The generic keys on its simple name: `AttributeModelHelper` puts the type arguments in the type definition rather than in `Name`, so `[Throws<Gone>]` arrives as `ThrowsAttribute` and the exact lookup finds it.

This closes what Arm B was built to probe. A spec-first author writes `[Throws<Gone>]`, the wire answers 410, the document says 200/400/404, and the build was silent — while the same declaration is `HRDT001`, a build error, code-first when the thrown type states no status.

## The placement rule was wrong where it was written down

`ServerAttribute`'s own documentation said "applied to the entry point" over an example on `Application`, which is the placement that publishes nothing: the document is written where the routes are, so in the layout the templates ship that is the library and not the host. `openapi.md` put `[Tag]` and `[Server]` under a column headed *On a `[Handler]` method*, and neither is valid on one — `[Tag]` on a method is `CS0592` (**D-06**). `attributes.md` and `openapi-document.md` both offered the assembly target.

**A limit now written down rather than implied.** `[Server]` declares `AttributeTargets.Assembly` and the writer takes the entry point's class attributes only, so `[assembly: Server(...)]` compiles and publishes nothing. That is the same defect class as B-03 and it is not in the trial, so this documents it rather than expanding scope. `DeclaredTimeoutSelector` reads `Compilation.Assembly.GetAttributes()` from the context `EntryPointSelector` already holds, if it should be built.

## Two things found on the way

Neither is in the trial. Both are the defect this PR is about, one level down.

**`ServiceSpecModel.Equals` ignored the identity.** `Title`, `Version`, `InfoDescription` and `SecuritySchemes` were not compared, so a contract that only renamed itself produced a model Roslyn compared equal and the provider carrying the identity downstream never recomputed — the stale title `DocumentIdentity`'s own remarks say it exists to prevent. `Servers` would have inherited it. All five are compared now.

**`FullyPopulated()` was not.** The serializer round-trip test builds a model through reflection precisely so a field added and forgotten fails without anyone remembering to extend the comparer, and it left those same four unset — so their round trip was written and never proven. It carries them now, with two servers because the list is ordered and one entry cannot show that, and no description on the second because that member has to stay null rather than becoming `""`.

## Verification

- `dotnet test Hardened.slnx` — 74 assemblies, 0 failures.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — 0 warnings, 0 errors.
- `scripts/verify-templates.sh` with the pinned Smithy CLI on `PATH` — every combination. The templates declare no `servers`, so no scaffolded document changes; the spec-first rows are what exercise the generator this touches, and the module class's own `[Server]` still publishes.
- `npm run build` in `docs/` — no dead links.
- New: `ServersTests` (7 cases over the parser, including both sides of the base path and a server variable), four document-writer cases covering each branch of the precedence, `AThrowsDeclarationIsReported`, `AClassLevelDeclarationIsReported` for both class attributes, and `AClassLevelDeclarationTheDescribedPathReadsIsNotReported` so the widened walk cannot pass by firing on everything.
- The model file header goes 6 → 7 for the new `server` record, the way 4 and 5 were bumped: a 6 reader handed a 7 file throws on the tag rather than skipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
