### PR TITLE
Serve MessagePack, and describe every media type an operation produces

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: release
+﻿name: release
 
 # Cutting a release:
 #   git tag v1.0.0 && git push origin v1.0.0
@@ -275,6 +275,7 @@ jobs:
             src/Requests/Hardened.Requests.Caching.Memory/Hardened.Requests.Caching.Memory.csproj \
             src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj \
             src/Requests/Hardened.Requests.Testing/Hardened.Requests.Testing.csproj \
+            src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Hardened.Requests.Serializers.MessagePack.csproj \
             src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Hardened.Requests.Serializers.Newtonsoft.csproj \
             src/Shared/Hardened.Shared.Runtime/Hardened.Shared.Runtime.csproj \
             src/Shared/Hardened.Shared.Testing/Hardened.Shared.Testing.csproj \
@@ -398,7 +399,8 @@ jobs:
           # adapters and the Hardened.Gcp.CloudRun meta package.
           # 65 with the rest of the Azure line: the HTTP, Timer, Event Hubs, Cosmos DB, Blobs and Event Grid
           # adapters and the Hardened.Azure.Functions meta package.
-          EXPECTED=65
+          # 66 with Hardened.Requests.Serializers.MessagePack.
+          EXPECTED=66
           ACTUAL=$(ls -1 ./artifacts/*.nupkg 2>/dev/null | wc -l | tr -d ' ')
 
           if [ "$ACTUAL" != "$EXPECTED" ]; then

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
     <!--
       Every package version in the repository, in one list.
@@ -88,6 +88,7 @@
         <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="2.0.0" />
         <PackageVersion Include="Microsoft.OpenApi" Version="3.10.0" />
         <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="3.10.0" />
+        <PackageVersion Include="MessagePack" Version="3.1.8" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageVersion Include="RazorBlade" Version="1.0.0" />
         <PackageVersion Include="Refit" Version="8.0.0" />

--- a/Hardened.slnx
+++ b/Hardened.slnx
@@ -1,4 +1,4 @@
-<Solution>
+﻿<Solution>
   <Folder Name="/Benchmarks/">
     <Project Path="src/Benchmarks/Hardened.Benchmarks.AspNetSut/Hardened.Benchmarks.AspNetSut.csproj" />
     <Project Path="src/Benchmarks/Hardened.Benchmarks.Contracts/Hardened.Benchmarks.Contracts.csproj" />
@@ -226,6 +226,8 @@
     <Project Path="src/Requests/Hardened.Requests.Runtime.Tests/Hardened.Requests.Runtime.Tests.csproj" />
     <Project Path="src/Requests/Hardened.Requests.Runtime/Hardened.Requests.Runtime.csproj" />
     <Project Path="src/Requests/Hardened.Requests.Testing/Hardened.Requests.Testing.csproj" />
+    <Project Path="src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/Hardened.Requests.Serializers.MessagePack.Tests.csproj" />
+    <Project Path="src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Hardened.Requests.Serializers.MessagePack.csproj" />
     <Project Path="src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft.Tests/Hardened.Requests.Serializers.Newtonsoft.Tests.csproj" />
     <Project Path="src/Requests/Serializers/Hardened.Requests.Serializers.Newtonsoft/Hardened.Requests.Serializers.Newtonsoft.csproj" />
   </Folder>

--- a/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
+++ b/src/IntegrationTests/Smithy/Hardened.IntegrationTests.Smithy.SUT/openapi/SmithyTestApp.json
@@ -43,7 +43,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/x-amz-json-1.0": {
                 "schema": {
                   "$ref": "#/components/schemas/AccountNotFound"
                 }
@@ -81,7 +81,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/x-amz-json-1.0": {
                 "schema": {
                   "$ref": "#/components/schemas/AccountNotFound"
                 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/MessagePackTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/MessagePackTests.cs
@@ -1,0 +1,133 @@
+using Hardened.IntegrationTests.WebApp.SUT.Controllers;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Serializers.MessagePack;
+using Hardened.Web.Runtime.Responses;
+using MessagePack;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Tests.Controllers;
+
+/// <summary>
+/// MessagePack through the real pipeline: the client's <c>Accept</c> deciding between two
+/// representations, the operation that offers one, and a MessagePack request body.
+/// </summary>
+/// <remarks>
+/// This fixture imports <c>[MessagePackSerializerLibrary]</c>, so the serializer is registered the
+/// way an application registers it rather than constructed by the test.
+/// </remarks>
+public class MessagePackTests {
+
+    private static MessagePackController.Reading Read(TestWebResponse response) {
+        response.Body.Position = 0;
+
+        return MessagePackSerializer.Deserialize<MessagePackController.Reading>(
+            response.Body, ContractlessOrGenerated);
+    }
+
+    /// <summary>
+    /// The options the package installs, reached from outside it the way any client would: the
+    /// generated formatter for <c>Reading</c> is in the SUT's compilation, and
+    /// <c>SourceGeneratedFormatterResolver</c> finds it.
+    /// </summary>
+    private static readonly MessagePackSerializerOptions ContractlessOrGenerated =
+        MessagePackSerializerOptions.Standard;
+
+    private static string ContentType(TestWebResponse response) =>
+        response.Headers[KnownHeaders.ContentType].ToString();
+
+    // ---------------------------------------------------------------- negotiated
+
+    /// <summary>
+    /// The operation declares JSON first, so a client expressing no preference is answered with it.
+    /// </summary>
+    [HardenedTest]
+    public async Task AClientWithNoPreferenceGetsTheTypeTheOperationLeadsWith(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/msgpack/negotiated/3");
+
+        response.Assert.Ok();
+
+        Assert.StartsWith(KnownContentType.Json, ContentType(response));
+    }
+
+    [HardenedTest]
+    public async Task AClientAskingForMessagePackGetsMessagePack(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/msgpack/negotiated/3",
+            request => request.Headers[KnownHeaders.Accept] = MessagePackContentType.Value);
+
+        response.Assert.Ok();
+
+        Assert.StartsWith(MessagePackContentType.Value, ContentType(response));
+        Assert.Equal(new MessagePackController.Reading("sensor-3", 9), Read(response));
+    }
+
+    /// <summary>
+    /// The same operation, the same handler, a different representation. Which is the whole point:
+    /// nothing about the handler says which one it answered with.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheSameOperationAnswersJsonForAClientThatAsksForIt(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get(
+            "/msgpack/negotiated/3",
+            request => request.Headers[KnownHeaders.Accept] = KnownContentType.Json);
+
+        response.Assert.Ok();
+
+        Assert.StartsWith(KnownContentType.Json, ContentType(response));
+        Assert.Contains("sensor-3", await response.ReadTextAsync());
+    }
+
+    // ---------------------------------------------------------------- one declared type
+
+    /// <summary>
+    /// One declared media type binds its serializer when the pipeline is composed rather than
+    /// negotiating per request, and the response still carries the content type - which nothing on
+    /// that path assigns but the serializer itself.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnOperationDeclaringMessagePackAloneAnswersIt(ITestWebApp testWebApp) {
+        var response = await testWebApp.Get("/msgpack/packed/4");
+
+        response.Assert.Ok();
+
+        Assert.StartsWith(MessagePackContentType.Value, ContentType(response));
+        Assert.Equal(new MessagePackController.Reading("sensor-4", 12), Read(response));
+    }
+
+    // ---------------------------------------------------------------- the request side
+
+    /// <summary>
+    /// No attribute declares this. A deserializer is chosen by the inbound <c>Content-Type</c>, so
+    /// an operation reads MessagePack because the client sent it.
+    /// </summary>
+    [HardenedTest]
+    public async Task AMessagePackBodyIsRead(ITestWebApp testWebApp) {
+        var body = MessagePackSerializer.Serialize(
+            new MessagePackController.Reading("sensor-9", 41), ContractlessOrGenerated);
+
+        var response = await testWebApp.Request(
+            "POST", null, "/msgpack/round",
+            request => {
+                request.Headers[KnownHeaders.ContentType] = MessagePackContentType.Value;
+                request.Headers[KnownHeaders.Accept] = MessagePackContentType.Value;
+                request.Body = body;
+            });
+
+        response.Assert.Ok();
+
+        Assert.Equal(new MessagePackController.Reading("sensor-9", 42), Read(response));
+    }
+
+    /// <summary>
+    /// And a JSON body still reads on the same operation, because the reader is chosen per request
+    /// rather than declared once.
+    /// </summary>
+    [HardenedTest]
+    public async Task AJsonBodyStillReadsOnTheSameOperation(ITestWebApp testWebApp) {
+        var response = await testWebApp.Post(
+            new MessagePackController.Reading("sensor-9", 41), "/msgpack/round");
+
+        response.Assert.Ok();
+
+        Assert.Contains("sensor-9", await response.ReadTextAsync());
+    }
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Application.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Application.cs
@@ -9,6 +9,7 @@ using Hardened.Web.Runtime.Handlers;
 using Hardened.Requests.Caching.Memory;
 using Hardened.Web.Runtime.Compression;
 using Hardened.Web.Runtime.OpenApi;
+using Hardened.Requests.Serializers.MessagePack;
 
 namespace Hardened.IntegrationTests.WebApp.SUT;
 
@@ -34,6 +35,7 @@ namespace Hardened.IntegrationTests.WebApp.SUT;
 [HardenedOpenApiUi(Title = "Integration Tests")]
 [HardenedOpenApiUi(Path = "/docs/internal", Title = "Internal", DocumentPath = "/internal.json")]
 [HardenedMemoryResponseCache]
+[MessagePackSerializerLibrary]
 [AspNetCoreRuntime]
 public partial class Application : IServiceCollectionConfiguration {
 

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/MessagePackController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/MessagePackController.cs
@@ -1,0 +1,59 @@
+﻿using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Serializers.MessagePack;
+using Hardened.Web.Runtime.Attributes;
+using MessagePack;
+
+namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
+
+/// <summary>
+/// Operations that answer MessagePack, through
+/// <c>Hardened.Requests.Serializers.MessagePack</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The fixture that makes the whole path real at once: the build diagnostic sees a serializer for
+/// the media type, the document describes both representations, and the runtime picks between them
+/// from <c>Accept</c>.
+/// </para>
+/// </remarks>
+[BasePath("/msgpack")]
+public class MessagePackController {
+
+    /// <summary>
+    /// A reading, annotated the way MessagePack requires.
+    /// </summary>
+    /// <remarks>
+    /// <c>[MessagePackObject]</c> and <c>partial</c> are what MessagePack's source generator needs
+    /// to write a formatter for this type. There is no reflection fallback in the resolver chain
+    /// this package installs, so a model without them fails the same way here as after a NativeAOT
+    /// publish rather than only after one.
+    /// </remarks>
+    [MessagePackObject]
+    public partial record Reading([property: Key(0)] string Sensor, [property: Key(1)] int Value);
+
+    /// <summary>
+    /// Two representations of one response. The client's <c>Accept</c> decides, and a client
+    /// expressing no preference gets the first.
+    /// </summary>
+    [Get("/negotiated/{id}")]
+    [Produces(KnownContentType.Json, MessagePackContentType.Value)]
+    public Reading Negotiated(int id) => new("sensor-" + id, id * 3);
+
+    /// <summary>
+    /// MessagePack alone, which is the shape that binds at composition rather than negotiating:
+    /// one declared media type under the default negotiation mode resolves its serializer once.
+    /// </summary>
+    [Get("/packed/{id}")]
+    [Produces(MessagePackContentType.Value)]
+    public Reading Packed(int id) => new("sensor-" + id, id * 3);
+
+    /// <summary>
+    /// A MessagePack request body. Nothing declares it: a deserializer is chosen by the inbound
+    /// <c>Content-Type</c>, so this reads MessagePack from a client that sends it and JSON from one
+    /// that does not.
+    /// </summary>
+    [Post("/round")]
+    [Produces(KnownContentType.Json, MessagePackContentType.Value)]
+    public Reading Round(Reading reading) => reading with { Value = reading.Value + 1 };
+}

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Hardened.IntegrationTests.WebApp.SUT.csproj
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Hardened.IntegrationTests.WebApp.SUT.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <!-- A test fixture, not a shipped package. Without this it packs and
@@ -37,6 +37,7 @@
       <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj" />
       <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Caching.Memory\Hardened.Requests.Caching.Memory.csproj" />
       <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj" />
+      <ProjectReference Include="..\..\..\Requests\Serializers\Hardened.Requests.Serializers.MessagePack\Hardened.Requests.Serializers.MessagePack.csproj" />
       <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj" />
       <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
       <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Web.SourceGenerator\Hardened.Web.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -51,6 +51,9 @@
       "name": "IntMath"
     },
     {
+      "name": "MessagePack"
+    },
+    {
       "name": "Registration"
     },
     {
@@ -3567,6 +3570,189 @@
         "x-hardened-timeout": 300000
       }
     },
+    "/msgpack/negotiated/{id}": {
+      "get": {
+        "tags": [
+          "MessagePack"
+        ],
+        "operationId": "negotiated",
+        "summary": "Two representations of one response. The client's Accept decides, and a client expressing no preference gets the first.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reading"
+                }
+              },
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reading"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              },
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              },
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
+    "/msgpack/packed/{id}": {
+      "get": {
+        "tags": [
+          "MessagePack"
+        ],
+        "operationId": "packed",
+        "summary": "MessagePack alone, which is the shape that binds at composition rather than negotiating: one declared media type under the default negotiation mode resolves its serializer once.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reading"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request failed validation.",
+            "content": {
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestValidationError"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
+    "/msgpack/round": {
+      "post": {
+        "tags": [
+          "MessagePack"
+        ],
+        "operationId": "round",
+        "summary": "A MessagePack request body. Nothing declares it: a deserializer is chosen by the inbound Content-Type, so this reads MessagePack from a client that sends it and JSON from one that does not.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Reading"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reading"
+                }
+              },
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reading"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              },
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
     "/registration": {
       "post": {
         "tags": [
@@ -5752,6 +5938,7 @@
       },
       "Reading": {
         "type": "object",
+        "description": "A reading, annotated the way MessagePack requires.",
         "required": [
           "sensor",
           "value"

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Abstract.approved.txt
@@ -71,6 +71,12 @@ namespace Hardened.Requests.Abstract.Attributes
     {
         public ResponseOnlyAttribute() { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple=true)]
+    public class WritesContentTypeAttribute : System.Attribute
+    {
+        public WritesContentTypeAttribute(params string[] contentTypes) { }
+        public string[] ContentTypes { get; }
+    }
 }
 namespace Hardened.Requests.Abstract.Authorization
 {

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Serializers.MessagePack.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Requests.Serializers.MessagePack.approved.txt
@@ -1,0 +1,66 @@
+[assembly: Hardened.Requests.Abstract.Attributes.WritesContentType(new string[] {
+        "application/x-msgpack"})]
+namespace Hardened.Requests.Serializers.MessagePack
+{
+    public interface IMessagePackSerializerConfiguration
+    {
+        System.Func<System.IServiceProvider, MessagePack.MessagePackSerializerOptions> OptionsProvider { get; }
+    }
+    public static class MessagePackContentType
+    {
+        public const string Value = "application/x-msgpack";
+    }
+    [Hardened.Shared.Runtime.Attributes.ConfigurationModel]
+    public class MessagePackSerializerConfiguration : Hardened.Requests.Serializers.MessagePack.IMessagePackSerializerConfiguration
+    {
+        public MessagePackSerializerConfiguration() { }
+        public System.Func<System.IServiceProvider, MessagePack.MessagePackSerializerOptions> OptionsProvider { get; set; }
+        public static MessagePack.IFormatterResolver[] AotResolvers { get; }
+    }
+    [DependencyModules.Runtime.Attributes.DependencyModule]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class MessagePackSerializerLibrary : DependencyModules.Runtime.Interfaces.IDependencyModule, DependencyModules.Runtime.Interfaces.IServiceCollectionConfiguration
+    {
+        public MessagePackSerializerLibrary() { }
+        public void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public void PopulateServiceCollection(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class MessagePackSerializerLibraryAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider
+    {
+        public MessagePackSerializerLibraryAttribute() { }
+        public DependencyModules.Runtime.Interfaces.IDependencyModule GetModule() { }
+    }
+}
+namespace Hardened.Requests.Serializers.MessagePack.Impl
+{
+    public interface ISharedMessagePackOptions
+    {
+        MessagePack.MessagePackSerializerOptions Options { get; }
+    }
+    [DependencyModules.Runtime.Attributes.TransientService]
+    public class MessagePackRequestDeserializer : Hardened.Requests.Abstract.Serializer.IRequestDeserializer
+    {
+        public MessagePackRequestDeserializer(Hardened.Requests.Serializers.MessagePack.Impl.ISharedMessagePackOptions options, Hardened.Shared.Runtime.Collections.IMemoryStreamPool memoryStreamPool) { }
+        public bool IsDefaultSerializer { get; }
+        public int Order { get; }
+        public bool CanProcessContext(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+        public System.Threading.Tasks.ValueTask<T?> DeserializeRequestBody<T>(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+    }
+    [DependencyModules.Runtime.Attributes.TransientService]
+    public class MessagePackResponseSerializer : Hardened.Requests.Abstract.Serializer.IResponseSerializer
+    {
+        public MessagePackResponseSerializer(Hardened.Requests.Serializers.MessagePack.Impl.ISharedMessagePackOptions options, Hardened.Shared.Runtime.Collections.IMemoryStreamPool memoryStreamPool) { }
+        public string ContentType { get; }
+        public bool IsDefaultSerializer { get; }
+        public System.Threading.Tasks.Task SerializeResponse(Hardened.Requests.Abstract.Execution.IExecutionContext context) { }
+    }
+    [DependencyModules.Runtime.Attributes.SingletonService]
+    public class SharedMessagePackOptions : Hardened.Requests.Serializers.MessagePack.Impl.ISharedMessagePackOptions
+    {
+        public SharedMessagePackOptions(System.IServiceProvider serviceProvider, Microsoft.Extensions.Options.IOptions<Hardened.Requests.Serializers.MessagePack.IMessagePackSerializerConfiguration> configuration, System.Collections.Generic.IEnumerable<MessagePack.IFormatterResolver> resolvers) { }
+        public MessagePack.MessagePackSerializerOptions Options { get; }
+    }
+}

--- a/src/PublicApi/Hardened.PublicApi.Tests/Hardened.PublicApi.Tests.csproj
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Hardened.PublicApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -67,6 +67,7 @@
         <ProjectReference Include="..\..\Requests\Hardened.Requests.Caching.Memory\Hardened.Requests.Caching.Memory.csproj"/>
         <ProjectReference Include="..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
         <ProjectReference Include="..\..\Requests\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
+        <ProjectReference Include="..\..\Requests\Serializers\Hardened.Requests.Serializers.MessagePack\Hardened.Requests.Serializers.MessagePack.csproj"/>
         <ProjectReference Include="..\..\Requests\Serializers\Hardened.Requests.Serializers.Newtonsoft\Hardened.Requests.Serializers.Newtonsoft.csproj"/>
         <ProjectReference Include="..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
         <ProjectReference Include="..\..\Shared\Hardened.Shared.Testing\Hardened.Shared.Testing.csproj"/>

--- a/src/PublicApi/Hardened.PublicApi.Tests/PublicApiSurfaceTests.cs
+++ b/src/PublicApi/Hardened.PublicApi.Tests/PublicApiSurfaceTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using PublicApiGenerator;
 using Xunit;
@@ -70,6 +70,7 @@ public class PublicApiSurfaceTests {
         "Hardened.Requests.Abstract",
         "Hardened.Requests.Caching.Memory",
         "Hardened.Requests.Runtime",
+        "Hardened.Requests.Serializers.MessagePack",
         "Hardened.Requests.Serializers.Newtonsoft",
         "Hardened.Requests.Testing",
         "Hardened.Shared.Runtime",

--- a/src/Requests/Hardened.Requests.Abstract/Attributes/WritesContentTypeAttribute.cs
+++ b/src/Requests/Hardened.Requests.Abstract/Attributes/WritesContentTypeAttribute.cs
@@ -1,0 +1,41 @@
+namespace Hardened.Requests.Abstract.Attributes;
+
+/// <summary>
+/// The media types a serializer in this assembly writes a model as.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For the build, not for the runtime.</b> Nothing reads this at request time: a serializer is
+/// located by its own <see cref="Serializer.IResponseSerializer.ContentType"/>, and registering one
+/// is what makes a media type producible. This is how a compilation that only references the
+/// package can know the same thing.
+/// </para>
+/// <para>
+/// It exists because <c>HRDR012</c> asks a question the build otherwise cannot answer. A property's
+/// value is not readable from metadata, so a generator looking at a referenced
+/// <c>IResponseSerializer</c> can see the type and not the media type it declares - which made the
+/// warning fire on every operation that declared anything but JSON, including the ones that had the
+/// serializer they needed. The alternative was to drop the check, and the check is worth keeping:
+/// <c>[Produces("text/csv")]</c> with no CSV serializer anywhere is a real mistake that otherwise
+/// surfaces as a 500 in an environment.
+/// </para>
+/// <para>
+/// Write it once per assembly that ships a serializer, naming what that serializer declares. An
+/// application with its own <c>IResponseSerializer</c> writes it too, in any file:
+/// <c>[assembly: WritesContentType("application/x-msgpack")]</c>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [assembly: WritesContentType("application/x-msgpack")]
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public class WritesContentTypeAttribute : Attribute {
+    public WritesContentTypeAttribute(params string[] contentTypes) {
+        ContentTypes = contentTypes;
+    }
+
+    /// <summary>The media types a serializer here writes.</summary>
+    public string[] ContentTypes { get; }
+}

--- a/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequestDeserializerRegistrationTests.cs
+++ b/src/Requests/Hardened.Requests.Runtime.Tests/Serializer/RequestDeserializerRegistrationTests.cs
@@ -1,0 +1,83 @@
+﻿using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Runtime.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Hardened.Requests.Runtime.Tests.Serializer;
+
+/// <summary>
+/// That the framework's JSON reader survives a second one being registered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>HardenedRequestModule</c> registered it as
+/// <c>TryAddSingleton&lt;IRequestDeserializer, SystemTextJsonRequestDeserializer&gt;</c>, which keys
+/// the Try on the service type rather than on the class. Any package registering an
+/// <c>IRequestDeserializer</c> ahead of it - which is what importing a MessagePack or protobuf
+/// serializer does - skipped the line, and the application was left with no JSON reader at all.
+/// Every request carrying a JSON body then answered 500 with "Could not find serializer".
+/// </para>
+/// <para>
+/// The response side carried the identical defect and was fixed the identical way. Precedence among
+/// readers is <c>RequestDeserializerOrder</c>'s, which the locator sorts on, so the Try was never
+/// carrying it.
+/// </para>
+/// </remarks>
+public class RequestDeserializerRegistrationTests {
+
+    /// <summary>A reader for one content type, the shape a serializer package registers.</summary>
+    private sealed class SpecialisedDeserializer : IRequestDeserializer {
+        public bool IsDefaultSerializer => false;
+
+        public int Order => (int)RequestDeserializerOrder.Specialized;
+
+        public bool CanProcessContext(IExecutionContext context) => false;
+
+        public ValueTask<T?> DeserializeRequestBody<T>(IExecutionContext context) =>
+            new(default(T));
+    }
+
+    private static IServiceCollection Configured(bool withSpecialised) {
+        var services = new ServiceCollection();
+
+        // Before the framework module, which is the order DependencyModules applies: dependencies
+        // first, then the module that imported them.
+        if (withSpecialised) {
+            services.AddTransient<IRequestDeserializer, SpecialisedDeserializer>();
+        }
+
+        new HardenedRequestModule().ConfigureServices(services);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Named as either half of a descriptor, so this reads the same against the registration that
+    /// carried the defect - which named the class only as an implementation type.
+    /// </summary>
+    private static bool RegistersTheJsonReader(IServiceCollection services) =>
+        services.Any(descriptor =>
+            descriptor.ServiceType == typeof(Runtime.Serializer.SystemTextJsonRequestDeserializer) ||
+            descriptor.ImplementationType == typeof(Runtime.Serializer.SystemTextJsonRequestDeserializer));
+
+    [Fact]
+    public void TheJsonReaderIsRegistered() =>
+        Assert.True(RegistersTheJsonReader(Configured(withSpecialised: false)));
+
+    [Fact]
+    public void AndStillIsWhenAPackageRegisteredOneFirst() =>
+        Assert.True(RegistersTheJsonReader(Configured(withSpecialised: true)));
+
+    /// <summary>
+    /// Both readers reach the locator, rather than the second replacing the first.
+    /// </summary>
+    [Fact]
+    public void BothReadersAreRegistered() {
+        var deserializers = Configured(withSpecialised: true)
+            .Where(descriptor => descriptor.ServiceType == typeof(IRequestDeserializer))
+            .ToList();
+
+        Assert.Equal(2, deserializers.Count);
+    }
+}

--- a/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
+++ b/src/Requests/Hardened.Requests.Runtime/DependencyInjection/HardenedRequestModule.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using DependencyModules.Runtime.Attributes;
 using DependencyModules.Runtime.Interfaces;
@@ -137,7 +137,17 @@ public partial class HardenedRequestModule : IServiceCollectionConfiguration {
             return;
         }
 
-        services.TryAddSingleton<IRequestDeserializer, SystemTextJsonRequestDeserializer>();
+        // Under its own class, then the interface pointing at it - not
+        // TryAddSingleton<IRequestDeserializer, SystemTextJsonRequestDeserializer>. That keyed the
+        // Try on the service type, so importing any package registering an IRequestDeserializer
+        // skipped this line and left the application with no JSON reader at all: every request with
+        // a JSON body answered 500 with "Could not find serializer". The response side had the same
+        // defect and the same fix; precedence here is RequestDeserializerOrder's, which the locator
+        // sorts on, so the Try was never carrying it.
+        services.TryAddSingleton<SystemTextJsonRequestDeserializer>();
+        services.AddSingleton<IRequestDeserializer>(
+            provider => provider.GetRequiredService<SystemTextJsonRequestDeserializer>());
+
         services.AddSingleton<IResponseSerializer, SystemTextJsonResponseSerializer>();
     }
 }

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/Hardened.Requests.Serializers.MessagePack.Tests.csproj
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/Hardened.Requests.Serializers.MessagePack.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.v3"/>
+        <PackageReference Include="NSubstitute"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Hardened.Requests.Serializers.MessagePack\Hardened.Requests.Serializers.MessagePack.csproj"/>
+
+        <!--
+            The in-memory transport, so the serializers are driven through a real request and
+            response rather than a mocked context. Both sides here read and write streams that the
+            caller owns, and a substituted context cannot fail when that ownership is broken.
+        -->
+        <ProjectReference Include="..\..\Hardened.Requests.Testing\Hardened.Requests.Testing.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/RegistrationTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/RegistrationTests.cs
@@ -1,0 +1,99 @@
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Requests.Serializers.MessagePack.Tests.Support;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.MessagePack.Tests;
+
+/// <summary>
+/// What the pair declares about itself, which is how the locator finds them.
+/// </summary>
+public class RegistrationTests {
+
+    [Fact]
+    public void TheSerializerRegistersUnderTheMessagePackMediaType() =>
+        Assert.Equal(
+            MessagePackContentType.Value,
+            Pipeline.ResponseSerializer(Pipeline.Pool()).ContentType);
+
+    /// <summary>
+    /// Installing the package does not change what an operation produces. A service that imports it
+    /// and declares nothing still answers JSON, because nothing declared is the service default and
+    /// this serializer does not claim to be one.
+    /// </summary>
+    [Fact]
+    public void ItIsNotTheDefaultSerializer() =>
+        Assert.False(Pipeline.ResponseSerializer(Pipeline.Pool()).IsDefaultSerializer);
+
+    /// <summary>
+    /// The response carries the media type it was written as. Nothing else assigns it on the bound
+    /// path: <c>ContextSerializationService</c> calls a serializer resolved at composition
+    /// directly, and only <c>SerializationLocatorService.FindDeclaredProducer</c> assigns one.
+    /// </summary>
+    [Fact]
+    public async Task SerializingCommitsTheContentType() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Pipeline.Payload("first", 2);
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context);
+
+        Assert.Equal(MessagePackContentType.Value, context.Response.ContentType);
+    }
+
+    /// <summary>An empty response still says what it would have been.</summary>
+    [Fact]
+    public async Task ANullResponseStillCommitsTheContentType() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = null;
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context);
+
+        Assert.Equal(MessagePackContentType.Value, context.Response.ContentType);
+    }
+
+    [Fact]
+    public void AMessagePackBodyIsClaimed() =>
+        Assert.True(
+            Pipeline.Deserializer(Pipeline.Pool())
+                .CanProcessContext(Pipeline.Context(contentType: MessagePackContentType.Value)));
+
+    /// <summary>
+    /// Parameters and all. A client sending <c>application/x-msgpack; charset=binary</c> is sending
+    /// MessagePack.
+    /// </summary>
+    [Fact]
+    public void AMediaTypeWithParametersIsClaimed() =>
+        Assert.True(
+            Pipeline.Deserializer(Pipeline.Pool())
+                .CanProcessContext(
+                    Pipeline.Context(contentType: MessagePackContentType.Value + "; charset=binary")));
+
+    [Fact]
+    public void AJsonBodyIsLeftToTheJsonReader() =>
+        Assert.False(
+            Pipeline.Deserializer(Pipeline.Pool())
+                .CanProcessContext(Pipeline.Context(contentType: KnownContentType.Json)));
+
+    /// <summary>
+    /// A body with no content type is not MessagePack. It is a JSON body from a client that did not
+    /// say so, which is what the default reader is for - and this reader is not one.
+    /// </summary>
+    [Fact]
+    public void ABodyWithNoContentTypeIsNotClaimed() {
+        var deserializer = Pipeline.Deserializer(Pipeline.Pool());
+
+        Assert.False(deserializer.CanProcessContext(Pipeline.Context(contentType: null)));
+        Assert.False(deserializer.IsDefaultSerializer);
+    }
+
+    /// <summary>
+    /// Ahead of the JSON readers, which is where a reader for one specific content type belongs.
+    /// </summary>
+    [Fact]
+    public void ItIsAskedBeforeTheGeneralPurposeReaders() =>
+        Assert.Equal(
+            (int)RequestDeserializerOrder.Specialized,
+            Pipeline.Deserializer(Pipeline.Pool()).Order);
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/ResolverChainTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/ResolverChainTests.cs
@@ -1,0 +1,91 @@
+﻿using Hardened.Requests.Serializers.MessagePack.Tests.Support;
+using MessagePack;
+using MessagePack.Formatters;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.MessagePack.Tests;
+
+/// <summary>
+/// Which formatters the package installs, and which it refuses to.
+/// </summary>
+public class ResolverChainTests {
+
+    /// <summary>
+    /// A model nobody annotated and nobody wrote a formatter for.
+    /// </summary>
+    /// <remarks>
+    /// Its own type, separate from <see cref="Hand"/>, and that separation is the test working. A
+    /// formatter declared anywhere in this assembly is found by
+    /// <c>SourceGeneratedFormatterResolver</c> once it is visible enough for MessagePack's analyzer
+    /// to accept it - MsgPack010 requires internal - so one type cannot be both unwritable and
+    /// hand-written.
+    /// </remarks>
+    public record Unannotated(string Name);
+
+    /// <summary>A model answered by a formatter this assembly declares.</summary>
+    public record Hand(string Name);
+
+    /// <summary>
+    /// <b>It throws rather than reflecting.</b> The chain carries no dynamic object resolver, so a
+    /// model with no <c>[MessagePackObject]</c> fails here exactly as it would after a NativeAOT
+    /// publish, where <c>DynamicObjectResolver</c> cannot emit anything at all.
+    /// </summary>
+    /// <remarks>
+    /// The same rule <c>AotResponseSerializer</c> states for JSON: a type missing from every
+    /// registered context must not serialize on a developer's machine, because the developer's
+    /// build is then the one configuration where the mistake is invisible.
+    /// </remarks>
+    [Fact]
+    public async Task AModelWithNoMessagePackObjectThrows() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Unannotated("first");
+
+        await Assert.ThrowsAsync<MessagePackSerializationException>(
+            () => Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context));
+    }
+
+    /// <summary>
+    /// A registered <see cref="IFormatterResolver"/> is asked first, which is how an application
+    /// answers for something the generator wrote no formatter for. The JSON side does the same with
+    /// <c>IJsonTypeInfoResolver</c>.
+    /// </summary>
+    [Fact]
+    public async Task ARegisteredResolverAnswersForATypeTheGeneratorDidNotWrite() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = new Hand("first");
+
+        await Pipeline
+            .ResponseSerializer(Pipeline.Pool(), Pipeline.Options(null, HandResolver.Instance))
+            .SerializeResponse(context);
+
+        Assert.Equal(
+            MessagePackSerializer.Serialize(
+                "first", MessagePackSerializerOptions.Standard,
+                TestContext.Current.CancellationToken),
+            Pipeline.BodyOf(context));
+    }
+
+    /// <summary>
+    /// Internal rather than private, and over the nullable type: MsgPack010 and MsgPack014, which
+    /// this package's analyzer reports and a CI build turns into errors.
+    /// </summary>
+    internal sealed class HandResolver : IFormatterResolver {
+        public static readonly HandResolver Instance = new();
+
+        public IMessagePackFormatter<T>? GetFormatter<T>() =>
+            typeof(T) == typeof(Hand) ? (IMessagePackFormatter<T>)(object)HandFormatter.Instance : null;
+    }
+
+    internal sealed class HandFormatter : IMessagePackFormatter<Hand?> {
+        public static readonly HandFormatter Instance = new();
+
+        public void Serialize(
+            ref MessagePackWriter writer, Hand? value, MessagePackSerializerOptions options) =>
+            writer.Write(value?.Name);
+
+        public Hand? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options) =>
+            reader.ReadString() is { } name ? new Hand(name) : null;
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/RoundTripTests.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/RoundTripTests.cs
@@ -1,0 +1,106 @@
+﻿using Hardened.Requests.Serializers.MessagePack.Tests.Support;
+using MessagePack;
+using Xunit;
+
+namespace Hardened.Requests.Serializers.MessagePack.Tests;
+
+/// <summary>
+/// A model out and the same model back, through the serializer pair the package registers.
+/// </summary>
+public class RoundTripTests {
+
+    private static async Task<byte[]> Write(object value) {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = value;
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context);
+
+        return Pipeline.BodyOf(context);
+    }
+
+    [Fact]
+    public async Task AModelGoesOutAsMessagePackAndComesBack() {
+        var bytes = await Write(new Pipeline.Payload("first", 2));
+
+        var read = await Pipeline.Deserializer(Pipeline.Pool())
+            .DeserializeRequestBody<Pipeline.Payload>(Pipeline.Context(bytes));
+
+        Assert.Equal(new Pipeline.Payload("first", 2), read);
+    }
+
+    /// <summary>
+    /// Not JSON. Obvious, and worth one assertion: the pipeline holds the value as <c>object</c>,
+    /// and a serializer that fell back to a type-keyed map or to a string would still round-trip
+    /// through itself.
+    /// </summary>
+    [Fact]
+    public async Task TheBytesAreMessagePack() {
+        var bytes = await Write(new Pipeline.Payload("first", 2));
+
+        Assert.Equal(
+            MessagePackSerializer.Serialize(
+                new Pipeline.Payload("first", 2), Pipeline.Options().Options,
+                TestContext.Current.CancellationToken),
+            bytes);
+    }
+
+    /// <summary>
+    /// A model keyed by property name rather than by index, which is the other shape
+    /// <c>[MessagePackObject]</c> takes.
+    /// </summary>
+    [Fact]
+    public async Task AStringKeyedModelRoundTrips() {
+        var bytes = await Write(new Pipeline.Named("first", 2));
+
+        Assert.Equal(
+            new Pipeline.Named("first", 2),
+            await Pipeline.Deserializer(Pipeline.Pool())
+                .DeserializeRequestBody<Pipeline.Named>(Pipeline.Context(bytes)));
+    }
+
+    /// <summary>
+    /// A collection of models, which the generated formatters do not cover on their own: the item
+    /// type is generated and the list around it comes from <c>DynamicGenericResolver</c>, which is
+    /// why the chain carries it.
+    /// </summary>
+    [Fact]
+    public async Task AListOfModelsRoundTrips() {
+        var bytes = await Write(
+            new List<Pipeline.Payload> { new("first", 1), new("second", 2) });
+
+        var read = await Pipeline.Deserializer(Pipeline.Pool())
+            .DeserializeRequestBody<List<Pipeline.Payload>>(Pipeline.Context(bytes));
+
+        Assert.Equal(
+            [new Pipeline.Payload("first", 1), new Pipeline.Payload("second", 2)],
+            read);
+    }
+
+    /// <summary>
+    /// The value is serialized as its runtime type. The pipeline holds it as <c>object</c>, and a
+    /// formatter for <c>object</c> writes a type-keyed map rather than the model - which is the
+    /// same trap <c>JsonTypeInfoLookup.For(options, value)</c> exists to avoid on the JSON side.
+    /// </summary>
+    [Fact]
+    public async Task TheRuntimeTypeDecidesTheFormatter() {
+        object boxed = new Pipeline.Payload("first", 2);
+
+        Assert.Equal(
+            MessagePackSerializer.Serialize(
+                new Pipeline.Payload("first", 2), Pipeline.Options().Options,
+                TestContext.Current.CancellationToken),
+            await Write(boxed));
+    }
+
+    [Fact]
+    public async Task ANullResponseWritesNothing() {
+        var context = Pipeline.Context();
+
+        context.Response.ResponseValue = null;
+
+        await Pipeline.ResponseSerializer(Pipeline.Pool()).SerializeResponse(context);
+
+        Assert.Empty(Pipeline.BodyOf(context));
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/Support/Pipeline.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack.Tests/Support/Pipeline.cs
@@ -1,0 +1,99 @@
+﻿using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Headers;
+using Hardened.Requests.Runtime.QueryString;
+using Hardened.Requests.Serializers.MessagePack.Impl;
+using Hardened.Requests.Testing;
+using Hardened.Shared.Runtime.Collections;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Hardened.Requests.Serializers.MessagePack.Tests.Support;
+
+/// <summary>
+/// Real request, real response, real pool - the arrangement
+/// <c>Hardened.Requests.Serializers.Newtonsoft.Tests</c> uses, and for its reason: both halves here
+/// borrow a pooled stream, and a substitute handing back a fresh one every call cannot fail when
+/// that ownership is broken.
+/// </summary>
+public static class Pipeline {
+
+    public static MemoryStreamPool Pool() => new();
+
+    /// <summary>
+    /// The options the package composes, built through <see cref="SharedMessagePackOptions"/> rather
+    /// than by hand, so a test exercises the resolver chain the package actually installs.
+    /// </summary>
+    public static ISharedMessagePackOptions Options(
+        Func<IServiceProvider, MessagePackSerializerOptions>? provider = null,
+        params IFormatterResolver[] resolvers) {
+        var configuration = new MessagePackSerializerConfiguration();
+
+        if (provider != null) {
+            configuration.OptionsProvider = provider;
+        }
+
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        return new SharedMessagePackOptions(
+            services,
+            Microsoft.Extensions.Options.Options.Create<IMessagePackSerializerConfiguration>(configuration),
+            resolvers);
+    }
+
+    public static MessagePackRequestDeserializer Deserializer(
+        IMemoryStreamPool pool, ISharedMessagePackOptions? options = null) =>
+        new(options ?? Options(), pool);
+
+    public static MessagePackResponseSerializer ResponseSerializer(
+        IMemoryStreamPool pool, ISharedMessagePackOptions? options = null) =>
+        new(options ?? Options(), pool);
+
+    /// <summary>A context whose request body is <paramref name="body"/>.</summary>
+    public static IExecutionContext Context(
+        byte[]? body = null, string? contentType = MessagePackContentType.Value) {
+        var provider = new ServiceCollection().BuildServiceProvider();
+
+        var request = new TestExecutionRequest(
+            "POST", "/", contentType ?? MessagePackContentType.Value,
+            new SimpleQueryStringCollection(new Dictionary<string, string>())) {
+            Body = body is null ? Stream.Null : new MemoryStream(body)
+        };
+
+        if (contentType != null) {
+            request.Headers[KnownHeaders.ContentType] = contentType;
+        }
+
+        return new TestExecutionContext(
+            provider,
+            provider,
+            Substitute.For<IKnownServices>(),
+            request,
+            new TestExecutionResponse(new MemoryStream()),
+            CancellationToken.None,
+            null);
+    }
+
+    /// <summary>Everything written to the response body.</summary>
+    public static byte[] BodyOf(IExecutionContext context) {
+        context.Response.Body.Position = 0;
+
+        using var buffer = new MemoryStream();
+
+        context.Response.Body.CopyTo(buffer);
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// A model annotated the way MessagePack requires. <c>partial</c> because the source generator
+    /// writes the formatter into this type's compilation and needs access to its members.
+    /// </summary>
+    [MessagePackObject]
+    public partial record Payload([property: Key(0)] string Name, [property: Key(1)] int Count);
+
+    /// <summary>A model with no keys, so the formatter is written by property name.</summary>
+    [MessagePackObject(keyAsPropertyName: true)]
+    public partial record Named(string Name, int Count);
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/AssemblyInfo.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.Requests.Serializers.MessagePack;
+
+// What HRDR012 reads. Without it every operation declaring this media type warns that nothing
+// writes it, including the operations that reference this package - see SerializerContentTypes.
+[assembly: WritesContentType(MessagePackContentType.Value)]

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Hardened.Requests.Serializers.MessagePack.csproj
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Hardened.Requests.Serializers.MessagePack.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+
+        <!--
+          MessagePack generates its formatters at build with a Roslyn source generator, which is
+          what makes this claim true. Nothing here resolves a contract by reflection: the options
+          this package composes carry the resolvers registered with the container and the built-in
+          formatters, and never DynamicObjectResolver - see SharedMessagePackOptions.
+        -->
+        <IsAotCompatible>true</IsAotCompatible>
+        <Description>MessagePack request and response serializer for the Hardened execution pipeline.</Description>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>Hardened.Requests.Serializers.MessagePack</PackageId>
+        <IsPackable>true</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="MessagePack"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+        <PackageReference Include="Microsoft.Extensions.Primitives"/>
+
+        <!--
+          The module attribute. [DependencyModule] on MessagePackSerializerLibrary is only a class
+          without this generator, and an application importing the package writes
+          [MessagePackSerializerLibrary] - which is the attribute it emits. The Newtonsoft package
+          omits it and its module attribute does not exist, which is why nothing imports that
+          package by name.
+        -->
+        <PackageReference Include="DependencyModules.SourceGenerator" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
+        <ProjectReference Include="..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\..\..\SourceGenerators\Hardened.Web.SourceGenerator\Hardened.Web.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="..\..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
+    </ItemGroup>
+</Project>

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Impl/MessagePackRequestDeserializer.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Impl/MessagePackRequestDeserializer.cs
@@ -1,0 +1,71 @@
+using DependencyModules.Runtime.Attributes;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Shared.Runtime.Collections;
+using MessagePack;
+
+namespace Hardened.Requests.Serializers.MessagePack.Impl;
+
+/// <summary>
+/// Reads a MessagePack request body.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>No attribute declares this.</b> A deserializer is chosen by the inbound <c>Content-Type</c>
+/// against <see cref="CanProcessContext"/>, so an operation reads a MessagePack body because the
+/// client sent one, whatever the operation says it produces. <c>[Produces]</c> is a statement about
+/// the response only.
+/// </para>
+/// </remarks>
+[TransientService]
+public class MessagePackRequestDeserializer : IRequestDeserializer {
+    private readonly ISharedMessagePackOptions _options;
+    private readonly IMemoryStreamPool _memoryStreamPool;
+
+    public MessagePackRequestDeserializer(
+        ISharedMessagePackOptions options, IMemoryStreamPool memoryStreamPool) {
+        _options = options;
+        _memoryStreamPool = memoryStreamPool;
+    }
+
+    /// <summary>
+    /// Never the fallback. A body with no content type, or one nothing claimed, is not MessagePack:
+    /// it is a JSON body from a client that did not say so, which is what the default reader is for.
+    /// </summary>
+    public bool IsDefaultSerializer => false;
+
+    /// <summary>
+    /// Ahead of the JSON readers, which is where a deserializer for one specific content type
+    /// belongs.
+    /// </summary>
+    /// <remarks>
+    /// It could sit anywhere ahead of a reader that claims the same type, and nothing else claims
+    /// this one. Stated rather than left at <c>Normal</c> so that adding a second MessagePack
+    /// reader later is a decision about order rather than about how two class names sort.
+    /// </remarks>
+    public int Order => (int)RequestDeserializerOrder.Specialized;
+
+    public bool CanProcessContext(IExecutionContext context) =>
+        context.Request.ContentType?.Contains(MessagePackContentType.Value) ?? false;
+
+    /// <summary>
+    /// Reads the body as it is. A compressed body was decoded by <c>RequestDecompressionFilter</c>
+    /// before the bind, which is why this does not look at <c>Content-Encoding</c>.
+    /// </summary>
+    /// <remarks>
+    /// Copied into a pooled buffer first, because <c>MessagePackSerializer.Deserialize</c> over a
+    /// stream reads it as a sequence and a host request body is forward-only and unbuffered.
+    /// <c>leaveOpen</c> does not arise: nothing wraps the buffer in a reader that would close it,
+    /// which is the trap <c>NewtonsoftDeserializer</c> records.
+    /// </remarks>
+    public async ValueTask<T?> DeserializeRequestBody<T>(IExecutionContext context) {
+        using var buffer = _memoryStreamPool.Get();
+
+        await context.Request.Body.CopyToAsync(buffer.Item);
+
+        buffer.Item.Position = 0;
+
+        return MessagePackSerializer.Deserialize<T>(
+            buffer.Item, _options.Options, context.CancellationToken);
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Impl/MessagePackResponseSerializer.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Impl/MessagePackResponseSerializer.cs
@@ -1,0 +1,77 @@
+using DependencyModules.Runtime.Attributes;
+using Hardened.Requests.Abstract.Execution;
+using Hardened.Requests.Abstract.Serializer;
+using Hardened.Shared.Runtime.Collections;
+using MessagePack;
+
+namespace Hardened.Requests.Serializers.MessagePack.Impl;
+
+/// <summary>
+/// Writes a response as MessagePack.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Not the default serializer.</b> It answers only where an operation declares
+/// <see cref="MessagePackContentType.Value"/>, which is what lets the package be installed by a
+/// service whose other operations answer JSON. <c>NewtonsoftSerializer</c> is the other shape: it
+/// declares <c>application/json</c> and exists to replace what is registered under it.
+/// </para>
+/// </remarks>
+[TransientService]
+public class MessagePackResponseSerializer : IResponseSerializer {
+    private readonly ISharedMessagePackOptions _options;
+    private readonly IMemoryStreamPool _memoryStreamPool;
+
+    public MessagePackResponseSerializer(
+        ISharedMessagePackOptions options, IMemoryStreamPool memoryStreamPool) {
+        _options = options;
+        _memoryStreamPool = memoryStreamPool;
+    }
+
+    public bool IsDefaultSerializer => false;
+
+    public string ContentType => MessagePackContentType.Value;
+
+    /// <summary>
+    /// Serializes the response value, committing the content type first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The assignment is load-bearing.</b> A serializer bound at composition - which is every
+    /// operation declaring one media type under <c>Lenient</c> - is called by
+    /// <c>ContextSerializationService</c> directly, and nothing on that path assigns
+    /// <c>Response.ContentType</c>. Only the negotiated path assigns it, in
+    /// <c>SerializationLocatorService.FindDeclaredProducer</c>. Both JSON serializers set it here
+    /// for the same reason.
+    /// </para>
+    /// <para>
+    /// Through a pooled buffer rather than straight at the body, because
+    /// <c>MessagePackSerializer.SerializeAsync</c> writes in several passes and a host that
+    /// flushes on first write would commit the response before the length header is known. It is
+    /// also what <c>ConditionalResponseStream</c> needs to compute an ETag over a complete body.
+    /// </para>
+    /// </remarks>
+    public async Task SerializeResponse(IExecutionContext context) {
+        context.Response.ContentType = MessagePackContentType.Value;
+
+        if (context.Response.ResponseValue == null) {
+            return;
+        }
+
+        using var buffer = _memoryStreamPool.Get();
+
+        // The runtime type, because the pipeline holds the value as object and a formatter for
+        // object writes a type-keyed map rather than the model. The JSON side has the identical
+        // problem and solves it the identical way, in JsonTypeInfoLookup.For(options, value).
+        MessagePackSerializer.Serialize(
+            context.Response.ResponseValue.GetType(),
+            buffer.Item,
+            context.Response.ResponseValue,
+            _options.Options,
+            context.CancellationToken);
+
+        buffer.Item.Position = 0;
+
+        await buffer.Item.CopyToAsync(context.Response.Body, 81920, context.CancellationToken);
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Impl/SharedMessagePackOptions.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/Impl/SharedMessagePackOptions.cs
@@ -1,0 +1,52 @@
+using DependencyModules.Runtime.Attributes;
+using MessagePack;
+using MessagePack.Resolvers;
+using Microsoft.Extensions.Options;
+
+namespace Hardened.Requests.Serializers.MessagePack.Impl;
+
+public interface ISharedMessagePackOptions {
+    MessagePackSerializerOptions Options { get; }
+}
+
+/// <summary>
+/// The options both halves of this package read, composed once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One instance, for the reason <c>SharedSerializer</c> is one: a reader and a writer that compose
+/// their own resolvers apply one set of formatters on the way out and another on the way in, and a
+/// model round-trips through neither.
+/// </para>
+/// <para>
+/// <b>Registered resolvers first, then the AOT chain.</b> The chain is the same shape as the JSON
+/// side's - <c>AotResponseSerializer</c> adds every registered <c>IJsonTypeInfoResolver</c> and then
+/// its primitive resolver last - so an application registers an <c>IFormatterResolver</c> to answer
+/// for something the generator did not write a formatter for, and it is asked first.
+/// </para>
+/// </remarks>
+[SingletonService]
+public class SharedMessagePackOptions : ISharedMessagePackOptions {
+    public SharedMessagePackOptions(
+        IServiceProvider serviceProvider,
+        IOptions<IMessagePackSerializerConfiguration> configuration,
+        IEnumerable<IFormatterResolver> resolvers) {
+        var options = configuration.Value.OptionsProvider(serviceProvider);
+
+        var registered = resolvers.ToArray();
+
+        // Only where the application registered one. CompositeResolver.Create allocates a caching
+        // resolver over the list, and composing a single-entry list around the same chain the
+        // default already carries buys a level of indirection on every lookup for nothing.
+        Options = registered.Length == 0
+            ? options.WithResolver(
+                CompositeResolver.Create(
+                    [], MessagePackSerializerConfiguration.AotResolvers))
+            : options.WithResolver(
+                CompositeResolver.Create(
+                    [],
+                    [..registered, ..MessagePackSerializerConfiguration.AotResolvers]));
+    }
+
+    public MessagePackSerializerOptions Options { get; }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/MessagePackContentType.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/MessagePackContentType.cs
@@ -1,0 +1,23 @@
+namespace Hardened.Requests.Serializers.MessagePack;
+
+/// <summary>
+/// The media type this package reads and writes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>One spelling, and this is it.</b> <c>application/msgpack</c> and
+/// <c>application/vnd.msgpack</c> are both in use, and supporting more than one here would not
+/// work: <c>SerializationLocatorService.ProducerOf</c> is an exact lookup on a serializer's own
+/// <c>ContentType</c>, and it is the lookup the compile-time binding uses. A second spelling
+/// answered through <c>CanProduce</c> alone would negotiate for an operation declaring two media
+/// types and fail to bind for one declaring it alone, which is a difference nothing on the outside
+/// explains.
+/// </para>
+/// <para>
+/// Public so an operation can name it without a string literal:
+/// <c>[Produces(KnownContentType.Json, MessagePackContentType.Value)]</c>.
+/// </para>
+/// </remarks>
+public static class MessagePackContentType {
+    public const string Value = "application/x-msgpack";
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/MessagePackSerializerConfiguration.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/MessagePackSerializerConfiguration.cs
@@ -1,0 +1,50 @@
+using Hardened.Shared.Runtime.Attributes;
+using MessagePack;
+using MessagePack.Resolvers;
+
+namespace Hardened.Requests.Serializers.MessagePack;
+
+/// <summary>
+/// How this package configures MessagePack.
+/// </summary>
+/// <remarks>
+/// A factory over the service provider rather than a built options object, matching
+/// <c>NewtonsoftSerializerConfiguration</c>: an application that wants its own resolver usually
+/// wants one that was constructed with something from the container.
+/// </remarks>
+[ConfigurationModel]
+public partial class MessagePackSerializerConfiguration {
+    private Func<IServiceProvider, MessagePackSerializerOptions> _optionsProvider = DefaultOptions();
+
+    /// <summary>
+    /// The resolvers every composition ends with, ahead of nothing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>No <c>StandardResolver</c>, and no dynamic resolver of any kind.</b> The tail of
+    /// <c>StandardResolver</c> is <c>DynamicObjectResolver</c>, which emits a formatter at run time
+    /// for any type that reached it - so a model nobody annotated serializes on a developer's
+    /// machine and throws <c>PlatformNotSupportedException</c> after a NativeAOT publish. That is
+    /// the failure <c>AotResponseSerializer</c> refuses a reflection resolver to avoid, said in the
+    /// same words: the one configuration where the mistake is invisible must not be the one the
+    /// developer builds in.
+    /// </para>
+    /// <para>
+    /// <see cref="SourceGeneratedFormatterResolver"/> is what answers for an application's own
+    /// models. MessagePack's source generator writes a formatter for every type carrying
+    /// <c>[MessagePackObject]</c>, and this resolver finds them, so a model that is annotated needs
+    /// no registration and a model that is not fails the same way everywhere.
+    /// </para>
+    /// </remarks>
+    public static IFormatterResolver[] AotResolvers { get; } = [
+        SourceGeneratedFormatterResolver.Instance,
+        BuiltinResolver.Instance,
+        AttributeFormatterResolver.Instance,
+        DynamicGenericResolver.Instance,
+        PrimitiveObjectResolver.Instance
+    ];
+
+    private static Func<IServiceProvider, MessagePackSerializerOptions> DefaultOptions() {
+        return _ => MessagePackSerializerOptions.Standard;
+    }
+}

--- a/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/MessagePackSerializerLibrary.cs
+++ b/src/Requests/Serializers/Hardened.Requests.Serializers.MessagePack/MessagePackSerializerLibrary.cs
@@ -1,0 +1,56 @@
+using DependencyModules.Runtime.Attributes;
+using DependencyModules.Runtime.Interfaces;
+using Hardened.Shared.Runtime.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Hardened.Requests.Serializers.MessagePack;
+
+/// <summary>
+/// Registers the MessagePack reader and writer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Importing this does not change what an operation produces. The serializer registers under
+/// <see cref="MessagePackContentType.Value"/> and answers only where an operation declares that
+/// media type, so a service that imports the package and declares nothing still answers JSON. That
+/// is the difference from <c>Hardened.Requests.Serializers.Newtonsoft</c>, which registers under
+/// <c>application/json</c> and exists to displace what is already there.
+/// </para>
+/// <para>
+/// <b>The configuration is registered here.</b> <c>[ConfigurationModel]</c> writes the interface and
+/// the implementation and nothing else: something has to hand the implementation to the
+/// configuration manager and bridge it to <c>IOptions&lt;T&gt;</c>, which is what
+/// <c>HardenedRequestModule</c> does for the four it owns. Without it, resolving
+/// <c>IOptions&lt;IMessagePackSerializerConfiguration&gt;</c> asks <c>OptionsFactory</c> to
+/// construct an interface and the container throws on the first request.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [HardenedModule]
+/// [MessagePackSerializerLibrary]
+/// public partial class MyApplication { }
+///
+/// [Get("/todos/{id}")]
+/// [Produces(KnownContentType.Json, MessagePackContentType.Value)]
+/// public Todo Get(int id) => ...;
+/// </code>
+/// </example>
+[DependencyModule]
+public partial class MessagePackSerializerLibrary : IServiceCollectionConfiguration {
+
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddSingleton<IConfigurationPackage>(
+            new SimpleConfigurationPackage(
+                new IConfigurationValueProvider[] {
+                    new NewConfigurationValueProvider<
+                        IMessagePackSerializerConfiguration, MessagePackSerializerConfiguration>(null)
+                }));
+
+        services.AddSingleton(
+            provider => Options.Create(
+                provider.GetRequiredService<IConfigurationManager>()
+                    .GetConfiguration<IMessagePackSerializerConfiguration>()));
+    }
+}

--- a/src/SourceGenerators/Hardened.Generation.Shared/Models/OperationModel.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Models/OperationModel.cs
@@ -1,4 +1,4 @@
-namespace Hardened.Generation.Models;
+﻿namespace Hardened.Generation.Models;
 
 internal class OperationModel : IEquatable<OperationModel> {
     public string OperationId { get; set; } = "";
@@ -204,6 +204,34 @@ internal class OperationModel : IEquatable<OperationModel> {
     public List<string> ProducedContentTypes { get; set; } = new();
 
     /// <summary>
+    /// The media types the <em>success</em> responses declare, in document order.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The first half of <see cref="ProducedContentTypes"/>, kept apart because the two answer
+    /// different questions. That list is what the response is negotiated against and has to carry
+    /// the error representations too, or an operation answering <c>text/plain</c> declares a set no
+    /// error model can travel as and every refusal on it reaches the caller as an empty 500.
+    /// </para>
+    /// <para>
+    /// This one is what the document says the success <em>is</em>. Describing it with the union
+    /// published <c>application/json</c> on a <c>text/plain</c> success, which is true of the wire
+    /// and untrue of the contract: the JSON there is the refusal's, and a client generator reading
+    /// it typed the success as two things.
+    /// </para>
+    /// </remarks>
+    public List<string> SuccessContentTypes { get; set; } = new();
+
+    /// <summary>
+    /// The media types the <em>error</em> responses declare, in document order.
+    /// </summary>
+    /// <remarks>
+    /// The other half. An error body goes out as one of these, and the document says so rather than
+    /// naming <c>application/json</c> for every operation.
+    /// </remarks>
+    public List<string> ErrorContentTypes { get; set; } = new();
+
+    /// <summary>
     /// Opt in to a <c>byte[]</c> signature for a response the spec types as a string.
     /// </summary>
     /// <remarks>
@@ -315,6 +343,8 @@ internal class OperationModel : IEquatable<OperationModel> {
                SuccessResponses.SequenceEqual(other.SuccessResponses) &&
                ErrorResponses.SequenceEqual(other.ErrorResponses) &&
                ProducedContentTypes.SequenceEqual(other.ProducedContentTypes) &&
+               SuccessContentTypes.SequenceEqual(other.SuccessContentTypes) &&
+               ErrorContentTypes.SequenceEqual(other.ErrorContentTypes) &&
                Parameters.SequenceEqual(other.Parameters) &&
                FilterInstances.SequenceEqual(other.FilterInstances) &&
                AuthorizationBranches.SequenceEqual(other.AuthorizationBranches) &&

--- a/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/SpecModelSerializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -631,6 +631,8 @@ internal static class SpecModelSerializer {
         record.Add("ResponseFormat", operation.ResponseFormat);
         record.Add("ResponseIsArray", operation.ResponseIsArray);
         record.Add("ProducedContentTypes", operation.ProducedContentTypes);
+        record.Add("SuccessContentTypes", operation.SuccessContentTypes);
+        record.Add("ErrorContentTypes", operation.ErrorContentTypes);
         record.Add("ResponseArrayItemsRef", operation.ResponseArrayItemsRef);
         record.Add("ResponseArrayItemsType", operation.ResponseArrayItemsType);
         record.Add("ResponseArrayItemsFormat", operation.ResponseArrayItemsFormat);
@@ -737,6 +739,8 @@ internal static class SpecModelSerializer {
         ResponseFormat = record.String("ResponseFormat"),
         ResponseIsArray = record.Bool("ResponseIsArray"),
         ProducedContentTypes = record.Strings("ProducedContentTypes") ?? new List<string>(),
+        SuccessContentTypes = record.Strings("SuccessContentTypes") ?? new List<string>(),
+        ErrorContentTypes = record.Strings("ErrorContentTypes") ?? new List<string>(),
         ResponseArrayItemsRef = record.String("ResponseArrayItemsRef"),
         ResponseArrayItemsType = record.String("ResponseArrayItemsType"),
         ResponseArrayItemsFormat = record.String("ResponseArrayItemsFormat"),

--- a/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
+++ b/src/SourceGenerators/Hardened.Idl.SourceGenerator/Hardened.Idl.SourceGenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="../CSharpAuthor.props"/>
 
@@ -113,6 +113,9 @@
         </Compile>
         <Compile Include="../Hardened.SourceGenerator/Web/StreamFramingDiagnostics.cs">
             <Link>Web\StreamFramingDiagnostics.cs</Link>
+        </Compile>
+        <Compile Include="../Hardened.SourceGenerator/Web/SerializerContentTypes.cs">
+            <Link>Web\SerializerContentTypes.cs</Link>
         </Compile>
         <Compile Include="../Hardened.SourceGenerator/Web/ContentTypeDiagnostics.cs">
             <Link>Web\ContentTypeDiagnostics.cs</Link>

--- a/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.BuildTask/Parsing/OpenApiSpecParser.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using System.Globalization;
 using System.Text.Json;
@@ -2248,6 +2248,13 @@ internal static class OpenApiSpecParser {
                             if (!opModel.ProducedContentTypes.Contains(declared)) {
                                 opModel.ProducedContentTypes.Add(declared);
                             }
+
+                            // Beside it, and only the successes. The list above gains the error
+                            // representations below so an error can be produced at all; this one is
+                            // what the document says the success is.
+                            if (!opModel.SuccessContentTypes.Contains(declared)) {
+                                opModel.SuccessContentTypes.Add(declared);
+                            }
                         }
 
                         var responseContent = SelectMediaType(response.Content);
@@ -2307,6 +2314,10 @@ internal static class OpenApiSpecParser {
                 foreach (var errorContentType in errorContentTypes) {
                     if (!opModel.ProducedContentTypes.Contains(errorContentType)) {
                         opModel.ProducedContentTypes.Add(errorContentType);
+                    }
+
+                    if (!opModel.ErrorContentTypes.Contains(errorContentType)) {
+                        opModel.ErrorContentTypes.Add(errorContentType);
                     }
                 }
             }

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/OpenApiDocumentSourceTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/OpenApiDocumentSourceTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using CSharpAuthor;
 using Hardened.Generation.Models;
 using Hardened.SourceGenerator.Models.Request;
@@ -44,7 +44,9 @@ public class OpenApiDocumentSourceTests {
         string method = "GET",
         int? successStatus = null,
         HandlerSchema? response = null,
-        IReadOnlyList<ResponseSchemaModel>? responses = null) =>
+        IReadOnlyList<ResponseSchemaModel>? responses = null,
+        string? produces = null,
+        bool returnsBytesOrText = false) =>
         new(
             new RequestHandlerNameModel(path, method),
             Type("TodoController"),
@@ -53,12 +55,17 @@ public class OpenApiDocumentSourceTests {
             [],
             new ResponseInformationModel {
                 ReturnType = Type("Todo"),
-                DefaultStatusCode = successStatus
+                DefaultStatusCode = successStatus,
+                ProducedContentTypes = produces,
+                ReturnsBytesOrText = returnsBytesOrText
             },
             []) {
             ResponseSchema = response,
             ResponseSchemas = responses ?? System.Array.Empty<ResponseSchemaModel>()
         };
+
+    private static string[] ContentKeys(JsonElement response) =>
+        response.GetProperty("content").EnumerateObject().Select(p => p.Name).ToArray();
 
     private static JsonElement Document(params RequestHandlerModel[] handlers) =>
         JsonDocument.Parse(
@@ -104,6 +111,145 @@ public class OpenApiDocumentSourceTests {
 
         Assert.True(responses.TryGetProperty("204", out var noContent));
         Assert.False(noContent.TryGetProperty("content", out _));
+    }
+
+    #endregion
+
+    #region what an operation produces
+
+    /// <summary>
+    /// The defect: an operation the runtime negotiates two representations of advertised one. The
+    /// set reached the model and the writer took the substring before the first comma.
+    /// </summary>
+    [Fact]
+    public void EveryDeclaredMediaTypeGetsAContentKey() {
+        var responses = Responses(
+            Document(Handler(response: Schema("Todo"),
+                produces: "application/json,application/x-msgpack")),
+            "/todos/{id}", "get");
+
+        Assert.Equal(
+            ["application/json", "application/x-msgpack"],
+            ContentKeys(responses.GetProperty("200")));
+    }
+
+    /// <summary>
+    /// In the declared order rather than sorted. The first is the representation the operation
+    /// leads with and the one a client expressing no preference is answered with, and
+    /// <c>OpenApiSpecParser</c> reads the keys back in document order, so sorting here would make a
+    /// round trip change what the operation prefers.
+    /// </summary>
+    [Fact]
+    public void TheDeclaredOrderIsTheDocumentOrder() {
+        var responses = Responses(
+            Document(Handler(response: Schema("Todo"),
+                produces: "application/x-msgpack,application/json")),
+            "/todos/{id}", "get");
+
+        Assert.Equal(
+            ["application/x-msgpack", "application/json"],
+            ContentKeys(responses.GetProperty("200")));
+    }
+
+    /// <summary>Each key names the same schema: one body, described several ways.</summary>
+    [Fact]
+    public void EveryKeyNamesTheSameSchema() {
+        var ok = Responses(
+            Document(Handler(response: Schema("Todo"),
+                produces: "application/json,application/x-msgpack")),
+            "/todos/{id}", "get").GetProperty("200");
+
+        var content = ok.GetProperty("content");
+
+        Assert.Equal(
+            content.GetProperty("application/json").GetProperty("schema").GetRawText(),
+            content.GetProperty("application/x-msgpack").GetProperty("schema").GetRawText());
+    }
+
+    [Fact]
+    public void ADeclaredSetAlsoReachesADeclaredResponse() {
+        var responses = Responses(
+            Document(Handler(
+                responses: [Response(200, "Todo")],
+                produces: "application/json,application/x-msgpack")),
+            "/todos/{id}", "get");
+
+        Assert.Equal(
+            ["application/json", "application/x-msgpack"],
+            ContentKeys(responses.GetProperty("200")));
+    }
+
+    #endregion
+
+    #region what an error goes out as
+
+    /// <summary>
+    /// <c>ExceptionResponseSerializer</c> puts the error model through the same locator the success
+    /// went through, so an operation declaring MessagePack answers its refusals as MessagePack
+    /// wherever a serializer for it is registered. This published <c>application/json</c> for every
+    /// operation, and the runtime did not.
+    /// </summary>
+    [Fact]
+    public void AnErrorIsDescribedAsTheDeclaredSet() {
+        var responses = Responses(
+            Document(Handler(
+                responses: [Response(200, "Todo"), Response(404, "NotFound")],
+                produces: "application/x-msgpack")),
+            "/todos/{id}", "get");
+
+        Assert.Equal(
+            ["application/x-msgpack", "application/json"],
+            ContentKeys(responses.GetProperty("404")));
+    }
+
+    /// <summary>
+    /// JSON beside the declared set, because the build cannot tell the two outcomes apart. The
+    /// exception path falls back to JSON only when nothing registered can write the error model as
+    /// any declared type, and what a host registers is not readable from this compilation.
+    /// </summary>
+    [Fact]
+    public void JsonIsListedBesideItBecauseTheFallbackIsReachable() {
+        var responses = Responses(
+            Document(Handler(
+                responses: [Response(200, "Todo"), Response(404, "NotFound")],
+                produces: "application/x-msgpack")),
+            "/todos/{id}", "get");
+
+        Assert.Contains("application/json", ContentKeys(responses.GetProperty("404")));
+    }
+
+    /// <summary>
+    /// An operation that only produces JSON describes its errors as JSON and nothing else, so this
+    /// adds no noise to the documents that have always been right.
+    /// </summary>
+    [Fact]
+    public void AJsonOperationStillDescribesJsonErrorsAlone() {
+        var responses = Responses(
+            Document(Handler(
+                responses: [Response(200, "Todo"), Response(404, "NotFound")],
+                produces: "application/json")),
+            "/todos/{id}", "get");
+
+        Assert.Equal(["application/json"], ContentKeys(responses.GetProperty("404")));
+    }
+
+    /// <summary>
+    /// A handler holding bytes or text writes them itself, and
+    /// <c>RawResponseSerializer.CanProduce</c> refuses a response value that is not already bytes.
+    /// So the exception path has nothing producible and commits JSON, which is what the literal
+    /// here was always right for.
+    /// </summary>
+    [Fact]
+    public void ARawHandlerKeepsJsonErrorBodies() {
+        var responses = Responses(
+            Document(Handler(
+                responses: [Response(200, "Todo"), Response(404, "NotFound")],
+                produces: "image/png",
+                returnsBytesOrText: true)),
+            "/todos/{id}", "get");
+
+        Assert.Equal(["application/json"], ContentKeys(responses.GetProperty("404")));
+        Assert.Equal(["image/png"], ContentKeys(responses.GetProperty("200")));
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
+++ b/src/SourceGenerators/Hardened.OpenApi.SourceGenerator.Tests/SpecFirstDocumentTests.cs
@@ -1,4 +1,4 @@
-using System.IO.Compression;
+﻿using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -606,6 +606,113 @@ public class SpecFirstDocumentTests {
 
         Assert.True(statuses.Count > 2);
         Assert.Equal(statuses.OrderBy(status => status).ToList(), statuses);
+    }
+
+    #endregion
+
+    #region what a described operation produces
+
+    /// <summary>
+    /// A contract offering two representations of one response.
+    /// </summary>
+    private const string TwoMediaTypes =
+        """
+        openapi: "3.0.0"
+        info: { title: Pets, version: "1.0" }
+        paths:
+          /pets/{petId}:
+            get:
+              tags: [Pet]
+              operationId: getPet
+              parameters:
+                - name: petId
+                  in: path
+                  required: true
+                  schema: { type: string }
+              responses:
+                '200':
+                  description: A pet
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Pet'
+                    application/x-msgpack:
+                      schema:
+                        $ref: '#/components/schemas/Pet'
+        components:
+          schemas:
+            Pet:
+              type: object
+              required: [id]
+              properties:
+                id: { type: string }
+        """;
+
+    /// <summary>
+    /// A specification-first document is generated from the normalised model, not served verbatim,
+    /// so the writer's shortcuts are this front end's too. The parser collected both media types
+    /// and the writer published the first, which is the same defect code-first had and was easy to
+    /// mistake for a code-first-only one.
+    /// </summary>
+    [Fact]
+    public void BothDeclaredMediaTypesReachThePublishedDocument() {
+        var content = PublishedDocument(TwoMediaTypes)
+            .GetProperty("paths").GetProperty("/pets/{petId}").GetProperty("get")
+            .GetProperty("responses").GetProperty("200").GetProperty("content");
+
+        Assert.Equal(
+            ["application/json", "application/x-msgpack"],
+            content.EnumerateObject().Select(media => media.Name));
+    }
+
+    /// <summary>The same contract, leading with MessagePack.</summary>
+    private const string MsgpackFirst =
+        """
+        openapi: "3.0.0"
+        info: { title: Pets, version: "1.0" }
+        paths:
+          /pets/{petId}:
+            get:
+              tags: [Pet]
+              operationId: getPet
+              parameters:
+                - name: petId
+                  in: path
+                  required: true
+                  schema: { type: string }
+              responses:
+                '200':
+                  description: A pet
+                  content:
+                    application/x-msgpack:
+                      schema:
+                        $ref: '#/components/schemas/Pet'
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Pet'
+        components:
+          schemas:
+            Pet:
+              type: object
+              required: [id]
+              properties:
+                id: { type: string }
+        """;
+
+    /// <summary>
+    /// Which makes the document a round trip: <c>OpenApiSpecParser</c> reads these keys back into
+    /// <c>ProducedContentTypes</c> in document order, so a service generated from a published
+    /// document negotiates the set the original contract declared, in the order it declared it.
+    /// </summary>
+    [Fact]
+    public void TheKeysAreInTheOrderTheContractDeclaredThem() {
+        var content = PublishedDocument(MsgpackFirst)
+            .GetProperty("paths").GetProperty("/pets/{petId}").GetProperty("get")
+            .GetProperty("responses").GetProperty("200").GetProperty("content");
+
+        Assert.Equal(
+            ["application/x-msgpack", "application/json"],
+            content.EnumerateObject().Select(media => media.Name));
     }
 
     #endregion

--- a/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
+++ b/src/SourceGenerators/Hardened.Smithy.BuildTask/Parsing/SmithySpecParser.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Hardened.Idl;
 using Hardened.Generation;
 using Hardened.Generation.Models;
@@ -509,11 +509,25 @@ internal static class SmithySpecParser {
             if (model.ResponseContentType != null &&
                 !model.ProducedContentTypes.Contains(model.ResponseContentType)) {
                 model.ProducedContentTypes.Add(model.ResponseContentType);
+
+                model.SuccessContentTypes.Add(model.ResponseContentType);
             }
 
             if (model.ErrorResponses.Count > 0 &&
                 !model.ProducedContentTypes.Contains("application/json")) {
                 model.ProducedContentTypes.Add("application/json");
+            }
+        }
+
+        // What the document says an error body is, stated here rather than worked out by the
+        // writer. The rule is the one above: JSON for a REST protocol whatever the success is, and
+        // the protocol's own content type for a dispatch protocol, which names one for everything.
+        if (model.ErrorResponses.Count > 0) {
+            var errorContentType =
+                protocol.Dispatches ? model.ResponseContentType : "application/json";
+
+            if (errorContentType != null) {
+                model.ErrorContentTypes.Add(errorContentType);
             }
         }
 

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/Caching/ModelComparisonTests.cs
@@ -1,4 +1,4 @@
-using CSharpAuthor;
+﻿using CSharpAuthor;
 using Hardened.SourceGenerator.Models.Request;
 using Hardened.SourceGenerator.Shared;
 using Hardened.SourceGenerator.Web;
@@ -198,7 +198,11 @@ public class ModelComparisonTests {
     /// status, header and body the type states, and a change to any of them has to be visible here.
     /// Whether the handler writes raw bytes is the sixth: it decides whether a serializer is bound
     /// at all, and it is read off the return type rather than any attribute. The two content-type
-    /// findings are the seventh and eighth, for the reason the framing finding is here.
+    /// findings are the seventh and eighth, for the reason the framing finding is here. Whether the
+    /// handler returns bytes or text is the ninth: it is wider than the raw-bytes flag by exactly
+    /// <c>string</c> and decides how error bodies are described. The success and error media types
+    /// are the tenth and eleventh: a described operation states both, and they are not the
+    /// negotiated set.
     /// </remarks>
     [Fact]
     public void AResponseModelDescribesAllOfItsResponseAnnotations() {
@@ -207,6 +211,7 @@ public class ModelComparisonTests {
             OutputType = Type("Fortunes"),
             RawResponseContentType = "text/csv",
             WritesRawBytes = true,
+            ReturnsBytesOrText = true,
             StreamFraming = "sse",
             ReturnType = Type("String"),
             DefaultStatusCode = 201,
@@ -214,6 +219,8 @@ public class ModelComparisonTests {
             DeclaredErrorBodiesExpression =
                 "new Dictionary<int, object> { { 401, Models.DefaultErrorBodies.UnauthorizedProblem } }",
             ProducedContentTypes = "text/plain,text/csv",
+            SuccessContentTypes = "text/plain",
+            ErrorContentTypes = "application/json",
             UnionCases = "global::App.Todo|201|01;global::App.NotFound|404|01",
             DeclaredResponse = "global::App.Created|201|111|global::App.Todo",
             ThrowsDiagnostic = "OutOfStock",
@@ -226,10 +233,10 @@ public class ModelComparisonTests {
         // Every field, because this string is what the incremental caches compare to decide
         // whether to rerun. A field left out of it is a change the generator does not notice.
         Assert.Equal(
-            "True:System.Fortunes:text/csv:True:sse:System.String:201:" +
+            "True:System.Fortunes:text/csv:True:True:sse:System.String:201:" +
             "Models.DefaultErrorBodies.NotFoundProblem:" +
             "new Dictionary<int, object> { { 401, Models.DefaultErrorBodies.UnauthorizedProblem } }:" +
-            "text/plain,text/csv:" +
+            "text/plain,text/csv:text/plain:application/json:" +
             "global::App.Todo|201|01;global::App.NotFound|404|01:" +
             "global::App.Created|201|111|global::App.Todo::OutOfStock:422:sse:True:text/csv",
             model.ToString());

--- a/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Models/Request/ResponseInformationModel.cs
@@ -118,6 +118,29 @@ public record ResponseInformationModel {
     public string? ProducedContentTypes { get; set; }
 
     /// <summary>
+    /// The media types the success responses declare, comma-joined, or null where nothing said.
+    /// </summary>
+    /// <remarks>
+    /// Spec-first only, and only where it differs from <see cref="ProducedContentTypes"/>. A
+    /// described operation's negotiated set carries its error representations as well as its
+    /// success ones - see <c>OperationModel.SuccessContentTypes</c> - so describing the success
+    /// with it published <c>application/json</c> on a <c>text/plain</c> success. Code-first the two
+    /// cannot differ: <c>[Produces]</c> is a statement about the response only, and the exception
+    /// path negotiates within whatever it named.
+    /// </remarks>
+    public string? SuccessContentTypes { get; set; }
+
+    /// <summary>
+    /// The media types the error responses declare, comma-joined, or null where nothing said.
+    /// </summary>
+    /// <remarks>
+    /// Spec-first only, for the same reason, and it is the exact answer where it is set: a contract
+    /// states what its refusals look like. Code-first the document writer works it out from the
+    /// declared set and the return type, because nothing states it.
+    /// </remarks>
+    public string? ErrorContentTypes { get; set; }
+
+    /// <summary>
     /// The content type put on the response before the handler runs, or empty for a handler that
     /// negotiates.
     /// </summary>
@@ -140,6 +163,21 @@ public record ResponseInformationModel {
     /// reading, and takes the writer by declaring a media type instead.
     /// </remarks>
     public bool WritesRawBytes { get; set; }
+
+    /// <summary>
+    /// Whether the handler's return value is already what goes on the wire, so no serializer
+    /// structures it: <see cref="WritesRawBytes"/> and <c>string</c>.
+    /// </summary>
+    /// <remarks>
+    /// Wider than <see cref="WritesRawBytes"/> by exactly <c>string</c>, and carried separately
+    /// because the two answer different questions. That one decides whether the pass-through writer
+    /// is bound; this one decides whether an error model can go out under the operation's declared
+    /// media type. It cannot: an error model is a model, and
+    /// <c>RawResponseSerializer.CanProduce</c> refuses anything that is not already bytes, so the
+    /// exception path commits JSON. The document writer reads this to describe error bodies the way
+    /// the runtime answers them.
+    /// </remarks>
+    public bool ReturnsBytesOrText { get; set; }
 
     /// <summary>
     /// The status the contract declares validation failures answer with, or null for the stock
@@ -261,9 +299,10 @@ public record ResponseInformationModel {
     /// </remarks>
     public override string ToString() {
         return $"{IsAsync}:{OutputType}:{RawResponseContentType}:{WritesRawBytes}" +
+               $":{ReturnsBytesOrText}" +
                $":{StreamFraming}:{ReturnType}" +
                $":{DefaultStatusCode}:{NullResponseBodyExpression}:{DeclaredErrorBodiesExpression}" +
-               $":{ProducedContentTypes}" +
+               $":{ProducedContentTypes}:{SuccessContentTypes}:{ErrorContentTypes}" +
                $":{UnionCases}:{DeclaredResponse}:{UnionDiagnostic}:{ThrowsDiagnostic}" +
                $":{ValidationErrorStatus}" +
                $":{StreamFramingDiagnostic}" +

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -710,9 +710,8 @@ public static class OpenApiDocumentGenerator {
 
         components["ErrorModel"] = ErrorModelSchema;
 
-        responses[403] = "{\"description\":\"The caller does not hold what this operation requires.\"," +
-                          "\"content\":{\"application/json\":{\"schema\":" +
-                          "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}";
+        responses[403] = Envelope(
+            handler, "The caller does not hold what this operation requires.", ErrorModelRef);
     }
 
     /// <summary>
@@ -779,21 +778,16 @@ public static class OpenApiDocumentGenerator {
 
         components["ErrorModel"] = ErrorModelSchema;
 
-        var builder = new StringBuilder(
-            "{\"description\":\"The operation did not finish inside its budget.\"");
-
         // A string, like every other response header this writes. A header is a string on the
         // wire whatever it carries, which is the rule ResponseHeaderModel states.
-        if (timeout.RetryAfterSeconds > 0) {
-            builder.Append(",\"headers\":{\"Retry-After\":{" +
-                           "\"description\":\"How long to wait before trying again, in seconds.\"," +
-                           "\"schema\":{\"type\":\"string\"}}}");
-        }
+        var headers = timeout.RetryAfterSeconds > 0
+            ? "\"headers\":{\"Retry-After\":{" +
+              "\"description\":\"How long to wait before trying again, in seconds.\"," +
+              "\"schema\":{\"type\":\"string\"}}}"
+            : null;
 
-        responses[timeout.Status] = builder
-            .Append(",\"content\":{\"application/json\":{\"schema\":" +
-                    "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}")
-            .ToString();
+        responses[timeout.Status] = Envelope(
+            handler, "The operation did not finish inside its budget.", ErrorModelRef, headers);
     }
 
     /// <summary>
@@ -863,8 +857,7 @@ public static class OpenApiDocumentGenerator {
         else if (handler.ResponseSchema != null) {
             Merge(components, handler.ResponseSchema);
 
-            builder.Append(",\"content\":{\"").Append(JsonSchemaWriter.Escape(ContentType(handler)))
-                .Append("\":{\"schema\":").Append(handler.ResponseSchema.Schema).Append("}}");
+            WriteContentMap(builder, ContentTypes(handler), handler.ResponseSchema.Schema);
         }
 
         responses[successStatus] = builder.Append('}').ToString();
@@ -897,7 +890,8 @@ public static class OpenApiDocumentGenerator {
             .GroupBy(response => response.Status)
             .OrderBy(group => group.Key);
 
-        var successContentType = ContentType(handler);
+        var successContentTypes = ContentTypes(handler);
+        var errorContentTypes = ErrorContentTypes(handler);
 
         foreach (var group in byStatus) {
             var description = group.First().Description;
@@ -912,10 +906,10 @@ public static class OpenApiDocumentGenerator {
 
             WriteResponseHeaders(builder, group);
 
-            // The handler's media type describes its success. An error body is written by the
-            // exception path, which serializes JSON whatever the success was - publishing the
-            // error under the raw media type described a body that path cannot produce.
-            var contentType = group.Key >= 400 ? "application/json" : successContentType;
+            // The handler's media types describe its success. An error body goes through the same
+            // locator under a set of its own, because the exception path serializes JSON only when
+            // nothing can write the error model as a declared type - see ErrorContentTypes.
+            var contentTypes = group.Key >= 400 ? errorContentTypes : successContentTypes;
 
             var bodies = group.Where(response => response.Schema != null).ToList();
 
@@ -926,38 +920,34 @@ public static class OpenApiDocumentGenerator {
                 WriteStreamedResponse(builder, handler, components, version);
             }
             else if (bodies.Count > 0) {
-                builder.Append(",\"content\":{\"").Append(JsonSchemaWriter.Escape(contentType))
-                    .Append("\":{\"schema\":");
+                string schema;
 
                 if (bodies.Count == 1) {
                     Merge(components, bodies[0].Schema!);
-                    builder.Append(bodies[0].Schema!.Schema);
+                    schema = bodies[0].Schema!.Schema;
                 }
                 else {
-                    builder.Append("{\"oneOf\":[");
+                    var oneOf = new StringBuilder("{\"oneOf\":[");
 
                     for (var i = 0; i < bodies.Count; i++) {
                         if (i > 0) {
-                            builder.Append(',');
+                            oneOf.Append(',');
                         }
 
                         Merge(components, bodies[i].Schema!);
-                        builder.Append(bodies[i].Schema!.Schema);
+                        oneOf.Append(bodies[i].Schema!.Schema);
                     }
 
-                    builder.Append("]}");
+                    schema = oneOf.Append("]}").ToString();
                 }
 
-                builder.Append("}}");
+                WriteContentMap(builder, contentTypes, schema);
             }
 
             responses[group.Key] = builder.Append('}').ToString();
         }
     }
 
-    /// <summary>
-    /// The media type the operation answers with, which is JSON unless it committed to another.
-    /// </summary>
     /// <summary>
     /// The <c>headers</c> a response declares, merged across the status's cases by wire name.
     /// </summary>
@@ -1048,9 +1038,7 @@ public static class OpenApiDocumentGenerator {
 
         components["RequestValidationError"] = ValidationErrorSchema;
 
-        responses[400] = "{\"description\":\"The request failed validation.\"," +
-                         "\"content\":{\"application/json\":{\"schema\":" +
-                         "{\"$ref\":\"#/components/schemas/RequestValidationError\"}}}}";
+        responses[400] = Envelope(handler, "The request failed validation.", ValidationErrorRef);
     }
 
     /// <summary>
@@ -1145,12 +1133,11 @@ public static class OpenApiDocumentGenerator {
 
         components["ErrorModel"] = ErrorModelSchema;
 
-        responses[401] = "{\"description\":\"Authentication required.\"," +
-                         "\"headers\":{\"WWW-Authenticate\":{" +
-                         "\"description\":\"The challenge naming the scheme to authenticate with.\"," +
-                         "\"schema\":{\"type\":\"string\"}}}," +
-                         "\"content\":{\"application/json\":{\"schema\":" +
-                         "{\"$ref\":\"#/components/schemas/ErrorModel\"}}}}";
+        responses[401] = Envelope(
+            handler, "Authentication required.", ErrorModelRef,
+            "\"headers\":{\"WWW-Authenticate\":{" +
+            "\"description\":\"The challenge naming the scheme to authenticate with.\"," +
+            "\"schema\":{\"type\":\"string\"}}}");
     }
 
     /// <summary>
@@ -1202,15 +1189,28 @@ public static class OpenApiDocumentGenerator {
         "with no body.";
 
     /// <summary>
-    /// The media type a success goes out as: what the operation declared, else the contract's, else
-    /// JSON.
+    /// The media type every response falls back to, and the one an error body can always be
+    /// written as.
+    /// </summary>
+    private const string Json = "application/json";
+
+    private static readonly string[] JsonOnly = { Json };
+
+    /// <summary>
+    /// The media types a success goes out as, in the order the operation prefers them: what it
+    /// declared, else the contract's, else JSON.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>The first of the declared set</b>, which is the representation the operation leads with
-    /// and the one a client expressing no preference is answered with. An operation producing
-    /// several is written under that key; naming all of them means a <c>content:</c> map per
-    /// response and is a separate change to this emitter.
+    /// <b>The whole declared set, one <c>content:</c> key each.</b> This took the first and dropped
+    /// the rest, so an operation the runtime negotiates two representations of advertised one -
+    /// <c>[Produces("application/json", "application/x-msgpack")]</c> published as JSON alone, and
+    /// a generated client had no MessagePack branch for a response the service answers with.
+    /// </para>
+    /// <para>
+    /// The first entry still means what it meant: the representation the operation leads with, and
+    /// the one a client expressing no preference is answered with. That is why the set keeps its
+    /// order here rather than being sorted - see <see cref="WriteContentMap"/>.
     /// </para>
     /// <para>
     /// Read from <c>ProducedContentTypes</c> ahead of <c>RawResponseContentType</c>, because the
@@ -1219,20 +1219,156 @@ public static class OpenApiDocumentGenerator {
     /// type code-first was <c>[RawResponse]</c>, which went on nothing else.
     /// </para>
     /// </remarks>
-    private static string ContentType(RequestHandlerModel handler) {
-        var produced = handler.ResponseInformation.ProducedContentTypes;
+    private static IReadOnlyList<string> ContentTypes(RequestHandlerModel handler) {
+        // The success half where the model carries it apart. A described operation's negotiated set
+        // ends with its error representations, which the runtime needs and the success response is
+        // not - see OperationModel.SuccessContentTypes.
+        var produced = handler.ResponseInformation.SuccessContentTypes ??
+                       handler.ResponseInformation.ProducedContentTypes;
 
         if (!string.IsNullOrEmpty(produced)) {
-            var comma = produced!.IndexOf(',');
+            var types = Split(produced!);
 
-            return (comma < 0 ? produced : produced.Substring(0, comma)).Trim();
+            if (types.Count > 0) {
+                return types;
+            }
         }
 
-        return !string.IsNullOrEmpty(handler.ResponseInformation.RawResponseContentType)
-            ? handler.ResponseInformation.RawResponseContentType!
-            : !string.IsNullOrEmpty(handler.ResponseInformation.DeclaredContentType)
-                ? handler.ResponseInformation.DeclaredContentType!
-                : "application/json";
+        if (!string.IsNullOrEmpty(handler.ResponseInformation.RawResponseContentType)) {
+            return new[] { handler.ResponseInformation.RawResponseContentType! };
+        }
+
+        return !string.IsNullOrEmpty(handler.ResponseInformation.DeclaredContentType)
+            ? new[] { handler.ResponseInformation.DeclaredContentType! }
+            : JsonOnly;
+    }
+
+    /// <summary>
+    /// The media types an error body goes out as.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Not JSON for every operation, which is what this published.</b>
+    /// <c>ExceptionResponseSerializer</c> puts the error model through the same locator the success
+    /// goes through, so an operation declaring <c>application/x-msgpack</c> answers its refusals as
+    /// MessagePack wherever a serializer for it is registered. The document said
+    /// <c>application/json</c> and the runtime did not.
+    /// </para>
+    /// <para>
+    /// <b>The declared set and JSON, because the build cannot tell which.</b> The fallback fires
+    /// only when nothing registered can write the error model as any declared type, and what a host
+    /// registers is not readable from this compilation - the same limit
+    /// <c>ContentTypeDiagnostics</c> works under. Describing both is honest where naming one is a
+    /// guess. The declared types come first, which is the order the runtime tries them in.
+    /// </para>
+    /// <para>
+    /// <b>A raw or streamed handler keeps JSON alone.</b> An error model is a model, and neither
+    /// writer will take one: <c>RawResponseSerializer.CanProduce</c> refuses a response value that
+    /// is not already bytes, and <c>StreamingJsonResponseSerializer.CanProduce</c> requires a
+    /// committed framing that a refusal before the first item never wrote. Both leave the exception
+    /// path with nothing producible, which is the case it commits JSON for.
+    /// </para>
+    /// </remarks>
+    private static IReadOnlyList<string> ErrorContentTypes(RequestHandlerModel handler) {
+        // Stated, where a contract stated it. A described operation says what its refusals look
+        // like, so there is nothing to work out and nothing to be generous about: those media types
+        // and no others.
+        if (handler.ResponseInformation.ErrorContentTypes is { } described) {
+            return Split(described);
+        }
+
+        if (handler.ResponseInformation.ReturnsBytesOrText ||
+            handler.ResponseInformation.IsAsyncEnumerable) {
+            return JsonOnly;
+        }
+
+        var declared = ContentTypes(handler);
+
+        if (declared.Count == 1 && declared[0] == Json) {
+            return JsonOnly;
+        }
+
+        var types = new List<string>(declared.Count + 1);
+
+        types.AddRange(declared);
+
+        if (!types.Contains(Json)) {
+            types.Add(Json);
+        }
+
+        return types;
+    }
+
+    private const string ErrorModelRef = "{\"$ref\":\"#/components/schemas/ErrorModel\"}";
+
+    private const string ValidationErrorRef =
+        "{\"$ref\":\"#/components/schemas/RequestValidationError\"}";
+
+    /// <summary>
+    /// One of the refusals the pipeline answers on its own: a description, optionally some headers,
+    /// and the error body under every media type the operation can answer it as.
+    /// </summary>
+    /// <remarks>
+    /// Four writers built this string by concatenation, each with <c>application/json</c> spelled
+    /// into it. That was one media type restated in four places, so an operation declaring another
+    /// had to be fixed in all four or in none.
+    /// </remarks>
+    private static string Envelope(
+        RequestHandlerModel handler, string description, string schema, string? headers = null) {
+        var builder = new StringBuilder("{\"description\":\"")
+            .Append(JsonSchemaWriter.Escape(description))
+            .Append('"');
+
+        if (headers != null) {
+            builder.Append(',').Append(headers);
+        }
+
+        WriteContentMap(builder, ErrorContentTypes(handler), schema);
+
+        return builder.Append('}').ToString();
+    }
+
+    /// <summary>
+    /// A comma-joined media type list as the set it names, in order and without repeats.
+    /// </summary>
+    private static List<string> Split(string contentTypes) {
+        var types = new List<string>();
+
+        foreach (var type in contentTypes.Split(',')) {
+            var trimmed = type.Trim();
+
+            if (trimmed.Length > 0 && !types.Contains(trimmed)) {
+                types.Add(trimmed);
+            }
+        }
+
+        return types;
+    }
+
+    /// <summary>
+    /// A <c>content:</c> map: one key per media type, each naming the same schema.
+    /// </summary>
+    /// <remarks>
+    /// Written in the order given rather than sorted, unlike <c>components</c> beside it. The order
+    /// is the operation's own preference - <c>[Produces]</c> is ordered, and
+    /// <c>OpenApiSpecParser</c> collects a response's keys in document order into
+    /// <c>ProducedContentTypes</c> - so sorting here would make a round trip through the document
+    /// change which representation the operation leads with.
+    /// </remarks>
+    private static void WriteContentMap(
+        StringBuilder builder, IReadOnlyList<string> contentTypes, string schema) {
+        builder.Append(",\"content\":{");
+
+        for (var i = 0; i < contentTypes.Count; i++) {
+            if (i > 0) {
+                builder.Append(',');
+            }
+
+            builder.Append('"').Append(JsonSchemaWriter.Escape(contentTypes[i]))
+                .Append("\":{\"schema\":").Append(schema).Append('}');
+        }
+
+        builder.Append('}');
     }
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -763,6 +763,7 @@ public abstract class BaseRequestModelGenerator {
 
         var producedContentTypes = DeclaredContentTypes(context, methodDeclaration);
         var writesRawBytes = WritesRawBytes(context, methodDeclaration);
+        var returnsBytesOrText = ReturnsBytesOrText(context, methodDeclaration);
 
         // Framing is named here and reported where a diagnostic can be - a syntax transform
         // cannot report one, so an attribute on a handler that streams nothing is carried forward
@@ -799,6 +800,7 @@ public abstract class BaseRequestModelGenerator {
             OutputType = output,
             ReturnType = returnType,
             WritesRawBytes = writesRawBytes,
+            ReturnsBytesOrText = returnsBytesOrText,
 
             // Bytes with nothing to say what they are. An error: no default could be inferred and
             // nothing downstream can supply one.
@@ -809,7 +811,7 @@ public abstract class BaseRequestModelGenerator {
             UnproducibleContentTypeDiagnostic = UnproducibleContentTypes(
                 producedContentTypes, context, methodDeclaration, isAsyncEnumerable),
             RawResponseContentType = CommittedContentType(
-                producedContentTypes, context, methodDeclaration, isAsyncEnumerable),
+                producedContentTypes, returnsBytesOrText, isAsyncEnumerable),
             // The type's status where it declares one, so a handler returning Created<T> publishes
             // 201 rather than the 200 nothing asked for.
             DefaultStatusCode = declaredCase.TypeName != null ? declaredCase.Status : successStatus,
@@ -882,12 +884,13 @@ public abstract class BaseRequestModelGenerator {
     /// </remarks>
     private static string? DeclaredContentTypes(
         GeneratorSyntaxContext context, MethodDeclarationSyntax methodDeclaration) {
-        return DeclaredOn(methodDeclaration.AttributeLists) ??
-               DeclaredOn(methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>()
+        return DeclaredOn(context, methodDeclaration.AttributeLists) ??
+               DeclaredOn(context, methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>()
                    .FirstOrDefault()?.AttributeLists);
     }
 
-    private static string? DeclaredOn(SyntaxList<AttributeListSyntax>? attributeLists) {
+    private static string? DeclaredOn(
+        GeneratorSyntaxContext context, SyntaxList<AttributeListSyntax>? attributeLists) {
         if (attributeLists == null) {
             return null;
         }
@@ -923,6 +926,22 @@ public abstract class BaseRequestModelGenerator {
 
                     if (literal.Length > 1 && literal[0] == '"' && literal[literal.Length - 1] == '"') {
                         types.Add(literal.Substring(1, literal.Length - 2));
+
+                        continue;
+                    }
+
+                    // A named constant, which is how a serializer package lets an operation state
+                    // its media type without a string literal - MessagePackContentType.Value, or
+                    // KnownContentType.Json. Read from syntax like everything else here, this was
+                    // not a literal and the whole attribute came back empty: the operation declared
+                    // nothing, the document published application/json, and the handler answered
+                    // JSON. Silently, because an attribute that parses is an attribute that ran.
+                    //
+                    // The literal above stays the fast path. This costs a semantic model lookup,
+                    // and only for an operation that wrote something other than a literal.
+                    if (context.SemanticModel.GetConstantValue(argument.Expression) is
+                        { HasValue: true, Value: string constant } && constant.Length > 0) {
+                        types.Add(constant);
                     }
                 }
 
@@ -955,13 +974,12 @@ public abstract class BaseRequestModelGenerator {
     /// </remarks>
     private static string CommittedContentType(
         string? producedContentTypes,
-        GeneratorSyntaxContext context,
-        MethodDeclarationSyntax methodDeclaration,
+        bool returnsBytesOrText,
         bool isAsyncEnumerable) {
         if (producedContentTypes == null ||
             producedContentTypes.IndexOf(',') >= 0 ||
             isAsyncEnumerable ||
-            !ReturnsBytesOrText(context, methodDeclaration)) {
+            !returnsBytesOrText) {
             return "";
         }
 
@@ -1024,7 +1042,8 @@ public abstract class BaseRequestModelGenerator {
     }
 
     /// <summary>
-    /// The declared media types that nothing visible here can write, comma-joined, or null.
+    /// The declared media types the return type alone does not rule producible, comma-joined, or
+    /// null.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -1035,9 +1054,11 @@ public abstract class BaseRequestModelGenerator {
     /// with another that declares the same media type.
     /// </para>
     /// <para>
-    /// Everything else is a model declared as something this compilation has no writer for. It may
-    /// still be right - the host registers the serializer - which is why it is a warning rather
-    /// than an error.
+    /// Everything else is a candidate, not a finding. Whether a serializer for it exists is a
+    /// question about the whole compilation, which a per-method syntax transform cannot ask without
+    /// taking the compilation as an input and rebuilding every handler on every keystroke.
+    /// <c>ContentTypeDiagnostics.Report</c> settles it against
+    /// <c>SerializerContentTypes</c> at the routing stage, where the answer is computed once.
     /// </para>
     /// <para>
     /// A streamed handler is skipped: its media types are the framing's, and the streaming writer

--- a/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/SpecBridge/SpecHandlerModelBuilder.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using CSharpAuthor;
 using Hardened.Generation.Models;
 using Hardened.SourceGenerator.Models.Request;
@@ -418,10 +418,15 @@ internal static class SpecHandlerModelBuilder {
         return Ordered(parameters, symbols);
     }
 
+    /// <summary>The list as the model carries it, or null where the contract said nothing.</summary>
+    private static string? Joined(List<string> contentTypes) =>
+        contentTypes.Count > 0 ? string.Join(",", contentTypes) : null;
+
     private static ResponseInformationModel BuildResponseInfo(
         OperationModel operation, IReadOnlyList<SchemaModel> schemas, string modelsNamespace,
         SpecResponseModel responseModel, string specFileName) {
         ITypeDefinition? returnType = null;
+        var returnsText = false;
 
         // A stream, ahead of everything else, exactly as ServiceInterfaceEmitter.GetReturnType
         // decides it: itemSchema means the body is many of the item one after another, so the
@@ -449,6 +454,8 @@ internal static class SpecHandlerModelBuilder {
                 ProducedContentTypes = operation.ProducedContentTypes.Count > 0
                     ? string.Join(",", operation.ProducedContentTypes)
                     : null,
+                SuccessContentTypes = Joined(operation.SuccessContentTypes),
+                ErrorContentTypes = Joined(operation.ErrorContentTypes),
                 ValidationErrorStatus = DeclaredValidationStatus(operation),
                 DeclaredErrorBodiesExpression =
                     DeclaredErrorBodies(operation, schemas, modelsNamespace, specFileName)
@@ -470,6 +477,8 @@ internal static class SpecHandlerModelBuilder {
                 ProducedContentTypes = operation.ProducedContentTypes.Count > 0
                     ? string.Join(",", operation.ProducedContentTypes)
                     : null,
+                SuccessContentTypes = Joined(operation.SuccessContentTypes),
+                ErrorContentTypes = Joined(operation.ErrorContentTypes),
                 ValidationErrorStatus = DeclaredValidationStatus(operation),
                 UnionCases = unionCases,
 
@@ -503,6 +512,7 @@ internal static class SpecHandlerModelBuilder {
             var csType = TypeMapper.MapToCSharpType(operation.ResponseType, operation.ResponseFormat);
             if (csType != "object") {
                 returnType = TypeMapper.GetTypeDefinition(modelsNamespace, csType, false);
+                returnsText = csType == "string";
             }
         }
 
@@ -524,6 +534,11 @@ internal static class SpecHandlerModelBuilder {
             // The same statement the code-first side reads off a byte[] return type, made here
             // because this is where that return type is chosen. Nothing serializes this response.
             WritesRawBytes = operation.RawBytesResponse,
+
+            // Wider by exactly string, and read for a different question: whether an error model
+            // can go out under the media type this operation declared. A contract answering
+            // text/plain returns a string the handler writes itself, so it cannot.
+            ReturnsBytesOrText = operation.RawBytesResponse || returnsText,
 
             // The payload carries its own headers where the contract binds them to its members,
             // which is Smithy's @httpHeader on an output. There is no response set on this path, so
@@ -554,6 +569,8 @@ internal static class SpecHandlerModelBuilder {
             ProducedContentTypes = operation.ProducedContentTypes.Count > 0
                 ? string.Join(",", operation.ProducedContentTypes)
                 : null,
+            SuccessContentTypes = Joined(operation.SuccessContentTypes),
+            ErrorContentTypes = Joined(operation.ErrorContentTypes),
 
             ValidationErrorStatus = DeclaredValidationStatus(operation)
         };

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/ContentTypeDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/ContentTypeDiagnostics.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 
 namespace Hardened.SourceGenerator.Web;
 
@@ -18,6 +18,13 @@ namespace Hardened.SourceGenerator.Web;
 /// library that cannot compile without its host is not a library. The entry point is the only place
 /// the full registration set exists, and that is where strictness could be raised later if it earns
 /// it. <c>ContentTypeNotProducibleException</c> still answers the case that reaches run time.
+/// </para>
+/// <para>
+/// <b>Visible means declared, not registered.</b> This used to treat every media type that was not
+/// <c>application/json</c> as unproducible, so installing a serializer package did not silence it
+/// and an application adopting one could not build warning-free. A serializer package says what it
+/// writes with <c>[assembly: WritesContentType]</c> and <see cref="SerializerContentTypes"/> reads
+/// that off this compilation and its references, which is what makes the warning answerable.
 /// </para>
 /// <para>
 /// Found in the syntax transform, where the return type is known, and reported from the routing
@@ -60,16 +67,22 @@ public static class ContentTypeDiagnostics {
         isEnabledByDefault: true);
 
     /// <summary>
-    /// Reports the findings the transform carried, if there are any.
+    /// Reports the findings the transform carried, if any survive what this compilation can write.
     /// </summary>
     /// <param name="unproducible">
-    /// The declared media types nothing can write, comma-joined, as the transform found them.
+    /// The declared media types the transform could not rule producible from the return type alone,
+    /// comma-joined.
+    /// </param>
+    /// <param name="writable">
+    /// The media types a serializer in reach declares, comma-joined - see
+    /// <see cref="SerializerContentTypes"/>. A candidate named here is produced and is not reported.
     /// </param>
     public static void Report(
         SourceProductionContext context,
         string handler,
         bool declaresNothing,
-        string? unproducible) {
+        string? unproducible,
+        string writable) {
         if (declaresNothing) {
             context.ReportDiagnostic(
                 Diagnostic.Create(MissingDeclaration(), Location.None, handler));
@@ -80,6 +93,10 @@ public static class ContentTypeDiagnostics {
         }
 
         foreach (var contentType in unproducible!.Split(',')) {
+            if (SerializerContentTypes.Writes(writable, contentType)) {
+                continue;
+            }
+
             context.ReportDiagnostic(
                 Diagnostic.Create(NothingProduces(), Location.None, handler, contentType));
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -104,7 +104,8 @@ public static class RoutingTableGenerator {
                 context,
                 name,
                 handler.ResponseInformation.MissingContentTypeDiagnostic,
-                handler.ResponseInformation.UnproducibleContentTypeDiagnostic);
+                handler.ResponseInformation.UnproducibleContentTypeDiagnostic,
+                options.WritableContentTypes);
         }
 
         // Per application, because the store is: [CacheResponse] on a handler and the module

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/SerializerContentTypes.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/SerializerContentTypes.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Hardened.SourceGenerator.Web;
+
+/// <summary>
+/// The media types this compilation can write a model as, read from
+/// <c>[assembly: WritesContentType]</c> on itself and on everything it references.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>HRDR012</c>'s other half. The transform decides which of an operation's declared media types
+/// are candidates, knowing only the return type; this decides which of those a serializer exists
+/// for, knowing only the compilation. Neither can answer alone, which is why the finding is carried
+/// from one to the other rather than reported where it is found.
+/// </para>
+/// <para>
+/// <b>Referenced assemblies as well as this one.</b> A serializer usually arrives as a package, so
+/// the attribute usually sits in metadata rather than in source. Reading only the current assembly
+/// would leave the warning exactly as wrong as it was.
+/// </para>
+/// <para>
+/// <b>Selected to one string.</b> A <c>CompilationProvider</c> hands back a new compilation on every
+/// keystroke, so anything derived from it has to collapse to a value that compares equal or it
+/// rebuilds the routing table for every edit. Sorted and joined for that reason, and for the same
+/// reason <c>WebGeneratorOptions</c> holds raw strings:
+/// <c>HandlerValidationGenerator</c> makes the identical move with a bool.
+/// </para>
+/// </remarks>
+public static class SerializerContentTypes {
+    private const string AttributeName = "Hardened.Requests.Abstract.Attributes.WritesContentTypeAttribute";
+
+    /// <summary>
+    /// <c>application/json</c> is always here. The framework registers a serializer for it, and an
+    /// application replacing that one replaces it with another declaring the same media type, so no
+    /// reference has to say so.
+    /// </summary>
+    public const string AlwaysWritable = "application/json";
+
+    public static string Read(Compilation compilation) {
+        var found = new SortedSet<string>(StringComparer.OrdinalIgnoreCase) { AlwaysWritable };
+
+        Collect(compilation.Assembly, found);
+
+        foreach (var reference in compilation.SourceModule.ReferencedAssemblySymbols) {
+            Collect(reference, found);
+        }
+
+        return string.Join(",", found);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="contentType"/> is one of the media types <paramref name="writable"/>
+    /// names.
+    /// </summary>
+    /// <remarks>
+    /// An exact comparison, because that is what the runtime does:
+    /// <c>SerializationLocatorService.ProducerOf</c> is a dictionary lookup on the serializer's own
+    /// tag, and it is the lookup the compile-time binding uses. A wildcard match here would go
+    /// quiet for a spelling the locator will not find.
+    /// </remarks>
+    public static bool Writes(string writable, string contentType) {
+        foreach (var declared in writable.Split(',')) {
+            if (declared.Equals(contentType, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void Collect(IAssemblySymbol assembly, ISet<string> found) {
+        foreach (var attribute in assembly.GetAttributes()) {
+            if (attribute.AttributeClass?.ToDisplayString() != AttributeName) {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length != 1) {
+                continue;
+            }
+
+            foreach (var value in attribute.ConstructorArguments[0].Values) {
+                if (value.Value is string contentType && contentType.Length > 0) {
+                    found.Add(contentType);
+                }
+            }
+        }
+    }
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebGeneratorOptions.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebGeneratorOptions.cs
@@ -1,7 +1,7 @@
-namespace Hardened.SourceGenerator.Web;
+﻿namespace Hardened.SourceGenerator.Web;
 
 /// <summary>
-/// The MSBuild properties the web generator reads, as one cacheable value.
+/// The inputs the web generator reads that are not handlers, as one cacheable value.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -22,7 +22,14 @@ namespace Hardened.SourceGenerator.Web;
 /// <c>&lt;HardenedOpenApiVersion&gt;</c> - which version the emitted document declares, and which
 /// spellings it uses. Null takes the default.
 /// </param>
-public record WebGeneratorOptions(string? AmbiguousRoutes, string? OpenApiVersion) {
+/// <param name="WritableContentTypes">
+/// The media types a serializer in reach writes a model as, comma-joined - see
+/// <see cref="SerializerContentTypes"/>. Not an MSBuild property, and here anyway because it is the
+/// same shape of input: a string derived once, compared to decide whether the table re-runs. A
+/// provider of its own would have cost a fourth level on a tuple that is already three deep.
+/// </param>
+public record WebGeneratorOptions(
+    string? AmbiguousRoutes, string? OpenApiVersion, string WritableContentTypes = SerializerContentTypes.AlwaysWritable) {
 
     /// <summary>What a build that set nothing gets.</summary>
     public static readonly WebGeneratorOptions Default = new(null, null);

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebIncrementalGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebIncrementalGenerator.cs
@@ -103,10 +103,19 @@ public static class WebIncrementalGenerator {
         // tuple SourceGeneratorWrapper.Wrap<> has to name grows a level with it. At two properties
         // that type was already three deep and near-unreadable; the next one would have made it
         // four.
+        // Collapsed to one string before it reaches the pipeline, for the reason
+        // HandlerValidationGenerator collapses its compilation read to a bool: a CompilationProvider
+        // yields a new compilation per keystroke, and combining one directly rebuilds the routing
+        // table on every edit.
+        var writableContentTypes = initializationContext.CompilationProvider.Select(
+            static (compilation, _) => SerializerContentTypes.Read(compilation));
+
         var options = initializationContext.AnalyzerConfigOptionsProvider.Select(
-            (provider, _) => new WebGeneratorOptions(
-                Value(provider, "HardenedAmbiguousRoutes"),
-                Value(provider, OpenApiVersionFacts.PropertyName)));
+                (provider, _) => new WebGeneratorOptions(
+                    Value(provider, "HardenedAmbiguousRoutes"),
+                    Value(provider, OpenApiVersionFacts.PropertyName)))
+            .Combine(writableContentTypes)
+            .Select(static (pair, _) => pair.Left with { WritableContentTypes = pair.Right });
 
         var routeProvider = entryPointProvider.Combine(collection).WithComparer(new CombinedComparer());
 

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ContentTypes/ContentTypeDiagnosticTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/ContentTypes/ContentTypeDiagnosticTests.cs
@@ -1,4 +1,4 @@
-using Hardened.Requests.Abstract.Attributes;
+﻿using Hardened.Requests.Abstract.Attributes;
 using Hardened.SourceGeneration.Testing;
 using Hardened.SourceGenerator.Web;
 using Hardened.Web.Runtime.Attributes;
@@ -25,7 +25,7 @@ public class ContentTypeDiagnosticTests {
         typeof(ProducesAttribute)  // Hardened.Requests.Abstract
     ];
 
-    private static GeneratorResult Generate(string handler) =>
+    private static GeneratorResult Generate(string handler, string assemblyAttributes = "") =>
         GeneratorTestHarness.Run(
             $$"""
             using System.Collections.Generic;
@@ -34,6 +34,8 @@ public class ContentTypeDiagnosticTests {
             using Hardened.Requests.Abstract.Attributes;
             using Hardened.Shared.Runtime.Attributes;
             using Hardened.Web.Runtime.Attributes;
+
+            {{assemblyAttributes}}
 
             namespace TestApp;
 
@@ -181,6 +183,88 @@ public class ContentTypeDiagnosticTests {
                     [Produces("application/json")]
                     public Reading Report() => new("a");
                     """),
+                ContentTypeDiagnostics.NothingProducesId));
+    }
+
+    // ── a serializer in reach declares the media type ──────────────────
+
+    /// <summary>
+    /// The finding this was written to catch, and the one it got wrong: a compilation that has a
+    /// serializer for the media type is not making a mistake.
+    /// </summary>
+    /// <remarks>
+    /// Before <c>[assembly: WritesContentType]</c> every media type but <c>application/json</c> was
+    /// treated as unproducible, so installing a serializer package did not silence this and an
+    /// application adopting MessagePack could not build warning-free.
+    /// </remarks>
+    [Fact]
+    public void ADeclaredMediaTypeASerializerWritesIsNotWarnedAbout() {
+        Assert.Empty(
+            Reported(
+                Generate(
+                    """
+                    [Get("/report")]
+                    [Produces("application/x-msgpack")]
+                    public Reading Report() => new("a");
+                    """,
+                    """[assembly: WritesContentType("application/x-msgpack")]"""),
+                ContentTypeDiagnostics.NothingProducesId));
+    }
+
+    /// <summary>
+    /// One type of a declared set having a writer says nothing about the others, so the set is
+    /// filtered rather than passed or failed whole.
+    /// </summary>
+    [Fact]
+    public void OnlyTheTypesWithNoWriterAreReported() {
+        var diagnostic = Assert.Single(
+            Reported(
+                Generate(
+                    """
+                    [Get("/report")]
+                    [Produces("application/x-msgpack", "text/csv")]
+                    public Reading Report() => new("a");
+                    """,
+                    """[assembly: WritesContentType("application/x-msgpack")]"""),
+                ContentTypeDiagnostics.NothingProducesId));
+
+        Assert.Contains("text/csv", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// One attribute naming several, which is how a package that writes two spellings of one format
+    /// declares them.
+    /// </summary>
+    [Fact]
+    public void OneAttributeCanNameSeveralMediaTypes() {
+        Assert.Empty(
+            Reported(
+                Generate(
+                    """
+                    [Get("/report")]
+                    [Produces("application/msgpack")]
+                    public Reading Report() => new("a");
+                    """,
+                    """[assembly: WritesContentType("application/x-msgpack", "application/msgpack")]"""),
+                ContentTypeDiagnostics.NothingProducesId));
+    }
+
+    /// <summary>
+    /// Exactly, because the runtime's lookup is exact: <c>SerializationLocatorService.ProducerOf</c>
+    /// is a dictionary hit on the serializer's own tag, and it is what the compile-time binding
+    /// uses. Matching a wildcard here would go quiet for a spelling the locator will not find.
+    /// </summary>
+    [Fact]
+    public void AWildcardDeclarationDoesNotCoverAConcreteType() {
+        Assert.Single(
+            Reported(
+                Generate(
+                    """
+                    [Get("/report")]
+                    [Produces("application/x-msgpack")]
+                    public Reading Report() => new("a");
+                    """,
+                    """[assembly: WritesContentType("application/*")]"""),
                 ContentTypeDiagnostics.NothingProducesId));
     }
 


### PR DESCRIPTION
`Hardened.Requests.Serializers.MessagePack` registers a reader and a writer for `application/x-msgpack`. It is not the default serializer, so importing the package changes nothing until an operation declares the media type. Both halves compose one `MessagePackSerializerOptions`, so a model round-trips through the same formatters it went out through.

```csharp
[HardenedModule]
[MessagePackSerializerLibrary]
public partial class MyApplication { }

[Get("/todos/{id}")]
[Produces(KnownContentType.Json, MessagePackContentType.Value)]
public Todo Get(int id) => ...;
```

The resolver chain carries no dynamic object resolver. MessagePack v3 generates formatters at build for types carrying `[MessagePackObject]`, and a model without one has to fail on a developer's machine the same way it fails after a NativeAOT publish. That is the rule `AotResponseSerializer` states for JSON, and it is why the package can claim `IsAotCompatible`.

## The document

The writer took the first of an operation's declared media types and dropped the rest, so an operation the runtime negotiates two representations of advertised one. It writes a content key per declared type now, in the declared order, which is the order the parser reads them back in. Both front ends were affected: a specification-first document is generated from the normalised model rather than served verbatim, so the shortcut was not code-first's alone.

Error bodies are no longer `application/json` for every operation. `ExceptionResponseSerializer` puts the error model through the same locator the success went through, so an operation declaring MessagePack answers its refusals as MessagePack wherever a serializer for it is registered. A described operation states its error media types and the document writes them. Code-first they are the declared set and JSON, because the fallback is reachable and the build cannot tell which way it goes. A raw or streamed handler keeps JSON alone: an error model is a model, and neither `RawResponseSerializer` nor `StreamingJsonResponseSerializer` will take one.

`HRDR012` treated every media type but `application/json` as unproducible, so installing a serializer package did not silence it and an application adopting MessagePack could not build warning-free. A package says what it writes with `[assembly: WritesContentType]`, and the routing generator reads that off the compilation and its references. Collapsed to one string before it reaches the pipeline, the way `HandlerValidationGenerator` collapses its compilation read to a bool, so the routing table does not rebuild on every keystroke.

## Three defects found on the way

`[Produces]` read quoted string literals only. `[Produces(KnownContentType.Json)]` declared nothing at all, silently, and the operation then answered JSON by falling through rather than by declaring it. Constants resolve through the semantic model now, behind the literal fast path.

A described operation's negotiated set carries its error representations as well as its success ones, which is what lets an error answer on a `text/plain` operation. Describing the success with that set published `application/json` on a `text/plain` success. The two are separate fields on the model now, and `OpenApiTestApp.json` is unchanged as a result.

`HardenedRequestModule` registered the JSON reader as `TryAddSingleton<IRequestDeserializer, SystemTextJsonRequestDeserializer>`, which keys the Try on the service type. Importing any package that registers an `IRequestDeserializer` skipped the line and left the application with no JSON reader at all, so every request carrying a JSON body answered 500 with "Could not find serializer". The response side carried the identical defect and took the identical fix; precedence here is `RequestDeserializerOrder`'s, which the locator sorts on, so the Try was never carrying it.

## Verification

`Hardened.IntegrationTests.WebApp.SUT` imports the package and carries a `MessagePackController`, so the whole path runs in CI: the diagnostic stays quiet, the document describes both representations, and the runtime picks between them from `Accept`. Driven over a socket against that fixture:

```
GET /msgpack/negotiated/3                                → application/json
GET /msgpack/negotiated/3  Accept: application/x-msgpack  → 92 a8 "sensor-3" 09
GET /msgpack/negotiated/3  Accept: application/json       → {"sensor":"sensor-3","value":9}
GET /msgpack/packed/4                                     → application/x-msgpack
POST /msgpack/round        Content-Type: x-msgpack         → read, answered as MessagePack
```

Scalar renders the 200 with a media type selector listing both types. Before this it had one key and no selector.

`SmithyTestApp.json` changes beyond the new operations: the `awsJson1_0` operation's errors are now `application/x-amz-json-1.0` rather than JSON, which is the Smithy parser's own rule for a dispatch protocol stated rather than worked out by the writer. Nothing in the tree produces that media type, so at run time those errors are still JSON.

## Not in this change

`[Consumes]`, so a MessagePack request body still documents as `application/json`. The runtime reads it either way, because a deserializer is chosen by the inbound `Content-Type`.

A coverage baseline entry for the new assembly. The gate errors on an entry no run reported, so that number has to come from a CI run rather than a local one. It will print as unbaselined until then.

Nothing writes `Vary: Accept` on a negotiated response, and `[CacheResponse<VaryByRoute>]` caches one representation and replays its content type to everyone. `VaryByHeader("Accept")` is the existing escape. Both are latent today and become reachable the moment an operation offers two representations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
