### PR TITLE
Point the documentation at 0.33.0-rc1000, and open the 0.34.0 line

### DIFF
--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -667,13 +667,13 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           # The open line, which is the one previews belong under - not the last one released.
-          # The line has released through v0.32.0-rc1000; there was no 0.7.0, and 0.23.0 through
+          # The line has released through v0.33.0-rc1000; there was no 0.7.0, and 0.23.0 through
           # 0.29.0 were skipped so the consolidation got a number of its own.
           #
           # This sat at 0.23.0 for the whole of v0.30.0-rc1000, so every preview that release
           # opened was stamped below it and the feed had nothing that could supersede the release.
           # It now moves in the same pull request as the tag it opens the line after.
-          RELEASE_LINE: 0.33.0
+          RELEASE_LINE: 0.34.0
         run: |
           BUILD=$(printf '%06d' "$GITHUB_RUN_NUMBER")
           echo "Packing $RELEASE_LINE-preview$BUILD"

--- a/docs/aws/lambda-function.md
+++ b/docs/aws/lambda-function.md
@@ -36,16 +36,16 @@ see [Triggers](/guide/triggers).
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="Hardened.Shared.Runtime" Version="0.32.0-rc1000" />
-    <PackageReference Include="Hardened.Requests.Runtime" Version="0.32.0-rc1000" />
-    <PackageReference Include="Hardened.Functions.Runtime" Version="0.32.0-rc1000" />
+    <PackageReference Include="Hardened.Shared.Runtime" Version="0.33.0-rc1000" />
+    <PackageReference Include="Hardened.Requests.Runtime" Version="0.33.0-rc1000" />
+    <PackageReference Include="Hardened.Functions.Runtime" Version="0.33.0-rc1000" />
 
     <!-- The host, and one adapter for the trigger the handler declares. -->
-    <PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.32.0-rc1000" />
-    <PackageReference Include="Hardened.Aws.Lambda.Invoke" Version="0.32.0-rc1000" />
+    <PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.33.0-rc1000" />
+    <PackageReference Include="Hardened.Aws.Lambda.Invoke" Version="0.33.0-rc1000" />
 
-    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.32.0-rc1000" />
-    <PackageReference Include="Hardened.Function.SourceGenerator" Version="0.32.0-rc1000"
+    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.33.0-rc1000" />
+    <PackageReference Include="Hardened.Function.SourceGenerator" Version="0.33.0-rc1000"
                       PrivateAssets="all" />
 </ItemGroup>
 ```

--- a/docs/aws/sqs.md
+++ b/docs/aws/sqs.md
@@ -26,8 +26,8 @@ Referencing `Hardened.Aws.Lambda.Sqs` is what decides that `[Queue]` means SQS. 
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Aws.Lambda.Sqs" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Aws.Lambda.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Aws.Lambda.Sqs" Version="0.33.0-rc1000" />
 ```
 
 `Hardened.Aws.Lambda.Sns` serves `[Topic]` the same way. A topic fans out — every subscriber sees

--- a/docs/azure/blob.md
+++ b/docs/azure/blob.md
@@ -18,9 +18,9 @@ public record BlobNotification(string Container, string Name, long? Size, string
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.Blobs" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.Blobs" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger blob` writes this shape with tests.

--- a/docs/azure/change.md
+++ b/docs/azure/change.md
@@ -17,9 +17,9 @@ public class OrderProjection {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.CosmosDb" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.CosmosDb" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger change` writes this shape with tests.

--- a/docs/azure/event.md
+++ b/docs/azure/event.md
@@ -19,9 +19,9 @@ its body.
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.EventGrid" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.EventGrid" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 The adapter reads the event through `Hardened.CloudEvents`, which names no cloud and is the same

--- a/docs/azure/queue.md
+++ b/docs/azure/queue.md
@@ -27,9 +27,9 @@ Bus queue. See [Triggers](/guide/triggers) for the vocabulary.
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 The same package serves `[Topic]`, from a subscription; see [Topics](/azure/topic).

--- a/docs/azure/stream.md
+++ b/docs/azure/stream.md
@@ -16,9 +16,9 @@ public class TelemetryHandlers {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.EventHubs" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.EventHubs" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger stream` writes this shape with tests.

--- a/docs/azure/timer.md
+++ b/docs/azure/timer.md
@@ -16,9 +16,9 @@ public class Housekeeping {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.Timer" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.Timer" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-function --host azure --trigger timer` writes this shape with tests.

--- a/docs/azure/topic.md
+++ b/docs/azure/topic.md
@@ -16,9 +16,9 @@ public class OrderEventHandlers {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.ServiceBus" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 The same package serves `[Queue]`; the delivery, the headers and the settlement are the ones

--- a/docs/azure/web.md
+++ b/docs/azure/web.md
@@ -19,9 +19,9 @@ public class OrderRoutes {
 
 ```xml
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
-<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.Http" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.32.0-rc1000" PrivateAssets="all" />
+<PackageReference Include="Hardened.Azure.Functions.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.Http" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Azure.Functions.SourceGenerator" Version="0.33.0-rc1000" PrivateAssets="all" />
 ```
 
 `dotnet new hardened-web --host azure-functions` writes this shape: a library with the routes

--- a/docs/gcp/blob.md
+++ b/docs/gcp/blob.md
@@ -28,8 +28,8 @@ declare one for a queue message.
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Storage" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Storage" Version="0.33.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger blob` writes this shape with tests.

--- a/docs/gcp/change.md
+++ b/docs/gcp/change.md
@@ -20,8 +20,8 @@ way the DynamoDB adapter unwraps a type-tagged item, so nothing in the handler k
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Firestore" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Firestore" Version="0.33.0-rc1000" />
 ```
 
 This is the one adapter in the line with a Google dependency. Firestore events are

--- a/docs/gcp/event.md
+++ b/docs/gcp/event.md
@@ -18,8 +18,8 @@ its body.
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Eventarc" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Eventarc" Version="0.33.0-rc1000" />
 ```
 
 The adapter reads the event through `Hardened.CloudEvents`, which names no cloud. Binary mode,

--- a/docs/gcp/invoke.md
+++ b/docs/gcp/invoke.md
@@ -20,8 +20,8 @@ public class OrderHandler(OrderLog log) {
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Invoke" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Invoke" Version="0.33.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger invoke` writes this shape with tests. It is the

--- a/docs/gcp/queue.md
+++ b/docs/gcp/queue.md
@@ -27,8 +27,8 @@ subscription. See [Triggers](/guide/triggers) for the vocabulary.
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.33.0-rc1000" />
 ```
 
 The same package serves `[Topic]`, from a different delivery; see [Topics](/gcp/topic).

--- a/docs/gcp/timer.md
+++ b/docs/gcp/timer.md
@@ -15,8 +15,8 @@ public class Rollups {
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.Scheduler" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Scheduler" Version="0.33.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger timer` writes this shape with tests.

--- a/docs/gcp/topic.md
+++ b/docs/gcp/topic.md
@@ -17,8 +17,8 @@ public class OrderEventHandlers {
 ## Packages
 
 ```xml
-<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.32.0-rc1000" />
-<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.Runtime" Version="0.33.0-rc1000" />
+<PackageReference Include="Hardened.Gcp.CloudRun.PubSub" Version="0.33.0-rc1000" />
 ```
 
 `dotnet new hardened-function --host gcp --trigger topic` writes this shape with tests.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -53,12 +53,12 @@ Two kinds of package reference, the runtime and the source generators:
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="Hardened.Shared.Runtime" Version="0.32.0-rc1000" />
-    <PackageReference Include="Hardened.Web.Runtime" Version="0.32.0-rc1000" />
-    <PackageReference Include="Hardened.Web.Kestrel.Runtime" Version="0.32.0-rc1000" />
+    <PackageReference Include="Hardened.Shared.Runtime" Version="0.33.0-rc1000" />
+    <PackageReference Include="Hardened.Web.Runtime" Version="0.33.0-rc1000" />
+    <PackageReference Include="Hardened.Web.Kestrel.Runtime" Version="0.33.0-rc1000" />
 
-    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.32.0-rc1000" />
-    <PackageReference Include="Hardened.Web.SourceGenerator" Version="0.32.0-rc1000" />
+    <PackageReference Include="Hardened.Library.SourceGenerator" Version="0.33.0-rc1000" />
+    <PackageReference Include="Hardened.Web.SourceGenerator" Version="0.33.0-rc1000" />
 </ItemGroup>
 ```
 

--- a/docs/guide/project-templates.md
+++ b/docs/guide/project-templates.md
@@ -245,7 +245,7 @@ routes as well as services, add `[HardenedWebModule]` to the module class and re
 Every template writes a `Directory.Packages.props` with one version for every Hardened package:
 
 ```xml
-<HardenedVersion>0.32.0-rc1000</HardenedVersion>
+<HardenedVersion>0.33.0-rc1000</HardenedVersion>
 ```
 
 It is the version the template package shipped with, and `--hardened-version` overrides it.
@@ -255,7 +255,7 @@ Templates do not update themselves. A newer release is a newer template package:
 
 ```bash
 dotnet new install Hardened.Templates                     # latest
-dotnet new install Hardened.Templates@0.32.0-rc1000       # a specific one
+dotnet new install Hardened.Templates@0.33.0-rc1000       # a specific one
 ```
 
 Existing projects keep the version in their own `Directory.Packages.props` until you change it.

--- a/docs/guide/response-caching.md
+++ b/docs/guide/response-caching.md
@@ -23,7 +23,7 @@ nothing. The two compose.
 A store is a package and an attribute on the module:
 
 ```xml
-<PackageReference Include="Hardened.Requests.Caching.Memory" Version="0.32.0-rc1000" />
+<PackageReference Include="Hardened.Requests.Caching.Memory" Version="0.33.0-rc1000" />
 ```
 
 ```csharp

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -54,7 +54,7 @@ Reference both packages:
 ```xml
 <ItemGroup>
     <PackageReference Include="RazorBlade" Version="1.0.0" />
-    <PackageReference Include="Hardened.Templates.RazorBlade" Version="0.32.0-rc1000" />
+    <PackageReference Include="Hardened.Templates.RazorBlade" Version="0.33.0-rc1000" />
 </ItemGroup>
 ```
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -261,7 +261,7 @@ Everything releases on one version line, from a `v*` tag:
 | Every package on this page | `{line}-rc1000` | `{line}-preview{build}` on every push to main |
 | `Hardened.Amz.*`, retired | `0.22.0-rc1000`, its last | none |
 
-The current line is **`0.32.0-rc1000`**. Releases go to nuget.org; the continuous feed is
+The current line is **`0.33.0-rc1000`**. Releases go to nuget.org; the continuous feed is
 [GitHub Packages](https://nuget.pkg.github.com/ipjohnson/index.json). Under one line, `preview`
 sorts below `rc`, so a preview never shadows the release it precedes.
 


### PR DESCRIPTION
The release pull request for **v0.33.0-rc1000**. Both halves ship with the tag rather than after it, for the reasons the release skill records.

## The open line moves to 0.34.0

`RELEASE_LINE` in `build-package.yaml` names the line previews are stamped under, which is the line **currently open** — not the last one released. Releasing 0.33.0-rc1000 while it still said 0.33.0 would stamp every subsequent preview `0.33.0-previewNNNNNN`, which sorts *below* the release, and the feed could serve a preview over it. That is not hypothetical: it sat at 0.23.0 through the whole of v0.30.0-rc1000.

Next minor, and the sequence skips numbers on purpose — there was no 0.7.0, and 0.23.0 through 0.29.0 were skipped so the consolidation got a number of its own.

## The documentation sweep is the workflow's own guard, run early

`release.yaml`'s *Check the documented version is this one* is step 464. *Push to nuget.org* is step 416. So that guard fires **after** the packages have shipped, which is how it failed v0.31.0-rc1000 with a published release and a red run.

57 citations across 22 pages: every copyable `PackageReference`, `<HardenedVersion>` and `dotnet new install` line under `docs/` outside `design/`, plus the prose line in `reference/packages.md` that names the current line. `design/` is left alone, because those are maintainer notes that cite historical versions on purpose, and no line mentioning `Hardened.Amz.` was touched — it is frozen at v0.22.0-rc1000.

## Preflight

Run before this branch existed, and all clean:

- On main, synced, clean.
- `v0.33.0-rc1000` is not already a tag.
- No open pull requests, so nothing is missing the cut.
- The pack list covers every packable project: 65 listed, 71 packable, and the six unlisted are the template scaffolding under `src/Templates/**/templates/` that are content rather than packages. Nothing is listed-but-not-packable.
- `npm run build` in `docs/` — no dead links.

## What this release contains

The whole of the 0.32 template trial's remediation, in five pull requests:

| | |
|---|---|
| [#327](https://github.com/ipjohnson/Hardened.Framework/pull/327) | The scaffold's `DocumentStatusTests` compares the document to the server, and the container-per-request rule that #315 shipped silently is written down |
| [#328](https://github.com/ipjohnson/Hardened.Framework/pull/328) | A contract's `servers` is published, and `HOAG032` names four inert declarations across both rungs |
| [#329](https://github.com/ipjohnson/Hardened.Framework/pull/329) | A Smithy `blob` under `@httpPayload` is an operation a client can call |
| [#330](https://github.com/ipjohnson/Hardened.Framework/pull/330) | `dotnet new` refuses the union host conflicts at instantiation |
| [#331](https://github.com/ipjohnson/Hardened.Framework/pull/331) | An event stream can be asserted in the mode it deploys in |

Plus [#326](https://github.com/ipjohnson/Hardened.Framework/pull/326), covering the entry-point rung where its assembly is measured.

The dry run and the tag follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
