### PR TITLE
Refuse the union host conflicts at instantiation, not only at the first build

### DIFF
--- a/docs/guide/project-templates.md
+++ b/docs/guide/project-templates.md
@@ -112,9 +112,13 @@ routes show the difference: they answer 404 and 409 in every mode, and creating 
 under `response` and `union` and 200 under `throws`. [Declared responses](/guide/responses) covers
 the three.
 
-`union` writes a `net11.0` project pinned to the .NET 11 SDK in `global.json`. It cannot be
-combined with `--host aws-lambda`, whose managed runtime is `net8.0`. `dotnet new` cannot refuse a
-combination of options, so the first build refuses with `HTPL001`.
+`union` writes a `net11.0` project pinned to the .NET 11 SDK in `global.json`. It cannot be combined
+with `--host aws-lambda`, whose managed runtime is `net8.0`, or with `--host azure-functions`, whose
+worker runs the versions the Functions host supports.
+
+Either combination is refused at instantiation: `dotnet new` prints the reason and exits non-zero.
+The files are written first and stay, because the template engine does not unwind what it created,
+so the first build of them refuses again with `HTPL001`.
 
 `standard` is accepted as the old name for `throws` and writes the same project.
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
@@ -408,6 +408,27 @@
   ],
   "postActions": [
     {
+      // dotnet new has no way to refuse a combination of parameters: there is no constraint that
+      // reads a symbol, and choices cannot be filtered by another choice's value. What it does
+      // have is this - a post action the CLI cannot run automatically, whose description and
+      // instructions it prints and whose failure it reports. So the refusal arrives at
+      // instantiation, with a non-zero exit, instead of the command reporting success for a
+      // combination the template already knows cannot build.
+      //
+      // The files are still written, because the engine does not unwind what it created. The
+      // build error in Directory.Build.props stays as the backstop for anyone who scaffolds past
+      // this, and it is what a second `dotnet build` still says.
+      "condition": "(lambdaUnionConflict || azureFunctionsUnionConflict)",
+      "description": "--response-model union cannot be combined with this host: union needs net11.0, and neither the AWS Lambda managed runtime nor the Azure Functions worker runs a net11.0 assembly.",
+      "manualInstructions": [
+        {
+          "text": "Regenerate with --response-model response, which declares the same set on net8.0. The project written here does not build as it stands - the first build refuses with HTPL001."
+        }
+      ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "continueOnError": false
+    },
+    {
       "condition": "(!skipRestore)",
       "description": "Restore the packages the template pinned.",
       "manualInstructions": [

--- a/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Build.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Build.props
@@ -51,7 +51,12 @@
     function is invoked - the build would be green, the package would upload, and the first request
     would fail to load the assembly.
 
-    dotnet new cannot refuse a combination of parameters, so the refusal is a build error instead.
+    The refusal arrives twice, and both are deliberate. dotnet new reports it at instantiation,
+    through a post action the CLI cannot run - the only mechanism the template engine has for
+    refusing a combination of parameters, because no constraint reads a symbol. That leaves the
+    files on disk, since the engine does not unwind what it created, so this target is the
+    backstop: it is what a build says to anyone who scaffolded past a non-zero exit.
+
     Regenerate with the response model set to `response`, which declares the same set on net8.0
     and needs no preview anything.
   -->

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -3,6 +3,37 @@
 A web application on [Hardened](https://github.com/ipjohnson/Hardened.Framework) — a compile-time,
 source-generated .NET framework. Routing, request handlers, parameter binding and dependency
 injection are written during the build rather than resolved by reflection at run time.
+#if (lambdaUnionConflict || azureFunctionsUnionConflict)
+
+## This project does not build
+
+You asked for `--response-model union` on a host that cannot run it, and `dotnet new` said so and
+exited non-zero. These files were written anyway, because the template engine does not unwind what
+it created, and the first build refuses:
+
+```
+#if (lambdaUnionConflict)
+error HTPL001: --host aws-lambda cannot be combined with --response-model union
+#endif
+#if (azureFunctionsUnionConflict)
+error HTPL007: --host azure-functions cannot be combined with --response-model union
+#endif
+```
+
+The union response model needs `net11.0`, because the compiler requires `IUnion` and
+`UnionAttribute` from the .NET 11 reference assemblies.
+#if (lambdaUnionConflict)
+The AWS Lambda managed runtime is `net8.0`, and a `net11.0` assembly does not load on it.
+#endif
+#if (azureFunctionsUnionConflict)
+The Azure Functions host starts its isolated worker on a released .NET, which a preview is not.
+#endif
+Nothing about that is visible at deploy time: the package would upload and the first invocation
+would fail to load the assembly. That is why the refusal is a build error rather than a warning.
+
+Delete this directory and scaffold again with `--response-model response`. It declares the same set
+of statuses, in the same shape, on `net8.0`.
+#endif
 
 ## Run it
 


### PR DESCRIPTION
From the 0.32 trial: what survived **C-01** after checking. The overturned half was the build error itself, which is a deliberate guard. What stood was narrower — `dotnet new` writes and restores 26 files and reports success for a combination the template already knows cannot build.

## `dotnet new` can refuse a combination, just not cleanly

The template's own comment said it could not: *"dotnet new cannot refuse a combination of parameters, so the refusal is a build error instead."* Half right. There is no constraint that reads a symbol, and a choice cannot be filtered by another choice's value. But there is a post action the CLI has no automatic handler for, whose `description` and `manualInstructions` it prints and whose failure it reports. Conditioned on either conflict, that is a non-zero exit carrying the reason.

```
exit=105  --host aws-lambda --response-model union
exit=105  --host azure-functions --response-model union
exit=0    --host aws-lambda
exit=0    --response-model union
exit=0    defaults
```

What a caller sees:

```
Description: --response-model union cannot be combined with this host: union needs net11.0,
and neither the AWS Lambda managed runtime nor the Azure Functions worker runs a net11.0
assembly.
Manual instructions: Regenerate with --response-model response, which declares the same set
on net8.0. The project written here does not build as it stands - the first build refuses
with HTPL001.
```

The `is not supported` line above it is the CLI's own wording for a post action it cannot run, and there is no quieter mechanism: the alternative is a run-script action, which needs a script file per platform and prompts for script permission.

## Both halves, because the files are still there

The trial offered the refusal *or* the reasoning in the generated `README`. This does both, because the template engine does not unwind what it created — the refusal exits non-zero and the 26 files remain, so the project that exists should explain itself. Its `README` leads with it, before *Run it*:

> ## This project does not build
>
> You asked for `--response-model union` on a host that cannot run it, and `dotnet new` said so and exited non-zero. These files were written anyway, because the template engine does not unwind what it created, and the first build refuses […]

A valid scaffold's `README` is unchanged.

`HTPL001` and `HTPL007` stay exactly as they are. They are the backstop for anyone who scaffolds past a non-zero exit, or who reaches these files some other way, and `Directory.Build.props` now says that is what they are for rather than claiming to be the only refusal available.

## Verification

Every combination driven against the template installed from the folder, then uninstalled — this machine has no Hardened template registered, as before.

- Both conflicts exit 105 with the reason printed; `--host aws-lambda` alone, `--response-model union` alone and the defaults all exit 0 and restore as they did.
- The generated `README` carries the section for both conflicts, naming `HTPL001` or `HTPL007` as appropriate, and carries none of it otherwise.
- `scripts/verify-templates.sh` — every combination, no failures, all eighteen web rows unchanged at 17 tests including both union rows.
- `dotnet build Hardened.slnx --configuration Release -p:ContinuousIntegrationBuild=true` — 0 warnings, 0 errors.
- `npm run build` in `docs/` — no dead links.

`project-templates.md` said the same thing the code comment did, and now describes both refusals and mentions the Azure conflict, which it had never named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
