### PR TITLE
Remove three allocations from the path every request takes

### DIFF
--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/StringConverterServiceTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/StringConverterServiceTests.cs
@@ -47,6 +47,88 @@ public class StringConverterServiceTests {
         Assert.Equal("hello", result);
     }
 
+    [Fact]
+    public void ParseRequired_ReturnsParsedBool() {
+        var result = _service.ParseRequired<bool>("true", "testValue");
+        Assert.True(result);
+    }
+
+    /// <summary>
+    /// The nullable shapes, which are what a generated binder actually calls.
+    /// </summary>
+    /// <remarks>
+    /// An optional parameter is emitted as <c>ParseOptional&lt;int?&gt;</c>, not
+    /// <c>ParseOptional&lt;int&gt;</c>, so the type argument is the nullable one and the conversion
+    /// takes a different branch from the required case. Asserting the required forms alone left
+    /// that branch to the integration tests.
+    /// </remarks>
+    [Fact]
+    public void ParseOptional_ReturnsParsedNullableInt() {
+        var result = _service.ParseOptional<int?>("42", "testValue");
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsParsedNullableLong() {
+        var result = _service.ParseOptional<long?>("9999999999", "testValue");
+        Assert.Equal(9999999999L, result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsParsedNullableGuid() {
+        var guid = Guid.NewGuid();
+        var result = _service.ParseOptional<Guid?>(guid.ToString(), "testValue");
+        Assert.Equal(guid, result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsParsedNullableBool() {
+        var result = _service.ParseOptional<bool?>("false", "testValue");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsParsedNullableDateTime() {
+        var result = _service.ParseOptional<DateTime?>("2024-01-15", "testValue");
+        Assert.Equal(new DateTime(2024, 1, 15), result);
+    }
+
+    [Fact]
+    public void ParseOptional_ReturnsNull_WhenNullableValueIsAbsent() {
+        var result = _service.ParseOptional<int?>("", "testValue");
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// A malformed nullable value is still an error rather than an absent one - the distinction the
+    /// class exists to keep - and the conversion branch it takes is not the required one.
+    /// </summary>
+    [Fact]
+    public void ParseOptional_Throws_WhenNullableValueIsMalformed() {
+        Assert.Throws<ValidationException>(() =>
+            _service.ParseOptional<int?>("not-a-number", "testValue"));
+    }
+
+    /// <summary>
+    /// Culture-invariant whatever the machine is set to, which is only observable on a type whose
+    /// literal form differs between cultures.
+    /// </summary>
+    [Fact]
+    public void ParseRequired_ParsesDateTimeInvariantly() {
+        var original = Thread.CurrentThread.CurrentCulture;
+
+        try {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+            var result = _service.ParseRequired<DateTime>("2024-01-15", "testValue");
+
+            Assert.Equal(new DateTime(2024, 1, 15), result);
+        }
+        finally {
+            Thread.CurrentThread.CurrentCulture = original;
+        }
+    }
+
     /// <summary>
     /// A missing required value reports under the same code a missing required property does, so a
     /// caller handling "you left something out" handles both without knowing that one came from the

--- a/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Logging/RequestLogger.cs
@@ -242,6 +242,43 @@ public partial class RequestLogger : IRequestLogger {
         span.DisplayName = context.Request.Method + " " + route;
     }
 
+    private static readonly object _ok = 200;
+    private static readonly object _notFound = 404;
+    private static readonly object _badRequest = 400;
+
+    /// <summary>
+    /// The status as a metric tag, boxed once for the codes most requests report.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>IMetricLogger.Tag</c> takes <c>object</c>, because a Meter dimension is a
+    /// <c>KeyValuePair&lt;string, object?&gt;</c> and a provider needs the value boxed. Handing it
+    /// an <c>int</c> boxed one per request on every deployment, including under the null provider
+    /// whose <c>Tag</c> discards it.
+    /// </para>
+    /// <para>
+    /// Three comparisons, in the order they are most likely to be taken - nothing assigns a status
+    /// on an ordinary success path, so 200 is what most requests report. Anything else falls
+    /// through and boxes, which is what every request did before, so a status not listed here costs
+    /// nothing extra and adding one costs two lines.
+    /// </para>
+    /// </remarks>
+    private static object StatusTag(int status) {
+        if (status == 200) {
+            return _ok;
+        }
+
+        if (status == 404) {
+            return _notFound;
+        }
+
+        if (status == 400) {
+            return _badRequest;
+        }
+
+        return status;
+    }
+
     public void RequestEnd(IExecutionContext context) {
         LogRequestFinished(
             context.Request.Method,
@@ -264,12 +301,14 @@ public partial class RequestLogger : IRequestLogger {
         // Tagged whether or not anything is tracing. Buffered by the Meter provider until the logger
         // is disposed, which is what lets a dimension be attached after the measurement it describes -
         // every host records TotalRequestDuration and only then calls this.
-        context.RequestMetrics.Tag("http.response.status_code", status);
+        var statusTag = StatusTag(status);
+
+        context.RequestMetrics.Tag("http.response.status_code", statusTag);
 
         if (_spans.TryGetValue(context, out var span)) {
             _spans.Remove(context);
 
-            span.SetTag("http.response.status_code", status);
+            span.SetTag("http.response.status_code", statusTag);
 
             // 4xx is the caller's mistake, not the server's. The conventions leave a server span
             // Unset for those and reserve Error for 5xx, so that a trace backend's error rate means

--- a/src/Requests/Hardened.Requests.Runtime/Serializer/StringConverterService.cs
+++ b/src/Requests/Hardened.Requests.Runtime/Serializer/StringConverterService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Runtime.CompilerServices;
 using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Serializer;
 using Hardened.Requests.Runtime.Validation;
@@ -172,10 +173,143 @@ public class StringConverterService : IStringConverterService {
     /// non-nullable case is there for the nullable one rather than the two lists drifting.
     /// </para>
     /// </remarks>
-    protected virtual T StandardConverter<T>(string value) =>
-        // Boxed and cast rather than converted per-branch: unboxing to Nullable<T> from a boxed
-        // underlying value is allowed, so one table serves both.
-        (T)Convert(Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T), value);
+    protected virtual T StandardConverter<T>(string value) {
+        if (TryStandardValue<T>(value, out var converted)) {
+            return converted;
+        }
+
+        // The fallback boxes, which is what lets one table serve both shapes: unboxing to
+        // Nullable<T> from a boxed underlying value is allowed. Everything the method above does
+        // not name arrives here.
+        return (T)Convert(Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T), value);
+    }
+
+    /// <summary>
+    /// The types route templates and query strings are actually written in, parsed without a box.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Convert"/> returns <c>object</c>, so every scalar a handler declares used to cost
+    /// a box on its way out of the parse - 24 bytes for an <c>int</c>, 32 for a <c>Guid</c>, once
+    /// per parameter per request. <see cref="Unsafe.As{TFrom,TTo}"/> reinterprets the parsed value
+    /// as <typeparamref name="T"/> instead, which is sound because the comparison immediately above
+    /// each call has established that the two are the same type.
+    /// </para>
+    /// <para>
+    /// <b>The comparisons cost nothing for the types they are written for.</b> A value-type
+    /// instantiation of a generic method is compiled on its own, so the JIT folds every
+    /// <c>typeof(T) ==</c> here to a constant and keeps the one branch that survives.
+    /// </para>
+    /// <para>
+    /// <b><c>string</c> is first for the case where they do cost something.</b> Every reference-type
+    /// instantiation shares one compiled body, where <c>typeof(T)</c> is a runtime lookup and the
+    /// comparisons genuinely run. <c>string</c> is by far the most common of them and leaves on the
+    /// first; a <c>Uri</c> or a <c>byte[]</c> walks the rest and falls through, which is a handful
+    /// of pointer comparisons against a parse that allocates anyway.
+    /// </para>
+    /// <para>
+    /// Nullable forms are listed rather than unwrapped, because unwrapping is what needed the box:
+    /// an optional parameter arrives as <c>Nullable&lt;T&gt;</c>, and the old path reached it by
+    /// unboxing a boxed underlying value. Each pair also skips the
+    /// <see cref="Nullable.GetUnderlyingType"/> call below.
+    /// </para>
+    /// <para>
+    /// Everything not here still goes through <see cref="Convert"/> and still boxes. This is the set
+    /// a route template or a query string is written in, not every type that can be parsed - adding
+    /// one is two lines, and leaving one out costs what it cost before.
+    /// </para>
+    /// </remarks>
+    private static bool TryStandardValue<T>(string value, out T converted) {
+        if (typeof(T) == typeof(string)) {
+            converted = (T)(object)value;
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(int)) {
+            var parsed = int.Parse(value, CultureInfo.InvariantCulture);
+
+            converted = Unsafe.As<int, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(int?)) {
+            int? parsed = int.Parse(value, CultureInfo.InvariantCulture);
+
+            converted = Unsafe.As<int?, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(long)) {
+            var parsed = long.Parse(value, CultureInfo.InvariantCulture);
+
+            converted = Unsafe.As<long, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(long?)) {
+            long? parsed = long.Parse(value, CultureInfo.InvariantCulture);
+
+            converted = Unsafe.As<long?, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(Guid)) {
+            var parsed = Guid.Parse(value);
+
+            converted = Unsafe.As<Guid, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(Guid?)) {
+            Guid? parsed = Guid.Parse(value);
+
+            converted = Unsafe.As<Guid?, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(bool)) {
+            var parsed = bool.Parse(value);
+
+            converted = Unsafe.As<bool, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(bool?)) {
+            bool? parsed = bool.Parse(value);
+
+            converted = Unsafe.As<bool?, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(DateTime)) {
+            var parsed = DateTime.Parse(value, CultureInfo.InvariantCulture);
+
+            converted = Unsafe.As<DateTime, T>(ref parsed);
+
+            return true;
+        }
+
+        if (typeof(T) == typeof(DateTime?)) {
+            DateTime? parsed = DateTime.Parse(value, CultureInfo.InvariantCulture);
+
+            converted = Unsafe.As<DateTime?, T>(ref parsed);
+
+            return true;
+        }
+
+        converted = default!;
+
+        return false;
+    }
 
     /// <summary>
     /// Every type a generated binder can ask for.

--- a/src/Web/Hardened.Web.Runtime/Handlers/WebExecutionHandlerService.cs
+++ b/src/Web/Hardened.Web.Runtime/Handlers/WebExecutionHandlerService.cs
@@ -15,7 +15,17 @@ public interface IWebExecutionHandlerService : IHandlerDispatch { }
 
 [SingletonService(Using = RegistrationType.Try)]
 public partial class WebExecutionHandlerService : IWebExecutionHandlerService {
-    private readonly IEnumerable<IWebExecutionRequestHandlerProvider> _handlers;
+    /// <summary>
+    /// The providers to ask, in the order they are asked.
+    /// </summary>
+    /// <remarks>
+    /// The array type is load bearing. <see cref="Match"/> walks this on every request, and a
+    /// <c>foreach</c> over a field declared <see cref="IEnumerable{T}"/> goes through
+    /// <see cref="IEnumerable{T}.GetEnumerator"/> however the array got there - which allocates an
+    /// enumerator and leaves <c>MoveNext</c> behind an interface call. Declared as the array, the
+    /// compiler emits an indexed walk instead.
+    /// </remarks>
+    private readonly IWebExecutionRequestHandlerProvider[] _handlers;
     private readonly IResourceNotFoundHandler _resourceNotFoundHandler;
     private readonly IMethodNotAllowedHandler _methodNotAllowedHandler;
     private readonly IRequestLogger _requestLogger;


### PR DESCRIPTION
Three allocations on the path every request takes, and the one that was on it unconditionally.

## What changed

`WebExecutionHandlerService` held its providers in a field declared `IEnumerable<T>` and assigned an array to it. A `foreach` over that goes through `IEnumerable<T>.GetEnumerator()` however the array got there, so every request allocated an enumerator and walked it behind an interface call. Declaring the field as the array is the whole change. The constructor still takes `IEnumerable<T>`, because that is what the container supplies. This was the only unconditional `foreach` on the request path.

`StringConverterService` reached every scalar through `Convert(Type, string)`, which returns `object`, so a route template or a query string cost a box per parameter per request. The types those are actually written in are now parsed and returned through `Unsafe.As`. That is sound because the comparison above each call has established the two types are the same. A value-type instantiation of a generic method is compiled on its own, so the JIT folds those comparisons away and keeps one branch. `string` is tested first, since reference-type instantiations share one body where the comparisons genuinely run. Anything not named still goes through `Convert` and still boxes, so a type left out costs what it cost before.

`IMetricLogger.Tag` takes `object`, so `RequestEnd` boxed the status code on every request. That included deployments under the null provider, whose `Tag` discards it. Three comparisons against statuses boxed once cover very nearly all of the traffic. Anything else falls through and boxes as before.

## Measured

Same machine, same job, back to back. `--filter "*StringConversion*"`:

| | before | after |
|---|---|---|
| `ParseIntDirect` (control) | 5.24 ns | 5.38 ns |
| `ParseInt` | 14.24 ns, 24 B | 9.64 ns, none |
| `ParseLong` | 17.72 ns, 24 B | 12.89 ns, none |
| `ParseGuid` | 22.44 ns, 32 B | 16.27 ns, none |
| `ParseDateTime` | 79.45 ns, 24 B | 76.81 ns, none |
| `ParseString` | 11.46 ns | 10.02 ns |

Whole requests on the Kestrel host, `--filter "*PipelineBenchmarks*"`:

| Route | before | after |
|---|---|---|
| `GET /bench/item` | 2.12 KB | 2.06 KB |
| `GET /bench/item/{id}` | 2.38 KB | 2.30 KB |
| `GET /bench/query` | 2.84 KB | 2.74 KB |
| `GET /bench/binding/{id}` | 3.13 KB | 3.08 KB |
| `POST /bench/sum` | 3.29 KB | 3.24 KB |

The deltas account for themselves on all five routes: the enumerator, the status box, and one box per bound scalar. The end-to-end timings moved by less than the run-to-run variance on this machine, so the case for these is the allocation and the micro-benchmark above rather than an end-to-end number.

## Tests

Nine added to `StringConverterServiceTests`. `bool` had no coverage at all. The nullable shapes had none either: the existing tests call `ParseOptional<int>`, while a generated binder emits `ParseOptional<int?>`, which is a different type argument and now a different branch.

The public API approval suite passes unchanged. Nothing here is anything but a private member.

## One thing this does not fix

The benchmark suite still refuses to run normally, and has since the AWS line was rebuilt. Its verification gate fails because `BenchmarkApplication` declares `[AspNetCoreRuntime]` so one assembly can serve both measured deployments, and `AspNetCoreRuntimeLibrary` unconditionally replaces `IResourceNotFoundHandler` with the non-terminal ASP.NET one. On the transport-free and Kestrel harnesses a miss then answers 200 with no body instead of 404. The numbers above were taken with `--no-verify`, which is safe here because `not-found` is not one of the timed scenarios, but the gate exists for a reason and wants its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
