### PR TITLE
Rename [ApiGatewayModule] to [LambdaHttpModule], package included

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -322,7 +322,7 @@ jobs:
             src/Functions/Hardened.Functions.Testing/Hardened.Functions.Testing.csproj \
             src/Clouds/Aws/Hardened.Aws.Lambda/Hardened.Aws.Lambda.csproj \
             src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hardened.Aws.Lambda.Runtime.csproj \
-            src/Clouds/Aws/Hardened.Aws.Lambda.ApiGateway/Hardened.Aws.Lambda.ApiGateway.csproj \
+            src/Clouds/Aws/Hardened.Aws.Lambda.Http/Hardened.Aws.Lambda.Http.csproj \
             src/Clouds/Aws/Hardened.Aws.Lambda.DynamoDb/Hardened.Aws.Lambda.DynamoDb.csproj \
             src/Clouds/Aws/Hardened.Aws.Lambda.EventBridge/Hardened.Aws.Lambda.EventBridge.csproj \
             src/Clouds/Aws/Hardened.Aws.Lambda.Invoke/Hardened.Aws.Lambda.Invoke.csproj \

--- a/Hardened.slnx
+++ b/Hardened.slnx
@@ -14,9 +14,9 @@
   <Folder Name="/Clouds/Aws/IntegrationTests/Runtime/">
     <Project Path="src/Clouds/Aws/IntegrationTests/Runtime/Hardened.IntegrationTests.LambdaRuntime.Tests/Hardened.IntegrationTests.LambdaRuntime.Tests.csproj" />
   </Folder>
-  <Folder Name="/Clouds/Aws/IntegrationTests/ApiGateway/">
-    <Project Path="src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT/Hardened.IntegrationTests.ApiGateway.SUT.csproj" />
-    <Project Path="src/Clouds/Aws/IntegrationTests/ApiGateway/Hardened.IntegrationTests.ApiGateway.SUT.Tests/Hardened.IntegrationTests.ApiGateway.SUT.Tests.csproj" />
+  <Folder Name="/Clouds/Aws/IntegrationTests/LambdaHttp/">
+    <Project Path="src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT/Hardened.IntegrationTests.LambdaHttp.SUT.csproj" />
+    <Project Path="src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/Hardened.IntegrationTests.LambdaHttp.SUT.Tests.csproj" />
   </Folder>
   <Folder Name="/Clouds/Aws/IntegrationTests/Invoke/">
     <Project Path="src/Clouds/Aws/IntegrationTests/Invoke/Hardened.IntegrationTests.Invoke.SUT/Hardened.IntegrationTests.Invoke.SUT.csproj" />
@@ -40,9 +40,9 @@
   </Folder>
   <Folder Name="/Clouds/Aws/IntegrationTests/Rie/">
     <Project Path="src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.Rie.SUT/Hardened.IntegrationTests.Rie.SUT.csproj" />
-    <Project Path="src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieApiGateway.SUT/Hardened.IntegrationTests.RieApiGateway.SUT.csproj" />
     <Project Path="src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieEvents.SUT/Hardened.IntegrationTests.RieEvents.SUT.csproj" />
     <Project Path="src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieInvoke.SUT/Hardened.IntegrationTests.RieInvoke.SUT.csproj" />
+    <Project Path="src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieLambdaHttp.SUT/Hardened.IntegrationTests.RieLambdaHttp.SUT.csproj" />
   </Folder>
   <Folder Name="/Clouds/Aws/IntegrationTests/Sqs/">
     <Project Path="src/Clouds/Aws/IntegrationTests/Sqs/Hardened.IntegrationTests.Sqs.SUT/Hardened.IntegrationTests.Sqs.SUT.csproj" />
@@ -149,9 +149,9 @@
   <Folder Name="/Clouds/Aws/">
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda/Hardened.Aws.Lambda.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.Runtime/Hardened.Aws.Lambda.Runtime.csproj" />
-    <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.ApiGateway/Hardened.Aws.Lambda.ApiGateway.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.DynamoDb/Hardened.Aws.Lambda.DynamoDb.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.EventBridge/Hardened.Aws.Lambda.EventBridge.csproj" />
+    <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.Http/Hardened.Aws.Lambda.Http.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.Invoke/Hardened.Aws.Lambda.Invoke.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.Kinesis/Hardened.Aws.Lambda.Kinesis.csproj" />
     <Project Path="src/Clouds/Aws/Hardened.Aws.Lambda.S3/Hardened.Aws.Lambda.S3.csproj" />

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The application names its runtime and the libraries it composes, and that is the
 
 ```csharp
 [HardenedModule]
-[KestrelRuntime]          // or [AspNetCoreRuntime], [ApiGatewayModule] for Lambda, [CloudRunRuntime] for Cloud Run, [HttpModule] for Azure Functions
+[KestrelRuntime]          // or [AspNetCoreRuntime], [LambdaHttpModule] for Lambda, [CloudRunRuntime] for Cloud Run, [HttpModule] for Azure Functions
 [TodosLibrary]
 public partial class Application;
 ```

--- a/build/coverage-baseline.json
+++ b/build/coverage-baseline.json
@@ -1,8 +1,4 @@
 {
-  "Hardened.Aws.Lambda.ApiGateway": {
-    "line": 83.6,
-    "branch": 67.1
-  },
   "Hardened.Aws.Lambda.DynamoDb": {
     "line": 83.8,
     "branch": 78.1
@@ -10,6 +6,10 @@
   "Hardened.Aws.Lambda.EventBridge": {
     "line": 93.6,
     "branch": 100.0
+  },
+  "Hardened.Aws.Lambda.Http": {
+    "line": 83.6,
+    "branch": 67.1
   },
   "Hardened.Aws.Lambda.Invoke": {
     "line": 91.6,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -93,7 +93,7 @@ const guide = [
     text: 'AWS',
     items: [
       { text: 'Overview', link: '/aws/' },
-      { text: 'API Gateway', link: '/aws/lambda-web' },
+      { text: 'Web applications', link: '/aws/lambda-web' },
       { text: 'Lambda functions', link: '/aws/lambda-function' },
       { text: 'Queues and topics', link: '/aws/sqs' },
       { text: 'Streams and change feeds', link: '/aws/ddb-streams' },

--- a/docs/aws/index.md
+++ b/docs/aws/index.md
@@ -32,7 +32,7 @@ stream models in its deployment bundle.
 | Package | Serves |
 |---|---|
 | `Hardened.Aws.Lambda.Runtime` | The host. The invocation loop, the bootstrap, logging and metrics. Every Lambda application references it |
-| `Hardened.Aws.Lambda.ApiGateway` | `[Get]`, `[Post]`, `[Put]`, `[Patch]`, `[Delete]` behind API Gateway |
+| `Hardened.Aws.Lambda.Http` | `[Get]`, `[Post]`, `[Put]`, `[Patch]`, `[Delete]`, behind an API Gateway HTTP API or a function URL |
 | `Hardened.Aws.Lambda.Invoke` | `[HardenedFunction]`, a direct invocation |
 | `Hardened.Aws.Lambda.Sqs` | `[Queue]` |
 | `Hardened.Aws.Lambda.Sns` | `[Topic]` |
@@ -83,7 +83,7 @@ The runtimes are compatible with trimming and Native AOT — every registration 
 
 | Area | Page | Source |
 |---|---|---|
-| HTTP behind API Gateway | [API Gateway](/aws/lambda-web) | [`Hardened.Aws.Lambda.ApiGateway`](https://github.com/ipjohnson/Hardened.Framework/tree/main/src/Clouds/Aws/Hardened.Aws.Lambda.ApiGateway) |
+| HTTP | [Web applications](/aws/lambda-web) | [`Hardened.Aws.Lambda.Http`](https://github.com/ipjohnson/Hardened.Framework/tree/main/src/Clouds/Aws/Hardened.Aws.Lambda.Http) |
 | The host, and direct invocation | [Lambda functions](/aws/lambda-function) | [`Hardened.Aws.Lambda.Runtime`](https://github.com/ipjohnson/Hardened.Framework/tree/main/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime) |
 | Queues and topics | [Queues](/aws/sqs) | [`Hardened.Aws.Lambda.Sqs`](https://github.com/ipjohnson/Hardened.Framework/tree/main/src/Clouds/Aws/Hardened.Aws.Lambda.Sqs) |
 | Change feeds and streams | [Streams](/aws/ddb-streams) | [`Hardened.Aws.Lambda.DynamoDb`](https://github.com/ipjohnson/Hardened.Framework/tree/main/src/Clouds/Aws/Hardened.Aws.Lambda.DynamoDb) |

--- a/docs/aws/lambda-function.md
+++ b/docs/aws/lambda-function.md
@@ -148,8 +148,9 @@ Started the AWS Lambda Test Tool on http://localhost:5050
 ```
 
 The tool's page on 5050 is where a payload is posted. A function that is not an HTTP API has no API
-Gateway emulator and nothing on 5080 — that is [API Gateway](/aws/lambda-web#running-it-locally),
-and it is the only shape that answers over HTTP locally.
+Gateway emulator and nothing on 5080 — that is a
+[web application](/aws/lambda-web#running-it-locally), and it is the only shape that answers over
+HTTP locally.
 
 The tool is a dotnet tool, pinned in the project's `.config/dotnet-tools.json` and restored during
 the build. A failed restore is a warning rather than a broken build, because the deployed artifact
@@ -162,4 +163,4 @@ with no AWS account and nothing to deploy; see [Testing AWS handlers](/aws/testi
 
 - [Triggers](/guide/triggers): the other seven sources a handler can name
 - [Testing AWS handlers](/aws/testing): the façades, and the two fidelity levels
-- [API Gateway](/aws/lambda-web): the same application behind HTTP
+- [Web applications](/aws/lambda-web): the same application behind HTTP

--- a/docs/aws/lambda-web.md
+++ b/docs/aws/lambda-web.md
@@ -1,15 +1,15 @@
-# API Gateway
+# Web applications
 
-`[ApiGatewayModule]` runs the routes you already wrote behind API Gateway. The controllers, filters
-and binding are the same as [any web application](/guide/routing).
+`[LambdaHttpModule]` runs the routes you already wrote on Lambda. The controllers, filters and
+binding are the same as [any web application](/guide/routing).
 
 ```csharp
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 using Hardened.Shared.Runtime.Attributes;
 using Hardened.Web.Runtime.Attributes;
 
 [HardenedModule]
-[ApiGatewayModule]
+[LambdaHttpModule]
 public partial class Application;
 
 public class ProductController {
@@ -33,8 +33,8 @@ way the Kestrel host does.
 
 ## The module
 
-`[ApiGatewayModule]` brings the API Gateway payload adapter and, through the runtime module it
-composes, the invocation loop and the web pipeline.
+`[LambdaHttpModule]` brings the HTTP payload adapter and, through the runtime module it composes,
+the invocation loop and the web pipeline.
 
 It is named here rather than inferred, which is the one place a Lambda application does name its
 cloud. A function whose handlers sit beside its entry point gets its adapter from their
@@ -43,8 +43,10 @@ other trigger. The templates put the handlers in a library project and the entry
 project, and a generator only sees the compilation it runs in, so the host says which adapter serves
 the routes it cannot see. The Kestrel and ASP.NET Core hosts name theirs for the same reason.
 
-The payload format is API Gateway HTTP API, version 2.0. There is no option for the REST API's
-payload format 1.0.
+The payload format is API Gateway HTTP API, version 2.0, which is also what a function URL
+delivers. The module is named for the shape it binds rather than for one sender, because both of
+those front doors send it. There is no option for the REST API's payload format 1.0, and an ALB
+sends a different shape again, which this does not serve.
 
 ## Configuration
 
@@ -57,7 +59,7 @@ using Hardened.Requests.Runtime.Configuration;
 using Hardened.Shared.Runtime.Configuration;
 
 [HardenedModule]
-[ApiGatewayModule]
+[LambdaHttpModule]
 public partial class Application : IServiceCollectionConfiguration {
     public void ConfigureServices(IServiceCollection services) {
         var config = new AppConfig();
@@ -175,9 +177,9 @@ Lambda involvement:
 [assembly: HardenedTestEntryPoint(typeof(Application))]
 ```
 
-That covers routing, binding, filters and serialization. It does not cover the API Gateway event
-conversion. `[LambdaWebTesting]` puts a real proxy event through the invocation loop instead; see
-[Testing AWS handlers](/aws/testing).
+That covers routing, binding, filters and serialization. It does not cover the payload format 2.0
+event conversion. `[LambdaWebTesting]` puts a real proxy event through the invocation loop instead;
+see [Testing AWS handlers](/aws/testing).
 
 ## Next
 

--- a/docs/aws/testing.md
+++ b/docs/aws/testing.md
@@ -184,7 +184,7 @@ Testcontainers needs a Docker daemon. On a machine without one, these tests fail
 startup rather than skipping.
 :::
 
-## Web handlers behind API Gateway
+## Web handlers on Lambda
 
 A Lambda web application's routes are ordinary routes, so
 [`ITestWebApp`](/guide/testing-web) drives them with no Lambda involvement:
@@ -209,9 +209,9 @@ it is visible in the test.
 That is what makes the portability claim checkable rather than asserted: the same test file runs on
 the pipeline, on Kestrel and here, and only an assembly attribute differs.
 
-One behaviour does differ, because the transport does. `[LambdaWebTesting]` is terminal: API Gateway
-has nothing behind it to hand an unmatched path to, so a path with no route is a 404 from the host
-rather than a fall-through.
+One behaviour does differ, because the transport does. `[LambdaWebTesting]` is terminal: a front
+door has nothing behind it to hand an unmatched path to, so a path with no route is a 404 from the
+host rather than a fall-through.
 
 ### Testing a streaming function
 

--- a/docs/azure/web.md
+++ b/docs/azure/web.md
@@ -58,7 +58,7 @@ The template writes that `host.json`, so a route answers at the same path on eve
 
 The routes live in the library, the generator runs in the host project, and a generator sees
 only the compilation it runs in. The host project therefore names the adapter, the way a Lambda
-host writes `[ApiGatewayModule]`:
+host writes `[LambdaHttpModule]`:
 
 ```csharp
 [HardenedModule]

--- a/docs/design/azure/application-types.md
+++ b/docs/design/azure/application-types.md
@@ -32,7 +32,7 @@ meets.
 2. **Nothing on the application names the host.** A function app is whatever the Functions host
    starts, and the host is told what to start by the build. `[HttpModule]` is the one adapter a
    host project writes out, when its routes live in a library, for the reason a Lambda host writes
-   `[ApiGatewayModule]`: a generator sees only the compilation it runs in.
+   `[LambdaHttpModule]`: a generator sees only the compilation it runs in.
 3. **A trigger attribute is what pulls an adapter in.** `[Queue]` on a handler makes the generator
    read `HardenedQueueModule` from the referenced package's build properties, register
    `ServiceBusModule`, and write `Queue_orders`. An adapter is written out on the application

--- a/docs/design/filter-rungs.md
+++ b/docs/design/filter-rungs.md
@@ -249,7 +249,7 @@ It is not replaced. It earns its place for two things a compile-time rung cannot
 
 `[Enable<ConditionalGet>]` on a **host** entry point can never publish into a **library's**
 document. They are separate compilations, and the template says as much twice: once about
-`[ApiGatewayModule]`, once about why `[Enable<OpenApiDocumentPublishing>]` belongs on the library
+`[LambdaHttpModule]`, once about why `[Enable<OpenApiDocumentPublishing>]` belongs on the library
 module and emits `"paths": {}` on the host. That is the argument for making the library-module and
 assembly rungs the ones an application reaches for, and leaving the host flag as the deployment
 switch it is.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -151,7 +151,7 @@ The runtime attribute is the only thing that changes:
 |---|---|---|
 | `[KestrelRuntime]` | `Hardened.Web.Kestrel.Runtime` | Kestrel, without the ASP.NET Core request pipeline |
 | `[AspNetCoreRuntime]` | `Hardened.Web.AspNetCore.Runtime` | Inside ASP.NET Core's pipeline, behind `app.UseHardened()` |
-| `[ApiGatewayModule]` | `Hardened.Aws.Lambda.ApiGateway` | Behind API Gateway on Lambda. See [AWS](/aws/) |
+| `[LambdaHttpModule]` | `Hardened.Aws.Lambda.Http` | On Lambda, behind an API Gateway HTTP API or a function URL. See [AWS](/aws/) |
 
 Handlers, filters, binding and the generated routing table do not change with the host. The
 templates put the implementation in one project and the host in another, and point the tests at

--- a/docs/guide/project-templates.md
+++ b/docs/guide/project-templates.md
@@ -67,12 +67,12 @@ authorization, or its hosting diagnostics. Instrumentation that subscribes to th
 `DiagnosticSource` names sees nothing under Kestrel. The [Kestrel host's README][kestrel] lists
 the trade-offs.
 
-`aws-lambda` puts the application behind API Gateway. The host project has a `Program.cs` like
-every other host, and the call to `LambdaEmulator.StartIfLocal` in it is what starts the AWS Lambda
-Test Tool beside the process when it is not the Lambda service running it. The application answers
-on 5080 through the tool's API Gateway emulator, so `dotnet run --project src/Todos.Host` and F5
-work the way they do on the other hosts; see
-[Running it locally](/aws/lambda-web#running-it-locally).
+`aws-lambda` puts the application on Lambda, behind an API Gateway HTTP API or a function URL. The
+host project has a `Program.cs` like every other host, and the call to
+`LambdaEmulator.StartIfLocal` in it is what starts the AWS Lambda Test Tool beside the process when
+it is not the Lambda service running it. The application answers on 5080 through the tool's API
+Gateway emulator, so `dotnet run --project src/Todos.Host` and F5 work the way they do on the other
+hosts; see [Running it locally](/aws/lambda-web#running-it-locally).
 
 `cloud-run` runs the application as a Google Cloud Run service: the Kestrel host in a container,
 listening on `PORT`, with `CloudRunHost.RunAsync` draining a request in flight when Cloud Run sends

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -280,7 +280,7 @@ with a 304, see [Conditional requests](/guide/conditional-requests).
 ## The web module
 
 Routing needs `[HardenedWebModule]`. `[KestrelRuntime]`, `[AspNetCoreRuntime]` and
-`[ApiGatewayModule]` each bring it, so an application names its runtime and nothing else. A
+`[LambdaHttpModule]` each bring it, so an application names its runtime and nothing else. A
 library that carries routes and is not the host imports `[HardenedWebModule]` itself. Declaring it
 twice is harmless.
 

--- a/docs/guide/triggers.md
+++ b/docs/guide/triggers.md
@@ -40,7 +40,7 @@ write `[InvokeModule]` itself would name a cloud in the one file that must not.
 
 The web verbs are on the same mechanism. `[Get]`, `[Post]`, `[Put]`, `[Patch]` and `[Delete]` all
 bind `HardenedHttpModule`, so a controller with a GET and a POST registers one adapter. That is why
-a Lambda web host names `[ApiGatewayModule]` and a function host names nothing: the handlers are in
+a Lambda web host names `[LambdaHttpModule]` and a function host names nothing: the handlers are in
 the host's own compilation in one case and in a referenced library in the other, and a generator
 only sees the compilation it runs in.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,8 @@ features:
   - title: The same application on Lambda
     details: >-
       A handler names the queue, topic, schedule or stream it serves, and never the cloud. Which
-      adapter delivers to it is a package reference, so the handlers you already wrote run behind
-      API Gateway or off an SQS batch unchanged.
+      adapter delivers to it is a package reference, so the handlers you already wrote run on a
+      Lambda front door or off an SQS batch unchanged.
     link: /aws/
     linkText: AWS runtimes
 

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -265,7 +265,7 @@ on a handler binds it. The exceptions are noted below.
 
 | Attribute | Namespace | Purpose |
 |---|---|---|
-| `[ApiGatewayModule]` | `Hardened.Aws.Lambda.ApiGateway` | API Gateway payload format 2.0 onto the web pipeline. Written out by a web host, whose routes live in a library the generator cannot see |
+| `[LambdaHttpModule]` | `Hardened.Aws.Lambda.Http` | Payload format 2.0 onto the web pipeline, from an API Gateway HTTP API or a function URL. Written out by a web host, whose routes live in a library the generator cannot see |
 | `[InvokeModule]` | `Hardened.Aws.Lambda.Invoke` | Direct invocation, for `[HardenedFunction]` |
 | `[SqsModule(ReportBatchItemFailures?)]` | `Hardened.Aws.Lambda.Sqs` | SQS, for `[Queue]`. Written out to turn on failure reporting, which has to match the event source mapping |
 | `[SnsModule]` | `Hardened.Aws.Lambda.Sns` | SNS, for `[Topic]` |
@@ -275,12 +275,16 @@ on a handler binds it. The exceptions are noted below.
 | `[S3Module]` | `Hardened.Aws.Lambda.S3` | S3, for `[Blob]` |
 | `[NewImage]` / `[OldImage]` | `Hardened.Aws.Lambda.DynamoDb` | Binds a change record's images as they arrived, type tags and all |
 | `[LambdaTesting]` | `Hardened.Aws.Lambda.Testing` | Assembly. Delivers through the real AWS envelope and the invocation loop rather than straight into the pipeline |
-| `[LambdaWebTesting]` | `Hardened.Aws.Lambda.Testing` | Assembly. API Gateway as a test host: a proxy event in, a proxy response out |
+| `[LambdaWebTesting]` | `Hardened.Aws.Lambda.Testing` | Assembly. The HTTP transport as a test host: a proxy event in, a proxy response out |
 | `[DynamoDbClientModule]` | `Hardened.Aws.DynamoDbClient` | Registers `IDynamoDbClientProvider`. A client, not an adapter — usable on any host |
 | `[LocalDynamoDb(Image?)]` | `Hardened.Aws.DynamoDbClient.Testing` | Points the client provider at DynamoDB Local in a container |
 
 Both were `[DynamoDbModule]` until 0.31.0, in two packages, so an application that read a table and
 handled its stream could not name either without qualifying it.
 
-A Lambda response is always buffered. There is no streaming mode and no environment variable that
-selects one; see [Response mode](/aws/lambda-web#response-mode).
+`[LambdaHttpModule]` was `[ApiGatewayModule]`, in `Hardened.Aws.Lambda.ApiGateway`, until 0.34.0.
+The adapter binds payload format 2.0, and a function URL sends that too, so the old name claimed a
+front door the module never required.
+
+A Lambda response is buffered or streamed, and `HARDENED_LAMBDA_RESPONSE_MODE` picks which; see
+[Response mode](/aws/lambda-web#response-mode).

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -133,7 +133,7 @@ reach.
 
 | Package | Serves | Module |
 |---|---|---|
-| `Hardened.Aws.Lambda.ApiGateway` | `[Get]`, `[Post]`, `[Put]`, `[Patch]`, `[Delete]` | `[ApiGatewayModule]` |
+| `Hardened.Aws.Lambda.Http` | `[Get]`, `[Post]`, `[Put]`, `[Patch]`, `[Delete]` | `[LambdaHttpModule]` |
 | `Hardened.Aws.Lambda.Invoke` | `[HardenedFunction]` | `[InvokeModule]` |
 | `Hardened.Aws.Lambda.Sqs` | `[Queue]` | `[SqsModule]` |
 | `Hardened.Aws.Lambda.Sns` | `[Topic]` | `[SnsModule]` |
@@ -143,7 +143,7 @@ reach.
 | `Hardened.Aws.Lambda.S3` | `[Blob]` | `[S3Module]` |
 
 An application does not normally write a module out. The trigger on a handler binds it, through a
-build property the adapter package declares. `[ApiGatewayModule]` is the exception, because a web
+build property the adapter package declares. `[LambdaHttpModule]` is the exception, because a web
 host's routes are in a library the generator cannot see; and any adapter is written out to set
 `ReportBatchItemFailures`, which is a fact about the deployment rather than the code.
 

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/Hardened.Aws.Lambda.Http.csproj
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/Hardened.Aws.Lambda.Http.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Description>Serves HTTP routes on AWS Lambda behind API Gateway: the proxy payload adapter for [Get], [Post] and the rest, in both v1 and v2 shapes.</Description>
+        <Description>Serves HTTP routes on AWS Lambda: the payload format 2.0 adapter for [Get], [Post] and the rest, behind an API Gateway HTTP API or a function URL.</Description>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>
-        <PackageId>Hardened.Aws.Lambda.ApiGateway</PackageId>
-        <PackageTags>Hardened;Hardened.Framework;aws;lambda;serverless;apigateway;http</PackageTags>
+        <PackageId>Hardened.Aws.Lambda.Http</PackageId>
+        <PackageTags>Hardened;Hardened.Framework;aws;lambda;serverless;http;apigateway;functionurl</PackageTags>
 
         <!--
           One adapter family, so a function that is not triggered this way never has these
@@ -43,7 +43,7 @@
       Package\ rather than build\ in the source tree, because .gitignore ignores build/.
     -->
     <ItemGroup>
-        <Content Include="Package\Hardened.Aws.Lambda.ApiGateway.targets">
+        <Content Include="Package\Hardened.Aws.Lambda.Http.targets">
             <Pack>true</Pack>
             <PackagePath>buildTransitive/</PackagePath>
             <PackageCopyToOutput>true</PackageCopyToOutput>

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpAdapter.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpAdapter.cs
@@ -8,10 +8,10 @@ using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Execution;
 using Hardened.Requests.Abstract.Execution;
 
-namespace Hardened.Aws.Lambda.ApiGateway;
+namespace Hardened.Aws.Lambda.Http;
 
 /// <summary>
-/// API Gateway payload format 2.0, which is also what a function URL and an ALB deliver.
+/// API Gateway payload format 2.0, which is also what a function URL delivers.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -22,7 +22,7 @@ namespace Hardened.Aws.Lambda.ApiGateway;
 /// <para>
 /// It brings its own <c>JsonTypeInfo</c>, per D3. That is what keeps ahead-of-time publishing
 /// honest: an adapter cannot reach a serializer the application did not declare, and the proxy
-/// request is declared in <see cref="ApiGatewaySerializerContext"/> rather than reflected over.
+/// request is declared in <see cref="LambdaHttpSerializerContext"/> rather than reflected over.
 /// Only the request needs one - the response is written field by field.
 /// </para>
 /// <para>
@@ -31,15 +31,22 @@ namespace Hardened.Aws.Lambda.ApiGateway;
 /// function does serve several sources and something has to choose.
 /// </para>
 /// </remarks>
-public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
+public sealed class LambdaHttpAdapter : IStreamingPayloadAdapter {
     /// <summary>
     /// The field that says this is payload format 2.0, and the whole of how it is told from 1.0.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Format 1.0 puts the method at <c>httpMethod</c> on the root and its <c>requestContext</c>
     /// carries no <c>http</c> object at all. That is not a hypothetical difference: selecting
     /// format 1.0 used to be accepted and ignored, the generator emitted a v2 handler anyway, and
     /// the function failed in production on a null <c>RequestContext.Http</c>.
+    /// </para>
+    /// <para>
+    /// An ALB is the same shape as 1.0 and so is not served here either: it puts the method on the
+    /// root and carries <c>requestContext.elb</c>, and it reads Set-Cookie out of
+    /// <c>multiValueHeaders</c> rather than the <c>cookies</c> array written below.
+    /// </para>
     /// </remarks>
     private const string RequestContext = "requestContext";
 
@@ -67,13 +74,13 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
     /// </remarks>
     public IExecutionRequest CreateRequest(LambdaPayload payload, ILambdaContext context) {
         var proxy = JsonSerializer.Deserialize(
-                        payload.Raw.Span, ApiGatewaySerializerContext.Default.APIGatewayHttpApiV2ProxyRequest)
+                        payload.Raw.Span, LambdaHttpSerializerContext.Default.APIGatewayHttpApiV2ProxyRequest)
                     ?? throw new InvalidOperationException(
-                        "The API Gateway adapter was given a payload that deserialized to null. " +
+                        "The Lambda HTTP adapter was given a payload that deserialized to null. " +
                         "The peek identified it as payload format 2.0 by its requestContext.http " +
                         "object, so this is a malformed event rather than a different source.");
 
-        return new ApiGatewayRequest(proxy, RequestBody(proxy));
+        return new LambdaHttpRequest(proxy, RequestBody(proxy));
     }
 
     /// <summary>
@@ -82,7 +89,7 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
     /// </summary>
     public HostFailurePolicy FailurePolicy => HostFailurePolicy.Answer500;
 
-    public IExecutionResponse CreateResponse(Stream output) => new ApiGatewayResponse(output);
+    public IExecutionResponse CreateResponse(Stream output) => new LambdaHttpResponse(output);
 
     /// <summary>
     /// The same status, headers and cookies <see cref="WriteResponse"/> would have written, sent as
@@ -109,7 +116,7 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
             prelude.Headers[header.Key] = header.Value.ToString();
         }
 
-        foreach (var cookie in SetCookies((ApiGatewayResponse)response)) {
+        foreach (var cookie in SetCookies((LambdaHttpResponse)response)) {
             prelude.Cookies.Add(cookie);
         }
 
@@ -132,11 +139,11 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
     /// </para>
     /// </remarks>
     public async ValueTask WriteResponse(IExecutionContext context, Stream output) {
-        var response = (ApiGatewayResponse)context.Response;
+        var response = (LambdaHttpResponse)context.Response;
 
         var body = response.Body as MemoryStream
                    ?? throw new InvalidOperationException(
-                       "The API Gateway adapter buffers its response, so the body has to be a " +
+                       "The Lambda HTTP adapter buffers its response, so the body has to be a " +
                        "MemoryStream it can read back. Stream mode is a different response mode, " +
                        "not a different body type here.");
 
@@ -155,7 +162,7 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
     /// <see cref="ReadOnlySpan{T}"/> local, and reading the body without copying it is the point of
     /// writing the response by hand.
     /// </remarks>
-    private static void Write(Utf8JsonWriter writer, ApiGatewayResponse response, MemoryStream body) {
+    private static void Write(Utf8JsonWriter writer, LambdaHttpResponse response, MemoryStream body) {
         writer.WriteStartObject();
 
         // Null means "handled, no opinion" - nothing sets a status on an ordinary success path -
@@ -195,7 +202,7 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
         body.TryGetBuffer(out var buffer) ? buffer.AsSpan() : body.ToArray();
 
     /// <summary>
-    /// The request body as a stream, decoded from base64 when the gateway says so.
+    /// The request body as a stream, decoded from base64 when the event says so.
     /// </summary>
     private static Stream RequestBody(APIGatewayHttpApiV2ProxyRequest request) {
         if (string.IsNullOrEmpty(request.Body)) {
@@ -227,7 +234,7 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
     /// Set-Cookie strings, which payload format 2.0 carries in its own array rather than as
     /// repeated headers.
     /// </summary>
-    private static void WriteCookies(Utf8JsonWriter writer, ApiGatewayResponse response) {
+    private static void WriteCookies(Utf8JsonWriter writer, LambdaHttpResponse response) {
         writer.WriteStartArray("cookies");
 
         foreach (var cookie in SetCookies(response)) {
@@ -246,7 +253,7 @@ public sealed class ApiGatewayAdapter : IStreamingPayloadAdapter {
     /// <c>Append(object)</c> and emits its <c>ToString()</c>, which is how every Set-Cookie once
     /// read "name=(value, CookieSetOptions { Expires = , ... })".
     /// </remarks>
-    private static IEnumerable<string> SetCookies(ApiGatewayResponse response) {
+    private static IEnumerable<string> SetCookies(LambdaHttpResponse response) {
         var builder = new StringBuilder();
 
         foreach (var cookie in response.Cookies.Cookies) {

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpModule.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpModule.cs
@@ -4,20 +4,20 @@ using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Modules;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Hardened.Aws.Lambda.ApiGateway;
+namespace Hardened.Aws.Lambda.Http;
 
 /// <summary>
-/// Registers the API Gateway adapter, applied to an application as <c>[ApiGatewayModule]</c>.
+/// Registers the HTTP adapter for Lambda, applied to an application as <c>[LambdaHttpModule]</c>.
 /// </summary>
 /// <remarks>
 /// Selected by the web verbs through <c>HardenedHttpModule</c>, which is what makes
-/// <c>[Get("/orders")]</c> run behind API Gateway without naming it - the same handler runs on
+/// <c>[Get("/orders")]</c> run on Lambda without naming a front door - the same handler runs on
 /// Kestrel and inside ASP.NET Core with only this binding changing.
 /// </remarks>
 [DependencyModule]
 [LambdaRuntimeModule]
-public partial class ApiGatewayModule : IServiceCollectionConfiguration {
+public partial class LambdaHttpModule : IServiceCollectionConfiguration {
     public void ConfigureServices(IServiceCollection services) {
-        services.AddSingleton<IPayloadAdapter, ApiGatewayAdapter>();
+        services.AddSingleton<IPayloadAdapter, LambdaHttpAdapter>();
     }
 }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpRequest.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpRequest.cs
@@ -8,17 +8,17 @@ using Hardened.Requests.Runtime.PathTokens;
 using Hardened.Requests.Runtime.QueryString;
 using Microsoft.Extensions.Primitives;
 
-namespace Hardened.Aws.Lambda.ApiGateway;
+namespace Hardened.Aws.Lambda.Http;
 
 /// <summary>
-/// The web-shaped request, from an API Gateway payload format 2.0 event.
+/// The web-shaped request, from a payload format 2.0 event.
 /// </summary>
 /// <remarks>
-/// Also a function URL and an ALB, which deliver the same shape. Payload format 1.0 is a different
-/// shape and gets its own adapter when one is written; it is not this class with a branch in it,
-/// which is what the design means by a payload format being a value rather than a fork.
+/// A function URL delivers the same shape, so both front doors bind this. Payload format 1.0 is a
+/// different shape and gets its own adapter when one is written; it is not this class with a branch
+/// in it, which is what the design means by a payload format being a value rather than a fork.
 /// </remarks>
-public class ApiGatewayRequest : IExecutionRequest {
+public class LambdaHttpRequest : IExecutionRequest {
     private readonly APIGatewayHttpApiV2ProxyRequest _proxyRequest;
     private readonly string _method;
     private IPathTokenCollection? _pathTokens;
@@ -27,11 +27,11 @@ public class ApiGatewayRequest : IExecutionRequest {
     private IReadOnlyList<string>? _cookies;
     private ITransportInfo? _transport;
 
-    public ApiGatewayRequest(APIGatewayHttpApiV2ProxyRequest request, Stream body)
+    public LambdaHttpRequest(APIGatewayHttpApiV2ProxyRequest request, Stream body)
         : this(request, body, null, null, null, null, null, null) {
     }
 
-    private ApiGatewayRequest(
+    private LambdaHttpRequest(
         APIGatewayHttpApiV2ProxyRequest request,
         Stream body,
         string? method,
@@ -67,7 +67,7 @@ public class ApiGatewayRequest : IExecutionRequest {
     public string Path { get; }
 
     /// <remarks>
-    /// Defaults to JSON when the gateway carried no header, which is the format the overwhelming
+    /// Defaults to JSON when the request carried no header, which is the format the overwhelming
     /// majority of callers send and what the binder would have to assume anyway.
     /// </remarks>
     public string? ContentType =>
@@ -86,11 +86,11 @@ public class ApiGatewayRequest : IExecutionRequest {
     IDictionary<string, StringValues> IExecutionRequest.Headers => Headers;
 
     /// <remarks>
-    /// API Gateway hands over <c>queryStringParameters</c> already percent-decoded, so nothing here
-    /// decodes a second time. That is the difference the conformance suite's decoding assertion
-    /// exists to hold: a timestamp's <c>+</c>, a base64 <c>=</c> and a space have to arrive as
-    /// themselves whatever the transport did to carry them, and a transport that parses its own
-    /// query string is where that goes wrong.
+    /// Payload format 2.0 hands over <c>queryStringParameters</c> already percent-decoded, so
+    /// nothing here decodes a second time. That is the difference the conformance suite's decoding
+    /// assertion exists to hold: a timestamp's <c>+</c>, a base64 <c>=</c> and a space have to
+    /// arrive as themselves whatever the transport did to carry them, and a transport that parses
+    /// its own query string is where that goes wrong.
     /// </remarks>
     public IQueryStringCollection QueryString => _queryStringCollection ??=
         new SimpleQueryStringCollection(_proxyRequest.QueryStringParameters);
@@ -104,7 +104,7 @@ public class ApiGatewayRequest : IExecutionRequest {
     /// Empty rather than null when the request carried no cookies.
     /// </summary>
     /// <remarks>
-    /// API Gateway omits the field entirely in that case, so
+    /// Payload format 2.0 omits the field entirely in that case, so
     /// <c>APIGatewayHttpApiV2ProxyRequest.Cookies</c> is null, and handing that back through a
     /// non-nullable <see cref="IReadOnlyList{T}"/> made every caller a null reference away from
     /// failing on the ordinary case of a request without cookies.
@@ -118,7 +118,7 @@ public class ApiGatewayRequest : IExecutionRequest {
     /// framework's own ASP.NET adapter getting this wrong.
     /// </summary>
     public ITransportInfo Transport =>
-        _transport ??= new ApiGatewayTransportInfo(_proxyRequest);
+        _transport ??= new LambdaHttpTransportInfo(_proxyRequest);
 
     /// <summary>
     /// Every argument is applied.
@@ -136,7 +136,7 @@ public class ApiGatewayRequest : IExecutionRequest {
         IDictionary<string, StringValues>? headers = null,
         IQueryStringCollection? queryString = null,
         IReadOnlyList<string>? cookies = null) {
-        return new ApiGatewayRequest(
+        return new LambdaHttpRequest(
             _proxyRequest,
             Body,
             method ?? _method,

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpResponse.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpResponse.cs
@@ -4,11 +4,11 @@ using Hardened.Requests.Abstract.Outputs;
 using Hardened.Requests.Runtime.Headers;
 using Microsoft.Extensions.Primitives;
 
-namespace Hardened.Aws.Lambda.ApiGateway;
+namespace Hardened.Aws.Lambda.Http;
 
 /// <summary>
 /// The web-shaped response. Accumulates a status, headers, cookies and a body; the adapter turns
-/// that into the gateway's payload once the chain has finished.
+/// that into the payload format 2.0 response once the chain has finished.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -27,10 +27,10 @@ namespace Hardened.Aws.Lambda.ApiGateway;
 /// a field that has no null.
 /// </para>
 /// </remarks>
-public class ApiGatewayResponse : IExecutionResponse {
+public class LambdaHttpResponse : IExecutionResponse {
     private IHeaderCollection? _headerCollection;
 
-    public ApiGatewayResponse(Stream body) {
+    public LambdaHttpResponse(Stream body) {
         Body = body;
         Cookies = new CookieSetCollectionImpl();
     }
@@ -68,7 +68,7 @@ public class ApiGatewayResponse : IExecutionResponse {
     public object Clone() => Clone(null);
 
     public IExecutionResponse Clone(IHeaderCollection? headerCollection) {
-        var clone = new ApiGatewayResponse(Body) {
+        var clone = new LambdaHttpResponse(Body) {
             ResponseValue = ResponseValue,
             OutputFactory = OutputFactory,
             Output = Output,

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpSerializerContext.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpSerializerContext.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
 using Amazon.Lambda.APIGatewayEvents;
 
-namespace Hardened.Aws.Lambda.ApiGateway;
+namespace Hardened.Aws.Lambda.Http;
 
 /// Case-insensitive rather than a camelCase policy, matching the other event contexts and AWS's
 // own serializer. A policy only reaches properties whose names differ from the wire, and getting
@@ -13,5 +13,5 @@ namespace Hardened.Aws.Lambda.ApiGateway;
 // APIGatewayHttpApiV2ProxyResponse.Body is a string and binding one would copy a six-megabyte
 // body through UTF-16 on its way back out to UTF-8.
 [JsonSerializable(typeof(APIGatewayHttpApiV2ProxyRequest))]
-internal partial class ApiGatewaySerializerContext : JsonSerializerContext {
+internal partial class LambdaHttpSerializerContext : JsonSerializerContext {
 }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpTransportInfo.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/LambdaHttpTransportInfo.cs
@@ -1,15 +1,15 @@
 using Amazon.Lambda.APIGatewayEvents;
 using Hardened.Requests.Abstract.Execution;
 
-namespace Hardened.Aws.Lambda.ApiGateway;
+namespace Hardened.Aws.Lambda.Http;
 
 /// <summary>
-/// The connection, as API Gateway describes it.
+/// The connection, as the event describes it.
 /// </summary>
 /// <remarks>
 /// <para>
 /// <b>This transport answers <see cref="KnownTransportKeys.ClientAddress"/> better than a
-/// self-hosted one can.</b> API Gateway terminates the connection and reports
+/// self-hosted one can.</b> The front door terminates the connection and reports
 /// <c>requestContext.http.sourceIp</c> as the caller it saw, so the address here is already the
 /// client behind the intermediary, which is exactly what the convention asks for. Kestrel has to
 /// answer with its socket peer and wait for a forwarded-headers filter to correct it; there is
@@ -17,16 +17,16 @@ namespace Hardened.Aws.Lambda.ApiGateway;
 /// </para>
 /// <para>
 /// <b><see cref="KnownTransportKeys.NetworkPeerAddress"/> is deliberately absent.</b> The immediate
-/// peer of this process is API Gateway itself, and the function is never told its address. Null is
-/// the honest answer, and answering with the source IP would claim an observation nothing made.
+/// peer of this process is the front door itself, and the function is never told its address. Null
+/// is the honest answer, and answering with the source IP would claim an observation nothing made.
 /// </para>
 /// <para>
-/// The bag takes any key, so AWS-specific facts - the gateway request id, the stage, the api id -
+/// The bag takes any key, so AWS-specific facts - the request id, the stage, the api id -
 /// can be published here without a change to the framework. Left out because the request id is
 /// already the correlation id and the rest have no consumer.
 /// </para>
 /// </remarks>
-public sealed class ApiGatewayTransportInfo : ITransportInfo {
+public sealed class LambdaHttpTransportInfo : ITransportInfo {
     private static readonly string[] KeyList = [
         KnownTransportKeys.ClientAddress,
         KnownTransportKeys.ServerAddress,
@@ -36,7 +36,7 @@ public sealed class ApiGatewayTransportInfo : ITransportInfo {
 
     private readonly APIGatewayHttpApiV2ProxyRequest _request;
 
-    public ApiGatewayTransportInfo(APIGatewayHttpApiV2ProxyRequest request) {
+    public LambdaHttpTransportInfo(APIGatewayHttpApiV2ProxyRequest request) {
         _request = request;
     }
 
@@ -48,12 +48,12 @@ public sealed class ApiGatewayTransportInfo : ITransportInfo {
 
             KnownTransportKeys.ServerAddress => Empty(_request.RequestContext?.DomainName),
 
-            // "HTTP/1.1" from the gateway; the convention wants the version alone.
+            // "HTTP/1.1" on the event; the convention wants the version alone.
             KnownTransportKeys.NetworkProtocolVersion =>
                 Version(_request.RequestContext?.Http?.Protocol),
 
-            // API Gateway does not serve plaintext, so this is not read off the request - there is
-            // nothing on it that could say otherwise.
+            // Neither API Gateway nor a function URL serves plaintext, so this is not read off
+            // the request - there is nothing on it that could say otherwise.
             KnownTransportKeys.UrlScheme => "https",
 
             _ => null
@@ -63,7 +63,7 @@ public sealed class ApiGatewayTransportInfo : ITransportInfo {
     /// Null for an absent value, because the framework contract is null rather than empty.
     /// </summary>
     /// <remarks>
-    /// The proxy request is deserialized from JSON, so a field the gateway omitted arrives as null
+    /// The proxy request is deserialized from JSON, so a field the sender omitted arrives as null
     /// and a field it sent empty arrives as "". Both mean the same thing here.
     /// </remarks>
     private static string? Empty(string? value) => string.IsNullOrEmpty(value) ? null : value;

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Http/Package/Hardened.Aws.Lambda.Http.targets
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Http/Package/Hardened.Aws.Lambda.Http.targets
@@ -15,6 +15,6 @@
             <HardenedHttpModule>MyCompany.SomeOtherModule</HardenedHttpModule>
     -->
     <PropertyGroup>
-        <HardenedHttpModule Condition="'$(HardenedHttpModule)' == ''">Hardened.Aws.Lambda.ApiGateway.ApiGatewayModule</HardenedHttpModule>
+        <HardenedHttpModule Condition="'$(HardenedHttpModule)' == ''">Hardened.Aws.Lambda.Http.LambdaHttpModule</HardenedHttpModule>
     </PropertyGroup>
 </Project>

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Adapters/LambdaHttpAdapterTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Adapters/LambdaHttpAdapterTests.cs
@@ -5,7 +5,7 @@ using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Execution;
 using Hardened.Aws.Lambda.Runtime.Tests.Infrastructure;
 using Xunit;
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 
 namespace Hardened.Aws.Lambda.Runtime.Tests.Adapters;
 
@@ -13,8 +13,8 @@ namespace Hardened.Aws.Lambda.Runtime.Tests.Adapters;
 /// The two halves the conformance suite does not reach: what the peek recognises, and what comes
 /// out the far end.
 /// </summary>
-public class ApiGatewayAdapterTests {
-    private readonly ApiGatewayAdapter _adapter = new();
+public class LambdaHttpAdapterTests {
+    private readonly LambdaHttpAdapter _adapter = new();
 
     private bool Handles(string json) {
         using var payload = new LambdaPayload(Encoding.UTF8.GetBytes(json));
@@ -77,8 +77,8 @@ public class ApiGatewayAdapterTests {
     }
 
     /// <summary>
-    /// An "http" nested deeper inside the caller's own requestContext is not the gateway's. Only a
-    /// direct property of requestContext counts, which is what the depth check is for.
+    /// An "http" nested deeper inside the caller's own requestContext is not the front door's.
+    /// Only a direct property of requestContext counts, which is what the depth check is for.
     /// </summary>
     [Fact]
     public void DeclinesAnHttpBuriedDeeperInsideSomeoneElsesContext() {
@@ -206,8 +206,8 @@ public class ApiGatewayAdapterTests {
     }
 
     /// <summary>Runs the response half: build one, let the caller write to it, read the payload.</summary>
-    private async Task<APIGatewayHttpApiV2ProxyResponse> Answer(Action<ApiGatewayResponse> write) {
-        var response = (ApiGatewayResponse)_adapter.CreateResponse(new MemoryStream());
+    private async Task<APIGatewayHttpApiV2ProxyResponse> Answer(Action<LambdaHttpResponse> write) {
+        var response = (LambdaHttpResponse)_adapter.CreateResponse(new MemoryStream());
 
         write(response);
 

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Adapters/PayloadDiscriminationTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Adapters/PayloadDiscriminationTests.cs
@@ -1,7 +1,7 @@
 using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Tests.Infrastructure;
 using Xunit;
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 using Hardened.Aws.Lambda.DynamoDb;
 using Hardened.Aws.Lambda.EventBridge;
 using Hardened.Aws.Lambda.Kinesis;
@@ -34,7 +34,7 @@ public class PayloadDiscriminationTests {
         ("kinesis", new KinesisAdapter()),
         ("s3", new S3Adapter()),
         ("eventbridge", new EventBridgeAdapter()),
-        ("apigateway", new ApiGatewayAdapter())
+        ("http", new LambdaHttpAdapter())
     ];
 
     public static TheoryData<string, string> Payloads() => new() {
@@ -45,7 +45,7 @@ public class PayloadDiscriminationTests {
         { "s3", Infrastructure.Payloads.S3Json },
         { "eventbridge", Infrastructure.Payloads.EventBridgeJson },
         { "eventbridge", Infrastructure.Payloads.ScheduledJson },
-        { "apigateway", Infrastructure.Payloads.ApiGatewayJson }
+        { "http", Infrastructure.Payloads.HttpJson }
     };
 
     [Theory]

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Conformance/LambdaHttpRequestConformanceTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Conformance/LambdaHttpRequestConformanceTests.cs
@@ -1,13 +1,13 @@
 using Amazon.Lambda.APIGatewayEvents;
 using Hardened.Aws.Lambda.Runtime.Execution;
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Testing.Conformance;
 
 namespace Hardened.Aws.Lambda.Runtime.Tests.Conformance;
 
 /// <summary>
-/// The API Gateway request, held to the web-shaped profile: all twenty-six assertions.
+/// The Lambda HTTP request, held to the web-shaped profile: all twenty-six assertions.
 /// </summary>
 /// <remarks>
 /// The full profile rather than the payload subset, because this transport really does carry a
@@ -15,16 +15,16 @@ namespace Hardened.Aws.Lambda.Runtime.Tests.Conformance;
 /// split encodes - it is about what the transport carried, not about how much of the pipeline the
 /// adapter happens to use.
 /// </remarks>
-public class ApiGatewayRequestConformanceTests : ExecutionRequestConformanceTests {
-    protected override IExecutionRequestConformanceAdapter Adapter { get; } = new GatewayAdapter();
+public class LambdaHttpRequestConformanceTests : ExecutionRequestConformanceTests {
+    protected override IExecutionRequestConformanceAdapter Adapter { get; } = new HttpAdapter_();
 
     /// <summary>
-    /// Builds the proxy event the gateway would have sent and hands it to the real request, doing
+    /// Builds the proxy event the front door would have sent and hands it to the real request,
     /// nothing else. Anything the mapping gets wrong reaches the assertions rather than being
     /// smoothed over here.
     /// </summary>
-    private sealed class GatewayAdapter : IExecutionRequestConformanceAdapter {
-        public string TransportName => "API Gateway v2";
+    private sealed class HttpAdapter_ : IExecutionRequestConformanceAdapter {
+        public string TransportName => "Lambda HTTP";
 
         public IExecutionRequest CreateRequest(ConformanceRequestSpec spec) {
             var proxy = new APIGatewayHttpApiV2ProxyRequest {
@@ -42,7 +42,7 @@ public class ApiGatewayRequestConformanceTests : ExecutionRequestConformanceTest
                 }
             };
 
-            // The gateway sends queryStringParameters already percent-decoded, so the spec's values
+            // Payload format 2.0 carries queryStringParameters already percent-decoded, so they
             // go across as themselves. Encoding them here would be testing this file's encoder
             // rather than the request's decoding, and the suite asserts a "+" in a timestamp and a
             // trailing "=" in base64 survive - which they do because nothing decodes twice.
@@ -59,7 +59,7 @@ public class ApiGatewayRequestConformanceTests : ExecutionRequestConformanceTest
 
             var body = spec.Body == null ? Stream.Null : new MemoryStream(spec.Body);
 
-            return new ApiGatewayRequest(proxy, body);
+            return new LambdaHttpRequest(proxy, body);
         }
     }
 }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/LambdaInvocationHandlerTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/LambdaInvocationHandlerTests.cs
@@ -5,7 +5,7 @@ using Hardened.Aws.Lambda.Runtime.Execution;
 using Hardened.Aws.Lambda.Runtime.Hosting;
 using Hardened.Aws.Lambda.Runtime.Streaming;
 using Hardened.Aws.Lambda.Runtime.Tests.Infrastructure;
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 using Hardened.Aws.Lambda.EventBridge;
 using Hardened.Aws.Lambda.Invoke;
 using Hardened.Aws.Lambda.Sns;
@@ -144,9 +144,9 @@ public class LambdaInvocationHandlerTests {
 
     [Fact]
     public async Task AWebAdapterAsksForTheFailureToBeAnswered() {
-        var (handler, executor) = Build(new ApiGatewayAdapter());
+        var (handler, executor) = Build(new LambdaHttpAdapter());
 
-        await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+        await handler.Invoke(Input(Payloads.HttpJson), Context());
 
         Assert.Equal(HostFailurePolicy.Answer500, executor.Policy);
     }
@@ -168,7 +168,7 @@ public class LambdaInvocationHandlerTests {
     /// </summary>
     [Fact]
     public async Task TheAdapterWritesTheAnswer() {
-        var (handler, executor) = Build(new ApiGatewayAdapter());
+        var (handler, executor) = Build(new LambdaHttpAdapter());
 
         executor.Body = context => {
             context.Response.Status = 201;
@@ -176,7 +176,7 @@ public class LambdaInvocationHandlerTests {
             return Task.CompletedTask;
         };
 
-        var output = await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+        var output = await handler.Invoke(Input(Payloads.HttpJson), Context());
 
         Assert.Contains("\"statusCode\":201", new StreamReader(output).ReadToEnd());
     }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/StreamedInvocationTests.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Hosting/StreamedInvocationTests.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Text;
 using Amazon.Lambda.Core;
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 using Hardened.Aws.Lambda.Runtime.Adapters;
 using Hardened.Aws.Lambda.Runtime.Hosting;
 using Hardened.Aws.Lambda.Runtime.Streaming;
@@ -36,11 +36,11 @@ public class StreamedInvocationTests {
     /// </summary>
     [Fact]
     public async Task StreamModeOpensAResponseStream() {
-        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new LambdaHttpAdapter());
 
         executor.Body = Writes("hello");
 
-        var output = await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+        var output = await handler.Invoke(Input(Payloads.HttpJson), Context());
 
         Assert.Equal("hello", streams.Target.Text);
 
@@ -54,11 +54,11 @@ public class StreamedInvocationTests {
     /// </summary>
     [Fact]
     public async Task BufferedModeWritesTheEnvelopeAndOpensNoStream() {
-        var (handler, executor, streams) = Build(LambdaResponseMode.Buffered, new ApiGatewayAdapter());
+        var (handler, executor, streams) = Build(LambdaResponseMode.Buffered, new LambdaHttpAdapter());
 
         executor.Body = Writes("hello");
 
-        var output = await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+        var output = await handler.Invoke(Input(Payloads.HttpJson), Context());
 
         Assert.Empty(streams.Preludes);
         Assert.Contains("\"body\":\"hello\"", await Text(output));
@@ -88,7 +88,7 @@ public class StreamedInvocationTests {
     /// </summary>
     [Fact]
     public async Task ThePreludeCarriesTheStatusHeadersAndCookies() {
-        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new LambdaHttpAdapter());
 
         executor.Body = async context => {
             context.Response.Status = 201;
@@ -98,7 +98,7 @@ public class StreamedInvocationTests {
             await context.Response.Body.WriteAsync("hi"u8.ToArray());
         };
 
-        await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+        await handler.Invoke(Input(Payloads.HttpJson), Context());
 
         var prelude = streams.Prelude;
 
@@ -119,7 +119,7 @@ public class StreamedInvocationTests {
     /// </remarks>
     [Fact]
     public async Task AStatusSetBeforeTheFirstByteReachesThePrelude() {
-        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new LambdaHttpAdapter());
 
         executor.Body = async context => {
             await context.Response.Body.WriteAsync("first"u8.ToArray());
@@ -128,7 +128,7 @@ public class StreamedInvocationTests {
             context.Response.Status = 500;
         };
 
-        await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+        await handler.Invoke(Input(Payloads.HttpJson), Context());
 
         Assert.Equal(HttpStatusCode.OK, streams.Prelude.StatusCode);
     }
@@ -144,9 +144,9 @@ public class StreamedInvocationTests {
     /// </remarks>
     [Fact]
     public async Task AnEmptyResponseStillOpensTheStream() {
-        var (handler, _, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+        var (handler, _, streams) = Build(LambdaResponseMode.Stream, new LambdaHttpAdapter());
 
-        await handler.Invoke(Input(Payloads.ApiGatewayJson), Context());
+        await handler.Invoke(Input(Payloads.HttpJson), Context());
 
         Assert.Single(streams.Preludes);
         Assert.Equal("\n", streams.Target.Text);
@@ -162,7 +162,7 @@ public class StreamedInvocationTests {
     /// </remarks>
     [Fact]
     public async Task AThrowAfterTheFirstByteKeepsWhatWasWritten() {
-        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new LambdaHttpAdapter());
 
         executor.Body = async context => {
             await context.Response.Body.WriteAsync("partial"u8.ToArray());
@@ -171,7 +171,7 @@ public class StreamedInvocationTests {
         };
 
         var failure = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => handler.Invoke(Input(Payloads.ApiGatewayJson), Context()));
+            () => handler.Invoke(Input(Payloads.HttpJson), Context()));
 
         Assert.Equal("nothing more to stream", failure.Message);
         Assert.Equal("partial", streams.Target.Text);
@@ -183,12 +183,12 @@ public class StreamedInvocationTests {
     /// </summary>
     [Fact]
     public async Task AThrowBeforeTheFirstByteOpensNoStream() {
-        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new ApiGatewayAdapter());
+        var (handler, executor, streams) = Build(LambdaResponseMode.Stream, new LambdaHttpAdapter());
 
         executor.Body = _ => throw new InvalidOperationException("nothing to stream");
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => handler.Invoke(Input(Payloads.ApiGatewayJson), Context()));
+            () => handler.Invoke(Input(Payloads.HttpJson), Context()));
 
         Assert.Empty(streams.Preludes);
     }

--- a/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Infrastructure/Payloads.cs
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda.Runtime.Tests/Infrastructure/Payloads.cs
@@ -170,7 +170,7 @@ public static class Payloads {
          "region":"us-east-1","records":[{"recordId":"r1","data":"aGVsbG8="}]}
         """;
 
-    public const string ApiGatewayJson = """
+    public const string HttpJson = """
         {"version":"2.0","rawPath":"/orders","requestContext":{"http":{"method":"GET"}}}
         """;
 

--- a/src/Clouds/Aws/Hardened.Aws.Lambda/Hardened.Aws.Lambda.csproj
+++ b/src/Clouds/Aws/Hardened.Aws.Lambda/Hardened.Aws.Lambda.csproj
@@ -33,7 +33,7 @@
     -->
     <ItemGroup>
         <ProjectReference Include="..\Hardened.Aws.Lambda.Runtime\Hardened.Aws.Lambda.Runtime.csproj"/>
-        <ProjectReference Include="..\Hardened.Aws.Lambda.ApiGateway\Hardened.Aws.Lambda.ApiGateway.csproj"/>
+        <ProjectReference Include="..\Hardened.Aws.Lambda.Http\Hardened.Aws.Lambda.Http.csproj"/>
         <ProjectReference Include="..\Hardened.Aws.Lambda.DynamoDb\Hardened.Aws.Lambda.DynamoDb.csproj"/>
         <ProjectReference Include="..\Hardened.Aws.Lambda.EventBridge\Hardened.Aws.Lambda.EventBridge.csproj"/>
         <ProjectReference Include="..\Hardened.Aws.Lambda.Invoke\Hardened.Aws.Lambda.Invoke.csproj"/>

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/AdapterRegistrationTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/AdapterRegistrationTests.cs
@@ -1,18 +1,18 @@
 using Hardened.Aws.Lambda.Runtime.Adapters;
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Shared.Testing.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
+namespace Hardened.IntegrationTests.LambdaHttp.SUT.Tests;
 
 /// <summary>
 /// What the verbs on the controller registered.
 ///
 /// <para>
 /// The one thing in this suite that is deliberately about AWS. Everything else is written as a web
-/// test and would pass on any host; these two say that on this host the verbs bound the API Gateway
+/// test and would pass on any host; these two say that on this host the verbs bound the Lambda HTTP
 /// adapter and that it answers a failure rather than rethrowing - which is the difference between
 /// the HTTP family and every other one.
 /// </para>
@@ -20,11 +20,11 @@ namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
 public class AdapterRegistrationTests {
 
     /// <summary>
-    /// Verbs bound the adapter. Nothing in the application mentions API Gateway, SQS or Lambda.
+    /// Verbs bound the adapter. Nothing in the application mentions a front door, SQS or Lambda.
     /// </summary>
     [HardenedTest]
-    public void TheVerbsRegisteredTheGatewayAdapter(IServiceProvider provider) {
-        Assert.IsType<ApiGatewayAdapter>(Assert.Single(provider.GetServices<IPayloadAdapter>()));
+    public void TheVerbsRegisteredTheHttpAdapter(IServiceProvider provider) {
+        Assert.IsType<LambdaHttpAdapter>(Assert.Single(provider.GetServices<IPayloadAdapter>()));
     }
 
     /// <summary>

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/Bootstrap.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/Bootstrap.cs
@@ -1,12 +1,12 @@
 using Hardened.Aws.Lambda.Testing;
-using Hardened.IntegrationTests.ApiGateway.SUT;
+using Hardened.IntegrationTests.LambdaHttp.SUT;
 using Hardened.Shared.Testing.Attributes;
 using Hardened.Web.Testing;
 
 // [WebTesting] is the harness every web suite uses; [LambdaWebTesting] is the only line that says
-// these run behind API Gateway. Remove it and the same tests run on the pipeline; swap it for
+// these run on Lambda. Remove it and the same tests run on the pipeline; swap it for
 // [KestrelTesting] and they run over a socket. That is the portability claim as something a build
 // can check rather than something a document asserts.
 [assembly: WebTesting]
 [assembly: LambdaWebTesting]
-[assembly: HardenedTestEntryPoint(typeof(ApiGatewayTestApp))]
+[assembly: HardenedTestEntryPoint(typeof(LambdaHttpTestApp))]

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/Hardened.IntegrationTests.LambdaHttp.SUT.Tests.csproj
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/Hardened.IntegrationTests.LambdaHttp.SUT.Tests.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Hardened.IntegrationTests.ApiGateway.SUT\Hardened.IntegrationTests.ApiGateway.SUT.csproj"/>
+        <ProjectReference Include="..\Hardened.IntegrationTests.LambdaHttp.SUT\Hardened.IntegrationTests.LambdaHttp.SUT.csproj"/>
         <ProjectReference Include="..\..\..\..\..\Web\Hardened.Web.Testing\Hardened.Web.Testing.csproj"/>
         <ProjectReference Include="..\..\..\Hardened.Aws.Lambda.Testing\Hardened.Aws.Lambda.Testing.csproj"/>
         <ProjectReference Include="..\..\..\..\..\Shared\Hardened.Shared.Testing.xUnit\Hardened.Shared.Testing.xUnit.csproj"/>

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/HostClientTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/HostClientTests.cs
@@ -1,11 +1,11 @@
 using System.Net.Http.Json;
 using DependencyModules.Testing.Attributes;
-using Hardened.IntegrationTests.ApiGateway.SUT;
+using Hardened.IntegrationTests.LambdaHttp.SUT;
 using Hardened.Shared.Testing.Attributes;
 using Hardened.Web.Testing;
 using Xunit;
 
-namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
+namespace Hardened.IntegrationTests.LambdaHttp.SUT.Tests;
 
 /// <summary>
 /// An ordinary <c>HttpClient</c> against the Lambda web host.
@@ -15,7 +15,7 @@ namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
 /// The suite drives <see cref="ITestWebApp"/> everywhere else, which reaches the host directly. A
 /// client goes the other way, through the message handler the host hands out, and that is a
 /// separate path with its own request translation - so a client that worked on the pipeline and not
-/// behind API Gateway would have gone unnoticed.
+/// on Lambda would have gone unnoticed.
 /// </para>
 /// <para>
 /// It also says the portability claim in a second voice. Nothing here mentions Lambda; the same
@@ -63,8 +63,8 @@ public class HostClientTests {
     }
 
     /// <summary>
-    /// The host says which deployment it stands for, and behind API Gateway that is one environment
-    /// per invocation.
+    /// The host says which deployment it stands for, and on Lambda that is one environment per
+    /// invocation.
     /// </summary>
     /// <remarks>
     /// Read by a person rather than by the harness, which is why it is asserted: a property nothing

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/HttpFunctionTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/HttpFunctionTests.cs
@@ -2,7 +2,7 @@ using Hardened.Shared.Testing.Attributes;
 using Hardened.Web.Testing;
 using Xunit;
 
-namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
+namespace Hardened.IntegrationTests.LambdaHttp.SUT.Tests;
 
 /// <summary>
 /// A web application deployed as a Lambda: ordinary verbs on a controller, reached through an API

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/ServerSentEventManifestTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/ServerSentEventManifestTests.cs
@@ -3,7 +3,7 @@ using Hardened.Shared.Testing.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
+namespace Hardened.IntegrationTests.LambdaHttp.SUT.Tests;
 
 /// <summary>
 /// The whole chain the buffered-mode warning rests on, through a real application rather than a

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/StreamedEventStreamTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT.Tests/StreamedEventStreamTests.cs
@@ -7,7 +7,7 @@ using Hardened.Shared.Testing.Attributes;
 using Hardened.Web.Testing;
 using Xunit;
 
-namespace Hardened.IntegrationTests.ApiGateway.SUT.Tests;
+namespace Hardened.IntegrationTests.LambdaHttp.SUT.Tests;
 
 /// <summary>
 /// An event stream handler through the mode it has to be deployed in.

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT/Hardened.IntegrationTests.LambdaHttp.SUT.csproj
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT/Hardened.IntegrationTests.LambdaHttp.SUT.csproj
@@ -5,21 +5,21 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>Hardened.IntegrationTests.ApiGateway.SUT</RootNamespace>
+        <RootNamespace>Hardened.IntegrationTests.LambdaHttp.SUT</RootNamespace>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     </PropertyGroup>
 
     <!--
       An HTTP function: web verbs on a controller and nothing that names AWS. The same handlers
-      compile against Kestrel and inside ASP.NET Core, and the only thing that makes them run behind
-      API Gateway is which runtime package this project references - which is the portability claim
+      compile against Kestrel and inside ASP.NET Core, and the only thing that makes them run on
+      Lambda is which runtime package this project references - which is the portability claim
       the whole adapter map exists for, and this is the fixture that holds it.
     -->
     <ItemGroup>
         <ProjectReference Include="..\..\..\..\..\Requests\Hardened.Requests.Abstract\Hardened.Requests.Abstract.csproj"/>
         <ProjectReference Include="..\..\..\..\..\Requests\Hardened.Requests.Runtime\Hardened.Requests.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
-        <ProjectReference Include="..\..\..\Hardened.Aws.Lambda.ApiGateway\Hardened.Aws.Lambda.ApiGateway.csproj"/>
+        <ProjectReference Include="..\..\..\Hardened.Aws.Lambda.Http\Hardened.Aws.Lambda.Http.csproj"/>
         <ProjectReference Include="..\..\..\..\..\SourceGenerators\Hardened.Library.SourceGenerator\Hardened.Library.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
         <ProjectReference Include="..\..\..\..\..\Web\Hardened.Web.Runtime\Hardened.Web.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\..\..\SourceGenerators\Hardened.Web.SourceGenerator\Hardened.Web.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
@@ -42,6 +42,6 @@
       attribute rather than living in one place.
     -->
     <Import Project="..\..\..\..\..\Web\Hardened.Web.Runtime\Package\Hardened.Web.Runtime.targets"/>
-    <Import Project="..\..\..\Hardened.Aws.Lambda.ApiGateway\Package\Hardened.Aws.Lambda.ApiGateway.targets"/>
+    <Import Project="..\..\..\Hardened.Aws.Lambda.Http\Package\Hardened.Aws.Lambda.Http.targets"/>
 
 </Project>

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT/LambdaHttpTestApp.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT/LambdaHttpTestApp.cs
@@ -1,18 +1,18 @@
 using Hardened.Shared.Runtime.Attributes;
 using Hardened.Web.Runtime.DependencyInjection;
 
-namespace Hardened.IntegrationTests.ApiGateway.SUT;
+namespace Hardened.IntegrationTests.LambdaHttp.SUT;
 
 /// <summary>
 /// An HTTP application, which happens to be deployed as a Lambda.
 /// </summary>
 /// <remarks>
 /// <c>[HardenedWebModule]</c> brings the routing table and the web pipeline, exactly as it would for
-/// Kestrel. Nothing here names API Gateway: the verbs on the controller bind
+/// Kestrel. Nothing here names a front door: the verbs on the controller bind
 /// <c>HardenedHttpModule</c>, and which module that is comes from the runtime package this project
 /// references. Swapping that reference is the whole of moving these handlers to another host.
 /// </remarks>
 [HardenedModule]
 [HardenedWebModule]
-public partial class ApiGatewayTestApp {
+public partial class LambdaHttpTestApp {
 }

--- a/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT/OrderController.cs
+++ b/src/Clouds/Aws/IntegrationTests/LambdaHttp/Hardened.IntegrationTests.LambdaHttp.SUT/OrderController.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
 using Hardened.Web.Runtime.Attributes;
 
-namespace Hardened.IntegrationTests.ApiGateway.SUT;
+namespace Hardened.IntegrationTests.LambdaHttp.SUT;
 
 public class Order {
     public string Id { get; set; } = "";

--- a/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.Rie.Tests/Hardened.IntegrationTests.Rie.Tests.csproj
+++ b/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.Rie.Tests/Hardened.IntegrationTests.Rie.Tests.csproj
@@ -25,7 +25,7 @@
                           ReferenceOutputAssembly="false"/>
         <ProjectReference Include="..\Hardened.IntegrationTests.RieEvents.SUT\Hardened.IntegrationTests.RieEvents.SUT.csproj"
                           ReferenceOutputAssembly="false"/>
-        <ProjectReference Include="..\Hardened.IntegrationTests.RieApiGateway.SUT\Hardened.IntegrationTests.RieApiGateway.SUT.csproj"
+        <ProjectReference Include="..\Hardened.IntegrationTests.RieLambdaHttp.SUT\Hardened.IntegrationTests.RieLambdaHttp.SUT.csproj"
                           ReferenceOutputAssembly="false"/>
         <ProjectReference Include="..\Hardened.IntegrationTests.RieInvoke.SUT\Hardened.IntegrationTests.RieInvoke.SUT.csproj"
                           ReferenceOutputAssembly="false"/>

--- a/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.Rie.Tests/LambdaHttpImageTests.cs
+++ b/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.Rie.Tests/LambdaHttpImageTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 namespace Hardened.IntegrationTests.Rie.Tests;
 
 /// <summary>
-/// The API Gateway fixture inside the Lambda base image. Web-shaped, so the proxy response the
+/// The HTTP fixture inside the Lambda base image. Web-shaped, so the proxy response the
 /// invocation returns is the whole observation.
 /// </summary>
 [Trait("Category", "Simulator")]
-public sealed class ApiGatewayImageTests : IClassFixture<ApiGatewayImageTests.Function> {
+public sealed class LambdaHttpImageTests : IClassFixture<LambdaHttpImageTests.Function> {
     private readonly Function _function;
 
-    public ApiGatewayImageTests(Function function) {
+    public LambdaHttpImageTests(Function function) {
         _function = function;
     }
 
@@ -68,8 +68,8 @@ public sealed class ApiGatewayImageTests : IClassFixture<ApiGatewayImageTests.Fu
 
     public sealed class Function : IAsyncLifetime {
         public LambdaRuntimeInterfaceEmulator Emulator { get; } = new(
-            ApplicationOutput.Of("Hardened.IntegrationTests.RieApiGateway.SUT"),
-            "Hardened.IntegrationTests.RieApiGateway.SUT");
+            ApplicationOutput.Of("Hardened.IntegrationTests.RieLambdaHttp.SUT"),
+            "Hardened.IntegrationTests.RieLambdaHttp.SUT");
 
         public async ValueTask InitializeAsync() => await Emulator.StartAsync(TestContext.Current.CancellationToken);
 

--- a/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieLambdaHttp.SUT/Hardened.IntegrationTests.RieLambdaHttp.SUT.csproj
+++ b/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieLambdaHttp.SUT/Hardened.IntegrationTests.RieLambdaHttp.SUT.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <!--
-      The ApiGateway fixture's application as a deployable function, for the container tier: the
+      The LambdaHttp fixture's application as a deployable function, for the container tier: the
       Lambda bootstrap against whatever AWS_LAMBDA_RUNTIME_API names, which inside
       public.ecr.aws/lambda/dotnet:8 is the Runtime Interface Emulator. See
       Hardened.IntegrationTests.Rie.SUT for why this is an executable without an apphost.
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\ApiGateway\Hardened.IntegrationTests.ApiGateway.SUT\Hardened.IntegrationTests.ApiGateway.SUT.csproj"/>
+        <ProjectReference Include="..\..\LambdaHttp\Hardened.IntegrationTests.LambdaHttp.SUT\Hardened.IntegrationTests.LambdaHttp.SUT.csproj"/>
         <ProjectReference Include="..\..\..\Hardened.Aws.Lambda.Runtime\Hardened.Aws.Lambda.Runtime.csproj"/>
         <ProjectReference Include="..\..\..\..\..\Shared\Hardened.Shared.Runtime\Hardened.Shared.Runtime.csproj"/>
     </ItemGroup>

--- a/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieLambdaHttp.SUT/Program.cs
+++ b/src/Clouds/Aws/IntegrationTests/Rie/Hardened.IntegrationTests.RieLambdaHttp.SUT/Program.cs
@@ -1,10 +1,10 @@
 using Hardened.Aws.Lambda.Runtime.Hosting;
-using Hardened.IntegrationTests.ApiGateway.SUT;
+using Hardened.IntegrationTests.LambdaHttp.SUT;
 using Hardened.Shared.Runtime.Application;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-// The API Gateway fixture hosted as a deployed function is. Nothing to observe: the proxy response
+// The HTTP fixture hosted as a deployed function. Nothing to observe: the proxy response
 // the invocation returns is the whole answer.
 
 var services = new ServiceCollection();
@@ -16,6 +16,6 @@ var services = new ServiceCollection();
 services.AddLogging(builder => builder.AddLambdaLogger().SetMinimumLevel(LogLevel.Warning));
 services.AddTransient<IHardenedEnvironment>(_ => new EnvironmentImpl(arguments: args));
 
-new ApiGatewayTestApp().PopulateServiceCollection(services);
+new LambdaHttpTestApp().PopulateServiceCollection(services);
 
 await HardenedLambdaBootstrap.Run(services.BuildServiceProvider());

--- a/src/Clouds/Azure/Hardened.Azure.Functions.Http/Hardened.Azure.Functions.Http.csproj
+++ b/src/Clouds/Azure/Hardened.Azure.Functions.Http/Hardened.Azure.Functions.Http.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <!--
-      No reference to Hardened.Web.Runtime, the same arrangement as Hardened.Aws.Lambda.ApiGateway:
+      No reference to Hardened.Web.Runtime, the same arrangement as Hardened.Aws.Lambda.Http:
       the adapter produces a web-shaped IExecutionRequest and the pipeline routes it through the
       table [HardenedWebModule] registered on the application. The invocation handler selects that
       table per invocation because the shim says it is the web function; nothing here names it.

--- a/src/Clouds/Azure/Hardened.Azure.Functions.Http/HttpAdapter.cs
+++ b/src/Clouds/Azure/Hardened.Azure.Functions.Http/HttpAdapter.cs
@@ -80,7 +80,7 @@ public sealed class HttpAdapter : ITriggerAdapter {
         }
 
         foreach (var cookie in response.Cookies.Cookies) {
-            // Item1 is the value and Item2 the options; see ApiGatewayAdapter for the tuple's history.
+            // Item1 is the value and Item2 the options; see LambdaHttpAdapter for the tuple's history.
             data.Cookies.Append(Cookie(cookie.Key, cookie.Value.Item1, cookie.Value.Item2));
         }
 

--- a/src/Clouds/Azure/Hardened.Azure.Functions.Http/HttpFunctionRequest.cs
+++ b/src/Clouds/Azure/Hardened.Azure.Functions.Http/HttpFunctionRequest.cs
@@ -14,7 +14,7 @@ namespace Hardened.Azure.Functions.Http;
 /// The web-shaped request, from the worker's <see cref="HttpRequestData"/>.
 /// </summary>
 /// <remarks>
-/// The counterpart of <c>ApiGatewayRequest</c>, and simpler because the worker has already done
+/// The counterpart of <c>LambdaHttpRequest</c>, and simpler because the worker has already done
 /// the transport's work: the query is parsed and decoded, the headers are a collection, the
 /// cookies are objects and the body is a stream. What is left is naming each the way the pipeline
 /// asks for it.

--- a/src/Clouds/Azure/Hardened.Azure.Functions.Http/HttpFunctionResponse.cs
+++ b/src/Clouds/Azure/Hardened.Azure.Functions.Http/HttpFunctionResponse.cs
@@ -12,7 +12,7 @@ namespace Hardened.Azure.Functions.Http;
 /// </summary>
 /// <remarks>
 /// It holds no <c>HttpResponseData</c> while the chain runs, for the reason
-/// <c>ApiGatewayResponse</c> gives: the status has to be null until something sets it, so the
+/// <c>LambdaHttpResponse</c> gives: the status has to be null until something sets it, so the
 /// not-found handler can tell an unmatched route from an answered one, and the worker's status is
 /// an enum with no null.
 /// </remarks>

--- a/src/Clouds/Azure/Hardened.Azure.Functions.SourceGenerator/AzureFunctionsGenerator.cs
+++ b/src/Clouds/Azure/Hardened.Azure.Functions.SourceGenerator/AzureFunctionsGenerator.cs
@@ -278,7 +278,7 @@ public static class AzureFunctionsGenerator {
 
             // The HTTP family is declared by a web verb in this compilation, or by the module
             // written on the application: a host project whose routes live in a library names
-            // [HttpModule] the way a Lambda host names [ApiGatewayModule], because a generator
+            // [HttpModule] the way a Lambda host names [LambdaHttpModule], because a generator
             // sees only the compilation it runs in.
             var declared = family.Scheme == "HTTP"
                 ? usesWeb || settings.Written

--- a/src/Clouds/Azure/IntegrationTests/Http/Hardened.IntegrationTests.AzureHttp.SUT/AzureHttpTestApp.cs
+++ b/src/Clouds/Azure/IntegrationTests/Http/Hardened.IntegrationTests.AzureHttp.SUT/AzureHttpTestApp.cs
@@ -11,7 +11,7 @@ namespace Hardened.IntegrationTests.AzureHttp.SUT;
 /// for Kestrel. Nothing here names Azure: the verbs on the controller bind
 /// <c>HardenedHttpModule</c>, and which module that is comes from the runtime package this project
 /// references. Swapping that reference is the whole of moving these handlers to another host -
-/// <c>ApiGatewayTestApp</c> is this file with another name.
+/// <c>LambdaHttpTestApp</c> is this file with another name.
 /// </remarks>
 [HardenedModule]
 [HardenedWebModule]

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.Http.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Aws.Lambda.Http.approved.txt
@@ -1,9 +1,9 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Hardened.Aws.Lambda.Runtime.Tests")]
-namespace Hardened.Aws.Lambda.ApiGateway
+namespace Hardened.Aws.Lambda.Http
 {
-    public sealed class ApiGatewayAdapter : Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter, Hardened.Aws.Lambda.Runtime.Adapters.IStreamingPayloadAdapter
+    public sealed class LambdaHttpAdapter : Hardened.Aws.Lambda.Runtime.Adapters.IPayloadAdapter, Hardened.Aws.Lambda.Runtime.Adapters.IStreamingPayloadAdapter
     {
-        public ApiGatewayAdapter() { }
+        public LambdaHttpAdapter() { }
         public Hardened.Requests.Abstract.Execution.HostFailurePolicy FailurePolicy { get; }
         public Amazon.Lambda.Core.ResponseStreaming.HttpResponseStreamPrelude CreatePrelude(Hardened.Requests.Abstract.Execution.IExecutionResponse response) { }
         public Hardened.Requests.Abstract.Execution.IExecutionRequest CreateRequest(Hardened.Aws.Lambda.Runtime.Execution.LambdaPayload payload, Amazon.Lambda.Core.ILambdaContext context) { }
@@ -14,23 +14,23 @@ namespace Hardened.Aws.Lambda.ApiGateway
     [DependencyModules.Runtime.Attributes.DependencyModule]
     [Hardened.Aws.Lambda.Runtime.Modules.LambdaRuntimeModule]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class ApiGatewayModule : DependencyModules.Runtime.Interfaces.IDependencyModule, DependencyModules.Runtime.Interfaces.IServiceCollectionConfiguration
+    public class LambdaHttpModule : DependencyModules.Runtime.Interfaces.IDependencyModule, DependencyModules.Runtime.Interfaces.IServiceCollectionConfiguration
     {
-        public ApiGatewayModule() { }
+        public LambdaHttpModule() { }
         public void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
         public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public void PopulateServiceCollection(Microsoft.Extensions.DependencyInjection.IServiceCollection services) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.Parameter, AllowMultiple=true)]
-    public class ApiGatewayModuleAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider
+    public class LambdaHttpModuleAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider
     {
-        public ApiGatewayModuleAttribute() { }
+        public LambdaHttpModuleAttribute() { }
         public DependencyModules.Runtime.Interfaces.IDependencyModule GetModule() { }
     }
-    public class ApiGatewayRequest : Hardened.Requests.Abstract.Execution.IExecutionRequest
+    public class LambdaHttpRequest : Hardened.Requests.Abstract.Execution.IExecutionRequest
     {
-        public ApiGatewayRequest(Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest request, System.IO.Stream body) { }
+        public LambdaHttpRequest(Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest request, System.IO.Stream body) { }
         public string? Accept { get; }
         public System.IO.Stream Body { get; set; }
         public string? ContentType { get; }
@@ -44,9 +44,9 @@ namespace Hardened.Aws.Lambda.ApiGateway
         public Hardened.Requests.Abstract.Execution.ITransportInfo Transport { get; }
         public Hardened.Requests.Abstract.Execution.IExecutionRequest Clone(string? method = null, string? path = null, System.Collections.Generic.IDictionary<string, Microsoft.Extensions.Primitives.StringValues>? headers = null, Hardened.Requests.Abstract.QueryString.IQueryStringCollection? queryString = null, System.Collections.Generic.IReadOnlyList<string>? cookies = null) { }
     }
-    public class ApiGatewayResponse : Hardened.Requests.Abstract.Execution.IExecutionResponse
+    public class LambdaHttpResponse : Hardened.Requests.Abstract.Execution.IExecutionResponse
     {
-        public ApiGatewayResponse(System.IO.Stream body) { }
+        public LambdaHttpResponse(System.IO.Stream body) { }
         public System.IO.Stream Body { get; set; }
         public string? ContentType { get; set; }
         public Hardened.Requests.Abstract.Headers.ICookieSetCollection Cookies { get; }
@@ -62,9 +62,9 @@ namespace Hardened.Aws.Lambda.ApiGateway
         public object Clone() { }
         public Hardened.Requests.Abstract.Execution.IExecutionResponse Clone(Hardened.Requests.Abstract.Headers.IHeaderCollection? headerCollection) { }
     }
-    public sealed class ApiGatewayTransportInfo : Hardened.Requests.Abstract.Execution.ITransportInfo
+    public sealed class LambdaHttpTransportInfo : Hardened.Requests.Abstract.Execution.ITransportInfo
     {
-        public ApiGatewayTransportInfo(Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest request) { }
+        public LambdaHttpTransportInfo(Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest request) { }
         public System.Collections.Generic.IReadOnlyList<string> Keys { get; }
         public string? Get(string key) { }
     }

--- a/src/PublicApi/Hardened.PublicApi.Tests/PublicApiSurfaceTests.cs
+++ b/src/PublicApi/Hardened.PublicApi.Tests/PublicApiSurfaceTests.cs
@@ -35,7 +35,7 @@ public class PublicApiSurfaceTests {
     private static readonly string[] Shipped = [
         "Hardened.Aws.DynamoDbClient",
         "Hardened.Aws.DynamoDbClient.Testing",
-        "Hardened.Aws.Lambda.ApiGateway",
+        "Hardened.Aws.Lambda.Http",
         "Hardened.Aws.Lambda.DynamoDb",
         "Hardened.Aws.Lambda.EventBridge",
         "Hardened.Aws.Lambda.Invoke",

--- a/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/.template.config/template.json
@@ -41,7 +41,7 @@
         },
         {
           "choice": "aws-lambda",
-          "description": "AWS Lambda behind API Gateway, with a harness that runs it locally over HTTP."
+          "description": "AWS Lambda behind an API Gateway HTTP API or a function URL, with a harness that runs it locally over HTTP."
         },
         {
           "choice": "cloud-run",

--- a/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/Directory.Packages.props
@@ -104,7 +104,7 @@
       with a generator from another.
     -->
     <PackageVersion Include="Hardened.Aws.Lambda.Runtime" Version="$(HardenedVersion)" />
-    <PackageVersion Include="Hardened.Aws.Lambda.ApiGateway" Version="$(HardenedVersion)" />
+    <PackageVersion Include="Hardened.Aws.Lambda.Http" Version="$(HardenedVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <!--
       The logging provider the Lambda entry point installs instead, on AWS's own line rather than

--- a/src/Templates/Hardened.Templates/templates/hardened-web/README.md
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/README.md
@@ -169,9 +169,9 @@ from a terminal browse to the page yourself.
 | `tests/Hardened1.Tests` | Tests, against the library rather than the host. |
 
 That split is the point rather than a convention. Swapping the host — Kestrel, ASP.NET Core,
-AWS Lambda behind API Gateway, Cloud Run, or Azure Functions — changes only the host project. The others are identical whichever
-one you pick, which is why the tests target the library: a test suite that named the host would be
-tied to a deployment target for no reason.
+AWS Lambda, Cloud Run, or Azure Functions — changes only the host project. The others are identical
+whichever one you pick, which is why the tests target the library: a test suite that named the host
+would be tied to a deployment target for no reason.
 
 ## Adding to it
 

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Application.cs
@@ -9,7 +9,7 @@ using Hardened.Web.Kestrel.Runtime;
 using Hardened.Web.AspNetCore.Runtime;
 #endif
 #if (lambda)
-using Hardened.Aws.Lambda.ApiGateway;
+using Hardened.Aws.Lambda.Http;
 #endif
 #if (cloudRun)
 using Hardened.Gcp.CloudRun.Runtime;
@@ -35,12 +35,12 @@ namespace Hardened1.Host;
 [AspNetCoreRuntime]
 #endif
 #if (lambda)
-// The API Gateway payload adapter, and through the runtime module it composes, the invocation loop
-// and the web pipeline. Named here rather than inferred: a function whose handlers sit beside its
-// entry point gets its adapter from their trigger attributes, but the handlers here are in the
+// The HTTP payload adapter for Lambda, and through the runtime module it composes, the invocation
+// loop and the web pipeline. Named here rather than inferred: a function whose handlers sit beside
+// its entry point gets its adapter from their trigger attributes, but the handlers here are in the
 // library project, and a generator only sees the compilation it runs in. The Kestrel and ASP.NET
 // hosts name theirs above for the same reason.
-[ApiGatewayModule]
+[LambdaHttpModule]
 #endif
 #if (cloudRun)
 // The host. A Cloud Run service is a container listening on a port, so this is named the way

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Hardened1.Host.csproj
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Hardened1.Host.csproj
@@ -32,7 +32,7 @@
       Program.cs rather than something emitted.
     -->
     <PackageReference Include="Hardened.Aws.Lambda.Runtime" />
-    <PackageReference Include="Hardened.Aws.Lambda.ApiGateway" />
+    <PackageReference Include="Hardened.Aws.Lambda.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
 <!--#endif -->
 <!--#if (cloudRun) -->

--- a/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
+++ b/src/Templates/Hardened.Templates/templates/hardened-web/src/Hardened1.Host/Program.cs
@@ -128,8 +128,8 @@ services.AddHardenedEnvironment(environment);
 
 new Application().PopulateServiceCollection(services);
 
-// No server and no port. API Gateway is the server, and what this starts is the loop that reads
-// the requests it forwards.
+// No server and no port. The front door is the server, and what this starts is the loop that
+// reads the requests it forwards.
 await HardenedLambdaBootstrap.Run(services.BuildServiceProvider());
 #endif
 #if (cloudRun)

--- a/src/Web/Hardened.Web.Runtime.Tests/Compression/ResponseCompressionFilterTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/Compression/ResponseCompressionFilterTests.cs
@@ -308,7 +308,7 @@ public class ResponseCompressionFilterTests {
     }
 
     [Fact]
-    public async Task ACompressedResponseIsMarkedBinaryForTheApiGatewayHost() {
+    public async Task ACompressedResponseIsMarkedBinaryForTheLambdaHttpHost() {
         var compressed = Context();
         var plain = Context(acceptEncoding: null);
 

--- a/src/Web/Hardened.Web.Runtime/Links/ILinkContext.cs
+++ b/src/Web/Hardened.Web.Runtime/Links/ILinkContext.cs
@@ -6,7 +6,7 @@ namespace Hardened.Web.Runtime.Links;
 /// <remarks>
 /// <para>
 /// <b>A static builder alone is wrong on this framework's primary host.</b>
-/// <c>ApiGatewayV2ExecutionRequest</c> does
+/// <c>LambdaHttpRequest</c> does
 /// </para>
 /// <code>
 /// Path = StripStagePath(request.RawPath, request.RequestContext?.Stage);


### PR DESCRIPTION
The package is `Hardened.Aws.Lambda.Http` and the types in it are `LambdaHttpAdapter`, `LambdaHttpRequest`, `LambdaHttpResponse`, `LambdaHttpSerializerContext` and `LambdaHttpTransportInfo`. The adapter binds API Gateway payload format 2.0, which a function URL sends as well, so the old name claimed a front door the module never required. `HardenedHttpModule`, the build property that selects it, already used the neutral name.

The adapter's summary said an ALB delivers the same shape. It does not: an ALB puts the method on the root, carries `requestContext.elb` and reads Set-Cookie out of `multiValueHeaders`, so `Handles` declines it. The remark now says which shapes are not served and why.

The attribute reference said a Lambda response is always buffered while linking to the page that documents `HARDENED_LAMBDA_RESPONSE_MODE`. Corrected.

No obsolete alias: nothing consumes the old name yet.

This is the last change before `v0.34.0-rc1000`, so the rename ships in that release rather than a later one and `Hardened.Aws.Lambda.ApiGateway` stops at 0.33.0-rc1000. `EXPECTED` stays 66: the pack list renames a line rather than gaining one. The coverage baseline entry is renamed with the assembly, which the gate requires.

Rebased onto `main` after #345. The only conflict was the current-line sentence in `AGENTS.md`, resolved to 0.34.0-rc1000.

Verified locally: both solutions build at `--configuration Release -p:ContinuousIntegrationBuild=true` with zero warnings, and 74 test assemblies pass with nothing failed or skipped, including the 54 public API approvals after a real build.

Co-authored-by: Ian Johnson <ianjohnson@mac.mynetworksettings.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)