### PR TITLE
Skip a verb attribute on an interface instead of crashing the generator

### DIFF
--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -67,6 +67,7 @@ front end only leaves a gap in the other.
 | `HRDR010` | warning | A parameter binds from the body of a request that carries none, on a `GET`, `HEAD` or `DELETE` |
 | `HRDR011` | error | A handler returns `byte[]` or `Stream` and carries no `[Produces]`. Nothing else can say what the bytes are |
 | `HRDR012` | warning | An operation declares a media type nothing in this compilation writes a model as. A host that registers a serializer for it makes this correct |
+| `HRDR013` | warning | A verb attribute sits on an interface member, which has no implementation to call, so no route is compiled for it |
 
 ## Validation
 

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -727,15 +727,25 @@ public abstract class BaseRequestModelGenerator {
         return methodDeclaration.Identifier.Text;
     }
 
+    /// <summary>
+    /// The type declaring the handler, whatever kind of type declaration it was written in.
+    /// </summary>
+    /// <remarks>
+    /// <c>TypeDeclarationSyntax</c> rather than <c>ClassDeclarationSyntax</c>, because a record is
+    /// not one. A handler on a record reached <c>First()</c> on an empty sequence and threw out of
+    /// the syntax transform, which is a <c>CS8785</c> and costs the whole assembly its generated
+    /// code. The selector is what keeps a declaration that cannot be called from arriving here at
+    /// all - see <c>WebRequestHandlerModelGenerator.SelectWebRequestMethods</c>.
+    /// </remarks>
     protected virtual ITypeDefinition GetControllerType(SyntaxNode contextNode) {
-        var classDeclarationSyntax =
-            contextNode.Ancestors().OfType<ClassDeclarationSyntax>().First();
+        var typeDeclarationSyntax =
+            contextNode.Ancestors().OfType<TypeDeclarationSyntax>().First();
 
-        var namespaceSyntax = classDeclarationSyntax.Ancestors()
+        var namespaceSyntax = typeDeclarationSyntax.Ancestors()
             .OfType<BaseNamespaceDeclarationSyntax>().First();
 
         return TypeDefinition.Get(namespaceSyntax.Name.ToFullString().TrimEnd(),
-            classDeclarationSyntax.Identifier.Text);
+            typeDeclarationSyntax.Identifier.Text);
     }
 
     protected virtual ResponseInformationModel GetResponseInformation(
@@ -885,7 +895,7 @@ public abstract class BaseRequestModelGenerator {
     private static string? DeclaredContentTypes(
         GeneratorSyntaxContext context, MethodDeclarationSyntax methodDeclaration) {
         return DeclaredOn(context, methodDeclaration.AttributeLists) ??
-               DeclaredOn(context, methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>()
+               DeclaredOn(context, methodDeclaration.Ancestors().OfType<TypeDeclarationSyntax>()
                    .FirstOrDefault()?.AttributeLists);
     }
 
@@ -1123,7 +1133,7 @@ public abstract class BaseRequestModelGenerator {
         filterList.AddRange(
             GetFiltersForMethod(context, methodDeclarationSyntax, cancellationToken));
         filterList.AddRange(GetFiltersForClass(context,
-            methodDeclarationSyntax.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault(),
+            methodDeclarationSyntax.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault(),
             cancellationToken));
 
         return filterList;
@@ -1131,7 +1141,7 @@ public abstract class BaseRequestModelGenerator {
 
     protected virtual IEnumerable<AttributeModel> GetFiltersForClass(
         GeneratorSyntaxContext context,
-        ClassDeclarationSyntax? parent,
+        TypeDeclarationSyntax? parent,
         CancellationToken cancellationToken) {
         if (parent == null) {
             return Enumerable.Empty<AttributeModel>();

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/InterfaceRouteDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/InterfaceRouteDiagnostics.cs
@@ -1,0 +1,147 @@
+using System.Linq;
+using System.Threading;
+using Hardened.SourceGenerator.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Hardened.SourceGenerator.Web.Routing;
+
+/// <summary>
+/// A verb attribute on an interface member, which declares a route and compiles to nothing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generator routes a method it can call, and an interface member has no implementation to
+/// call. Until the selector was taught that, such a declaration threw out of the syntax transform
+/// and cost the assembly every route it had. Skipping it silently would trade that for the other
+/// failure the routing diagnostics exist to prevent: a declaration that reads in review as a route
+/// the application serves, and answers 404.
+/// </para>
+/// <para>
+/// A warning rather than an error, like the rest of the HRDR warnings, and
+/// <c>TreatWarningsAsErrors</c> is on for continuous-integration builds - so it cannot merge while
+/// still not blocking a refactor in progress.
+/// </para>
+/// </remarks>
+public static class InterfaceRouteDiagnostics {
+    public const string DiagnosticId = "HRDR013";
+
+    /// <summary>
+    /// The namespace Hardened's own verb attributes are declared in.
+    /// </summary>
+    /// <remarks>
+    /// Checked, because the names are not Hardened's alone. Refit declares <c>[Get]</c>,
+    /// <c>[Post]</c> and the rest on exactly the shape this looks at - an interface method - and a
+    /// Refit client interface sharing a project with a Hardened test host is correct code that
+    /// must not warn. The selector matches the bare name and cannot tell them apart; this resolves
+    /// the attribute and can.
+    /// </remarks>
+    private const string VerbNamespace = "Hardened.Web.Runtime.Attributes";
+
+    private static readonly string[] VerbAttributeNames = {
+        "GetAttribute", "PostAttribute", "PutAttribute", "PatchAttribute", "DeleteAttribute"
+    };
+
+    /// <summary>
+    /// Built per call rather than held in a static field, for the RS2008 reason every other
+    /// descriptor in this assembly is - see <c>UnresolvedHandler</c>.
+    /// </summary>
+    private static DiagnosticDescriptor Descriptor() => new(
+        id: DiagnosticId,
+        title: "Route declared on an interface",
+        messageFormat:
+        "'{0}' carries [{1}] on an interface member, which has no implementation to call, so no " +
+        "route is compiled for it. Move the attribute to the class that implements it.",
+        category: "Hardened.Generation",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Syntax only, and deliberately wider than what is reported: every interface method carrying
+    /// an attribute whose bare name is a verb. <see cref="Transform"/> resolves it and drops the
+    /// ones that belong to another library.
+    /// </summary>
+    public static bool Predicate(SyntaxNode node, CancellationToken cancellationToken) {
+        if (node is not MethodDeclarationSyntax method ||
+            method.Parent is not InterfaceDeclarationSyntax) {
+            return false;
+        }
+
+        foreach (var list in method.AttributeLists) {
+            foreach (var attribute in list.Attributes) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var name = attribute.Name.ToString();
+                var simple = name.Substring(name.LastIndexOf('.') + 1);
+
+                if (!simple.EndsWith("Attribute")) {
+                    simple += "Attribute";
+                }
+
+                if (Array.IndexOf(VerbAttributeNames, simple) >= 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The declaration, or null where the attribute turned out to be another library's.
+    /// </summary>
+    public static InterfaceRouteModel? Transform(
+        GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+        var method = (MethodDeclarationSyntax)context.Node;
+        var declaringInterface = (InterfaceDeclarationSyntax)method.Parent!;
+
+        foreach (var list in method.AttributeLists) {
+            foreach (var attribute in list.Attributes) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var type = context.SemanticModel.GetTypeInfo(attribute, cancellationToken).Type;
+
+                if (type == null ||
+                    Array.IndexOf(VerbAttributeNames, type.Name) < 0 ||
+                    type.ContainingNamespace?.ToDisplayString() != VerbNamespace) {
+                    continue;
+                }
+
+                return new InterfaceRouteModel(
+                    declaringInterface.Identifier.Text,
+                    method.Identifier.Text,
+                    type.Name,
+                    // The identifier rather than the whole declaration, so the squiggle lands on
+                    // the method name instead of underlining the signature.
+                    LocationInfo.From(method.Identifier));
+            }
+        }
+
+        return null;
+    }
+
+    public static void Report(SourceProductionContext context, InterfaceRouteModel? model) {
+        if (model == null) {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Descriptor(),
+            model.DeclaredAt?.ToLocation() ?? Location.None,
+            model.Handler,
+            model.AttributeName));
+    }
+}
+
+/// <summary>
+/// What the diagnostic needs and nothing else, carrying a location because nothing downstream of
+/// it emits source - the trade <see cref="LocationInfo"/> describes.
+/// </summary>
+public record InterfaceRouteModel(
+    string InterfaceName,
+    string MethodName,
+    string AttributeName,
+    LocationInfo? DeclaredAt) {
+
+    public string Handler => InterfaceName + "." + MethodName;
+}

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebIncrementalGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebIncrementalGenerator.cs
@@ -73,6 +73,17 @@ public static class WebIncrementalGenerator {
                 (context, pair) =>
                     RequireAuthorizationDiagnostics.Report(context, pair.Left, pair.Right)));
 
+        // A verb attribute on an interface member, which the selector above skips. Its own
+        // provider, reported per declaration, for the reason the authorization diagnostic gives:
+        // it carries a location, and nothing downstream of it emits source.
+        var interfaceRoutes = initializationContext.SyntaxProvider.CreateSyntaxProvider(
+            InterfaceRouteDiagnostics.Predicate,
+            InterfaceRouteDiagnostics.Transform);
+
+        initializationContext.RegisterSourceOutput(
+            interfaceRoutes,
+            SourceGeneratorWrapper.Wrap<InterfaceRouteModel?>(InterfaceRouteDiagnostics.Report));
+
         var invokeGenerator = new WebExecutionHandlerCodeGenerator();
 
         // The handler stage reports a route token nothing declares, so it has to know what the

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/WebRequestHandlerModelGenerator.cs
@@ -22,7 +22,7 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
         GeneratorSyntaxContext context, CancellationToken cancellationToken) {
         var model = base.GenerateRequestModel(context, cancellationToken);
 
-        var controller = context.Node.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+        var controller = context.Node.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
 
         model.Tag = GetTagFromController(context, controller, cancellationToken);
         model.OperationId = GetOperationId(context, context.Node as MethodDeclarationSyntax);
@@ -97,7 +97,7 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
 
     private static string? GetTagFromController(
         GeneratorSyntaxContext context,
-        ClassDeclarationSyntax? classDeclaration,
+        TypeDeclarationSyntax? classDeclaration,
         CancellationToken cancellationToken) {
         if (classDeclaration == null) {
             return null;
@@ -148,7 +148,7 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
             }
         }
 
-        var classDeclarationSyntaxes = generatorSyntaxContext.Node.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+        var classDeclarationSyntaxes = generatorSyntaxContext.Node.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
 
         
         if (classDeclarationSyntaxes != null) {
@@ -171,12 +171,12 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
     protected override ITypeDefinition GetInvokeHandlerType(GeneratorSyntaxContext context,
         MethodDeclarationSyntax methodDeclaration,
         CancellationToken cancellation) {
-        var classDeclarationSyntax =
-            methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>().First();
+        var typeDeclarationSyntax =
+            methodDeclaration.Ancestors().OfType<TypeDeclarationSyntax>().First();
 
-        var namespaceSyntax = classDeclarationSyntax.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().First();
+        var namespaceSyntax = typeDeclarationSyntax.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().First();
 
-        var className = classDeclarationSyntax.Identifier + "_" + methodDeclaration.Identifier.Text;
+        var className = typeDeclarationSyntax.Identifier + "_" + methodDeclaration.Identifier.Text;
 
         if (methodDeclaration.ParameterList.Parameters.Count > 0) {
             var parameterString = "";
@@ -308,10 +308,42 @@ public class WebRequestHandlerModelGenerator : BaseRequestModelGenerator {
         }
     }
 
+    /// <summary>
+    /// Every method carrying a verb attribute, written somewhere a handler can be called from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The container test is not a refinement. A verb attribute on an interface member used to be
+    /// selected, reach <see cref="BaseRequestModelGenerator.GetControllerType"/>, find no class
+    /// above it and throw out of the syntax transform - a <c>CS8785</c>, which costs the whole
+    /// assembly its generated code rather than the one declaration that caused it. That is the
+    /// failure <c>UnresolvedHandler</c> exists to prevent for a parameter that does not resolve,
+    /// and it was reachable again through the declaration site.
+    /// </para>
+    /// <para>
+    /// Syntactic, because a predicate has no semantic model. It also cannot tell Hardened's
+    /// <c>[Get]</c> from another library's of the same name, which is why it only decides whether
+    /// to build a handler. Whether the declaration deserves a diagnostic is
+    /// <see cref="Routing.InterfaceRouteDiagnostics"/>, which resolves the attribute first.
+    /// </para>
+    /// </remarks>
     public bool SelectWebRequestMethods(SyntaxNode arg1, CancellationToken arg2) {
         return arg1 is MethodDeclarationSyntax methodDeclarationSyntax &&
+               IsCallable(methodDeclarationSyntax) &&
                GetWebAttribute(methodDeclarationSyntax, arg2) != null;
     }
+
+    /// <summary>
+    /// Whether the method has an implementation the pipeline could invoke.
+    /// </summary>
+    /// <remarks>
+    /// An interface member has none, and neither does a method with no type declaration above it
+    /// at all. A record is callable and is selected, which is the other half of what widening
+    /// <see cref="BaseRequestModelGenerator.GetControllerType"/> to a type declaration bought.
+    /// </remarks>
+    private static bool IsCallable(MethodDeclarationSyntax method) =>
+        method.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault()
+            is not (null or InterfaceDeclarationSyntax);
 
     private static AttributeSyntax? GetWebAttribute(MethodDeclarationSyntax node, CancellationToken cancellationToken) {
         var attributeNames =

--- a/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/InterfaceRouteDiagnosticsTests.cs
+++ b/src/SourceGenerators/Hardened.Web.SourceGenerator.Tests/Routing/InterfaceRouteDiagnosticsTests.cs
@@ -1,0 +1,149 @@
+using Hardened.Requests.Abstract.Attributes;
+using Hardened.SourceGeneration.Testing;
+using Hardened.Web.Runtime.Attributes;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Hardened.Web.SourceGenerator.Tests.Routing;
+
+/// <summary>
+/// A verb attribute written somewhere a handler cannot be called from.
+///
+/// <para>
+/// <c>[Get]</c> on an interface member threw out of the syntax transform, which Roslyn reports as
+/// <c>CS8785</c> and which costs the whole assembly its generated code - every route in the
+/// project, not just the declaration that caused it. The same crash reached a record, because the
+/// controller was read as a <c>ClassDeclarationSyntax</c> and a record is not one.
+/// </para>
+/// </summary>
+public class InterfaceRouteDiagnosticsTests {
+    private const string DiagnosticId = "HRDR013";
+
+    private static readonly Type[] Anchors = [
+        typeof(GetAttribute),
+        typeof(FromBodyAttribute)
+    ];
+
+    private static GeneratorResult Generate(
+        string declarations, string? second = null) {
+        var sources = new Dictionary<string, string> {
+            ["Test.cs"] = $$"""
+                    using Hardened.Shared.Runtime.Attributes;
+                    using Hardened.Web.Runtime.Attributes;
+                    using System.Threading.Tasks;
+
+                    namespace TestApp;
+
+                    [HardenedModule]
+                    public partial class TestApplication { }
+
+                    {{declarations}}
+
+                    public class PingController {
+                        [Get("/ping")]
+                        public string Ping() => "ok";
+                    }
+                    """
+        };
+
+        if (second != null) {
+            sources["Second.cs"] = second;
+        }
+
+        return GeneratorTestHarness.Run(
+            sources,
+            new IIncrementalGenerator[] { new WebLibrarySourceGenerator() },
+            Anchors);
+    }
+
+    /// <summary>
+    /// The whole point of the fix. One declaration in the wrong place used to cost every route in
+    /// the assembly, so the healthy controller beside it is what this asserts on.
+    /// </summary>
+    [Fact]
+    public void AnInterfaceDeclarationCostsNoOtherRoute() {
+        var result = Generate(
+            """
+            public interface IPetApi {
+                [Get("/pets/{id}")]
+                Task<string> GetPet(int id);
+            }
+            """);
+
+        Assert.Empty(result.GeneratorExceptions);
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "CS8785");
+        Assert.Contains("\"/ping\"", result.SourceContaining("Ping"));
+    }
+
+    /// <summary>
+    /// Skipped, but not silently. A verb attribute is a route declaration, and one that compiles to
+    /// nothing reads in review as a route the application serves.
+    /// </summary>
+    [Fact]
+    public void AnInterfaceDeclarationIsReported() {
+        var result = Generate(
+            """
+            public interface IPetApi {
+                [Get("/pets/{id}")]
+                Task<string> GetPet(int id);
+            }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == DiagnosticId);
+
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("IPetApi.GetPet", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// Another library's verb attribute of the same name is not a Hardened route declaration, and
+    /// reporting it would warn on every Refit client interface that shares a project with a test
+    /// host. The selector cannot tell the two apart - it matches the bare name - so the diagnostic
+    /// resolves the attribute before it speaks.
+    /// </summary>
+    [Fact]
+    public void AVerbAttributeFromAnotherLibraryIsNotReported() {
+        // A namespace of its own, declaring a GetAttribute of its own. A nearer namespace wins
+        // over a using, so the [Get] below is that one and never Hardened's - which is exactly how
+        // a Refit interface reads in a project that also has Hardened's attributes in scope.
+        var result = Generate("", """
+            using Hardened.Web.Runtime.Attributes;
+            using System.Threading.Tasks;
+
+            namespace Contracts;
+
+            public class GetAttribute(string path) : System.Attribute {
+                public string Path { get; } = path;
+            }
+
+            public interface IPetApi {
+                [Get("/pets/{id}")]
+                Task<string> GetPet(int id);
+            }
+            """);
+
+        Assert.Empty(result.GeneratorExceptions);
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == DiagnosticId);
+        Assert.Contains("\"/ping\"", result.SourceContaining("Ping"));
+    }
+
+    /// <summary>
+    /// A record can be constructed and called, so its handlers are routes like any other. It
+    /// crashed for the same reason the interface did and is fixed by the same widening.
+    /// </summary>
+    [Fact]
+    public void ARecordControllerRoutes() {
+        var result = Generate(
+            """
+            public record PetController {
+                [Get("/pets")]
+                public string List() => "";
+            }
+            """);
+
+        result.AssertNoErrors();
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == DiagnosticId);
+        Assert.Contains("\"/pets\"", result.SourceContaining("List"));
+    }
+}


### PR DESCRIPTION
`[Get]` on an interface member took down the whole assembly's generated code.

The method was selected as a handler, reached `GetControllerType`, found no class above it and threw out of the syntax transform. Roslyn reports that as `CS8785`. Every route in the project disappears over one declaration, including controllers that had nothing to do with it. It is the same blast radius `UnresolvedHandler` was written to close for a parameter that does not resolve, reachable again through the declaration site.

A record controller crashed identically, because the controller was read as a `ClassDeclarationSyntax` and a record is not one.

## What changed

The container lookups widen to `TypeDeclarationSyntax`, which fixes the record half and makes a record route like any other controller.

The interface half is skipped rather than routed, because an interface member has no implementation to call. Skipping it silently would trade the crash for the failure the routing diagnostics exist to prevent, so it reports `HRDR013`.

`HRDR013` resolves the attribute before it speaks. Refit declares `[Get]`, `[Post]` and the rest on exactly this shape, and a Refit client interface sharing a project with a Hardened test host is correct code that must not warn. The selector matches the bare name and cannot tell the two apart; the diagnostic reads the symbol and can.

## Verified

Four tests in `InterfaceRouteDiagnosticsTests`. Three of them fail on `main` with `InvalidOperationException: Sequence contains no elements`.

- an interface declaration costs no other route in the assembly
- an interface declaration reports `HRDR013` as a warning naming the member
- another library's verb attribute of the same name reports nothing
- a record controller routes

Full suite in Release with `-p:ContinuousIntegrationBuild=true`: 8886 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)