### PR TITLE
Take a blob as a request body, and stop calling bytes JSON

### DIFF
--- a/docs/guide/smithy.md
+++ b/docs/guide/smithy.md
@@ -260,8 +260,45 @@ public async Task<CreatePetOutput> CreatePet(CreatePetInput body) {
 | `@streaming union`, bound as an `@httpPayload` output | the same struct, and `IAsyncEnumerable<TUnion>` on the interface. The response streams as server-sent events: each item is one member as `data:`, with the member's name as `event:`, and the document describes the item as the choice of its members |
 | `document` | `JsonElement` |
 | `Timestamp` | `DateTimeOffset` |
-| `Blob` | `byte[]` |
+| `Blob` | `byte[]`, whether it is a member of a body or the body itself |
 | `@jsonName("x")` | `[JsonPropertyName("x")]` on the property |
+
+## A body that is not JSON
+
+`@httpPayload` makes one member the whole body rather than a member of one, in either direction.
+What it targets decides the media type:
+
+| Payload target | Content type |
+|---|---|
+| a `blob` | `application/octet-stream` |
+| anything else | `application/json` |
+| any shape carrying `@mediaType` | what the trait says |
+
+```smithy
+@http(method: "PUT", uri: "/pets/{petId}/photo", code: 200)
+operation PutPetPhoto {
+    input := {
+        @httpLabel
+        @required
+        petId: String
+
+        @required
+        @httpPayload
+        photo: Blob
+    }
+}
+```
+
+```csharp
+public Task<PutPetPhotoOutput> PutPetPhoto(string petId, byte[] body) =>
+    Task.FromResult(new PutPetPhotoOutput(body.Length));
+```
+
+The published operation declares `application/octet-stream` with a `string`/`byte` schema, which is
+how a generated client learns to send the bytes rather than a JSON document.
+
+A blob inside a structure is the other thing, and stays base64 in a JSON body. `@httpPayload` is
+what moves it onto the wire as itself.
 
 ## Bounding an operation
 

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/PetStoreServiceImpl.cs
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/PetStoreServiceImpl.cs
@@ -45,6 +45,18 @@ public class PetStoreServiceImpl : IPetStoreService {
     }
 
     /// <summary>
+    /// The blob is the body, so the parameter is <c>byte[]</c> and the bytes are the ones sent.
+    /// </summary>
+    /// <remarks>
+    /// The signature is the assertion. It came out <c>string</c>, because the request side dropped
+    /// the format the response side kept, and a handler cannot read a binary body through one. That
+    /// this file compiles is what says the parameter is bytes; the count it answers is what says
+    /// they arrived unchanged rather than through a text round trip.
+    /// </remarks>
+    public Task<PutPetPhotoOutput> PutPetPhoto(string petId, byte[] body) =>
+        Task.FromResult(new PutPetPhotoOutput(body.Length));
+
+    /// <summary>
     /// The three parameters are the three bindings: <c>@httpLabel</c>, <c>@httpQuery("verbose")</c>
     /// and <c>@httpHeader("X-Trace-Id")</c>. The header's C# name comes from its wire name, because
     /// NameAllocator assigns every name in the model from the wire spelling.

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/Specs/petstore.smithy
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/Specs/petstore.smithy
@@ -14,7 +14,7 @@ use hardened.api#timeout
 @httpBearerAuth
 service PetStore {
     version: "2024-01-01"
-    operations: [GetPet, ListPets, CreatePet, GetSecuredPet, PetEvents]
+    operations: [GetPet, ListPets, CreatePet, GetSecuredPet, PetEvents, PutPetPhoto]
 }
 
 @documentation("Requires an authenticated caller.")
@@ -75,6 +75,38 @@ operation ListPets {
         pets: PetList
 
         nextToken: String
+    }
+}
+
+// The @httpPayload direction this model never exercised: a blob as the whole body rather than a
+// member of one. CreatePet's `photo` is the other path - a blob inside a JSON structure, so base64
+// in a document; this is bytes on the wire.
+//
+// It produced an operation no client could call. The parameter came out `string`, because the
+// request side dropped the format the response side kept. The document carried no requestBody at
+// all, because only a named body was ever written. And the content map said application/json for a
+// body that cannot be JSON.
+//
+// Comments rather than /// doc comments deliberately: a /// here is the operation's `description`
+// in the published document, and this reasoning belongs to the repository rather than to anyone
+// reading the contract.
+
+/// Replaces a pet's photo, sent as the whole request body.
+@auth([])
+@http(method: "PUT", uri: "/pets/{petId}/photo", code: 200)
+operation PutPetPhoto {
+    input := {
+        @httpLabel
+        @required
+        petId: String
+
+        @required
+        @httpPayload
+        photo: Blob
+    }
+    output := {
+        @required
+        byteCount: Integer
     }
 }
 

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
@@ -22,7 +22,7 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "application/x-amz-json-1.0": {
               "schema": {
                 "$ref": "#/components/schemas/GetBalanceInput"
               }
@@ -60,7 +60,7 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "application/x-amz-json-1.0": {
               "schema": {
                 "$ref": "#/components/schemas/TransferInput"
               }
@@ -371,6 +371,48 @@
           }
         }
       }
+    },
+    "/pets/{petId}/photo": {
+      "put": {
+        "tags": [
+          "PetStore"
+        ],
+        "operationId": "PutPetPhoto",
+        "description": "Replaces a pet's photo, sent as the whole request body.",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "byte"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutPetPhotoOutput"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -644,6 +686,17 @@
         "required": [
           "petId",
           "grams"
+        ]
+      },
+      "PutPetPhotoOutput": {
+        "type": "object",
+        "properties": {
+          "byteCount": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "byteCount"
         ]
       },
       "RequestValidationError": {

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/OperationModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/OperationModel.cs
@@ -110,6 +110,18 @@ internal class OperationModel : IEquatable<OperationModel> {
     public string? RequestBodyType { get; set; }
 
     /// <summary>
+    /// The request body's <c>format</c>, where it is a scalar the contract typed rather than named.
+    /// </summary>
+    /// <remarks>
+    /// The mirror of <see cref="ResponseFormat"/>, and absent until it was needed: the response
+    /// side carried the format and the request side dropped it, so a Smithy <c>blob</c> bound as
+    /// <c>@httpPayload</c> came out <c>byte[]</c> on the way back and <c>string</c> on the way in.
+    /// A parameter typed <c>string</c> cannot take a binary body, which is what made the operation
+    /// one no client could call.
+    /// </remarks>
+    public string? RequestBodyFormat { get; set; }
+
+    /// <summary>
     /// The media type the response schema was read from - "application/json", "text/plain",
     /// "text/html". Null when the operation declares no response content.
     /// </summary>
@@ -291,6 +303,7 @@ internal class OperationModel : IEquatable<OperationModel> {
                RequestBodyContentType == other.RequestBodyContentType &&
                RequestBodyRef == other.RequestBodyRef &&
                RequestBodyType == other.RequestBodyType &&
+               RequestBodyFormat == other.RequestBodyFormat &&
                ResponseContentType == other.ResponseContentType &&
                ResponseRef == other.ResponseRef &&
                ResponseType == other.ResponseType &&

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -66,7 +66,12 @@ internal static class SpecModelSerializer {
     /// new record tag, same reasoning as 4: a 6 reader handed a 7 file throws on the tag rather
     /// than skipping it.
     /// </remarks>
-    private const string Header = "#hardened-openapi-model 7";
+    /// <remarks>
+    /// 8 adds each operation's <c>RequestBodyFormat</c>. Additive, and bumped for the reason 6 was:
+    /// a 7 reader handed an 8 file finds no format and maps the body to the type alone, which puts
+    /// <c>string</c> where <c>byte[]</c> belongs - the silent half of the defect the field closes.
+    /// </remarks>
+    private const string Header = "#hardened-openapi-model 8";
 
     private const char FieldSeparator = '\t';
 
@@ -603,6 +608,7 @@ internal static class SpecModelSerializer {
         record.Add("IsDeprecated", operation.IsDeprecated);
         record.Add("SecurityRequirements", operation.SecurityRequirements);
         record.Add("RequestBodyContentType", operation.RequestBodyContentType);
+        record.Add("RequestBodyFormat", operation.RequestBodyFormat);
         record.Add("RequestBodyRef", operation.RequestBodyRef);
         record.Add("RequestBodyType", operation.RequestBodyType);
         record.Add("ResponseContentType", operation.ResponseContentType);
@@ -720,6 +726,7 @@ internal static class SpecModelSerializer {
         IsDeprecated = record.Bool("IsDeprecated"),
         SecurityRequirements = record.Strings("SecurityRequirements") ?? new List<string>(),
         RequestBodyContentType = record.String("RequestBodyContentType"),
+        RequestBodyFormat = record.String("RequestBodyFormat"),
         RequestBodyRef = record.String("RequestBodyRef"),
         RequestBodyType = record.String("RequestBodyType"),
         ResponseContentType = record.String("ResponseContentType"),

--- a/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
+++ b/src/SourceGenerators/Hardened.Idl.Emit/Emitters/ServiceInterfaceEmitter.cs
@@ -247,7 +247,12 @@ internal static class ServiceInterfaceEmitter {
         if (operation.RequestBodyRef != null) {
             method.AddParameter(Model(operation.RequestBodyRef, modelsNamespace), "body");
         } else if (operation.RequestBodyType != null) {
-            var csType = TypeMapper.MapToCSharpType(operation.RequestBodyType, null);
+            // With the format, which the response side has always passed: a blob is
+            // ("string", "byte") and maps to byte[], and dropping the format put a string in the
+            // signature of a handler whose body is bytes.
+            var csType = TypeMapper.MapToCSharpType(
+                operation.RequestBodyType, operation.RequestBodyFormat);
+
             method.AddParameter(TypeMapper.GetTypeDefinition(modelsNamespace, csType, false), "body");
         }
 

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyBlobPayloadTests.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask.Tests/SmithyBlobPayloadTests.cs
@@ -1,0 +1,157 @@
+using Hardened.Generation.Models;
+using Hardened.Smithy.BuildTask.Parsing;
+using Xunit;
+
+namespace Hardened.Smithy.BuildTask.Tests;
+
+/// <summary>
+/// A <c>blob</c> bound as <c>@httpPayload</c>, in both directions.
+/// </summary>
+/// <remarks>
+/// The request side dropped the format and always said <c>application/json</c>, so an operation
+/// whose whole point is a binary body took a <c>string</c> parameter, published no
+/// <c>requestBody</c> at all, and refused a real body when one was sent. The response side kept the
+/// format and so answered <c>byte[]</c> correctly, but read the content type from
+/// <c>@mediaType</c> alone - so a blob that named none went out quoted as JSON.
+///
+/// The framework's own Smithy subject binds <c>@httpPayload</c> on outputs only, which is how a
+/// whole direction of this stayed unexercised.
+/// </remarks>
+public class SmithyBlobPayloadTests {
+
+    private static string Model(string payloadTarget, string extraShapes = "") =>
+        $$"""
+          { "smithy": "2.0", "shapes": {
+              "com.example#Svc": {
+                "type": "service", "version": "1",
+                "operations": [
+                  { "target": "com.example#Put" },
+                  { "target": "com.example#Get" } ] },
+              "com.example#Put": {
+                "type": "operation",
+                "traits": { "smithy.api#http": { "method": "PUT", "uri": "/blobs/{id}", "code": 200 } },
+                "input": { "target": "com.example#PutInput" } },
+              "com.example#PutInput": {
+                "type": "structure",
+                "members": {
+                  "id": { "target": "smithy.api#String",
+                          "traits": { "smithy.api#httpLabel": {}, "smithy.api#required": {} } },
+                  "content": { "target": "{{payloadTarget}}",
+                               "traits": { "smithy.api#httpPayload": {} } } } },
+              "com.example#Get": {
+                "type": "operation",
+                "traits": { "smithy.api#http": { "method": "GET", "uri": "/blobs/{id}", "code": 200 } },
+                "input": { "target": "com.example#GetInput" },
+                "output": { "target": "com.example#GetOutput" } },
+              "com.example#GetInput": {
+                "type": "structure",
+                "members": {
+                  "id": { "target": "smithy.api#String",
+                          "traits": { "smithy.api#httpLabel": {}, "smithy.api#required": {} } } } },
+              "com.example#GetOutput": {
+                "type": "structure",
+                "members": {
+                  "content": { "target": "{{payloadTarget}}",
+                               "traits": { "smithy.api#httpPayload": {} } } } }
+              {{extraShapes}} } }
+          """;
+
+    private static (OperationModel Put, OperationModel Get) Parse(
+        string payloadTarget = "smithy.api#Blob", string extraShapes = "") {
+        var diagnostics = new List<string>();
+        var model = SmithySpecParser.Parse(Model(payloadTarget, extraShapes), "blob", diagnostics);
+
+        Assert.NotNull(model);
+        Assert.Empty(diagnostics);
+
+        var operations = Assert.Single(model!.Services).Operations;
+
+        return (
+            Assert.Single(operations, operation => operation.OperationId == "Put"),
+            Assert.Single(operations, operation => operation.OperationId == "Get"));
+    }
+
+    /// <summary>
+    /// The pair that has to agree, and did not.
+    /// </summary>
+    /// <remarks>
+    /// <c>OperationModel</c> had a <c>ResponseFormat</c> and no request equivalent, so the same
+    /// shape came out ("string", "byte") on the way back and ("string", null) on the way in -
+    /// <c>byte[]</c> and <c>string</c> once mapped.
+    /// </remarks>
+    [Fact]
+    public void ABlobPayloadCarriesItsFormatInBothDirections() {
+        var (put, get) = Parse();
+
+        Assert.Equal("string", put.RequestBodyType);
+        Assert.Equal("byte", put.RequestBodyFormat);
+
+        Assert.Equal("string", get.ResponseType);
+        Assert.Equal("byte", get.ResponseFormat);
+    }
+
+    /// <summary>
+    /// Bytes are not JSON, in either direction.
+    /// </summary>
+    /// <remarks>
+    /// The request side had no rule and always said <c>application/json</c>, so a binary body was
+    /// negotiated as JSON and refused. The response side read <c>@mediaType</c> and nothing else.
+    /// </remarks>
+    [Fact]
+    public void ABlobPayloadIsOctetStreamInBothDirections() {
+        var (put, get) = Parse();
+
+        Assert.Equal("application/octet-stream", put.RequestBodyContentType);
+        Assert.Equal("application/octet-stream", get.ResponseContentType);
+    }
+
+    /// <summary>A declared media type wins over the shape's default, as it always did on the way out.</summary>
+    [Fact]
+    public void ADeclaredMediaTypeWinsOverTheDefault() {
+        var (put, get) = Parse(
+            "com.example#Pdf",
+            """
+            , "com.example#Pdf": {
+                "type": "blob",
+                "traits": { "smithy.api#mediaType": "application/pdf" } }
+            """);
+
+        Assert.Equal("application/pdf", put.RequestBodyContentType);
+        Assert.Equal("application/pdf", get.ResponseContentType);
+        Assert.Equal("byte", put.RequestBodyFormat);
+    }
+
+    /// <summary>
+    /// A payload that is not a blob keeps the JSON default it always had.
+    /// </summary>
+    /// <remarks>
+    /// The control. Without it the octet-stream arm could pass its own tests by answering
+    /// octet-stream for every payload there is.
+    /// </remarks>
+    [Fact]
+    public void AStructurePayloadIsStillJson() {
+        var (put, get) = Parse(
+            "com.example#Pet",
+            """
+            , "com.example#Pet": {
+                "type": "structure",
+                "members": { "id": { "target": "smithy.api#String" } } }
+            """);
+
+        Assert.Equal("application/json", put.RequestBodyContentType);
+        Assert.Null(put.RequestBodyFormat);
+        Assert.NotNull(put.RequestBodyRef);
+
+        Assert.Equal("application/json", get.ResponseContentType);
+    }
+
+    /// <summary>A string payload keeps the JSON default too, unless it names a media type.</summary>
+    [Fact]
+    public void AStringPayloadIsStillJson() {
+        var (put, _) = Parse("smithy.api#String");
+
+        Assert.Equal("application/json", put.RequestBodyContentType);
+        Assert.Equal("string", put.RequestBodyType);
+        Assert.Null(put.RequestBodyFormat);
+    }
+}

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -576,14 +576,20 @@ internal static class SmithySpecParser {
 
                 if (target != null) {
                     // Classified like any member, for the reasons the output payload gives.
-                    Describe(context, target, out var type, out _, out var reference, out var facts);
+                    Describe(context, target, out var type, out var format, out var reference,
+                        out var facts);
 
-                    model.RequestBodyContentType ??= "application/json";
+                    model.RequestBodyContentType ??= PayloadContentType(context, target, format);
 
                     if (reference != null) {
                         model.RequestBodyRef = reference;
                     } else if (type != null && !facts.IsArray) {
                         model.RequestBodyType = type;
+
+                        // The format the response side has always kept. Dropped here, a blob became
+                        // a string parameter that cannot take a binary body, and neither the
+                        // generated signature nor the published document said so.
+                        model.RequestBodyFormat = format;
                     } else {
                         context.Diagnostics.Add(
                             $"operation '{operationName}' binds @httpPayload to '{target}', a " +
@@ -783,11 +789,16 @@ internal static class SmithySpecParser {
 
                 // @mediaType on the payload target is the response's content type - text/plain on
                 // a string label, application/pdf on a blob. Accepted by the trait table and never
-                // read, which left a Smithy service unable to answer anything but JSON.
-                if (context.Ast.TryGetShape(target, out var payloadShape) &&
-                    SmithyAst.TryGetTrait(payloadShape, SmithyTraits.MediaType, out var mediaType) &&
-                    mediaType.ValueKind == JsonValueKind.String) {
-                    model.ResponseContentType = mediaType.GetString();
+                // read, which left a Smithy service unable to answer anything but JSON. A blob that
+                // names no media type is bytes all the same, and JSON cannot carry them.
+                //
+                // Assigned only where the payload implies something other than the default, so
+                // every shape that was already answering JSON keeps whatever the rest of the parse
+                // decided for it.
+                var responseContentType = PayloadContentType(context, target, format);
+
+                if (responseContentType != "application/json") {
+                    model.ResponseContentType = responseContentType;
                 }
 
                 return headers;
@@ -816,6 +827,30 @@ internal static class SmithySpecParser {
     /// body anyway, and the parser disagreed with the protocol it implements. It also runs once per
     /// shape, so a structure reached by two operations would take the first one's bindings.
     /// </remarks>
+    /// <summary>
+    /// The content type an <c>@httpPayload</c> target implies.
+    /// </summary>
+    /// <remarks>
+    /// <c>@mediaType</c> on the target where it declares one, and otherwise the default for the
+    /// shape: a blob is bytes and JSON cannot carry them. Everything else keeps the JSON default
+    /// this front end has always applied.
+    ///
+    /// One rule for both directions, because the shape decides it rather than the direction. The
+    /// request side had no rule at all and always said <c>application/json</c>, so a binary body
+    /// was negotiated as JSON and refused; the response side read <c>@mediaType</c> and nothing
+    /// else, so a blob with no media type went out quoted.
+    /// </remarks>
+    private static string PayloadContentType(ParseContext context, string target, string? format) {
+        if (context.Ast.TryGetShape(target, out var shape) &&
+            SmithyAst.TryGetTrait(shape, SmithyTraits.MediaType, out var mediaType) &&
+            mediaType.ValueKind == JsonValueKind.String &&
+            mediaType.GetString() is { Length: > 0 } declared) {
+            return declared;
+        }
+
+        return format == "byte" ? "application/octet-stream" : "application/json";
+    }
+
     private static void MarkHeaderBound(
         ParseContext context, string outputId, IReadOnlyDictionary<string, string> boundOut) {
         if (boundOut.Count == 0) {

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/RequestHandlerModel.cs
@@ -60,6 +60,7 @@ public class RequestHandlerModel {
             DeclaredResponsesAreComplete = DeclaredResponsesAreComplete,
             DeclaredTimeout = DeclaredTimeout,
             RequestSchema = RequestSchema,
+            RequestContentType = RequestContentType,
             Tag = Tag,
             TagDescription = TagDescription,
             OperationId = OperationId,
@@ -196,6 +197,17 @@ public class RequestHandlerModel {
 
     /// <summary>The request body's JSON Schema, on the same terms.</summary>
     public HandlerSchema? RequestSchema { get; set; }
+
+    /// <summary>
+    /// The media type the request body is read as, when it is not <c>application/json</c>.
+    /// </summary>
+    /// <remarks>
+    /// Null for every operation that takes JSON, which is nearly all of them, and the document
+    /// writer takes the default in that case. It was the default for all of them: the writer
+    /// spelled <c>application/json</c> into every <c>requestBody</c> it produced, so an operation
+    /// whose body is a blob published a content map naming the one media type its body cannot be.
+    /// </remarks>
+    public string? RequestContentType { get; set; }
 
     /// <summary>
     /// The <c>operationId</c> the handler declared with <c>[Operation]</c>, or the one its

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -590,7 +590,15 @@ public static class OpenApiDocumentGenerator {
 
         Merge(components, handler.RequestSchema);
 
-        builder.Append(",\"requestBody\":{\"required\":true,\"content\":{\"application/json\":{\"schema\":")
+        // The media type the operation actually reads, which was hardcoded to JSON - so an
+        // operation taking a blob published a content map naming the one type its body cannot be,
+        // and a generated client sent the wrong Content-Type on the request the operation exists
+        // for.
+        var contentType = handler.RequestContentType ?? "application/json";
+
+        builder.Append(",\"requestBody\":{\"required\":true,\"content\":{\"")
+            .Append(JsonSchemaWriter.Escape(contentType))
+            .Append("\":{\"schema\":")
             .Append(handler.RequestSchema.Schema)
             .Append("}}}");
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -217,7 +217,20 @@ internal static class SpecHandlerModelBuilder {
             // walks a type symbol, and these types are written by the build task rather than
             // declared in the consumer's source - so the published document carried paths and
             // operation ids and no schemas at all.
-            RequestSchema = SpecSchemaWriter.ForRef(operation.RequestBodyRef, schemas),
+            // A named body is a reference; a scalar one the contract typed without naming has to
+            // be written inline, the way a scalar response already is. Without the second arm a
+            // blob payload published no requestBody at all, so a generated client sent a bodyless
+            // request to an operation whose whole point is the body.
+            RequestSchema = SpecSchemaWriter.ForRef(operation.RequestBodyRef, schemas)
+                            ?? SpecSchemaWriter.ForScalar(
+                                operation.RequestBodyType, operation.RequestBodyFormat),
+
+            // Only where the contract named something other than JSON, so the writer's default
+            // stays the default rather than being restated on every operation.
+            RequestContentType =
+                operation.RequestBodyContentType is { } contentType && contentType != "application/json"
+                    ? contentType
+                    : null,
             ResponseSchemas = BuildResponseSchemas(operation, schemas),
 
             // One item of a streamed response, which the document writer publishes as itemSchema
@@ -365,7 +378,12 @@ internal static class SpecHandlerModelBuilder {
                 "",
                 index++));
         } else if (operation.RequestBodyType != null) {
-            var csType = TypeMapper.MapToCSharpType(operation.RequestBodyType, null);
+            // The format too, so the bound parameter is the type the generated interface declares.
+            // ServiceInterfaceEmitter reads the same pair; the two disagreeing is a signature the
+            // dispatch cannot call.
+            var csType = TypeMapper.MapToCSharpType(
+                operation.RequestBodyType, operation.RequestBodyFormat);
+
             var bodyType = TypeMapper.GetTypeDefinition(modelsNamespace, csType, false);
 
             parameters.Add(new RequestParameterInformation(


### PR DESCRIPTION
Closes the 0.32 trial's **C-03**. A Smithy `blob` bound as `@httpPayload` produced an operation no client could call — three faults at once, none of them reported by a diagnostic.

## What it produced

Parsing a model that binds the same `blob` as `@httpPayload` in both directions:

```
PUT  RequestBodyType=string  RequestBodyRef=<null>  RequestBodyContentType=application/json
GET  ResponseType=string  ResponseFormat=byte  ResponseRef=<null>  ResponseContentType=application/json
diagnostics: <none>
```

Three separate things are wrong there.

**The format.** `OperationModel` had a `ResponseFormat` and no request equivalent, and the input branch discarded it with `out _`. So the same shape came out `("string", "byte")` on the way back and `("string", null)` on the way in — `byte[]` and `string` once mapped, and a `string` parameter cannot take a binary body. `RequestBodyFormat` is the mirror, and both the generated interface and the bound parameter read it, because the two disagreeing is a signature the dispatch cannot call.

**The missing `requestBody`.** `SpecHandlerModelBuilder` wrote `RequestSchema` from `RequestBodyRef` alone, so a scalar payload published nothing and a generated client wrote a bodyless `PutAsync` for the operation whose whole point is the body. `SpecSchemaWriter.ForScalar` already existed for exactly this on the response side; the request side never called it.

**The content type**, hardcoded twice over. The parser always said `application/json` for a request payload, and `WriteRequestBody` spelled `application/json` into every `requestBody` it produced. So a binary body was negotiated as JSON and refused, which is the other half of "a real binary body is refused too".

## A correction to the trial

It reports the response side as correct. That is true of the C# type and not of the content type: the output branch read `@mediaType` and nothing else, so a blob naming none went out quoted as JSON.

One rule serves both directions now, because the payload's shape decides it rather than the direction:

| Payload target | Content type |
|---|---|
| a `blob` | `application/octet-stream` |
| anything else | `application/json` |
| any shape carrying `@mediaType` | what the trait says |

The response side is assigned only where the payload implies something other than JSON, so every shape that was already answering JSON keeps whatever the rest of the parse decided for it.

## Evidence

`petstore.smithy` gains the direction it never had — the subject bound `@httpPayload` on outputs only, which is how a whole direction of this stayed unexercised. The implementation is the first assertion:

```csharp
public Task<PutPetPhotoOutput> PutPetPhoto(string petId, byte[] body) =>
    Task.FromResult(new PutPetPhotoOutput(body.Length));
```

That file compiles against a generated interface. Before this it would not have — the interface declared `PutPetPhoto(string, string)`.

The exported document is the second:

```json
"requestBody": {
  "required": true,
  "content": {
    "application/octet-stream": {
      "schema": { "type": "string", "format": "byte" }
    }
  }
}
```

## The model file header

6 → 7 was `servers` in #328; 7 → 8 here for `RequestBodyFormat`. Additive, and bumped for the reason 6 was: a 7 reader handed an 8 file finds no format and maps the body to the type alone, which puts `string` where `byte[]` belongs — the silent half of the defect the field closes.

## Verification

- `dotnet test Hardened.slnx` — 74 assemblies, 0 failures.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — 0 warnings, 0 errors.
- `scripts/verify-templates.sh` with the pinned Smithy CLI on `PATH` — every combination, no failures, both Smithy rows unchanged at 17 tests.
- `npm run build` in `docs/` — no dead links.
- New: five parser cases covering both directions, `@mediaType` winning over the default, and structure and string payload controls so the octet-stream arm cannot pass by applying to every payload there is; three over the wire, including a body of bytes no text encoding round-trips, so a body that went through one comes back the wrong length rather than merely looking different.
- `smithy.md` gains the payload media-type table and the `byte[]` example. The operation's own contract comment is a `//` block rather than `///` on purpose: a `///` there is the operation's `description` in the published document, and that reasoning belongs to this repository rather than to anyone reading the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
