### PR TITLE
Add a docs style guide and architecture, and rewrite the validation page against them

### DIFF
--- a/docs/design/docs-architecture.md
+++ b/docs/design/docs-architecture.md
@@ -1,0 +1,116 @@
+# Docs architecture
+
+What the site covers, tab by tab, and what each page owns. A page states its own subject and links
+rather than restating a neighbour's. Written alongside [the style guide](./writing-style.md), which
+governs how a page reads.
+
+68 pages today: 37 under `guide/`, 4 under `reference/`, 7 AWS, 10 Google Cloud, 10 Azure.
+
+## The five tabs
+
+| Tab | Answers | Reader |
+|---|---|---|
+| Guide | How do I build this with Hardened | Has a project, wants a feature |
+| AWS, Google Cloud, Azure | What changes on this cloud | Has a project, picked a cloud |
+| Reference | What is the exact name, code, or package | Knows what they want, needs the spelling |
+
+A cloud tab holds only what differs on that cloud. The handler, the pipeline and the contract are
+the same everywhere and belong in the guide. A cloud page that explains routing again is wrong.
+
+The Reference tab is generated or tabular: every attribute, every diagnostic, every package. No
+prose beyond a line per entry.
+
+## Guide sections
+
+Nine sections, in the order a reader meets them. The section is the unit a reader scans, so a page
+belongs to the section matching the question it answers, not the subsystem that implements it.
+
+### Start here
+
+`getting-started`, `project-templates`, `modules`, `services`.
+
+Everything needed before a first successful build. A reader who opens only this section has a running
+application with tests. `getting-started` owns the assembled-by-hand path and nothing else;
+`project-templates` owns the template options.
+
+### Application
+
+`configuration`, `environments`.
+
+What the application is, outside any one request.
+
+### Handlers
+
+`routing`, `triggers`, `parameter-binding`, `responses`, `validation`, `execution-pipeline`.
+
+One request, from the route to the response. Each page owns one stage:
+
+| Page | Owns |
+|---|---|
+| `routing` | The verb attributes, path tokens, route constraints, `[BasePath]`, how a route is matched |
+| `triggers` | A handler reached by something other than HTTP: queue, topic, timer, change, stream, blob |
+| `parameter-binding` | Where a parameter's value comes from, and what a binding failure answers |
+| `responses` | Declaring statuses: `Response<T1..Tn>`, `[Throws<T>]`, unions, the built-in response records |
+| `validation` | Constraint attributes, required members, the 400 envelope, replacing it |
+| `execution-pipeline` | Filters, ordering, `chain.Next()`, the shipped positions |
+
+### Contracts
+
+`openapi`, `smithy`, `openapi-document`, `clients`.
+
+`openapi` and `smithy` own generating an application from a contract. `openapi-document` owns the
+document Hardened publishes. `clients` owns generating a client from it. The three are frequently
+confused and each page says in its first paragraph which direction it describes.
+
+### Security
+
+`authentication`, `authorization`.
+
+### Serialization
+
+`content-negotiation`, `json`, `message-pack`, `streaming`, `templates`.
+
+`content-negotiation` owns how a media type is chosen and `[Produces]`. Every other page in the
+section owns one representation and links back for the negotiation rules rather than restating them.
+
+### Performance and limits
+
+`response-caching`, `conditional-requests`, `compression`, `rate-limiting`, `request-timeouts`.
+
+Each is a filter with an attribute. Same page shape across all five: what to declare, where it sits
+in the pipeline, what it answers when it refuses.
+
+### Testing
+
+Nine pages: `testing`, `testing-web`, `testing-mocks`, `testing-credentials`, `testing-clients`,
+`testing-responses`, `testing-hosts`, `testing-steps`, `testing-attributes`.
+
+`testing` owns the first test and the three assembly attributes. The rest each own one tool, and none
+of them reintroduces the wiring.
+
+## Page budget
+
+A guide page states one subsystem. Over roughly 250 lines it is either two pages or padded, and
+padded is the usual answer. The longest pages today are `smithy` at 462, `openapi` at 391 and
+`responses` at 346.
+
+Counted as prose words rather than lines, because tables and code blocks are the parts that earn
+their length. `validation` carried 1328 prose words for 10 sections.
+
+## Rewrite order
+
+Page by page, worst first, each one written from a fact list extracted from the implementation, the
+test assertions and the diagnostic messages. Not edited from the existing page: editing inside the
+old paragraphs preserves the padding.
+
+| Order | Page | Why first |
+|---|---|---|
+| 1 | `validation` | Already diagnosed. The required-member section is the worst case in the site |
+| 2 | `message-pack` | Newest, longest rationale sections, whole paragraphs defending decisions |
+| 3 | `content-negotiation` | Dense with real behaviour, buried under posed questions |
+| 4 | `smithy`, `openapi` | Longest pages, and the two most likely to overlap each other |
+| 5 | everything else | |
+
+Facts do not come from XML doc comments in the source. Those carry the same voice the pages do:
+`RequiredMemberPresenceTests` has "presence is the reader's question, content is the validator's" in a
+`<summary>`, and `SerializationLocatorService` explains negotiation the same way.

--- a/docs/design/writing-style.md
+++ b/docs/design/writing-style.md
@@ -1,0 +1,98 @@
+# Docs style guide
+
+The site is reference documentation for a working .NET developer. It describes what Hardened does.
+It does not teach C#, teach HTTP, or argue that a design is correct.
+
+Two roles follow this file. A writer produces a page against it. An editor reviews the page against
+it and reports violations by rule number, with the sentence quoted. Neither role rewrites the other's
+structure: the writer owns the page, the editor owns the list of rules broken.
+
+## 1. What earns prose
+
+A fact earns a sentence if a competent C# developer could not predict it. Everything else is a table
+row, a code comment, or nothing.
+
+These earn prose:
+
+- A declaration produces something at build time: a route, a validator, a binder, a formatter.
+- One declaration is read by two generators, or two declarations are read by one.
+- A diagnostic fires. Name the code and what to change. The message itself lives in
+  `reference/diagnostics`.
+- A declaration does nothing without a second one.
+- A default differs from the platform default, or from what another framework does.
+- A service is replaceable. Name the interface, the stock implementation, and the registration.
+
+These do not:
+
+- What a record, a constructor, a non-nullable reference type, an initializer or a property is.
+- What the C# compiler, `System.Text.Json` or ASP.NET Core does on its own. State it only where
+  Hardened changes it, and then state the difference, not the background.
+- Behaviour that matches what every other server does. A path that does not match a route is a 404
+  everywhere. It needs no paragraph here.
+- What a feature does not do, what was removed, or what was considered and rejected.
+
+## 2. Rules
+
+An editor cites these by number.
+
+**2.1 No posed question and answer.** Do not set up a question in order to answer it. Do not split a
+behaviour into a rhetorical pair. "Presence is the reader's question; content is the validator's" is
+a violation. Write what is checked, and where.
+
+**2.2 No defending a decision.** The page states behaviour. It does not argue that the behaviour is
+right. Cut "deliberately", "that is the design rather than a gap", "and will not", "not for want of",
+"which is exactly the case it should decide". A constraint a reader must work within is a fact: "an
+index is never assigned; `HOAT033` names the member and the next free index". Why it is never
+assigned belongs in `design/`.
+
+**2.3 No epigrams or balanced clauses.** No aphorism, no antithesis, no sentence built for its shape.
+
+**2.4 Name the mechanism.** Use the type, attribute, property, diagnostic code or package name. A
+mechanism does not ask, know, own, decide for itself, or have a question.
+`System.Text.Json`'s deserializer is not "the reader".
+
+**2.5 No abstract noun as a sentence subject.** Not "Absence is the one thing a validator cannot
+see". Write "a validator never sees an omitted member", or delete it.
+
+**2.6 No sentence that restates the code below it.** One line introduces a block by naming what to
+look at. The block shows the rest.
+
+**2.7 No framing, motivating or announcing.** Cut "Note that", "It is worth saying", "The trade is
+worth knowing", "This matters because", "Deserialization is simpler".
+
+**2.8 No selling.** No "worth having", "reads better", "it is yours to edit", "which is what a client
+should be anyway". The reader decides what is worth having.
+
+**2.9 No em-dashes.** An aside is a sentence, or it is cut.
+
+**2.10 Headings name their subject.** A noun phrase a reader would scan for: "Request bodies",
+"Required members", "Registering a serializer". Not "Presence, and who checks it", "The request side
+is not negotiated", "Rules the vocabulary cannot express".
+
+**2.11 Plain words, present tense, active voice.** A test fails. It does not explode.
+
+**2.12 One idea per sentence, result first.** The detail goes after the result, in its own sentence.
+
+## 3. Page shape
+
+1. An H1 naming the feature.
+2. One paragraph: what it does, and what the reader writes to get it. No preamble.
+3. A code block showing the smallest complete example, and the response it produces where there is
+   one.
+4. Sections in the order a reader meets them: declaring it, what the build generates, what the
+   runtime does, extending it, limits.
+5. A `## Next` list of two to four links, each with four to eight words on what is there.
+
+A table is the default for anything enumerable: options and their values, attributes and what they
+check, facets and what they generate, inputs and their status codes. Prose around a table repeats the
+table.
+
+## 4. Code blocks
+
+Complete enough to compile, with the `using` lines a reader would have to grep for. A comment in a
+block states the result, not the intent: `// {} is a 400`, not `// this is required`.
+
+## 5. What the editor returns
+
+A list. Each entry is the rule number, the sentence quoted, and what it should be instead or that it
+should be cut. No rewritten page, no praise, and no findings outside these rules.

--- a/docs/design/writing-style.md
+++ b/docs/design/writing-style.md
@@ -73,7 +73,34 @@ is not negotiated", "Rules the vocabulary cannot express".
 
 **2.12 One idea per sentence, result first.** The detail goes after the result, in its own sentence.
 
-## 3. Page shape
+**2.13 No unexplained term of art.** Use the names the reader has in front of them. A contract
+declares `minLength`, `maximum` and `pattern`; calling those "facets" introduces JSON Schema
+vocabulary the page never defines.
+
+## 3. Paragraphs
+
+The rules above are about sentences. A page can pass every one of them and still read as a list of
+facts in the order someone thought of them. These are about what a paragraph is for.
+
+**3.1 A paragraph has a topic and develops it.** The first sentence says what the paragraph is about
+and the rest adds to that. A paragraph that states one fact and stops is a table row, or it belongs
+in the paragraph beside it.
+
+**3.2 Facts that share a topic go in one paragraph.** Three ways to declare a member present is one
+paragraph, not three. Two sentences about what a response contains is one paragraph, wherever the
+two mechanisms live.
+
+**3.3 No run of single-sentence paragraphs.** Two in a row is the limit, and only where each states a
+separate rule. A section of five is the symptom this rule exists for.
+
+**3.4 A fact belongs to the section whose subject it serves.** What a response contains goes in the
+section about the response, not in the section where the mechanism was introduced. A contract's
+behaviour goes in the contract section.
+
+**3.5 A section is a lead paragraph, its table or code, and at most one paragraph after it.** Six
+paragraphs in a section means the facts were never grouped.
+
+## 4. Page shape
 
 1. An H1 naming the feature.
 2. One paragraph: what it does, and what the reader writes to get it. No preamble.
@@ -87,7 +114,7 @@ A table is the default for anything enumerable: options and their values, attrib
 check, facets and what they generate, inputs and their status codes. Prose around a table repeats the
 table.
 
-## 4. Code blocks
+## 5. Code blocks
 
 Complete enough to compile. The first block on a page carries its `using` lines, and a later block
 adds one only for a namespace the page has not shown yet. Repeating the same `using` in every block
@@ -95,7 +122,10 @@ is the padding this guide exists to remove.
 
 A comment in a block states the result, not the intent: `// {} is a 400`, not `// this is required`.
 
-## 5. What the editor returns
+## 6. What the editor returns
 
 A list. Each entry is the rule number, the sentence quoted, and what it should be instead or that it
 should be cut. No rewritten page, no praise, and no findings outside these rules.
+
+Section 3 is reported per section rather than per sentence: name the section, the number of
+paragraphs in it, and which ones should merge or move.

--- a/docs/design/writing-style.md
+++ b/docs/design/writing-style.md
@@ -89,8 +89,11 @@ table.
 
 ## 4. Code blocks
 
-Complete enough to compile, with the `using` lines a reader would have to grep for. A comment in a
-block states the result, not the intent: `// {} is a 400`, not `// this is required`.
+Complete enough to compile. The first block on a page carries its `using` lines, and a later block
+adds one only for a namespace the page has not shown yet. Repeating the same `using` in every block
+is the padding this guide exists to remove.
+
+A comment in a block states the result, not the intent: `// {} is a 400`, not `// this is required`.
 
 ## 5. What the editor returns
 

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -30,7 +30,7 @@ without referencing it compiles, enforces nothing, and reports `HRDV006`.
 ## Constraint attributes
 
 The attributes are in `ValidationModules.Constraints`. Bounded attributes take named `Min` and `Max`
-arguments.
+arguments, and `[Required]` on a non-nullable value type reports `HRDV003`.
 
 | Attribute | Checks |
 |---|---|
@@ -42,22 +42,18 @@ arguments.
 | `[MultipleOf]` | divisibility |
 | `[AllowedValues]` | membership of a set |
 
-`[Required]` on a non-nullable value type reports `HRDV003`.
-
 ## Required members
 
-`System.Text.Json` ignores nullable reference annotations. `RequiredMemberPresence` marks a
-non-nullable reference member required on the deserializer's metadata instead, so `{}` against
-`record NewTodo(string Title)` is refused before any constraint runs. One response names every
-missing member.
+`System.Text.Json` ignores nullable reference annotations, so Hardened marks the members itself.
+`RequiredMemberPresence` sets `IsRequired` on the deserializer's metadata for every non-nullable
+reference member a constructor takes, which refuses `{}` against `record NewTodo(string Title)`
+before any constraint runs. One response names every member that was missing.
 
 ```json
 { "errors": [
   { "field": "body.accountId", "code": "required", "message": "accountId is required." },
   { "field": "body.weightKg",  "code": "required", "message": "weightKg is required." } ] }
 ```
-
-A member the model already declares `required` or `[JsonRequired]` is left as it is.
 
 | Member | Published as | Presence checked |
 |---|---|---|
@@ -67,17 +63,10 @@ A member the model already declares `required` or `[JsonRequired]` is left as it
 | any value type | required | no |
 | `[ResponseOnly]` | `readOnly` | no |
 
-`[Required]`, `required` or `[JsonRequired]` adds a presence check to any row marked no.
-
-When a body omits a required member and also breaks a constraint, the response names the omission
-alone and the constraint comes back on the next request.
-
-An AOT-published application declares presence with `required` or `[JsonRequired]`. Under a
-source-generated `JsonSerializerContext` the deserializer reads `IsRequired` from that generator
-rather than from reflection.
-
-A contract-first model does not need `RequiredMemberPresence`. A contract's `required` compiles to
-`[Required]` whatever the member's type.
+`[Required]`, `required` or `[JsonRequired]` adds a presence check to any row marked no, and a
+member that already declares one is left as it is. An AOT-published application has to use them:
+under a source-generated `JsonSerializerContext` the deserializer reads `IsRequired` from that
+generator rather than from reflection.
 
 ## Constraints on handler parameters
 
@@ -97,9 +86,8 @@ public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) 
 public string Region([FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
 ```
 
-The response names the value the caller sent, `precision` or `X-Region`.
-
-`When` or `Unless` names another member of the model the constraint sits on. Either one on a handler
+The response names the value the caller sent, `precision` or `X-Region`. `When` and `Unless` are the
+exception: each names another member of the model its constraint sits on, so either one on a handler
 parameter reports `HRDV005`.
 
 ## Nested models
@@ -119,8 +107,10 @@ sealed or declare a polymorphism mode, or ValidationModules reports `VM1503`.
 
 ## Constraints from a contract
 
-A contract declares constraints as OpenAPI facets on schema properties and parameters. A Smithy
-model uses `@length`, `@range` and `@pattern`.
+A contract declares constraints with the JSON Schema keywords on a schema property or a parameter,
+and a Smithy model with `@length`, `@range` and `@pattern`. A contract's `required` compiles to
+`[Required]` whatever the member's type, so a contract-first model does not need
+`RequiredMemberPresence`.
 
 ```yaml
 components:
@@ -136,9 +126,10 @@ components:
 ```
 
 The build task writes the matching attribute onto the generated model, and the validation generator
-reads it as it reads a hand-written one.
+reads it as it reads a hand-written one. A bound left out stays out, so `minimum: 1` with no
+`maximum` generates `[Range(Min = 1)]` and the message reads "at least 1".
 
-| Facet | Attribute |
+| Keyword | Attribute |
 |---|---|
 | `minLength` / `maxLength` | `[StringLength]` |
 | `minimum` / `maximum` | `[Range]` |
@@ -147,8 +138,6 @@ reads it as it reads a hand-written one.
 | `enum` | `[AllowedValues]`, or the generated enum type |
 | `minItems` / `maxItems` | `[ItemCount]` |
 | `required` | `[Required]` |
-
-`minimum: 1` with no `maximum` generates `[Range(Min = 1)]`, and the message reads "at least 1".
 
 ## The 400 response
 
@@ -168,17 +157,18 @@ An unreadable body is reported under `body`:
 
 `body` is the handler's own parameter identifier, so a handler taking `MemberRequest request`
 reports `request`. On the third row the path names where parsing stopped rather than the fault, so
-`{"accountId":` is reported as `body.accountId`.
+`{"accountId":` is reported as `body.accountId`. A body that omits a required member and also breaks
+a constraint is answered about the omission alone, and the constraint comes back on the next
+request.
 
 ## What the document publishes
 
-The document republishes every constraint as the facet it came from. An operation with a generated
-validator also publishes the 400, with its schema under
-`components.schemas.RequestValidationError`. See
+The document republishes every constraint as the keyword it came from, and an operation with a
+generated validator publishes the 400 alongside them, with its schema under
+`components.schemas.RequestValidationError`. A constraint on a path token is the exception. It is a
+[route constraint](/guide/routing#constraining-what-a-token-matches) tested before any filter runs,
+so the router answers it and the operation publishes no 400. See
 [The OpenAPI document](/guide/openapi-document).
-
-A constraint on a path token is a [route constraint](/guide/routing#constraining-what-a-token-matches),
-tested before any filter runs.
 
 | Declaration | Refused by | Published |
 |---|---|---|
@@ -192,7 +182,7 @@ tested before any filter runs.
 ## Custom rules
 
 Write a rule the attributes cannot express in the handler. Throwing `ValidationException` produces
-the same response a constraint does:
+the same response a constraint does, from the immutable `ValidationResult` its factory builds:
 
 ```csharp
 using Hardened.Requests.Runtime.Validation;
@@ -208,8 +198,6 @@ public async Task<Pet> CreatePet(CreatePetRequest body) {
     ...
 }
 ```
-
-`ValidationResult` is immutable.
 
 ## Refusing with another status
 
@@ -229,7 +217,7 @@ public async Task<Pet> CreatePet(CreatePetRequest body) {
 }
 ```
 
-Without `[Throws<T>]` the throw answers 409. The document then describes only the 200. See
+Without `[Throws<T>]` the throw still answers 409, and the document then describes only the 200. See
 [Declaring what a handler throws](/guide/responses#declaring-what-a-handler-throws).
 
 ## Replacing the status and body

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -24,13 +24,13 @@ public record CreatePetRequest(
 }
 ```
 
-The validator is written by `Hardened.Validation.SourceGenerator`. A project that declares
-constraints without referencing it compiles, enforces nothing, and reports `HRDV006`.
+`Hardened.Validation.SourceGenerator` writes the validator. A project that declares constraints
+without referencing it compiles, enforces nothing, and reports `HRDV006`.
 
 ## Constraint attributes
 
 The attributes are in `ValidationModules.Constraints`. Bounded attributes take named `Min` and `Max`
-arguments, so a single bound is one argument.
+arguments.
 
 | Attribute | Checks |
 |---|---|
@@ -42,14 +42,14 @@ arguments, so a single bound is one argument.
 | `[MultipleOf]` | divisibility |
 | `[AllowedValues]` | membership of a set |
 
-`[Required]` on a non-nullable value type reports `HRDV003`. There is no absent `int`.
+`[Required]` on a non-nullable value type reports `HRDV003`.
 
 ## Required members
 
-`System.Text.Json` does not enforce nullable reference annotations, so `{}` deserializes into
-`record NewTodo(string Title)` with `Title` null. `RequiredMemberPresence` marks those members
-required on the deserializer's metadata instead, which refuses the body before any constraint runs
-and names every missing member in one response.
+`System.Text.Json` ignores nullable reference annotations. `RequiredMemberPresence` marks a
+non-nullable reference member required on the deserializer's metadata instead, so `{}` against
+`record NewTodo(string Title)` is refused before any constraint runs. One response names every
+missing member.
 
 ```json
 { "errors": [
@@ -57,10 +57,7 @@ and names every missing member in one response.
   { "field": "body.weightKg",  "code": "required", "message": "weightKg is required." } ] }
 ```
 
-A member is marked when it matches a constructor parameter by name, that parameter has no default
-value, it is a reference type whose annotation says not-null, and it does not carry
-`[ResponseOnly]`. A member the model already declares `required` or `[JsonRequired]` is left as it
-is.
+A member the model already declares `required` or `[JsonRequired]` is left as it is.
 
 | Member | Published as | Presence checked |
 |---|---|---|
@@ -70,16 +67,16 @@ is.
 | any value type | required | no |
 | `[ResponseOnly]` | `readOnly` | no |
 
-`[Required]`, `required` or `[JsonRequired]` demands one of the unchecked rows.
+`[Required]`, `required` or `[JsonRequired]` adds a presence check to any row marked no.
 
-A body that omits a required member and also breaks a constraint is answered about the omission
-alone. The constraint is reported on the next request.
+When a body omits a required member and also breaks a constraint, the response names the omission
+alone and the constraint comes back on the next request.
 
-Under a source-generated `JsonSerializerContext` the deserializer reads `IsRequired` from that
-generator rather than from reflection, so an AOT-published application declares presence with
-`required` or `[JsonRequired]`.
+An AOT-published application declares presence with `required` or `[JsonRequired]`. Under a
+source-generated `JsonSerializerContext` the deserializer reads `IsRequired` from that generator
+rather than from reflection.
 
-A contract-first model needs none of this. A contract's `required` compiles to `[Required]` whatever
+A contract-first model does not need `RequiredMemberPresence`. A contract's `required` compiles to `[Required]` whatever
 the member's type.
 
 ## Constraints on handler parameters
@@ -88,6 +85,8 @@ The same attributes go on a handler's parameters, for a value bound from the que
 or the path:
 
 ```csharp
+using Hardened.Web.Runtime.Attributes;
+
 [Get("/rates/{count:int}")]
 public int Page([Range(Min = 1, Max = 100)] int count) => count;
 
@@ -98,10 +97,10 @@ public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) 
 public string Region([FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
 ```
 
-A failure is reported under the name the caller sent, `precision` or `X-Region`.
+The response names the value the caller sent, `precision` or `X-Region`.
 
-`When` and `Unless` name another member of the model the constraint sits on. A parameter sits on no
-model, and either reports `HRDV005`.
+`When` or `Unless` names another member of the model the constraint sits on. Either one on a handler
+parameter reports `HRDV005`.
 
 ## Nested models
 
@@ -153,12 +152,11 @@ reads it as it reads a hand-written one.
 
 ## The 400 response
 
-The generated filter answers the envelope above, with an entry per failed field. A value that does
-not parse as its declared type takes the same shape, so `?limit=abc` against an `int` parameter is
-reported under `limit`. A member missing from a nested object is reported under that object:
-`body.lines[0].sku`.
+The generated filter answers the envelope above. A value that does not parse as its declared type
+takes the same shape, so `?limit=abc` against an `int` parameter is reported under `limit`. A nested
+object carries its own path, so a member missing from one is reported as `body.lines[0].sku`.
 
-A body that cannot be read at all is reported against the body itself:
+An unreadable body is reported under `body`:
 
 | Sent | Field | Code |
 |---|---|---|
@@ -173,12 +171,12 @@ A body that cannot be read at all is reported against the body itself:
 
 ## What the document publishes
 
-The document republishes every constraint as the facet it came from, and an operation with a
-generated validator publishes the 400 with its schema under
+The document republishes every constraint as the facet it came from. An operation with a generated
+validator also publishes the 400, with its schema under
 `components.schemas.RequestValidationError`. See [The OpenAPI document](/guide/openapi-document).
 
-A constraint on a path token is a [route constraint](/guide/routing#constraining-what-a-token-matches)
-and is tested before any filter runs, so the operation publishes no 400.
+A constraint on a path token is a [route constraint](/guide/routing#constraining-what-a-token-matches),
+tested before any filter runs.
 
 | Declaration | Refused by | Published |
 |---|---|---|
@@ -191,8 +189,8 @@ and is tested before any filter runs, so the operation publishes no 400.
 
 ## Custom rules
 
-A rule the attributes cannot express is handler code. Throwing `ValidationException` produces the
-same response a constraint does:
+Write a rule the attributes cannot express in the handler. Throwing `ValidationException` produces
+the same response a constraint does:
 
 ```csharp
 using Hardened.Requests.Runtime.Validation;
@@ -209,12 +207,12 @@ public async Task<Pet> CreatePet(CreatePetRequest body) {
 }
 ```
 
-`ValidationResult` is immutable. Build it with `ValidationResult.FromErrors`.
+`ValidationResult` is immutable.
 
 ## Refusing with another status
 
-A well-formed request refused for its own reason usually wants its own status. Throw the response
-for that status and declare it:
+A refusal that is not about a field takes its own status. Throw the response for that status and
+declare it:
 
 ```csharp
 [Post("/pets")]
@@ -229,13 +227,12 @@ public async Task<Pet> CreatePet(CreatePetRequest body) {
 }
 ```
 
-Without `[Throws<T>]` the throw answers 409 and the document describes only the 200, so a generated
-client has no case for it. See
+Without `[Throws<T>]` the throw answers 409. The document then describes only the 200. See
 [Declaring what a handler throws](/guide/responses#declaring-what-a-handler-throws).
 
 ## Replacing the status and body
 
-`ExceptionResponseSerializer` asks `IExceptionToModelConverter` for the status and body of every
+`ExceptionResponseSerializer` calls `IExceptionToModelConverter` for the status and body of every
 failure. The stock converter registers with `RegistrationType.Try`, so an application's own
 registration replaces it.
 
@@ -269,9 +266,12 @@ public class UnprocessableContentConverter : IExceptionToModelConverter {
 ```
 
 Delegating to the stock converter keeps thrown declared statuses, the binding 400 and the 500. Two
-validation exception types reach it: Hardened's `ValidationException`, thrown by the generated
-filters and the binder, and ValidationModules' own, thrown by code that calls a generated validator
-directly.
+validation exception types reach it, and the stock converter maps both.
+
+| Exception | Thrown by |
+|---|---|
+| `Hardened.Requests.Runtime.Validation.ValidationException` | the generated filters and the binder |
+| `ValidationModules.ValidationException` | code that calls a generated validator directly |
 
 ## Next
 

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -1,7 +1,7 @@
 # Validation
 
 Constraint attributes on a model become a generated validator. A request that fails one answers 400
-before the handler runs, with an entry per failed field.
+before the handler runs, in a validation envelope with an entry per failed field.
 
 ```csharp
 using ValidationModules.Constraints;
@@ -30,7 +30,8 @@ without referencing it compiles, enforces nothing, and reports `HRDV006`.
 ## Constraint attributes
 
 The attributes are in `ValidationModules.Constraints`. Bounded attributes take named `Min` and `Max`
-arguments, and `[Required]` on a non-nullable value type reports `HRDV003`.
+arguments, and every constraint takes `When` and `Unless`, each naming another member of the model
+that decides whether the constraint runs.
 
 | Attribute | Checks |
 |---|---|
@@ -45,15 +46,9 @@ arguments, and `[Required]` on a non-nullable value type reports `HRDV003`.
 ## Required members
 
 `System.Text.Json` ignores nullable reference annotations, so Hardened marks the members itself.
-`RequiredMemberPresence` sets `IsRequired` on the deserializer's metadata for every non-nullable
-reference member a constructor takes, which refuses `{}` against `record NewTodo(string Title)`
-before any constraint runs. One response names every member that was missing.
-
-```json
-{ "errors": [
-  { "field": "body.accountId", "code": "required", "message": "accountId is required." },
-  { "field": "body.weightKg",  "code": "required", "message": "weightKg is required." } ] }
-```
+`{}` against `record NewTodo(string Title)` is refused before any constraint runs, and one response
+names every member that was missing. `RequiredMemberPresence` sets `IsRequired` on the
+deserializer's metadata for every non-nullable reference member a constructor takes.
 
 | Member | Published as | Presence checked |
 |---|---|---|
@@ -61,12 +56,13 @@ before any constraint runs. One response names every member that was missing.
 | constructor parameter with a default value | optional | no |
 | property that is not a constructor parameter | required, unless it has an initializer | no |
 | any value type | required | no |
-| `[ResponseOnly]` | `readOnly` | no |
+| `[ResponseOnly]`, a member the server owns | `readOnly` | no |
 
 `[Required]`, `required` or `[JsonRequired]` adds a presence check to any row marked no, and a
-member that already declares one is left as it is. An AOT-published application has to use them:
-under a source-generated `JsonSerializerContext` the deserializer reads `IsRequired` from that
-generator rather than from reflection.
+member that already declares one is left as it is. `[Required]` on a value type reports `HRDV003`
+instead. An AOT-published application has to use one of the three: under a source-generated
+`JsonSerializerContext` the deserializer reads `IsRequired` from that generator rather than from
+reflection.
 
 ## Constraints on handler parameters
 
@@ -86,9 +82,7 @@ public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) 
 public string Region([FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
 ```
 
-The response names the value the caller sent, `precision` or `X-Region`. `When` and `Unless` are the
-exception: each names another member of the model its constraint sits on, so either one on a handler
-parameter reports `HRDV005`.
+`When` or `Unless` on a handler parameter reports `HRDV005`.
 
 ## Nested models
 
@@ -103,7 +97,8 @@ public record NewJob(
 ```
 
 Without it the nested constraints compile, never run, and report `HRDV004`. The nested type must be
-sealed or declare a polymorphism mode, or ValidationModules reports `VM1503`.
+sealed, or `[ValidateNested]` must name a `Polymorphism` mode, or ValidationModules reports
+`VM1503`.
 
 ## Constraints from a contract
 
@@ -125,9 +120,9 @@ components:
         nicknames: { type: array, items: { type: string }, maxItems: 5 }
 ```
 
-The build task writes the matching attribute onto the generated model, and the validation generator
-reads it as it reads a hand-written one. A bound left out stays out, so `minimum: 1` with no
-`maximum` generates `[Range(Min = 1)]` and the message reads "at least 1".
+`Hardened.OpenApi.SourceGenerator` writes the matching attribute onto the generated model, and the
+validation generator reads it as it reads a hand-written one. `minimum: 1` with no `maximum`
+generates `[Range(Min = 1)]`, and the message reads "at least 1".
 
 | Keyword | Attribute |
 |---|---|
@@ -141,10 +136,11 @@ reads it as it reads a hand-written one. A bound left out stays out, so `minimum
 
 ## The 400 response
 
-The generated filter answers the envelope above. A value that does not parse as its declared type
-takes the same shape, so `?limit=abc` against an `int` parameter is reported under `limit`. A
-nested object carries its own path, so a member missing from one is reported as
-`body.lines[0].sku`.
+The generated validator answers the validation envelope. A value that does not parse as its declared
+type takes the same shape, so `?limit=abc` against an `int` parameter is reported under `limit`, and
+a nested object carries its own path, so a member missing from one is reported as
+`body.lines[0].sku`. A parameter is reported under the name the caller sent, `precision` or
+`X-Region`.
 
 An unreadable body is reported under `body`:
 
@@ -157,18 +153,18 @@ An unreadable body is reported under `body`:
 
 `body` is the handler's own parameter identifier, so a handler taking `MemberRequest request`
 reports `request`. On the third row the path names where parsing stopped rather than the fault, so
-`{"accountId":` is reported as `body.accountId`. A body that omits a required member and also breaks
-a constraint is answered about the omission alone, and the constraint comes back on the next
-request.
+`{"accountId":` is reported as `body.accountId`. When a body omits a required member and also breaks
+a constraint, the response names the omission only, and a later request that sends the member is
+answered about the constraint.
 
-## What the document publishes
+## The published document
 
-The document republishes every constraint as the keyword it came from, and an operation with a
-generated validator publishes the 400 alongside them, with its schema under
-`components.schemas.RequestValidationError`. A constraint on a path token is the exception. It is a
-[route constraint](/guide/routing#constraining-what-a-token-matches) tested before any filter runs,
-so the router answers it and the operation publishes no 400. See
-[The OpenAPI document](/guide/openapi-document).
+The [OpenAPI document](/guide/openapi-document) Hardened publishes republishes every constraint as
+the keyword it came from, and an operation with a generated validator publishes the 400 alongside
+them, with its schema under `components.schemas.RequestValidationError`. A constraint on a path
+token is the exception. It is a
+[route constraint](/guide/routing#constraining-what-a-token-matches) tested during routing, so the
+router answers it and the operation publishes no 400.
 
 | Declaration | Refused by | Published |
 |---|---|---|
@@ -177,12 +173,12 @@ so the router answers it and the operation publishes no 400. See
 | `required` on a path token | the router | 404, no body |
 | `pattern` on a query value or header | the validator | 400, the envelope |
 | `minimum` on a path token | the validator | 400, the envelope |
-| `{id:long}` binding an `int` parameter | the binder | 400, the envelope |
+| `{id:long}` binding an `int` parameter | the [binder](/guide/parameter-binding) | 400, the envelope |
 
 ## Custom rules
 
 Write a rule the attributes cannot express in the handler. Throwing `ValidationException` produces
-the same response a constraint does, from the immutable `ValidationResult` its factory builds:
+the same response a constraint does:
 
 ```csharp
 using Hardened.Requests.Runtime.Validation;
@@ -201,7 +197,7 @@ public async Task<Pet> CreatePet(CreatePetRequest body) {
 
 ## Refusing with another status
 
-A refusal that is not about a field takes its own status. Throw the response for that status and
+Give a refusal that is not about a field its own status. Throw the response for that status and
 declare it:
 
 ```csharp

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -166,8 +166,8 @@ An unreadable body is reported under `body`:
 | a document that does not parse | `body` | `invalid` |
 | `{"weightKg":"heavy"}` | `body.weightKg` | `invalid` |
 
-`body` is the handler's own parameter identifier, so a handler taking `MemberRequest request` reports
-`request`. On the third row the path names where parsing stopped rather than the fault, so
+`body` is the handler's own parameter identifier, so a handler taking `MemberRequest request`
+reports `request`. On the third row the path names where parsing stopped rather than the fault, so
 `{"accountId":` is reported as `body.accountId`.
 
 ## What the document publishes

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -1,7 +1,7 @@
 # Validation
 
-A constraint on a model becomes a generated validator. A request that fails answers 400 before the
-handler runs, with one entry per failed field, and the handler only ever sees values that passed.
+Constraint attributes on a model become a generated validator. A request that fails one answers 400
+before the handler runs, with an entry per failed field.
 
 ```csharp
 using ValidationModules.Constraints;
@@ -24,66 +24,13 @@ public record CreatePetRequest(
 }
 ```
 
-There is no validator class to write and no registration to remember. Declaring the constraint is
-the whole of it.
+The validator is written by `Hardened.Validation.SourceGenerator`. A project that declares
+constraints without referencing it compiles, enforces nothing, and reports `HRDV006`.
 
-## Declaring constraints in code
+## Constraint attributes
 
-The attributes live in the `ValidationModules.Constraints` namespace. Every bounded attribute
-takes named `Min` and `Max` arguments, so a single bound is one argument. `[Required]` marks a
-member the caller may not send as `null`. On a non-nullable value type it is unnecessary, because
-absence is unrepresentable there — and `HRDV003` says so.
-
-### Presence, and who checks it
-
-A non-nullable reference member the constructor takes is one the caller must send. Nothing else
-declares it:
-
-```csharp
-public record NewTodo(string Title);        // {} is a 400: title is required
-public record Draft(string? Title);         // {} is accepted, Title is null
-public record Paged(string Cursor = "");    // {} is accepted, Cursor is ""
-```
-
-That is the same declaration the published document reads — `required: ["title"]` comes from the
-annotation on `Title` and from nothing else — so the document and the server now answer the same
-question the same way. A member the server owns is excluded from both by `[ResponseOnly]`.
-
-A settable property is not demanded, whatever its type:
-
-```csharp
-public class Manifest {
-    public string Id { get; set; } = "";        // optional, and the document says so
-    public string Carrier { get; set; }         // the document says required; nothing checks it
-}
-```
-
-An initializer is how a property says "this when nothing sends it", and it compiles into the
-constructor body where reflection cannot see it — so demanding these would refuse bodies their author
-meant to accept. The document reads the initializer from source and leaves `id` optional; `carrier`,
-which has none, is published as required and is `[Required]`'s to enforce. Write the demand where the
-reader can see it — a constructor parameter, `required string Carrier`, or `[JsonRequired]` — or
-declare `[Required]` and let the validator answer.
-
-**Presence is the reader's question; content is the validator's.** Absence is the one thing a
-validator cannot see, and the one thing the JSON reader knows for certain, so a body that omits a
-required member is refused before any constraint runs. Every member it missed is named at once:
-
-```json
-{ "errors": [
-  { "field": "body.accountId", "code": "required", "message": "accountId is required." },
-  { "field": "body.weightKg",  "code": "required", "message": "weightKg is required." } ] }
-```
-
-The trade is worth knowing: a body that both omits a required member and breaks a constraint on a
-member it did send is answered about the omission, and about the constraint on the next request.
-Everything the reader accepted is validated together, as before.
-
-A non-nullable **value** type is not covered by this. The document publishes one as required because
-C# serialization cannot omit it — a fact about what a response always contains rather than a demand
-its author made, and `int?` or `= 0` are the only ways C# has to say otherwise. To demand one, say
-so: `required int Grams`, or `[JsonRequired]`. A contract-first model needs neither, because a
-contract's `required` is a demand and is compiled as one whatever the member's type.
+The attributes are in `ValidationModules.Constraints`. Bounded attributes take named `Min` and `Max`
+arguments, so a single bound is one argument.
 
 | Attribute | Checks |
 |---|---|
@@ -95,8 +42,50 @@ contract's `required` is a demand and is compiled as one whatever the member's t
 | `[MultipleOf]` | divisibility |
 | `[AllowedValues]` | membership of a set |
 
-The same attributes go on a handler's own parameters, for a value bound from the query string, a
-header or the path:
+`[Required]` on a non-nullable value type reports `HRDV003`. There is no absent `int`.
+
+## Required members
+
+`System.Text.Json` does not enforce nullable reference annotations, so `{}` deserializes into
+`record NewTodo(string Title)` with `Title` null. `RequiredMemberPresence` marks those members
+required on the deserializer's metadata instead, which refuses the body before any constraint runs
+and names every missing member in one response.
+
+```json
+{ "errors": [
+  { "field": "body.accountId", "code": "required", "message": "accountId is required." },
+  { "field": "body.weightKg",  "code": "required", "message": "weightKg is required." } ] }
+```
+
+A member is marked when it matches a constructor parameter by name, that parameter has no default
+value, it is a reference type whose annotation says not-null, and it does not carry
+`[ResponseOnly]`. A member the model already declares `required` or `[JsonRequired]` is left as it
+is.
+
+| Member | Published as | Presence checked |
+|---|---|---|
+| constructor parameter, non-nullable reference type | required | yes |
+| constructor parameter with a default value | optional | no |
+| property that is not a constructor parameter | required, unless it has an initializer | no |
+| any value type | required | no |
+| `[ResponseOnly]` | `readOnly` | no |
+
+`[Required]`, `required` or `[JsonRequired]` demands one of the unchecked rows.
+
+A body that omits a required member and also breaks a constraint is answered about the omission
+alone. The constraint is reported on the next request.
+
+Under a source-generated `JsonSerializerContext` the deserializer reads `IsRequired` from that
+generator rather than from reflection, so an AOT-published application declares presence with
+`required` or `[JsonRequired]`.
+
+A contract-first model needs none of this. A contract's `required` compiles to `[Required]` whatever
+the member's type.
+
+## Constraints on handler parameters
+
+The same attributes go on a handler's parameters, for a value bound from the query string, a header
+or the path:
 
 ```csharp
 [Get("/rates/{count:int}")]
@@ -109,17 +98,14 @@ public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) 
 public string Region([FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
 ```
 
-A failure is reported under the name the caller sent, `precision` or `X-Region`, in the same
-envelope a body failure uses. A route constraint and a value constraint answer different
-questions: `/rates/abc` matches no route and is a 404, while `/rates/0` reaches the handler's
-filter and is a 400.
+A failure is reported under the name the caller sent, `precision` or `X-Region`.
 
-A parameter's constraint cannot carry a `When` or `Unless`, which names a member of the model the
-constraint sits on. A parameter sits on no model, and `HRDV005` says so at build time.
+`When` and `Unless` name another member of the model the constraint sits on. A parameter sits on no
+model, and either reports `HRDV005`.
 
-### Nested models
+## Nested models
 
-A constraint on a member of a nested model runs only when the member carries `[ValidateNested]`:
+Constraints on a nested model run only where the member carries `[ValidateNested]`:
 
 ```csharp
 public record Address([property: StringLength(Min = 1, Max = 8)] string Postcode);
@@ -129,17 +115,13 @@ public record NewJob(
     [property: ValidateNested] Address Pickup);
 ```
 
-Without it the nested constraints compile and never run, and `HRDV004` says so at build time:
-*'NewJob.Pickup' does not declare [ValidateNested] and its Address type declares constraints, so
-none of them run and an invalid 'Address' is accepted with no error. Add [ValidateNested] to the
-property, or set NoWarn HRDV004 if the skip is intended.* The nested record must be sealed, or
-declare a polymorphism mode, or ValidationModules reports `VM1503`.
+Without it the nested constraints compile, never run, and report `HRDV004`. The nested type must be
+sealed or declare a polymorphism mode, or ValidationModules reports `VM1503`.
 
-## Declaring constraints in a contract
+## Constraints from a contract
 
-A contract-first application declares constraints as ordinary OpenAPI facets, on schema
-properties and on parameters alike. A Smithy model uses `@length`, `@range` and `@pattern` the
-same way.
+A contract declares constraints as OpenAPI facets on schema properties and parameters. A Smithy
+model uses `@length`, `@range` and `@pattern`.
 
 ```yaml
 components:
@@ -148,27 +130,16 @@ components:
       type: object
       required: [name]
       properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 100
-        age:
-          type: integer
-          minimum: 0
-          maximum: 30
-        tag:
-          type: string
-          pattern: "^[a-zA-Z0-9-]+$"
-        nicknames:
-          type: array
-          items: { type: string }
-          maxItems: 5
+        name: { type: string, minLength: 1, maxLength: 100 }
+        age: { type: integer, minimum: 0, maximum: 30 }
+        tag: { type: string, pattern: "^[a-zA-Z0-9-]+$" }
+        nicknames: { type: array, items: { type: string }, maxItems: 5 }
 ```
 
-The build task turns each facet into the matching attribute on the generated model, and the
-validation generator reads those exactly as it reads attributes you wrote by hand:
+The build task writes the matching attribute onto the generated model, and the validation generator
+reads it as it reads a hand-written one.
 
-| Contract facet | Generated attribute |
+| Facet | Attribute |
 |---|---|
 | `minLength` / `maxLength` | `[StringLength]` |
 | `minimum` / `maximum` | `[Range]` |
@@ -178,61 +149,50 @@ validation generator reads those exactly as it reads attributes you wrote by han
 | `minItems` / `maxItems` | `[ItemCount]` |
 | `required` | `[Required]` |
 
-A bound you leave out is left out. `minimum: 1` with no `maximum` generates `[Range(Min = 1)]`,
-and the failure message says "at least 1" without inventing an upper bound.
+`minimum: 1` with no `maximum` generates `[Range(Min = 1)]`, and the message reads "at least 1".
 
-## The 400 envelope
+## The 400 response
 
-A failed request never reaches the handler. The generated filter answers 400 with one entry per
-failed field, in the shape at the top of this page. A value that fails to parse as its declared
-type takes the same shape: `?limit=abc` against an `int` parameter answers this envelope with
-`limit` as the field, not a 500. So does a body that omitted a required member, reported under the
-object that was missing it — `body.lines[0].sku`, not `body.sku`. Which layer caught a fault is not
-something a caller can tell.
+The generated filter answers the envelope above, with an entry per failed field. A value that does
+not parse as its declared type takes the same shape, so `?limit=abc` against an `int` parameter is
+reported under `limit`. A member missing from a nested object is reported under that object:
+`body.lines[0].sku`.
 
-A body the reader could not use at all is answered as a fact about the body:
+A body that cannot be read at all is reported against the body itself:
 
 | Sent | Field | Code |
 |---|---|---|
 | nothing, or an empty body | `body` | `required` |
 | `null` | `body` | `required` |
-| `{"weightKg":` — a document that does not parse | `body` | `invalid` |
-| `{"weightKg":"heavy"}` — a value that would not convert | `body.weightKg` | `invalid` |
+| a document that does not parse | `body` | `invalid` |
+| `{"weightKg":"heavy"}` | `body.weightKg` | `invalid` |
 
-The field is the handler's own body parameter identifier, so a handler taking `MemberRequest request`
-reports `request`. Only the last row names a member: a malformed document has a reader path too, and
-it means wherever the text ran out rather than what is wrong — `{"accountId":` was answered
-`body.accountId`, about a member that is present and correct as far as it goes.
+`body` is the handler's own parameter identifier, so a handler taking `MemberRequest request` reports
+`request`. On the third row the path names where parsing stopped rather than the fault, so
+`{"accountId":` is reported as `body.accountId`.
 
-## What the document says
+## What the document publishes
 
-The published OpenAPI document repeats every declared constraint as the facet it came from, so the
-rule a client is validated against is the one the document advertises. Operations with generated
-validators also publish the 400 itself, with the envelope's schema, under
+The document republishes every constraint as the facet it came from, and an operation with a
+generated validator publishes the 400 with its schema under
 `components.schemas.RequestValidationError`. See [The OpenAPI document](/guide/openapi-document).
 
-An operation the router already guards publishes no 400. A constraint on a path token is a
-[route constraint](/guide/routing#constraining-what-a-token-matches), tested before any filter or
-binder runs, so a value that would have failed it is a 404 and the validator never sees one:
+A constraint on a path token is a [route constraint](/guide/routing#constraining-what-a-token-matches)
+and is tested before any filter runs, so the operation publishes no 400.
 
 | Declaration | Refused by | Published |
 |---|---|---|
-| `pattern` on a path token | the router | 404, with no body |
-| `{id:int}` with an `int` parameter | the router | 404, with no body |
-| `required` on a path token | the router, as a route that did not match | 404, with no body |
-| `pattern` on a query value or a header | the validator | 400, the envelope |
+| `pattern` on a path token | the router | 404, no body |
+| `{id:int}` with an `int` parameter | the router | 404, no body |
+| `required` on a path token | the router | 404, no body |
+| `pattern` on a query value or header | the validator | 400, the envelope |
 | `minimum` on a path token | the validator | 400, the envelope |
-| a parameter whose type the constraint does not cover, `{id:long}` binding an `int` | the binder | 400, the envelope |
+| `{id:long}` binding an `int` parameter | the binder | 400, the envelope |
 
-So `pattern` and `minimum` on the same token answer differently, and deliberately: the first says
-which URLs name a resource, the second judges a request that named one. Where the operation declares
-a 404 of its own, its description says the router answers that status too, and without the declared
-body — two 404s reach the wire and a document can key one.
+## Custom rules
 
-## Rules the vocabulary cannot express
-
-A business rule is handler code. Throw the same exception the generated filters throw and the
-response is indistinguishable from a declared constraint's:
+A rule the attributes cannot express is handler code. Throwing `ValidationException` produces the
+same response a constraint does:
 
 ```csharp
 using Hardened.Requests.Runtime.Validation;
@@ -249,14 +209,12 @@ public async Task<Pet> CreatePet(CreatePetRequest body) {
 }
 ```
 
-`ValidationResult` is ValidationModules' immutable result type. Build it with
-`ValidationResult.FromErrors`; there is no mutable `AddError` form.
+`ValidationResult` is immutable. Build it with `ValidationResult.FromErrors`.
 
-## Refusing with a declared status
+## Refusing with another status
 
-When the request was well-formed and refused for a reason of its own, the answer usually wants a
-status of its own rather than a 400. Throw the response for that status, and declare it so the
-document says so:
+A well-formed request refused for its own reason usually wants its own status. Throw the response
+for that status and declare it:
 
 ```csharp
 [Post("/pets")]
@@ -271,19 +229,15 @@ public async Task<Pet> CreatePet(CreatePetRequest body) {
 }
 ```
 
-`[Throws<T>]` puts the status in the published document. Without it the throw still answers 409
-and the document describes only the 200, so a client generated from it has no case for the
-refusal. See [Declaring what a handler throws](/guide/responses#declaring-what-a-handler-throws).
-Keep the validation envelope for "this field is wrong".
+Without `[Throws<T>]` the throw answers 409 and the document describes only the 200, so a generated
+client has no case for it. See
+[Declaring what a handler throws](/guide/responses#declaring-what-a-handler-throws).
 
-## Choosing the status and the shape
+## Replacing the status and body
 
-The stock behaviour is a 400 with the envelope above. Both are decided in one replaceable service:
-`ExceptionResponseSerializer` asks `IExceptionToModelConverter` for the status and the body of
-every failure, and the stock converter registers with `RegistrationType.Try`, so a registration
-the application makes wins.
-
-A converter that answers 422 with its own body, and leaves everything else to the stock rules:
+`ExceptionResponseSerializer` asks `IExceptionToModelConverter` for the status and body of every
+failure. The stock converter registers with `RegistrationType.Try`, so an application's own
+registration replaces it.
 
 ```csharp
 using DependencyModules.Runtime.Attributes;
@@ -314,14 +268,13 @@ public class UnprocessableContentConverter : IExceptionToModelConverter {
 }
 ```
 
-Delegating to the stock converter keeps every other mapping: thrown declared statuses, the binding
-400, the anonymous 500. Two validation exception types reach the converter, and the stock one maps
-both: Hardened's `ValidationException`, thrown by the generated filters and the binder, and
-ValidationModules' own, thrown by code calling a generated validator directly. A converter that
-should catch both matches on each type the way the stock converter does.
+Delegating to the stock converter keeps thrown declared statuses, the binding 400 and the 500. Two
+validation exception types reach it: Hardened's `ValidationException`, thrown by the generated
+filters and the binder, and ValidationModules' own, thrown by code that calls a generated validator
+directly.
 
 ## Next
 
-- [The OpenAPI document](/guide/openapi-document): what publishes, including the synthesized 400
-- [Declared responses](/guide/responses): declaring the statuses a handler answers deliberately
-- [Parameter binding](/guide/parameter-binding): how values reach the validated model
+- [The OpenAPI document](/guide/openapi-document): the published 400 and its schema
+- [Declared responses](/guide/responses): declaring a handler's statuses
+- [Parameter binding](/guide/parameter-binding): how a value reaches a validated model

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -76,8 +76,8 @@ An AOT-published application declares presence with `required` or `[JsonRequired
 source-generated `JsonSerializerContext` the deserializer reads `IsRequired` from that generator
 rather than from reflection.
 
-A contract-first model does not need `RequiredMemberPresence`. A contract's `required` compiles to `[Required]` whatever
-the member's type.
+A contract-first model does not need `RequiredMemberPresence`. A contract's `required` compiles to
+`[Required]` whatever the member's type.
 
 ## Constraints on handler parameters
 
@@ -153,8 +153,9 @@ reads it as it reads a hand-written one.
 ## The 400 response
 
 The generated filter answers the envelope above. A value that does not parse as its declared type
-takes the same shape, so `?limit=abc` against an `int` parameter is reported under `limit`. A nested
-object carries its own path, so a member missing from one is reported as `body.lines[0].sku`.
+takes the same shape, so `?limit=abc` against an `int` parameter is reported under `limit`. A
+nested object carries its own path, so a member missing from one is reported as
+`body.lines[0].sku`.
 
 An unreadable body is reported under `body`:
 
@@ -173,7 +174,8 @@ An unreadable body is reported under `body`:
 
 The document republishes every constraint as the facet it came from. An operation with a generated
 validator also publishes the 400, with its schema under
-`components.schemas.RequestValidationError`. See [The OpenAPI document](/guide/openapi-document).
+`components.schemas.RequestValidationError`. See
+[The OpenAPI document](/guide/openapi-document).
 
 A constraint on a path token is a [route constraint](/guide/routing#constraining-what-a-token-matches),
 tested before any filter runs.


### PR DESCRIPTION
Page one of a page-by-page rewrite, with the two documents the rewrite runs on.

## The two documents

`docs/design/writing-style.md` is shared by a writer and an editor. Rule 1 is the gate: a fact earns
a sentence if a competent C# developer could not predict it, and the list under it names what does
not qualify. What a record or an initializer is. What `System.Text.Json` does on its own. Behaviour
that matches every other server. What a feature does not do.

The numbered rules after it are the moves that produced the current prose, each citable by number:
no posed question and answer (2.1), no defending a decision (2.2), no epigrams (2.3), name the
mechanism instead of personifying it (2.4), no abstract noun as a subject (2.5), no sentence that
restates the code below it (2.6), no framing (2.7), no selling (2.8), no em-dashes (2.9), headings
that name their subject (2.10).

`docs/design/docs-architecture.md` maps the five tabs, the nine guide sections, what each page owns,
the page budget, and the rewrite order.

## Page one

`guide/validation`, written from a fact list extracted from the implementation and the diagnostics
rather than edited from the existing page. 1328 prose words to 620, with every table, code block and
diagnostic kept.

Extraction found two facts the page did not have. `HRDV006` fires where constraints are declared and
no generator compiles them, so nothing is enforced. And a source-generated `JsonSerializerContext`
carries `IsRequired` from its own generator, so an AOT-published application declares presence with
`required` rather than relying on nullability.

The required-member section is now one paragraph and a five-row table. What went was the explanation
of what a non-nullable reference type, a constructor default and an initializer are.

## The editor pass

A second agent reviewed the page against the guide and reported 24 violations by rule number. 21 are
applied.

Rejected: renaming "What the document publishes" to "Published constraints", which narrows a section
that also covers the published 400 and the operations that publish none. Softened two cuts that
carried a fact rather than framing.

The finding about missing `using` lines was a defect in the guide, not the page. Requiring every
block to carry them repeats three lines per snippet, which is the padding the guide exists to remove.
Section 4 now puts them in a page's first block.

`npm run build` in `docs/` passes.

Next pages in the order the architecture document sets: `message-pack`, `content-negotiation`, then
`smithy` and `openapi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)