### PR TITLE
Rewrite validation, routing and response caching in Simple Technical English

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -134,7 +134,7 @@ such as whether this caller owns this row.
 
 ::: tip An ownership check changes how the response may be cached
 A handler that filters by caller is `CacheScope.PerCaller`. See
-[who the answer is for](/guide/response-caching#say-who-the-answer-is-for).
+[cache scope](/guide/response-caching#cache-scope).
 :::
 
 ## What a principal carries

--- a/docs/guide/authorization.md
+++ b/docs/guide/authorization.md
@@ -212,4 +212,4 @@ verdict.
 
 - [Authentication](/guide/authentication): the scheme and the principal source
 - [Credentials](/guide/testing-credentials): sending a test as a caller holding grants
-- [Response caching](/guide/response-caching#say-who-the-answer-is-for): what a guarded handler may cache
+- [Response caching](/guide/response-caching#cache-scope): what a guarded handler may cache

--- a/docs/guide/json.md
+++ b/docs/guide/json.md
@@ -133,7 +133,7 @@ is required of a caller because the reader reads the model's nullable annotation
 reflection — so under AOT that member becomes optional again while the document still publishes it
 as required. Say it in the model instead, with `required string Title` or `[JsonRequired]`: the
 source generator reads both, and a contract-first model needs neither, because its `required` was
-compiled in at build time. See [Validation](/guide/validation#presence-and-who-checks-it).
+compiled in at build time. See [Validation](/guide/validation#required-members-and-absent-values).
 
 ## Next
 

--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -58,7 +58,7 @@ by equality.
 
 A library module in another assembly carries its own handlers, services and route prefix.
 `[BasePath]` on it prefixes every route in that assembly, so the application lists none of the
-library's routes. See [Prefixing with BasePath](/guide/routing#prefixing-with-basepath).
+library's routes. See [The route attributes](/guide/routing#the-route-attributes).
 
 ## Registering by hand
 

--- a/docs/guide/parameter-binding.md
+++ b/docs/guide/parameter-binding.md
@@ -71,7 +71,7 @@ public int TypedQuery([FromQueryString] int page) => page + 1;
 ```
 
 The body is deserialized as JSON into the parameter type. A value that fails to parse as its type
-answers 400 with the [validation envelope](/guide/validation#the-400-envelope).
+answers 400 with the [validation envelope](/guide/validation#the-failure-response).
 
 ## Naming
 

--- a/docs/guide/rate-limiting.md
+++ b/docs/guide/rate-limiting.md
@@ -155,7 +155,7 @@ Ahead of `FilterOrder.Serialization`, the filter records the refusal on the resp
 `Next()` anyway. The filter that turns a failure into bytes sits behind it, so returning early
 would produce a 429 with an empty body. The serialization filter finds a request already decided,
 reads no body, invokes no handler, and writes the refusal on the way out. Authorization follows
-the same rule, and the [response cache](/guide/response-caching#what-is-not-cached) checks for a
+the same rule, and the [response cache](/guide/response-caching#handlers-that-are-not-cached) checks for a
 recorded failure rather than reading "still travelling" as "still permitted".
 
 ## Not built

--- a/docs/guide/response-caching.md
+++ b/docs/guide/response-caching.md
@@ -1,203 +1,193 @@
 # Response caching
 
-A handler that answers the same bytes to every caller for the next minute should not run a
-thousand times to do it. `[CacheResponse<T>]` stores what the handler answered and serves it
-again without running the handler, without binding the request and without serializing anything.
+`[CacheResponse<T>]` stores the bytes a handler answered. A later request with the same key gets
+those bytes, and the handler does not run.
 
 ```csharp
+using Hardened.Requests.Abstract.Caching;
 using Hardened.Requests.Runtime.Caching;
+using Hardened.Web.Runtime.Attributes;
 using Hardened.Web.Runtime.Caching;
 
-[Get("/catalog")]
-[CacheResponse<VaryByQuery>("culture", "region", Duration = 60)]
-public Catalog Browse([FromQueryString] string culture, [FromQueryString] string region) =>
-    _catalog.For(culture, region);
+public class CatalogController {
+
+    [Get("/catalog")]
+    [CacheResponse<VaryByQuery>("culture", "region", Duration = 60)]
+    public string Browse([FromQueryString] string culture, [FromQueryString] string region) =>
+        _catalog.For(culture, region);
+}
 ```
 
-This is the store half of caching. The header half is
-[`[CacheControl]`](/guide/routing#caching), which tells somebody else to cache and stores
-nothing. The two compose.
+The type argument names the key strategy. The positional arguments configure that strategy.
 
-## Turning it on
+`[CacheControl]` is a different attribute. It writes a `Cache-Control` header and stores nothing.
+See [Routing](/guide/routing).
 
-A store is a package and an attribute on the module:
+## The attribute
 
-```xml
-<PackageReference Include="Hardened.Requests.Caching.Memory" Version="0.34.0-rc1000" />
-```
+| Member | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `TProvider` | type argument | none | Names the key strategy. |
+| positional values | `params string[]` | empty | The strategy's arguments, such as query keys. |
+| `Duration` | `int` | `0`, which means 60 seconds | How long the store keeps the entry, in seconds. |
+| `Scope` | `CacheScope` | `CacheScope.Unstated` | Who the stored answer is served to. |
+| `Tags` | `string[]` | empty | The names that evict this entry. |
+
+The attribute applies to a method or to a class. `AllowMultiple` is true.
+
+## The store
+
+Nothing registers a store by default. Reference the `Hardened.Requests.Caching.Memory` package.
+Write `[HardenedMemoryResponseCache]` on the application module.
 
 ```csharp
 [HardenedModule]
 [HardenedWebModule]
 [HardenedMemoryResponseCache]
-[KestrelRuntime]
+[AspNetCoreRuntime]
 public partial class Application { }
 ```
 
-On a project the template wrote, put the store on the library module rather than the host. The
-tests boot the library module alone, so a store on the host answers the "no store" 500 in every
-test.
+This repository ships one store, the in-process one. `IResponseCacheStore` is the seam for another.
+An application that registers its own implementation does not need the module attribute.
 
-Nothing registers a store by default, so an application that caches nothing does not carry the
-cache. Without a store, the first request to a handler declaring `[CacheResponse]` answers the
-framework's error envelope, and the log names the handler, the package to reference and the
-attribute to add.
+### The module the attribute goes on
 
-## Pick what the key is
+Put `[HardenedMemoryResponseCache]` on the library module, beside the handlers. The web template
+splits an application into a library module and a host module. The host carries the runtime
+attribute and imports the library.
 
-The type parameter is the strategy. The positional arguments configure it:
+A test boots the library module alone. The template writes
+`[assembly: HardenedTestEntryPoint(typeof(TemplateModuleNameLibrary))]`. A store on the host module
+is therefore absent in every test. Each cached handler then answers the no-store failure.
 
-| Strategy | From | Keys on |
-|---|---|---|
-| `VaryByQuery("culture", "region")` | `Hardened.Web.Runtime` | The named query-string values |
-| `VaryByHeader("Accept-Language")` | `Hardened.Web.Runtime` | The named request headers, and writes `Vary` |
-| `VaryByRoute` | `Hardened.Web.Runtime` | The route's own tokens |
-| `ByPayload` | `Hardened.Requests.Runtime` | The whole request body |
+The build says nothing about that mistake. `HRDW005` is asked of the host, and the host registers a
+store. A library module that carries the attribute registers the store for every host that imports
+it.
 
-Every key is prefixed with the handler's method and path, so two handlers keyed the same way
-never answer each other's requests. `VaryByRoute` on a route with no tokens is a cache of one
-entry, which is what a collection endpoint wants.
+### The build warning
 
-`VaryByQuery` and `VaryByHeader` take named keys rather than everything. A cache keyed on the
-whole query string is one a caller misses at will by adding a parameter nothing reads.
+The generator reports `HRDW005` when an application declares caching and applies no store module.
+The severity is Warning. The message is:
 
-`Duration` is in seconds. Omitting it means 60.
+```text
+'{handlers}' declares [CacheResponse] and this application registers no response cache store, so
+every request to it answers an error. Add the Hardened.Requests.Caching.Memory package and
+[HardenedMemoryResponseCache] to the module, or register an IResponseCacheStore yourself and
+suppress HRDW005.
+```
 
-### Writing a strategy
+One report covers the whole assembly. The message names every handler that fails.
 
-`ICacheKeyProvider` is an interface anyone can implement:
+The generator asks this question of the compilation whose entry point applies a web runtime. A
+library that declares cached handlers reports nothing. The host that imports the library is told
+which of its handlers cache. A library that applies `[HardenedMemoryResponseCache]` itself
+registers the store for every host that imports it.
+
+The check reads module attributes only. A store registered by hand in `ConfigureServices` is
+invisible to it. That is why the report is a warning and not an error.
+
+### The run-time failure
+
+A cached handler in an application with no store answers 500 and the error envelope. The filter
+records `ResponseCacheStoreMissingException` on the response and calls the next filter. The message
+reaches the log:
+
+```text
+GET /catalog declares [CacheResponse] and no IResponseCacheStore is registered. Reference
+Hardened.Requests.Caching.Memory and add [HardenedMemoryResponseCache] to the application module,
+or register a store of your own.
+```
+
+The failure arrives on a request rather than at startup. Hardened builds a handler on the first
+request its route matches.
+
+## The cache key
+
+The filter composes one key from the handler and from every strategy on it. The parts are joined
+with the unit separator, `U+001F`. The parts appear in this order.
+
+1. The handler's method and path, as `GET /catalog`.
+2. The caller's issuer and subject, when the scope is `CacheScope.PerCaller`.
+3. Each strategy's part, in the order the attributes were declared.
+
+Two handlers keyed the same way never answer each other's requests. The method and path sit in
+front of every key.
+
+| Strategy | Namespace | Arguments | Key part |
+| --- | --- | --- | --- |
+| `VaryByRoute` | `Hardened.Web.Runtime.Caching` | none | `name=value&` for every route token |
+| `VaryByQuery` | `Hardened.Web.Runtime.Caching` | one or more query keys | `name=value&` for each named key |
+| `VaryByHeader` | `Hardened.Web.Runtime.Caching` | one or more header names | `Name=value&` for each named header |
+| `ByPayload` | `Hardened.Requests.Runtime.Caching` | none | the SHA-256 of the body, base64 |
+
+`VaryByQuery` reads only the keys it was named. A caller who adds another parameter still hits the
+same entry. An absent key reads as empty.
+
+`VaryByHeader` also writes the response's `Vary` header. It adds each name it varies on, and keeps
+the names already there. It reads a request header whatever the case of the name. It refuses
+`Cookie`, because a response keyed on a session has one caller.
+
+`VaryByRoute` reads every token the route declares, bound or not. A route with no token keys as
+empty. That is one entry for the route.
+
+`ByPayload` reads the whole request body. It runs ahead of the bind, so it buffers the body, hashes
+it, and puts the buffer back. A request with no body keys as empty.
+
+Each strategy refuses arguments it cannot use. `VaryByRoute` and `ByPayload` take no values.
+`VaryByQuery` and `VaryByHeader` need at least one. The failure names the handler and wraps the
+strategy's own message:
+
+```text
+[CacheResponse] on GET /catalog could not build its cache key strategy: VaryByRoute keys on the
+route's own tokens and takes no values, but was given culture. Name query keys with VaryByQuery
+instead.
+```
+
+### A strategy of your own
+
+Implement `ICacheKeyProvider`. `Create` builds the strategy once per handler from the attribute's
+positional arguments. `Key` answers what this request is stored under.
 
 ```csharp
 public sealed class VaryByTenant : ICacheKeyProvider {
-    public static ICacheKeyProvider Create(string[] values) =>
-        values.Length == 0
-            ? new VaryByTenant()
-            : throw new ArgumentException("VaryByTenant takes no values.", nameof(values));
+
+    public static ICacheKeyProvider Create(string[] values) => new VaryByTenant();
 
     public ValueTask<string?> Key(IExecutionContext context) =>
         new(context.CallerPrincipal.Subject);
 }
 ```
 
-`Create` is a static abstract interface member, called once per handler as the filter chain is
-built. That is also where arity is checked: `[CacheResponse<ByPayload>("culture")]` compiles, so
-`Create` throwing is what turns the stray argument into a startup failure naming the handler.
-Returning `null` from `Key` leaves the request neither looked up nor stored.
+A null key leaves the request uncached. The filter neither reads the store nor writes to it.
+`Create` may throw on an argument the strategy cannot use. That failure names the handler.
 
-### Composing two
+### Two strategies on one handler
 
-`[CacheResponse<T>]` is `AllowMultiple`, and two different type arguments on one method need it:
+Write the attribute twice. Both parts go into one key, and one filter serves the handler.
 
 ```csharp
 [Get("/composed")]
 [CacheResponse<VaryByQuery>("culture")]
 [CacheResponse<VaryByHeader>("Accept-Language", Duration = 60)]
-public Catalog Composed([FromQueryString] string culture) => ...;
+public string Composed([FromQueryString] string culture) => _catalog.For(culture);
 ```
 
-The parts compose into one key, in the order they were declared, and the handler gets one filter.
-`Duration` and `Scope` may each appear on more than one attribute: the first that sets one wins,
-and two that disagree fail as the chain is built. `Tags` accumulate, deduped.
+A null from any one strategy leaves the whole request uncached. There is no partial key.
 
-## Say who the answer is for
+Composed attributes share one entry, so they share one lifetime and one audience. The first
+declared `Duration` wins. Two that disagree fail as the chain is built:
 
-```csharp
-[Get("/alerts/{alertId}")]
-[Authorize<BearerAuth>]
-[CacheResponse<VaryByRoute>(Duration = 60, Scope = CacheScope.PerCaller)]
-public Alert Read(string alertId) => _alerts.OwnedBy(_caller.Principal.Subject, alertId);
+```text
+GET /composed declares [CacheResponse] twice with different durations, 300 and 60. Composed
+attributes share one lifetime, so set Duration on one of them.
 ```
 
-`CacheScope.PerCaller` puts the caller's issuer and subject in the key, so one caller's answer is
-never handed to another. `CacheScope.AllCallers` is one entry shared by whoever the guard admits,
-for an authorized read of something public.
+Two scopes that disagree fail the same way. Tags from every declaration form one set, and a tag
+two of them name is one tag.
 
-A handler that requires anything of its caller and states neither fails as its filter chain is
-built, naming the handler. Sharing the entry would leak one caller's data the moment the answer
-depends on who asked, and keying per caller would silently turn one shared entry into one per
-caller. Nothing on the handler tells the two apart, so the handler has to say. A handler that
-requires nothing of its caller states nothing.
-
-A caller with no subject is never cached under `PerCaller`.
-
-## Invalidate by tag
-
-```csharp
-[Get("/rates/{symbol}")]
-[CacheResponse<VaryByRoute>(Duration = 3600, Tags = ["rates"])]
-public Rate Read(string symbol) => _rates.Latest(symbol);
-```
-
-```csharp
-public async Task Publish(RateSet set, CancellationToken cancellationToken) {
-    await _rates.Save(set, cancellationToken);
-    await _store.EvictByTag("rates", cancellationToken);
-}
-```
-
-Inject `IResponseCacheStore` where you change what a cached read reads. `EvictByTag` drops every
-entry stored under the tag, and a tag nothing was stored under is not an error. Without a tag, an
-application's only way to reach its own entries is to wait for them to expire.
-
-## What is not cached
-
-A handler whose authorization reads the request. The filter runs at `FilterOrder.ResponseCache`,
-after authorization over grants alone and before authorization that reads bound parameters. Such
-a requirement would not run on a hit, so the filter is not installed, decided once per handler.
-
-A request something already refused. Authorization and rate limiting sit ahead of this stage and
-refuse by recording the failure and continuing. The cache reads what they recorded, so the
-request is neither answered from the store nor stored.
-
-Anything that is not a 200. A 404 or a 500 is about the moment rather than the resource. A
-redirect or a 304 carries its meaning in headers this does not model.
-
-## What a hit carries
-
-A stored entry holds what the representation is, not what its first request was. Three kinds of
-header are dropped as a response is captured:
-
-| Dropped | Why |
-|---|---|
-| `Set-Cookie` | Belongs to a caller. Replaying one hands a second caller the first one's session |
-| `Transfer-Encoding`, `Connection`, `Keep-Alive`, `TE`, `Trailer`, `Upgrade`, `Proxy-Authenticate`, `Proxy-Authorization`, `Content-Length`, `Date`, `Server` | Belong to a connection or to a moment |
-| Anything the response already carried on the way in | Belongs to this request. Whatever wrote it sits ahead of this stage and runs on a hit as well, so its own value is already there. A header the chain changed is kept |
-
-What is left is what the handler and the filters inside the cache produced, which is what carries
-`Cache-Control` and `ETag` onto a hit. `Vary` reaches a hit because `VaryByHeader` writes it while
-composing the key, on every request.
-
-## What it stores
-
-Bytes, not the value the handler returned, so a hit skips the serializer as well as the handler.
-A stored entry is therefore one representation. Content negotiation happened on the request that
-filled the cache, so the key has to include whatever the response varies on. Add
-`VaryByHeader("Accept")` to a handler that answers more than one media type.
-
-## Apply it everywhere
-
-The attribute goes on a `[HardenedModule]` class, where it covers every handler compiled with it:
-
-```csharp
-[HardenedModule]
-[HardenedWebModule]
-[CacheResponse<VaryByRoute>(Duration = 60)]
-public partial class Catalog { }
-```
-
-A handler declaring `[CacheResponse<VaryByRoute>]` itself keeps its own and the module's is dropped
-for that handler, so explicit beats convention.
-
-::: warning Two strategies do not replace each other
-The dedup is on the closed type, which is what lets
-[two strategies compose on one handler](#composing-two). So a handler declaring
-`[CacheResponse<VaryByQuery>]` beside a module's `[CacheResponse<VaryByRoute>]` gets **both**, and
-two that disagree about a `Duration` or a `Scope` fail as the chain is built. Close the module's
-declaration over the same strategy the handlers vary from, or declare per handler.
-:::
-
-`AddGlobalFilter` does the same at run time, and is what a host writes for handlers it only
-references:
+A `[CacheResponse<T>]` registered through `AddGlobalFilter` applies to a handler that declares none
+of its own. The global one does not apply to a handler that declares its own.
 
 ```csharp
 services.AddGlobalFilter(
@@ -205,25 +195,198 @@ services.AddGlobalFilter(
     when: info => info.Method == "GET");
 ```
 
-A globally registered instance stands down on any handler that declares `[CacheResponse]`
-itself, on the same terms.
+### A declaration on the module
 
-## Configuration
+`[CacheResponse<T>]` on a `[HardenedModule]` class covers every handler in the same compilation.
+That is how an application caches by convention. The generator emits the declaration once beside
+the routing table. Each handler's chain merges it into that handler's metadata.
 
-```csharp
-services.ConfigureMemoryResponseCache(cache => {
-    cache.SizeLimit = 32 * 1024 * 1024;
-    cache.MaximumBodySize = 1024 * 1024;
-});
+The merge drops a declaration whose closed type the handler already carries. `VaryByRoute` and
+`VaryByQuery` close the attribute differently, so they are two types. A handler declaring
+`[CacheResponse<VaryByQuery>]` under a module declaring `[CacheResponse<VaryByRoute>]` gets both.
+The two compose into one key. Two that disagree on `Duration` or on `Scope` fail as the chain is
+built.
+
+A module declaration stands down only for the identical closed type. `AddGlobalFilter` is the
+looser rule. There, any declaration on the handler stands the global one down.
+
+## Cache scope
+
+`CacheScope` states who a stored answer may be served to.
+
+| Value | What it means |
+| --- | --- |
+| `Unstated` | The declaration said nothing. This is the default. |
+| `AllCallers` | One entry, served to every caller the guard admits. |
+| `PerCaller` | One entry for each caller. The issuer and the subject go into the key. |
+
+A handler that requires nothing of its caller needs no scope. `Unstated` becomes `AllCallers`.
+
+A handler with an authorization requirement must state a scope. `Unstated` on such a handler throws
+`CacheScopeUndeclaredException` as the filter chain is built. The first request to that route
+answers 500 and the error envelope:
+
+```text
+GET /catalog requires {requirement} of its caller and declares [CacheResponse] without saying who a
+stored response may be served to. Set Scope = CacheScope.PerCaller if the answer depends on who
+asked - an owner-scoped read, anything filtered by the caller's tenant - or
+Scope = CacheScope.AllCallers if every caller the guard admits gets the same bytes.
 ```
 
-Defaults are 100 MB total and 64 MB per entry.
+The exception carries the handler on its `Handler` property, as `GET /catalog`.
 
-## Testing a duration
+Use `PerCaller` when the handler's own code narrows the answer to the caller. An ownership check
+inside the handler is invisible to the framework. Nothing on the handler tells that case apart from
+a shared read.
 
-`[HardenedMemoryResponseCache]` registers `TimeProvider.System` with `TryAddSingleton`, and the
-in-process store decides on it whether an entry is still valid. Register a `TimeProvider` of your
-own and a test moves time instead of waiting for it:
+```csharp
+[Get("/owned-by-subject")]
+[AuthorizeGrants("pets:read")]
+[CacheResponse<VaryByRoute>(Duration = 60, Scope = CacheScope.PerCaller)]
+public string OwnedBySubject() => _rows.For(_currentCaller.Principal.Subject);
+```
+
+`PerCaller` keys on the issuer as well as the subject. Two issuers naming one subject are two
+callers. A request from a caller with no subject is neither looked up nor stored.
+
+## Handlers that are not cached
+
+The filter runs at `FilterOrder.ResponseCache`. That position is after
+`FilterOrder.GrantAuthorization` and before `FilterOrder.Authorization`.
+
+A requirement that reads the request runs after the cache would have answered.
+`Requirement.Predicate` sets `RequiresContext`, and the attribute then installs no filter at all.
+`Requirement.Grant` and `Requirement.Authenticated` do not set it, so those handlers are cached.
+
+A refused request is neither answered from the store nor stored. Every filter ahead of
+`FilterOrder.Serialization` refuses by recording the failure and calling the next filter. The cache
+reads `IExecutionResponse.Refused`, which is true once `ExceptionValue` is set. A caller the
+authorization filter turned away gets the refusal, not the stored body.
+
+The filter reads no request method. It stores the answer of a handler on any verb.
+
+Nothing refuses a handler that streams. Whether a handler returns `IAsyncEnumerable<T>` is not on
+`IExecutionRequestHandlerInfo`. Capturing a response buffers it, so such a handler holds its whole
+sequence in memory.
+
+## Duration
+
+`Duration` is a whole number of seconds. `0` means `ResponseCacheFilter.DefaultDuration`, which is
+60 seconds.
+
+The entry expires at a fixed point after the store took it. A hit does not extend it. The store
+checks the expiry on every read, and drops an entry it finds expired.
+
+## Invalidation by tag
+
+`Tags` names an entry. `IResponseCacheStore.EvictByTag` drops every entry under one name.
+
+```csharp
+[Get("/tagged")]
+[CacheResponse<VaryByRoute>(Duration = 3600, Tags = ["catalog"])]
+public string Tagged() => _catalog.Read();
+
+[Post("/publish")]
+public async Task<string> Publish(CancellationToken cancellationToken) {
+    await _store.EvictByTag("catalog", cancellationToken);
+
+    return "published";
+}
+```
+
+Inject `IResponseCacheStore` into the handler that changes the data a cached read returns. A tag
+nothing was stored under is not an error.
+
+`EvictByTag` is the only way an application reaches its own entries. There is no removal by key.
+The key is composed from the handler, the caller and each strategy, and nothing publishes that
+shape.
+
+## The stored entry
+
+`CachedResponse` holds the status, the content type, the body bytes, some response headers, and the
+tags. `Size` is the body length. Headers do not count towards it.
+
+Only a 200 is stored. A 302, a 304, a 404 and a 500 are not. A refused response is not.
+
+These response headers never reach an entry, whatever wrote them.
+
+| Headers | Reason |
+| --- | --- |
+| `Set-Cookie` | It belongs to one caller. |
+| `Transfer-Encoding`, `Content-Length`, `Connection`, `Keep-Alive`, `TE`, `Trailer`, `Upgrade`, `Proxy-Authenticate`, `Proxy-Authorization` | The transport frames each response as it writes it. |
+| `Content-Encoding` | The entry holds identity bytes. |
+| `Date`, `Server` | They belong to the host and to the moment. |
+
+A header the response already carried before the cache filter ran is not stored either. The filter
+that wrote it sits ahead of the cache and writes it again on a hit. A correlation id and a rate
+limit header therefore carry the current request's value. A header the inner chain changed is
+stored, because a miss would change it the same way.
+
+An entry is one representation. It holds one content type and one body. The serializer runs at
+`FilterOrder.Serialization`, which is inside the cache, so a hit negotiates nothing. The first
+request settled the media type for every hit after it.
+
+A handler that declares several media types with `[Produces]` must key on what it varies by. Add
+`[CacheResponse<VaryByHeader>("Accept")]`. Without it a client asking for the second media type
+gets the first one's bytes.
+
+The filter puts a strong entity tag on a stored response that carries none. The tag is the SHA-256
+of the stored bytes, base64, in quotes. A handler that wrote its own `ETag` keeps it. A response
+that is not stored gets no tag.
+
+## A served hit
+
+A hit sets the stored status, the stored headers and the stored content type, then writes the
+stored bytes. No header marks a response as a hit.
+
+The filter returns without calling the next filter, so the bind, the handler and the serializer do
+not run. Filters ordered ahead of `FilterOrder.ResponseCache` still run, on the way in and on the
+way out.
+
+| Filter | Order | On a hit |
+| --- | --- | --- |
+| `[ConditionalGet]` | `FilterOrder.Conditional` | Runs. Answers 304 against the replayed `ETag`. |
+| `[Compress]` | `FilterOrder.Before + FilterOrder.ResponseCache` | Runs. Encodes the stored bytes on the way out. |
+| `[CacheControl]` | `FilterOrder.BeforeSerialization` | Does not run. Its header is replayed with the rest. |
+
+The compression filter does not consult its predicate on a hit. A hit carries no handler value, so
+the media-type rule decides instead.
+
+Concurrent misses on one key all run the handler. The filter holds no lock and takes no permit. The
+last request to finish writes the entry that stays.
+
+## The in-memory store
+
+`MemoryResponseCacheStore` owns its own `MemoryCache`. It does not use the application's
+`IMemoryCache`.
+
+| Setting | Default |
+| --- | --- |
+| `SizeLimit` | 104857600 bytes, which is 100 MB |
+| `MaximumBodySize` | 67108864 bytes, which is 64 MB |
+
+A response over `MaximumBodySize` is not stored. The store refuses by doing nothing. The response
+already reached the client, so the only consequence is that the next request misses.
+
+Set the limits with `ConfigureMemoryResponseCache`. It amends the configuration, so two calls both
+apply.
+
+```csharp
+public void ConfigureServices(IServiceCollection services) {
+    services.ConfigureMemoryResponseCache(cache => {
+        cache.SizeLimit = 32 * 1024 * 1024;
+        cache.MaximumBodySize = 1024 * 1024;
+    });
+}
+```
+
+The module registers the store with `TryAddSingleton`. An `IResponseCacheStore` already in the
+collection wins, whichever order the modules were listed in.
+
+## The store clock
+
+The store decides expiry on the `TimeProvider` it was given. A test moves the clock instead of
+waiting out a duration.
 
 ```csharp
 private sealed class TestClock : TimeProvider {
@@ -235,56 +398,36 @@ private sealed class TestClock : TimeProvider {
 }
 ```
 
+`[HardenedMemoryResponseCache]` registers `TimeProvider.System` with `TryAddSingleton`. A
+`TimeProvider` already in the collection is kept.
+
+`MemoryCache` still holds an absolute expiry on the machine clock. That one only decides when the
+memory is freed.
+
+## AWS Lambda
+
+`[HardenedMemoryResponseCache]` keeps this process's answers. Each execution environment holds its
+own entries and its own tag index. `EvictByTag` reaches the environment it ran in.
+
+A hit does not avoid the invoke. The request still runs and is still billed for its duration. This
+is a downstream cache and not a CDN.
+
+`MemoryCache` in .NET 8 checks expiry when it reads an entry. Its scan is not timer-driven. A
+freeze of any length therefore does not produce a stale hit. Only reclamation happens late.
+
+`ByPayload` is the strategy for a function handler. A directly invoked Lambda carries no caller
+principal on `ILambdaContext`, so a function cannot vary its answer by caller. Whatever a caller
+passes is in the payload.
+
 ```csharp
-services.AddSingleton<TimeProvider>(clock);
-
-await app.Get("/rates/EUR");
-clock.Advance(TimeSpan.FromHours(2));
+[HardenedFunction]
+[CacheResponse<ByPayload>(Duration = 300)]
+public Quote Price(QuoteRequest request) => _pricing.Quote(request);
 ```
-
-A day-long entry is testable in a millisecond. `FakeTimeProvider` from
-`Microsoft.Extensions.TimeProvider.Testing` does the same job if you already reference it.
-[Substituting services](/guide/testing-mocks#a-fake-instead-of-a-mock) shows the registration as
-a test attribute.
-
-`MemoryCache`'s own absolute expiration is still set and still runs on the machine clock. That
-one decides when the memory is freed, not what a request is answered with.
-
-## On Lambda
-
-Nothing eliminates the invoke, so this is a downstream cache rather than a CDN. It is worth
-having when the handler's work is a DynamoDB query or an external call, and worth nothing when
-the handler is cheap.
-
-`ByPayload` is the strategy for a directly invoked function. IAM authorizes at the boundary and
-`ILambdaContext` carries no caller principal, so a function cannot vary its answer by caller.
-The moment a caller does pass a tenant or a user id, it is in the payload.
-
-`MemoryCache` is not timer-driven in .NET 8 and checks expiry on read, so the store stays correct
-across a freeze of any length. Only reclamation happens late.
-
-## Revalidating a hit
-
-A cached handler that also declares [`[ConditionalGet]`](/guide/conditional-requests) answers a
-caller who already holds the response with a 304 and no body, without running the handler and
-without sending the stored bytes. Every entry the store is handed carries an entity-tag, computed
-as the response is captured when the handler wrote none, so the tag goes out with the miss and is
-replayed with the hit.
-
-## Not built
-
-- **Per-resource invalidation.** A tag names a handler's entries, not a row. "Drop every cached
-  response touching pet 7" needs the tag to carry the id, which means the declaration cannot be a
-  constant.
-- **Stampede protection.** *n* concurrent misses run the handler *n* times and the last one wins.
-
-::: danger Do not cache a stream
-`[CacheResponse]` on a handler returning `IAsyncEnumerable<T>` buffers the whole sequence in
-memory before storing it. Nothing refuses this yet.
-:::
 
 ## Next
 
-- [Conditional requests](/guide/conditional-requests): a 304 for a caller holding the response
-- [Compression](/guide/compression): a hit is encoded on the way out
-- [Substituting services](/guide/testing-mocks#a-fake-instead-of-a-mock): the clock in a test
+- [Conditional requests](/guide/conditional-requests)
+- [Compression](/guide/compression)
+- [Execution pipeline](/guide/execution-pipeline)
+- [Diagnostics](/reference/diagnostics)

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -1,292 +1,132 @@
 # Routing
 
-A route is an attribute on a method of a plain class. There is no base type and no registration.
-The generator finds the attribute during the build and emits a handler bound to that method.
+A route is an attribute on a method of a plain class. The class has no base type and no interface.
+Nothing registers it. The build finds the method and compiles a matcher for it.
 
 ```csharp
 using Hardened.Web.Runtime.Attributes;
 
-[BasePath("/orders")]
-public class OrderController {
-    [Get("/")]                          // GET /orders
-    public IReadOnlyList<Order> List() => _orders.All();
+namespace Todos;
 
-    [Get("/{id:int}")]                  // GET /orders/42
-    public Order ById(int id) => _orders.Find(id);
+[BasePath("/todos")]
+public class TodoController {
 
-    [Post("/", SuccessStatus = 201)]    // POST /orders, answers 201
-    public Order Create(OrderModel model) => _orders.Add(model);
+    [Get("/{id:int}")]
+    public string ById(int id) => id.ToString();
+
+    [Post("/", SuccessStatus = 201)]
+    public string Create() => "created";
 }
 ```
 
-The class name means nothing. `Controller` is a convention, and the class is never registered as
-a service. The generator instantiates it through the container when a request arrives.
+`GET /todos/7` reaches `ById` with `id` bound to 7. `GET /todos/abc` is a 404. `POST /todos`
+answers 201.
 
 ## The route attributes
 
-| Attribute | Method |
-|---|---|
-| `[Get(path)]` | `GET` |
-| `[Post(path)]` | `POST` |
-| `[Put(path)]` | `PUT` |
-| `[Delete(path)]` | `DELETE` |
-| `[Patch(path)]` | `PATCH` |
+The route attributes live in `Hardened.Web.Runtime.Attributes`, in the `Hardened.Web.Runtime`
+package.
 
-All five behave the same: the same path templates, the same binding, the same filters. Two routes
-may share a path under different verbs, so `GET /orders/{id}` and `DELETE /orders/{id}` reach
-different handlers.
+| Attribute | Applies to | Verb it routes |
+|---|---|---|
+| `[Get(path)]` | a method | GET |
+| `[Post(path)]` | a method | POST |
+| `[Put(path)]` | a method | PUT |
+| `[Patch(path)]` | a method | PATCH |
+| `[Delete(path)]` | a method | DELETE |
 
-Every verb attribute has `SuccessStatus`, the status a successful response answers with and the
-[OpenAPI document](/guide/openapi-document) publishes. Unset means 200. The framework writes no
-body for 204, 205 or 304 whatever the handler returned.
+The path argument is optional. An absent argument routes the method at `/`.
 
-### HEAD, and 405
+Each of the five declares one named property, `SuccessStatus`, and no other. See
+[Status codes](#status-codes) below.
 
-`HEAD` is `GET` without a body, so every `[Get]` route answers it. The handler, its filters and
-its serializer all run. The bytes are counted and dropped rather than written, so
-`Content-Length` is the real number.
+These four attributes change how a group of routes is matched or answered.
 
-A request whose path matches a route but whose verb has none gets `405 Method Not Allowed`, with
-an `Allow` header listing the verbs the path does answer, `HEAD` included. A path nobody declared
-is `404`.
+| Attribute | Applies to | What it does |
+|---|---|---|
+| `[BasePath(path)]` | a controller, or the entry point | Prefixes the routes below it |
+| `[CaseInsensitiveRoutes]` | the entry point | Matches this module in any case |
+| `[RouteConstraint(name)]` | a static method | Declares a constraint a template may use |
+| `[CacheControl]` | a method or a controller | Sets the `Cache-Control` response header |
 
-## Path tokens
+The entry point is the class that carries `[HardenedModule]`.
 
-Braces mark a token, and the token binds to the parameter of the same name:
-
-```csharp
-[Get("/hello/{name}")]
-public string Hello(string name) => $"Hello, {name}!";
-
-[Get("/pair/{first}/{second}")]
-public string Pair(string first, string second) => $"{first}:{second}";
-```
-
-Tokens arrive as strings and are converted to the parameter's declared type:
-
-```csharp
-[Get("/double/{count}")]
-public int Double(int count) => count * 2;
-```
-
-A value the type cannot take, such as `/double/abc`, reaches the handler's binder and comes back
-`400`.
-
-### Constraining what a token matches
-
-`{id:int}` matches only a segment that passes the test, and rejects the rest before any filter or
-binder runs:
-
-```csharp
-[Get("/users/{id:int}")]
-public User ById(int id) => _users.Find(id);
-```
-
-`/users/abc` is now a `404` rather than a `400`. Use a constraint when the segment is an identifier
-and a wrong value means "no such URL". Leave it off when the value is input being validated and
-`400` is the honest answer.
-
-| Constraint | Matches |
-|---|---|
-| `guid` | a GUID in any form `Guid.TryParse` accepts |
-| `date` | an ISO 8601 date, `yyyy-MM-dd` |
-| `datetime` | an ISO 8601 date and time |
-| `bool` | `true` or `false` |
-| `int` | a 32-bit integer |
-| `long` | a 64-bit integer |
-| `decimal` | a decimal number |
-| `hex` | `^[0-9a-fA-F]+$`: a hash, a sha, a request id |
-| `alpha` | `^[A-Za-z]+$` |
-| `slug` | `^[a-z0-9]+(-[a-z0-9]+)*$`. A leading, trailing or doubled hyphen does not match, and neither does upper case |
-
-Parsing is invariant, so the same request matches on every machine. Where two constraints could
-match one segment, the narrower is tried first, in the order of the table.
-
-A constrained token changes the published document as well as the wire. The operation gains a 404
-describing the refusal, and loses the 400 it would have published for a conversion the constraint
-now guarantees — see [what the document says](/guide/validation#what-the-document-says). The router
-answers that 404 before binding, so it carries no body; where the operation declares a 404 of its
-own, the description says so.
-
-### Declaring your own constraint
-
-```csharp
-[RouteConstraint("isbn")]
-public static bool IsIsbn(ReadOnlySpan<char> value) => Isbn().IsMatch(value);
-
-[GeneratedRegex(@"^\d{13}$")]
-private static partial Regex Isbn();
-```
-
-Then `[Get("/books/{code:isbn}")]`. The generator emits a direct static call, so there is no
-allocation and no lookup per request. A declared constraint is tried after every built-in.
-
-A `[GeneratedRegex]` is compiled at build time and `IsMatch(ReadOnlySpan<char>)` allocates
-nothing. There is no `{code:regex(...)}` form. A method that is not a
-`static bool(ReadOnlySpan<char>)` is a build error, and so is a constraint name nothing declares.
-
-### Two routes that differ only by constraint
-
-```csharp
-[Get("/users/{id:int}")]   // and
-[Get("/users/{name}")]     // HRDR001, a build error
-```
-
-Which handler a request reaches would depend on the content of the value, and the pair cannot be
-written in an OpenAPI document. The same applies to `{name}` beside `{*name}`. A literal beside a
-token, `/users/me` and `/users/{id}`, is fine.
-
-`<HardenedAmbiguousRoutes>warning</HardenedAmbiguousRoutes>` allows it for a project, and
-`dotnet_diagnostic.HRDR001.severity = warning` in `.editorconfig` for a file. Prefer `warning`
-over `none`, so that under `TreatWarningsAsErrors` the opt-in stays a deliberate decision.
-
-### How much a token matches
-
-A token matches exactly one segment of at least one character. `/users/{id}` answers `/users/42`.
-It does not answer `/users/42/posts`, which is deeper than the route declares, and it does not
-answer `/users/`, because the empty string after a trailing slash is not a segment. Neither is the
-nothing between the two slashes of `//`.
-
-`{id?}` and `{id=5}` are build errors. For a default, give the C# parameter one. For an optional
-segment, declare two routes.
-
-Token names belong to the route, not to the position, so `/users/{id}` and
-`/users/{userId}/posts/{postId}` bind correctly side by side. The name is what binds, whatever
-else the token carries: `{*path}` and `{id:int}` bind to parameters named `path` and `id`.
-
-### Matching the rest of the path
-
-Prefix the last token with `*` to take everything that remains, separators included:
-
-```csharp
-[Get("/assets/{*path}")]
-public Stream Asset(string path) => _files.Open(path);   // /assets/img/logo.png -> "img/logo.png"
-```
-
-A literal in the same position still wins, so `/assets/index` reaches an `[Get("/assets/index")]`
-handler if one exists.
-
-A catch-all cannot be written in an OpenAPI document. A route generated from a specification is
-always single-segment, and a document generated from a `{*path}` route describes it as `{path}`.
-
-## Case and trailing slashes
-
-A path is matched as written. `/Orders` and `/orders` are different URLs:
+Two generators read `[BasePath]`, and the two positions compose. On a controller the handler
+generator folds it into each route on that class. On the `[HardenedModule]` class the routing table
+prefixes it onto every route in the compilation. A route under both answers only at the
+concatenation of the two.
 
 ```csharp
 [HardenedModule]
-[CaseInsensitiveRoutes]          // match without regard to case
-public partial class Application { }
-```
+[BasePath("/module")]
+public partial class Application;
 
-`/orders` and `/orders/` are also different URLs, and strict is the default:
-
-```csharp
-services.Configure<WebRoutingConfiguration>(config =>
-    config.TrailingSlash = TrailingSlash.Redirect);
-```
-
-| Setting | A request for the other spelling gets |
-|---|---|
-| `Strict` | whatever it would have got, usually a 404 |
-| `Normalise` | the route, with no difference visible to the client |
-| `Redirect` | `308 Permanent Redirect` to the declared path. 308 rather than 301, so the method and body survive |
-
-## Prefixing with `[BasePath]`
-
-`[BasePath]` on the class prefixes every route in it. A route of `/` is the base path itself,
-which is how a collection is served from its own address:
-
-```csharp
-[BasePath("/orders")]
+[BasePath("/api")]
 public class OrderController {
-    [Get("/")]                 // /orders
-    public IReadOnlyList<Order> List() => _orders.All();
 
-    [Get("/{id}")]             // /orders/{id}
-    public Order ById(string id) => _orders.Find(id);
-
-    [Get("/items/")]           // /orders/items/, the trailing slash kept
-    public IReadOnlyList<Item> Items() => _items.All();
+    [Get("/orders/{id}")]
+    public string GetOrder(string id) => id;
 }
 ```
 
-On the assembly, `[BasePath]` prefixes every route in that assembly, which is how a
-[library module](/guide/modules#composing-modules) owns its URL space:
+That route answers at `/module/api/orders/7` and at nothing else. The handler reports
+`/module/api/orders/{id}` as its own path.
+
+A template of `/` under a base path contributes nothing to the route. `[BasePath("/collection")]`
+with `[Get("/")]` answers at `/collection`. The boundary slash is collapsed and never doubled.
+
+## What the build generates
+
+The generator selects every method declaration that carries one of the five verb attributes. The
+method must sit inside a type declaration that is not an interface.
+
+For each selected method the generator emits a handler class in the controller's namespace plus
+`.Generated`. The class is named after the controller and the method. It binds the parameters and
+invokes the handler.
+
+For each `[HardenedModule]` class the generator emits three more things.
+
+| Generated source | What it holds |
+|---|---|
+| `{EntryPoint}.Routing` | A nested `RoutingTable` class, and the code that registers it |
+| `{EntryPoint}.Links` | The `Routes` and `Links` types. See [Routes by name](#routes-by-name). |
+| `{EntryPoint}.OpenApiDocument` | The document, when the entry point asked for one |
+
+`RoutingTable` implements `IWebExecutionRequestHandlerProvider` and registers as a singleton. It
+holds one method per shared path prefix. Each method compares characters of the request path
+against a `ReadOnlySpan<char>`.
+
+`[HardenedWebModule]` registers the service that asks the tables. The host attributes import it.
 
 ```csharp
+using Hardened.Shared.Runtime.Attributes;
+using Hardened.Web.Kestrel.Runtime;
+using Hardened.Web.Runtime.DependencyInjection;
+
+namespace Todos;
+
 [HardenedModule]
 [HardenedWebModule]
-[BasePath("/billing")]
-public partial class BillingLibrary { }
+public partial class TodosLibrary;
+
+[HardenedModule]
+[KestrelRuntime]
+[TodosLibrary]
+public partial class Application;
 ```
 
-## Return values and status codes
+`[KestrelRuntime]` and `[AspNetCoreRuntime]` each declare `[HardenedWebModule]` themselves. A
+module that declares it a second time is unaffected, because modules deduplicate by equality.
 
-Return whatever the handler produces. A value is serialized to the response body. `Task` with no
-result produces an empty body. `Task<T>` is awaited first.
-
-### Returning `null`
-
-| Method | Status for a `null` return |
-|---|---|
-| `GET`, `PUT` | `404` |
-| `POST`, `DELETE`, `PATCH` and anything else | `200` |
-
-So a lookup is a 404 without an `if`, and a delete of something already gone is a 200. A 404 is
-logged at information level with the method and path.
-
-To control an error status, set `context.Response.Status` from an
-[execution filter](/guide/execution-pipeline), or declare the set with
-[a response type](/guide/responses). The `NullReturnStatus`, `ValidationErrorStatus` and
-`ErrorStatus` properties the verb attributes once carried are gone.
-
-### Response shape
-
-`[Produces]` states the media type, and a handler returning `string`, `byte[]` or `Stream` writes
-its value to the body without serializing it:
+On `[AspNetCoreRuntime]` the host's `Program.cs` installs the middleware with `UseHardened()`. The
+call inserts the Hardened middleware and runs the registered startup services. It puts the routing
+filter at the end of the chain. Nothing else installs it, so without the call no declared route
+answers.
 
 ```csharp
-[Get("/robots.txt")]
-[Produces("text/plain")]
-public string Robots() => "User-agent: *\nDisallow:";
-```
+using Hardened.Web.AspNetCore.Runtime;
 
-`[Output<T>]` hands the response to a view:
-
-```csharp
-[Get("/orders/{id}")]
-[Output<Views.OrderDetail>]
-public OrderModel Order(string id) => _repository.Get(id);
-```
-
-Declaring an output takes the response out of negotiation. The output answers what the client
-asked for, or the request gets `406`. See [Views](/guide/templates).
-
-### Caching
-
-`[CacheControl]` sets the response's cache headers and stores nothing:
-
-```csharp
-[Get("/static/rates")]
-[CacheControl(MaxAge = 3600, Type = CacheControlEnum.MaxAge | CacheControlEnum.Public)]
-public RateTable Rates() => _rates.Current;
-```
-
-To store the response on the server and serve it again without running the handler, see
-[Response caching](/guide/response-caching). To answer a caller who already holds the response
-with a 304, see [Conditional requests](/guide/conditional-requests).
-
-## The web module
-
-Routing needs `[HardenedWebModule]`. `[KestrelRuntime]`, `[AspNetCoreRuntime]` and
-`[LambdaHttpModule]` each bring it, so an application names its runtime and nothing else. A
-library that carries routes and is not the host imports `[HardenedWebModule]` itself. Declaring it
-twice is harmless.
-
-Under ASP.NET Core the host also installs the middleware:
-
-```csharp
+var builder = Application.CreateBuilder(args);
 var app = builder.Build();
 
 app.UseHardened();
@@ -294,37 +134,371 @@ app.UseHardened();
 app.Run();
 ```
 
-## Links to your own routes
+A test project on this host declares `[assembly: AspNetCoreTesting]`, and the default composition
+is `app.UseHardened()` alone. A project whose `Program.cs` puts other middleware around Hardened
+names an `IAspNetCoreTestComposition` in that attribute. See [testing web](/guide/testing-web).
 
-Every module gets two generated types built from the routes it declares:
+`[KestrelRuntime]` takes no such call. `HardenedKestrelApplication.Create` builds the pipeline from
+the populated service collection.
+
+The generator ships as an analyzer in `Hardened.Web.SourceGenerator`. A project that references
+only the runtime packages compiles routes into nothing, and every route answers 404. The build
+reports that as `HRDR006`.
+
+A verb attribute on an interface member compiles to no route. An interface member has no
+implementation to call. The build reports `HRDR013` as a warning and names the attribute.
+
+## Path tokens
+
+A token is a name in braces. It binds to the handler parameter of the same name.
+
+| Form | What it matches |
+|---|---|
+| `{name}` | Exactly one path segment |
+| `{*name}` | The rest of the path, separators included |
+| `{name:constraint}` | One segment that passes the constraint |
+
+The name binds without the marker and without the constraint. `{*path}` binds a parameter called
+`path`, and `{id:int}` binds a parameter called `id`.
+
+A token matches at least one character. `/collection/` does not match `/collection/{id}`, and
+`/binding/pair//second` does not match `/binding/pair/{first}/{second}`. Both answer 404. A
+catch-all follows the same rule, so `/assets/` does not match `/assets/{*path}`.
+
+A token binds by exact name, case included. `[Get("/{eventid}")]` beside a parameter called
+`eventId` binds nothing, and the binder reads that parameter from the request body. The build
+reports that as `HRDR005`.
+
+These brace forms do not compile. Each one is `HRDR002`, an error, reported once per token.
+
+| Written | Why it is refused |
+|---|---|
+| `{id?}` | An optional token is two routes. Declare both. |
+| `{id=5}` | Give the handler's parameter a C# default instead. |
+| `{id` or a stray `}` | The brace has no partner. |
+| `{}` or `{:int}` | A token with no name binds nothing. |
+| The same name twice in one route | Two tokens cannot both bind one parameter. |
+| `{id:isbn}` with no `isbn` declared | Nothing declares that constraint. |
+
+The message quotes the token as written and names the route and the handler. It carries no source
+location.
+
+## Route constraints
+
+A constraint is part of the match. A value that fails it produces a 404, not a 400. An
+unconstrained token behaves differently. `/path-typed/abc` with an `int` parameter reaches the
+binder, which answers 400. `/path-constrained/abc` with `{count:int}` answers 404.
+
+The generated table calls the test in `Hardened.Web.Runtime.Routing.RouteConstraints` directly.
+Every test takes a `ReadOnlySpan<char>` and allocates nothing.
+
+| Name | Matches | Does not match |
+|---|---|---|
+| `int` | A 32-bit integer, invariant culture | `abc`, `4.5`, `1,000` |
+| `long` | A 64-bit integer, invariant culture | `abc` |
+| `guid` | A GUID | `not-a-guid` |
+| `bool` | `true` or `false` | `yes` |
+| `decimal` | A sign and a decimal point, nothing else | `abc`, `1,000` |
+| `date` | `yyyy-MM-dd` exactly | `2026-8-17`, `12/06/2026` |
+| `datetime` | One of four ISO 8601 forms, listed below | `2026-08-17 09:30` |
+| `alpha` | One or more ASCII letters | `beta2` |
+| `hex` | One or more ASCII hex digits | `0g9` |
+| `slug` | Lower-case ASCII words joined by single hyphens | `My-First-Post`, `-lead`, `a--b` |
+
+`datetime` accepts `yyyy-MM-ddTHH:mm:ssK`, `yyyy-MM-ddTHH:mm:ss.FFFFFFFK`, `yyyy-MM-ddTHH:mmK` and
+`yyyy-MM-dd`. Every constraint parses under the invariant culture.
+
+Seven more names take whole-number arguments. Nothing else is a valid argument.
+
+| Name | Matches |
+|---|---|
+| `length(n)` | Exactly n characters |
+| `length(min,max)` | Between min and max characters, inclusive |
+| `minlength(n)` | n characters or more |
+| `maxlength(n)` | n characters or fewer |
+| `min(n)` | An integer of n or more |
+| `max(n)` | An integer of n or less |
+| `range(min,max)` | An integer between min and max, inclusive |
+
+A name used at an arity it does not have is `HRDR002`. The message says which arities it takes.
+
+A token may carry several constraints, separated by colons. The chain is a conjunction and every
+term must pass. `{id:int:min(1)}` matches `42` and rejects `0` and `abc`.
+
+### Declaring a constraint
+
+Write a static method, give it `[RouteConstraint]`, and name the constraint.
 
 ```csharp
-ApplicationRoutes.Orders.Order("42")        // "/orders/42": the path, from anywhere
-_links.Orders.Order("42")                   // what a client should call
-_links.Orders.OrderAbsolute("42")           // with a scheme and host, for a Location header
+public static class Codes {
+
+    [RouteConstraint("code")]
+    public static bool IsCode(ReadOnlySpan<char> value) {
+        if (value.Length != 3) {
+            return false;
+        }
+
+        foreach (var character in value) {
+            if (character < 'A' || character > 'Z') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
 ```
 
-The names come from the controller and the method, so a rename is a compile error at every call
-site, including inside a view:
+Then write `[Get("/items/{id:code}")]`. The table calls `Codes.IsCode` directly, on every request
+that reaches that position.
 
-```razor
-<a href="@Links.Orders.Order(Model.Id)">@Model.Reference</a>
-```
+The method must be `static`, return `bool`, and take one `ReadOnlySpan<char>`. A declaration that
+is not that shape is `HRDR003`, an error, and the generator emits no call to it. Names are compared
+in lower case. A declared constraint takes no arguments, so `{id:code(3)}` is `HRDR002`.
 
-`ApplicationLinks` is in the container, so a handler can take it as a constructor parameter. It
-resolves through an `ILinkContext`, which keeps a link correct on a host that strips a prefix
-before the application sees the path, such as API Gateway's stage:
+`[RouteConstraint]` is repeatable, so one method can serve under more than one name.
+
+## Matching order
+
+A literal segment beats a token in the same position, at every depth. The table tries the literal
+branches first and consults the token branch only when they all decline.
 
 ```csharp
-services.Configure<LinkConfiguration>(config => {
-    config.BasePath = "/prod";
-    config.Scheme = "https";
-    config.Host = "api.example.com";
-});
+[Get("/r/fixed")]      // answers /r/fixed
+[Get("/r/{id}")]       // answers /r/other, and /r/fixedly with id = "fixedly"
+[Get("/r/fixed/sub")]  // answers /r/fixed/sub
+[Get("/r/{id}/sub")]   // answers /r/other/sub
 ```
+
+A literal also beats a catch-all. `/assets/index` reaches `[Get("/assets/index")]` beside
+`[Get("/assets/{*path}")]`.
+
+A token stops at the next segment boundary. `/files/{name}/download` matches `/files/a/download`
+and does not match `/files/a/b/c/download`. A path deeper than any route declares matches nothing.
+A route may put a literal other than `/` after a token: `/f/{id}.json` binds `id` to `7` for
+`/f/7.json`.
+
+A catch-all takes everything that is left. `/assets/{*path}` binds `path` to `a/b/c.png` for
+`/assets/a/b/c.png`. It still matches a single segment.
+
+Two routes that match the same paths and differ only in what their token accepts are `HRDR001`, an
+error. `/users/{id:int}` beside `/users/{name}` is the case, and so is `{path}` beside `{*path}`.
+The handler a request reaches then depends on the value in it. Lower the severity per file or per
+project when an existing pair has to stay.
+
+```ini
+# .editorconfig
+dotnet_diagnostic.HRDR001.severity = warning
+```
+
+```xml
+<PropertyGroup>
+  <HardenedAmbiguousRoutes>warning</HardenedAmbiguousRoutes>
+</PropertyGroup>
+```
+
+The rule leaves a literal beside a token alone. It leaves one shape under two different verbs
+alone as well.
+
+One path is one node however many verbs answer at it. A constraint declared by any route at a
+position constrains that position for every verb there. `[Get("/items/{id:int}")]` beside
+`[Delete("/items/{id}")]` makes `/items/abc` a 404 under both verbs.
+
+The web pipeline consults routing tables in reverse registration order. A route an application
+declares therefore shadows one a framework module registered earlier. It asks a provider that
+implements `IFallbackRequestHandlerProvider` after every ordinary one.
+
+## What a route publishes
+
+The published path template carries no routing syntax. The document writer strips the constraint
+and the catch-all marker from every token. `/todos/{id:int}` publishes as `/todos/{id}`, and
+`/receipts/{*path}` as `/receipts/{path}`. No published path contains `:` or `*`.
+
+A catch-all therefore does not survive a round trip. A route generated from a specification takes
+one segment, because a path template has no way to say otherwise.
+
+A constrained token adds a 404 to the operation. That response carries no body. Its description
+reads "The path did not name a resource: a token failed its route constraint." An operation that
+declares its own 404 keeps that description and gains a sentence saying the same thing.
+
+The constraint also removes the 400 the document would otherwise publish. `{id:int}` makes the
+same test the converter makes, so the converter can no longer refuse that value. A handler taking
+an `int id` at `/todos/{id:int}` publishes 200 and 404 and no 400. The same handler at
+`/todos/{id}` publishes the 400.
+
+## Case and trailing slashes
+
+Routes match by exact case. `/orders/summary` does not answer `/Orders/Summary`. A route declared
+in mixed case matches its own spelling.
+
+`[CaseInsensitiveRoutes]` on the `[HardenedModule]` class matches that module's routes in any case.
+The attribute carries no state. The comparison is compiled into the table, so the attribute is the
+only switch.
+
+A trailing slash is part of the path. `/orders` and `/orders/` are two routes, and a route declared
+as one does not answer the other. An empty segment is a segment, so `/a//b` and `/a/b` are two
+paths as well.
+
+`IWebRoutingConfiguration.TrailingSlash` changes what a path that differs only by a trailing slash
+gets. The value is `TrailingSlash.Strict` unless the application sets it.
+
+| Value | What the other spelling gets |
+|---|---|
+| `Strict` | Nothing. Only the declared spelling answers. |
+| `Normalise` | The route, with no difference visible to the client. |
+| `Redirect` | `308 Permanent Redirect`, with `Location` set to the declared path. |
+
+The root has no other spelling, so every value leaves `/` alone. The policy runs after static
+content and before the 405.
+
+## Verbs and status codes
+
+The five verb attributes are the whole set. No attribute declares a HEAD route.
+
+HEAD reaches the GET handler. The table emits a `case "HEAD":` beside every `case "GET":`. The
+handler, its filters and its serializer all run. The framework counts the body and discards it on
+the way out, and `Content-Length` reports the count. The status and every header match the GET.
+
+A request whose path matches under another verb gets 405. The response carries `Allow` and no
+body. `Allow` lists the verbs declared at that path, sorted. It includes HEAD wherever GET is
+declared.
+
+```console
+$ curl -i -X PUT localhost:5080/todos/7
+HTTP/1.1 405 Method Not Allowed
+Allow: GET, HEAD
+```
+
+A path no table declares gets 404. A 405 therefore tells a client that the resource exists.
+
+### Status codes
+
+A successful response carries 200. `SuccessStatus` on the verb attribute changes it.
+
+```csharp
+[Post("/created", SuccessStatus = 201)]
+public string CreateItem() => "created";
+
+[Delete("/emptied", SuccessStatus = 204)]
+public string EmptyItem() => "this body is not written";
+```
+
+`SuccessStatus = 200` and an unset `SuccessStatus` mean the same thing. The framework writes no
+body for 204, 205 or 304, whatever the handler returned.
+
+A handler that returns null gets a status from the request method.
+
+| Method | Status for a null return |
+|---|---|
+| GET | 404 |
+| PUT | 404 |
+| POST | 200 |
+| DELETE | 200 |
+| Anything else | 200 |
+
+A declared `SuccessStatus` replaces that status only where it is already 2xx. A null return on a
+GET stays 404, and a null return on a POST declaring 201 answers 201.
+
+## The Cache-Control header
+
+`[CacheControl]` writes the `Cache-Control` header on a handler's responses. On a controller it
+applies to every handler on the class. It takes two named properties.
+
+| Property | Default | What it carries |
+|---|---|---|
+| `MaxAge` | `0` | Seconds for `max-age` |
+| `Type` | `CacheControlEnum.MaxAge \| CacheControlEnum.Public` | The directives to write |
+
+`CacheControlEnum` has `MaxAge`, `NoCache`, `NoStore`, `NoTransform`, `Public` and `Private`. The
+header is written in that order: `private` or `public`, then `no-cache`, `no-store`, `max-age`,
+`no-transform`. `Private` wins over `Public` when both are set. `max-age` appears only when the
+`MaxAge` flag is set, so the value alone does not put it there.
+
+```csharp
+[Get("/default")]
+[CacheControl]                                    // public, max-age=0
+public string Default() => "default";
+
+[Get("/none")]
+[CacheControl(Type = CacheControlEnum.NoStore)]   // no-store
+public string None() => "none";
+
+[Get("/private")]
+[CacheControl(MaxAge = 60, Type = CacheControlEnum.MaxAge | CacheControlEnum.Private)]
+public string Private() => "private";             // private, max-age=60
+```
+
+A handler without the attribute sends no `Cache-Control` header. The filter writes every flag that
+is set, including combinations a cache reads as contradictory.
+
+This attribute writes a header and stores nothing. To store a handler's answer, see
+[response caching](/guide/response-caching).
+
+## Routes by name
+
+The build emits a static path builder and a link builder for every entry point. Both are nested in
+the entry point class. A rename of a controller or a handler is then a compile error at every call
+site.
+
+```csharp
+// [Get("/items/{id:int}")] on ItemController.Read
+var path = Application.Routes.Item.Read(42);   // "/items/42"
+```
+
+The group is the controller's name with a `Controller` suffix removed, or what `[Tag]` declared.
+The method is the handler's name. Where the two are equal the verb is appended, so a `Health`
+handler on `HealthController` becomes `HealthGet`.
+
+A string argument is escaped with `Uri.EscapeDataString`. A catch-all argument is not, because it
+is a path fragment. Anything else is formatted with `Convert.ToString` under the invariant culture.
+
+`Application.Links` answers the same routes as links a client can call. It is registered as a
+transient service. `Links.Item.Read(42)` prefixes `BasePath`, and `Links.Item.ReadAbsolute(42)`
+also prefixes the scheme and the host. Half an origin falls back to the relative link.
+
+`LinkConfiguration`, in `Hardened.Web.Runtime.Links`, carries the three values. `BasePath` is empty
+by default, which is right for Kestrel and for ASP.NET Core. A host that strips a prefix before the
+application sees the path has to put that prefix back here. API Gateway's stage is the case this
+exists for. `LinkContext` trims a trailing slash off `BasePath`, so both spellings build one link.
+
+```csharp
+public void ConfigureServices(IServiceCollection services) {
+    services.AddSingleton<IConfigurationPackage>(
+        new SimpleConfigurationPackage(
+            Array.Empty<IConfigurationValueProvider>(),
+            new IConfigurationValueAmender[] {
+                new SimpleConfigurationValueAmender<LinkConfiguration>(
+                    (_, links) => {
+                        links.BasePath = "/prod";
+                        links.Scheme = "https";
+                        links.Host = "api.example.com";
+
+                        return links;
+                    })
+            }));
+}
+```
+
+`Links.Item.Read(42)` then answers `/prod/items/42`, and `Links.Item.ReadAbsolute(42)` answers
+`https://api.example.com/prod/items/42`. A host that reads the stage off each request registers its
+own `ILinkContext`. The default registration steps aside for it.
+
+A route that `HRDR002` refused gets no link.
+
+## Routing diagnostics
+
+| Code | Reports | Severity |
+|---|---|---|
+| `HRDR001` | Two routes differing only in what their token accepts | Error |
+| `HRDR002` | A brace form the build does not compile | Error |
+| `HRDR003` | A `[RouteConstraint]` that is not a `static bool(ReadOnlySpan<char>)` | Error |
+| `HRDR005` | A route token that binds no parameter, beside one read from the body | Error |
+| `HRDR006` | Routes in an assembly with no routing generator referenced | Error |
+| `HRDR013` | A verb attribute on an interface member | Warning |
 
 ## Next
 
-- [Parameter binding](/guide/parameter-binding): where each argument comes from
-- [Declared responses](/guide/responses): more than one status in the signature
-- [Sending requests](/guide/testing-web): driving these routes from a test
+- [Parameter binding](/guide/parameter-binding) for what a handler's other parameters bind from.
+- [Responses](/guide/responses) for declaring more than one status on a handler.
+- [Response caching](/guide/response-caching) for storing a handler's answer.
+- [OpenAPI](/guide/openapi) for the document these routes publish.

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -158,7 +158,7 @@ A view built on a generated base has a `Links` property:
 
 RazorBlade copies `@` expressions verbatim and emits `#line` directives with exact spans, so
 renaming the route or its handler breaks the template at build time, reported at its own line
-and column. See [Links to your own routes](/guide/routing#links-to-your-own-routes).
+and column. See [Routes by name](/guide/routing#routes-by-name).
 
 ## What gets rendered
 
@@ -213,5 +213,5 @@ shipping services alongside a generated type is one attribute rather than two.
 ## Next
 
 - [Content negotiation](/guide/content-negotiation): serving JSON and HTML from one handler
-- [Routing](/guide/routing#links-to-your-own-routes): the generated links a view uses
+- [Routing](/guide/routing#routes-by-name): the generated links a view uses
 - [Sending requests](/guide/testing-web#the-response): reading a rendered page in a test

--- a/docs/guide/testing-mocks.md
+++ b/docs/guide/testing-mocks.md
@@ -110,7 +110,7 @@ hit and reads `1.10m` again.
 Registration attributes run after the application's modules, so a registration here replaces one
 there. They are valid on a method, a class or the assembly.
 [Writing a test attribute](/guide/testing-attributes) has the other interfaces, and
-[Testing a duration](/guide/response-caching#testing-a-duration) is the response cache's side of
+[The store clock](/guide/response-caching#the-store-clock) is the response cache's side of
 this example.
 
 ## Choosing a registration by environment

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -1,327 +1,449 @@
 # Validation
 
-A constraint on a model becomes a generated validator. A request that fails answers 400 before the
-handler runs, with one entry per failed field, and the handler only ever sees values that passed.
+Hardened compiles constraint attributes into a validator and runs it before the handler. The
+request is refused with 400, and the body names every field that failed.
+
+```csharp
+using Hardened.Web.Runtime.Attributes;
+using ValidationModules.Constraints;
+
+public class RegistrationModel {
+    [Required]
+    [StringLength(Min = 3, Max = 20)]
+    public string? Name { get; set; }
+
+    [Range(18, 120)]
+    public int Age { get; set; }
+}
+
+[BasePath("/registration")]
+public class RegistrationController {
+
+    [Post("/")]
+    public string Register(RegistrationModel model) => model.Name ?? "";
+}
+```
+
+The controller declares no filter and no registration. The constraints are the whole declaration.
+
+## The package
+
+The constraint attributes come from `ValidationModules.Constraints`, which the application already
+references. A second package compiles them.
+
+```xml
+<PackageReference Include="Hardened.Validation.SourceGenerator" />
+```
+
+A project that declares constraints without this package builds clean and enforces nothing. The
+build reports `HRDV006` for that case.
+
+## The constraint attributes
+
+Every attribute below lives in `ValidationModules.Constraints`.
+
+| Attribute | Arguments | Applies to | Document facet |
+| --- | --- | --- | --- |
+| `[Required]` | none | any member | the name in `required` |
+| `[StringLength]` | `(min, max)` or `Min =`, `Max =` | a string | `minLength`, `maxLength` |
+| `[Range]` | `(min, max)` or `Min =`, `Max =`, `ExclusiveMin =`, `ExclusiveMax =` | a number | `minimum`, `maximum` |
+| `[Pattern]` | `("regex")` or `(typeof(T), nameof(T.Member))` | a string | `pattern` |
+| `[ItemCount]` | `(min, max)` or `Min =`, `Max =` | a collection | `minItems`, `maxItems` |
+| `[AllowedValues]` | one string per permitted value | a string | `enum` |
+| `[ValidateNested]` | none | a member with structure | none |
+
+`[MultipleOf]` and `[UniqueItems]` publish `multipleOf` and `uniqueItems`. The contract-first build
+task maps neither keyword back into an attribute.
+
+`[Range]` declares its bounds as `object?`, so a decimal bound is written as a string. The build
+parses that string against the member's own type.
+
+The generator reads `System.ComponentModel.DataAnnotations` through the same front end. A model
+carrying only `[Required]` and `[StringLength(64, MinimumLength = 1)]` gets a validator. Both
+vocabularies declare a `Required` and a `Range`, so a model using both needs an alias.
 
 ```csharp
 using ValidationModules.Constraints;
-
-public record CreatePetRequest(
-    [property: StringLength(Min = 1, Max = 100)] string Name,
-    [property: Range(Min = 0, Max = 30)] int Age,
-    [property: Pattern("^[a-zA-Z0-9-]+$")] string? Tag,
-    [property: ItemCount(Max = 5)] List<string>? Nicknames);
+using DataAnnotations = System.ComponentModel.DataAnnotations;
 ```
+
+The published OpenAPI document carries facets for the `ValidationModules.Constraints` vocabulary
+only. A DataAnnotations constraint runs and is absent from the document.
+
+## What the build generates
+
+`Hardened.Validation.SourceGenerator` reads every type declaration in the compilation. A type whose
+members carry a constraint gets a validator class named `<TypeName>Validator`. A type that declares
+no constraint gets nothing.
+
+The same generator writes a partial of the entry point class that registers each validator as a
+singleton. The file is named `<EntryPoint>.ValidationModule.g.cs`. A compilation with no validator
+gets no registration file. A compilation with no entry point still gets its validators.
+
+The web generator and the function generator emit a second validator, for the handler's nested
+`Parameters` class, named `<Handler>ParametersValidator`. That validator descends into a body whose
+type has a validator. It also checks the constraints written on the handler's own parameters. The
+generator then adds `ValidationFilterProvider<...Parameters>` to the handler's filter list.
+
+A handler whose types and parameters constrain nothing gets no filter. A validated handler runs its
+filter at `FilterOrder.Validation`, which is one stage after binding and one stage before
+authorization.
+
+Two other cases generate no filter. A project without `Hardened.Validation.SourceGenerator`
+attaches nothing, because the filter would name a validator that nobody emits. A contract-first
+operation already carries `[Validate<I...Parameters>]` from the contract bridge, so the handler
+generator leaves it alone.
+
+## Build-time diagnostics
+
+| Code | Severity | Condition | Fix |
+| --- | --- | --- | --- |
+| `HRDV002` | Error | Two validators claim the same generated file. | Report it. The cause is a defect in the generator. |
+| `HRDV003` | Warning | `[Required]` sits on a non-nullable value type. | Declare the member `required`, or add `[JsonRequired]`, or make the type nullable. |
+| `HRDV004` | Warning | A property omits `[ValidateNested]`, and its type declares constraints. | Add `[ValidateNested]`, or set `<NoWarn>$(NoWarn);HRDV004</NoWarn>`. |
+| `HRDV005` | Error | A constraint on a handler parameter sets `When` or `Unless`. | Remove the condition, or move the constraint onto a model property. |
+| `HRDV006` | Warning | The project declares constraints and references no validation generator. | Reference `Hardened.Validation.SourceGenerator`, or remove the constraints. |
+
+`HRDV003` fires because `[Required]` compiles to a null check, and a value type is never null. An
+omitted `int` arrives as `0` and passes. An omitted enum arrives as its first declared member, which
+reads as a deliberate choice.
+
+`HRDV004` fires only on a parent that constrains something itself. The child type must also be
+declared in the same compilation. A child type from a package is left alone.
+
+`HRDV005` fires because `When` and `Unless` name a member of the model the constraint sits on. A
+handler parameter sits on no model.
+
+`HRDV006` is reported once per assembly, however many handlers declare constraints.
+
+`HRDV001` is retired. It warned that a constraint on a handler parameter was not compiled, and those
+constraints are compiled now.
+
+## The failure response
+
+A failed constraint answers 400 with this body.
 
 ```json
 {
   "type": "ValidationError",
   "message": "One or more validation errors occurred.",
   "errors": [
-    { "field": "body.name", "code": "required", "message": "name is required." },
-    { "field": "body.age", "code": "range", "message": "age must be between 0 and 30." }
+    { "field": "model.name", "code": "string_length", "message": "..." },
+    { "field": "model.age", "code": "range", "message": "..." }
   ]
 }
 ```
 
-There is no validator class to write and no registration to remember. Declaring the constraint is
-the whole of it.
+Every failing constraint is reported, not only the first.
 
-## Declaring constraints in code
+| Code | Raised by |
+| --- | --- |
+| `required` | a `[Required]` on a null value, an absent required member, an empty body, a `null` body |
+| `string_length` | `[StringLength]` |
+| `range` | `[Range]` |
+| `pattern` | `[Pattern]` |
+| `invalid` | a value that does not convert to the declared type, or a body that does not parse |
 
-The attributes live in the `ValidationModules.Constraints` namespace. Every bounded attribute
-takes named `Min` and `Max` arguments, so a single bound is one argument. `[Required]` marks a
-member the caller may not send as `null`. On a non-nullable value type it is unnecessary, because
-absence is unrepresentable there — and `HRDV003` says so.
+Four layers produce this body, and the caller cannot tell them apart. The generated filter produces
+it. The string converter produces it for a query, header or path value that does not parse. The
+JSON reader's refusal is reshaped into it. A handler throwing `ValidationException` produces it.
 
-### Presence, and who checks it
+`ExceptionToModelConverter` writes the body, and it is the only place that decides what a validation
+failure looks like.
 
-A non-nullable reference member the constructor takes is one the caller must send. Nothing else
-declares it:
+## Field names
+
+A failure inside the body is pathed under the handler's own body parameter name. A handler taking
+`RegistrationModel model` reports `model.name`. A contract-first operation reports `body.name`,
+because the generated member is called `body`. A failing element of an array carries its index, as
+`body.lines[0].sku`.
+
+A query, header or path value is reported bare, under the name the caller sent. A parameter bound by
+`[FromHeader("X-Region")]` reports `X-Region`, never the C# identifier. One bound by
+`[FromQueryString("p")]` reports `p`.
+
+Property names are wire names. A property called `Reference` reports as `reference`.
+
+## Required members and absent values
+
+Absence is the deserializer's question, and content is the validator's. A validator cannot see an
+absent value, because an omitted `int` is indistinguishable from `0` once the model is built.
+
+The deserializer demands a member that is a constructor parameter, is a non-nullable reference type,
+and has no default value. It refuses `{}` against `record Todo(string Title)`. It names every
+missing member in one answer.
+
+| Member | Demanded by the deserializer |
+| --- | --- |
+| a non-nullable reference constructor parameter | yes |
+| a nullable reference constructor parameter | no |
+| a constructor parameter with a default value | no |
+| a value type | no. See `HRDV003` |
+| a settable property | no. Its initializer is invisible to reflection |
+| a `[ResponseOnly]` member | no. The server owns the value |
+| a get-only member with no constructor parameter | no |
+| a member declared `required` or `[JsonRequired]` | yes |
+
+A sent `null` is not an absence. It satisfies the deserializer and `[Required]` refuses it.
+
+The rule above is installed by the reflection-based deserializer. A source-generated resolver
+carries the same answer from its own generator, decided at build time.
+
+A body parameter the handler declared non-nullable is checked by the generated binder. A literal
+`null` body, and an empty body, both answer `required` against the body parameter name. A handler
+declaring `Quote?` receives the null.
+
+## Constraints on handler parameters
+
+A constraint on a query, header or path parameter is compiled into the handler's parameters
+validator.
 
 ```csharp
-public record NewTodo(string Title);        // {} is a 400: title is required
-public record Draft(string? Title);         // {} is accepted, Title is null
-public record Paged(string Cursor = "");    // {} is accepted, Cursor is ""
-```
+[BasePath("/constraints")]
+public class ConstraintsController {
 
-That is the same declaration the published document reads — `required: ["title"]` comes from the
-annotation on `Title` and from nothing else — so the document and the server now answer the same
-question the same way. A member the server owns is excluded from both by `[ResponseOnly]`.
+    [Get("/precision")]
+    public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) => precision;
 
-A settable property is not demanded, whatever its type:
+    [Get("/region")]
+    public string Region([FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
 
-```csharp
-public class Manifest {
-    public string Id { get; set; } = "";        // optional, and the document says so
-    public string Carrier { get; set; }         // the document says required; nothing checks it
+    [Get("/page/{count:int}")]
+    public int Page([Range(Min = 1, Max = 100)] int count) => count;
+
+    [Get("/tagged")]
+    public string Tagged([FromQueryString] [Required] [Pattern("^[a-z]+$")] string? tag) => tag!;
 }
 ```
 
-An initializer is how a property says "this when nothing sends it", and it compiles into the
-constructor body where reflection cannot see it — so demanding these would refuse bodies their author
-meant to accept. The document reads the initializer from source and leaves `id` optional; `carrier`,
-which has none, is published as required and is `[Required]`'s to enforce. Write the demand where the
-reader can see it — a constructor parameter, `required string Carrier`, or `[JsonRequired]` — or
-declare `[Required]` and let the validator answer.
+A constraint attribute is not a binding attribute. The generator treats an unrecognised parameter
+attribute as a custom binder. It recognises both constraint vocabularies, so a constrained parameter
+still binds from its declared source.
 
-**Presence is the reader's question; content is the validator's.** Absence is the one thing a
-validator cannot see, and the one thing the JSON reader knows for certain, so a body that omits a
-required member is refused before any constraint runs. Every member it missed is named at once:
+A route constraint and a value constraint answer different questions. `/constraints/page/abc`
+matches no route and answers 404. `/constraints/page/0` matches the route and answers 400.
+
+A value that does not parse is a failure rather than an absence. `?limit=abc` answers 400 with code
+`invalid` and the message `limit is not a valid Int32`. An omitted optional parameter still
+succeeds.
+
+## Nested models
+
+A generated validator descends into a member only where `[ValidateNested]` says to.
+
+```csharp
+public class RegistrationModel {
+    [Required]
+    [StringLength(Min = 3, Max = 20)]
+    public string? Name { get; set; }
+
+    [ValidateNested]
+    public AddressModel? Address { get; set; }
+}
+
+public sealed class AddressModel {
+    [Required]
+    public string? City { get; set; }
+
+    [StringLength(2, 2)]
+    public string? Country { get; set; }
+}
+```
+
+`[ValidateNested]` covers an object, each element of a collection, and each value of a dictionary.
+Omitting it stops every constraint on the child type, and the build reports `HRDV004`. An absent
+optional nested member is not a failure.
+
+## Contract-first constraints
+
+An OpenAPI document or a Smithy model declares the same constraints. The build task writes them onto
+the emitted members as the attributes above. The validation generator then reads them out of the
+compilation. No part of the generator is contract-aware.
+
+| OpenAPI facet | Attribute |
+| --- | --- |
+| `required` | `[Required]` |
+| `minLength`, `maxLength` on a string | `[StringLength(Min =, Max =)]` |
+| `minimum`, `maximum` on a number | `[Range(Min =, Max =)]` |
+| `exclusiveMinimum`, `exclusiveMaximum` | `[Range(ExclusiveMin = true, ExclusiveMax = true)]` |
+| `pattern` on a string | `[Pattern(typeof(PetstorePatterns), nameof(PetstorePatterns.P_c37a8736))]` |
+| `minItems`, `maxItems` | `[ItemCount(Min =, Max =)]` |
+| `enum` on a string | `[AllowedValues("a", "b")]` |
+
+The task drops a facet the C# type cannot carry. A `minimum` on a string emits nothing. So does an
+`enum` on a member that fell back to `JsonElement`, and a `minLength` on an integer. The comparison
+the validator would emit does not compile.
+
+Two cases suppress `required`. A non-nullable value type suppresses it, for the reason `HRDV003`
+gives. A path parameter suppresses it, because the router already refused a request with an absent
+segment.
+
+A pattern becomes a `[GeneratedRegex]` member on a class named after the contract file, such as
+`PetstorePatterns`. The attribute points at that member. Identical patterns collapse onto one
+member. A pattern that .NET's engine refuses is reported against the contract and emits no
+attribute.
+
+The task maps no `multipleOf`, `uniqueItems` or `not`. A contract that declares one of those gets
+warning `HOAT024`. A Smithy model gets `HSMT024`. The message names the keyword and where it sits.
+
+A Smithy model declares the same constraints as traits. The parser reads each trait into the facet
+above.
+
+| Smithy trait | Facet |
+| --- | --- |
+| `@required` | `required` |
+| `@length` on a string | `minLength`, `maxLength` |
+| `@length` on a list, set or map | `minItems`, `maxItems` |
+| `@range` | `minimum`, `maximum` |
+| `@pattern` | `pattern` |
+
+A trait may sit on the member or on the shape it targets. The member wins where both declare one.
+
+For a constrained operation the task emits a public partial interface, named for the operation's
+method. `GetPet` gets `IGetPetParameters`. The interface carries one get-only property per
+parameter, plus a `body` member for a constrained body. The generated `Parameters` class implements
+it, and the handler carries `[Validate<IGetPetParameters>]`. An operation the contract constrains
+nothing about gets no interface and no filter.
+
+## What the document publishes
+
+An operation with a generated validator publishes a 400. Its schema is
+`#/components/schemas/RequestValidationError`, and the build writes that schema into `components`.
+An operation that declares its own 400 keeps it.
+
+Parameter and property constraints are published as facets on the parameter's or the property's
+schema.
 
 ```json
-{ "errors": [
-  { "field": "body.accountId", "code": "required", "message": "accountId is required." },
-  { "field": "body.weightKg",  "code": "required", "message": "weightKg is required." } ] }
+{
+  "name": "precision",
+  "in": "query",
+  "schema": { "type": "integer", "minimum": 2, "maximum": 8 }
+}
 ```
 
-The trade is worth knowing: a body that both omits a required member and breaks a constraint on a
-member it did send is answered about the omission, and about the constraint on the next request.
-Everything the reader accepted is validated together, as before.
+Facets are not written beside a `$ref`, because OpenAPI 3.0 readers ignore a `$ref`'s siblings.
+Exclusive bounds use the JSON Schema 2020-12 spelling, so the bound is the number under
+`exclusiveMinimum`. `[Pattern]` in its `typeof` form publishes no `pattern`, because the expression
+lives in an attribute on another type.
 
-A non-nullable **value** type is not covered by this. The document publishes one as required because
-C# serialization cannot omit it — a fact about what a response always contains rather than a demand
-its author made, and `int?` or `= 0` are the only ways C# has to say otherwise. To demand one, say
-so: `required int Grams`, or `[JsonRequired]`. A contract-first model needs neither, because a
-contract's `required` is a demand and is compiled as one whatever the member's type.
+## Changing the status code
 
-| Attribute | Checks |
-|---|---|
-| `[Required]` | the member was sent |
-| `[StringLength(Min, Max)]` | a string's length |
-| `[Range(Min, Max)]` | a numeric bound. `ExclusiveMin` and `ExclusiveMax` open the ends |
-| `[Pattern(regex)]` | a regular expression |
-| `[ItemCount(Min, Max)]` | a collection's size |
-| `[MultipleOf]` | divisibility |
-| `[AllowedValues]` | membership of a set |
-
-The same attributes go on a handler's own parameters, for a value bound from the query string, a
-header or the path:
-
-```csharp
-[Get("/rates/{count:int}")]
-public int Page([Range(Min = 1, Max = 100)] int count) => count;
-
-[Get("/precision")]
-public int Precision([FromQueryString] [Range(Min = 2, Max = 8)] int precision) => precision;
-
-[Get("/region")]
-public string Region([FromHeader("X-Region")] [StringLength(2, 2)] string region) => region;
-```
-
-A failure is reported under the name the caller sent, `precision` or `X-Region`, in the same
-envelope a body failure uses. A route constraint and a value constraint answer different
-questions: `/rates/abc` matches no route and is a 404, while `/rates/0` reaches the handler's
-filter and is a 400.
-
-A parameter's constraint cannot carry a `When` or `Unless`, which names a member of the model the
-constraint sits on. A parameter sits on no model, and `HRDV005` says so at build time.
-
-### Nested models
-
-A constraint on a member of a nested model runs only when the member carries `[ValidateNested]`:
-
-```csharp
-public record Address([property: StringLength(Min = 1, Max = 8)] string Postcode);
-
-public record NewJob(
-    [property: Required] string Title,
-    [property: ValidateNested] Address Pickup);
-```
-
-Without it the nested constraints compile and never run, and `HRDV004` says so at build time:
-*'NewJob.Pickup' does not declare [ValidateNested] and its Address type declares constraints, so
-none of them run and an invalid 'Address' is accepted with no error. Add [ValidateNested] to the
-property, or set NoWarn HRDV004 if the skip is intended.* The nested record must be sealed, or
-declare a polymorphism mode, or ValidationModules reports `VM1503`.
-
-## Declaring constraints in a contract
-
-A contract-first application declares constraints as ordinary OpenAPI facets, on schema
-properties and on parameters alike. A Smithy model uses `@length`, `@range` and `@pattern` the
-same way.
-
-```yaml
-components:
-  schemas:
-    CreatePetRequest:
-      type: object
-      required: [name]
-      properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 100
-        age:
-          type: integer
-          minimum: 0
-          maximum: 30
-        tag:
-          type: string
-          pattern: "^[a-zA-Z0-9-]+$"
-        nicknames:
-          type: array
-          items: { type: string }
-          maxItems: 5
-```
-
-The build task turns each facet into the matching attribute on the generated model, and the
-validation generator reads those exactly as it reads attributes you wrote by hand:
-
-| Contract facet | Generated attribute |
-|---|---|
-| `minLength` / `maxLength` | `[StringLength]` |
-| `minimum` / `maximum` | `[Range]` |
-| `exclusiveMinimum` / `exclusiveMaximum` | `[Range(..., ExclusiveMin = true)]` |
-| `pattern` | `[Pattern]` |
-| `enum` | `[AllowedValues]`, or the generated enum type |
-| `minItems` / `maxItems` | `[ItemCount]` |
-| `required` | `[Required]` |
-
-A bound you leave out is left out. `minimum: 1` with no `maximum` generates `[Range(Min = 1)]`,
-and the failure message says "at least 1" without inventing an upper bound.
-
-## The 400 envelope
-
-A failed request never reaches the handler. The generated filter answers 400 with one entry per
-failed field, in the shape at the top of this page. A value that fails to parse as its declared
-type takes the same shape: `?limit=abc` against an `int` parameter answers this envelope with
-`limit` as the field, not a 500. So does a body that omitted a required member, reported under the
-object that was missing it — `body.lines[0].sku`, not `body.sku`. Which layer caught a fault is not
-something a caller can tell.
-
-A body the reader could not use at all is answered as a fact about the body:
-
-| Sent | Field | Code |
-|---|---|---|
-| nothing, or an empty body | `body` | `required` |
-| `null` | `body` | `required` |
-| `{"weightKg":` — a document that does not parse | `body` | `invalid` |
-| `{"weightKg":"heavy"}` — a value that would not convert | `body.weightKg` | `invalid` |
-
-The field is the handler's own body parameter identifier, so a handler taking `MemberRequest request`
-reports `request`. Only the last row names a member: a malformed document has a reader path too, and
-it means wherever the text ran out rather than what is wrong — `{"accountId":` was answered
-`body.accountId`, about a member that is present and correct as far as it goes.
-
-## What the document says
-
-The published OpenAPI document repeats every declared constraint as the facet it came from, so the
-rule a client is validated against is the one the document advertises. Operations with generated
-validators also publish the 400 itself, with the envelope's schema, under
-`components.schemas.RequestValidationError`. See [The OpenAPI document](/guide/openapi-document).
-
-An operation the router already guards publishes no 400. A constraint on a path token is a
-[route constraint](/guide/routing#constraining-what-a-token-matches), tested before any filter or
-binder runs, so a value that would have failed it is a 404 and the validator never sees one:
-
-| Declaration | Refused by | Published |
-|---|---|---|
-| `pattern` on a path token | the router | 404, with no body |
-| `{id:int}` with an `int` parameter | the router | 404, with no body |
-| `required` on a path token | the router, as a route that did not match | 404, with no body |
-| `pattern` on a query value or a header | the validator | 400, the envelope |
-| `minimum` on a path token | the validator | 400, the envelope |
-| a parameter whose type the constraint does not cover, `{id:long}` binding an `int` | the binder | 400, the envelope |
-
-So `pattern` and `minimum` on the same token answer differently, and deliberately: the first says
-which URLs name a resource, the second judges a request that named one. Where the operation declares
-a 404 of its own, its description says the router answers that status too, and without the declared
-body — two 404s reach the wire and a document can key one.
-
-## Rules the vocabulary cannot express
-
-A business rule is handler code. Throw the same exception the generated filters throw and the
-response is indistinguishable from a declared constraint's:
+A handler declares the status a validation failure answers with `[Throws<RequestValidationError>]`.
 
 ```csharp
 using Hardened.Requests.Runtime.Validation;
-using ValidationModules;
+using Hardened.Web.Runtime.Responses;
 
-public async Task<Pet> CreatePet(CreatePetRequest body) {
-    if (await _pets.NameExists(body.Name)) {
-        throw new ValidationException(ValidationResult.FromErrors([
-            new ValidationError("name", "duplicate", "A pet with this name already exists.")
-        ]));
-    }
-
-    ...
-}
+[Post("/registration/declared-422")]
+[Throws<RequestValidationError>(422)]
+public string Register(RegistrationModel model) => model.Name ?? "";
 ```
 
-`ValidationResult` is ValidationModules' immutable result type. Build it with
-`ValidationResult.FromErrors`; there is no mutable `AddError` form.
+The declaration serves both halves. It puts the 422 in the published document, and it sets the
+status the runtime answers with. The filter's refusal, a handler's own `ValidationException`, and a
+body the deserializer could not read all answer 422. The document then carries the 422 alone, with
+no 400 beside it.
 
-## Refusing with a declared status
+The match is by full name. An application's own type called `RequestValidationError` sets nothing.
 
-When the request was well-formed and refused for a reason of its own, the answer usually wants a
-status of its own rather than a 400. Throw the response for that status, and declare it so the
-document says so:
+Contract-first, an operation that declares a 422 error response reaches the same result.
 
-```csharp
-[Post("/pets")]
-[Throws<Conflict<Problem>>]
-public async Task<Pet> CreatePet(CreatePetRequest body) {
-    if (await _pets.NameExists(body.Name)) {
-        throw new Conflict<Problem>(
-            new Problem { Detail = $"A pet named '{body.Name}' already exists." }).AsException();
-    }
+## Changing the body
 
-    ...
-}
-```
-
-`[Throws<T>]` puts the status in the published document. Without it the throw still answers 409
-and the document describes only the 200, so a client generated from it has no case for the
-refusal. See [Declaring what a handler throws](/guide/responses#declaring-what-a-handler-throws).
-Keep the validation envelope for "this field is wrong".
-
-## Choosing the status and the shape
-
-The stock behaviour is a 400 with the envelope above. Both are decided in one replaceable service:
-`ExceptionResponseSerializer` asks `IExceptionToModelConverter` for the status and the body of
-every failure, and the stock converter registers with `RegistrationType.Try`, so a registration
-the application makes wins.
-
-A converter that answers 422 with its own body, and leaves everything else to the stock rules:
+`ExceptionToModelConverter` is registered with `RegistrationType.Try`, so an application replaces it
+by registering its own.
 
 ```csharp
 using DependencyModules.Runtime.Attributes;
 using Hardened.Requests.Abstract.Errors;
 using Hardened.Requests.Abstract.Execution;
-using Hardened.Requests.Runtime.Errors;
-using Hardened.Requests.Runtime.Validation;
 
-public record FieldProblem(string Name, string Reason);
-
-public record UnprocessableContent(string Title, IReadOnlyList<FieldProblem> Fields);
-
-[SingletonService]
-public class UnprocessableContentConverter : IExceptionToModelConverter {
-    private readonly ExceptionToModelConverter _stock = new();
-
+[SingletonService(Using = RegistrationType.Replace)]
+public class ProblemDetailConverter : IExceptionToModelConverter {
     public (int, object) ConvertExceptionToModel(IExecutionContext context, Exception exp) {
-        if (exp is ValidationException validation) {
-            return (422, new UnprocessableContent(
-                "The request was understood and refused.",
-                validation.ValidationResult.Errors
-                    .Select(error => new FieldProblem(error.Field, error.Message))
-                    .ToList()));
-        }
-
-        return _stock.ConvertExceptionToModel(context, exp);
+        // return the status and the body for every failure, validation included
     }
 }
 ```
 
-Delegating to the stock converter keeps every other mapping: thrown declared statuses, the binding
-400, the anonymous 500. Two validation exception types reach the converter, and the stock one maps
-both: Hardened's `ValidationException`, thrown by the generated filters and the binder, and
-ValidationModules' own, thrown by code calling a generated validator directly. A converter that
-should catch both matches on each type the way the stock converter does.
+Use `Replace` rather than `Add`. `Add` leaves the framework's descriptor registered, and anything
+enumerating the service would still construct it.
+
+## Raising a failure from handler code
+
+A handler throws `ValidationException` for a rule the attributes cannot express. The response is the
+same envelope at the same status.
+
+```csharp
+using ValidationModules;
+using ValidationException = Hardened.Requests.Runtime.Validation.ValidationException;
+
+[Post("/orders")]
+public string Place(OrderModel model) {
+    if (!_catalogue.Stocks(model.Sku)) {
+        throw new ValidationException(ValidationResult.FromErrors([
+            new ValidationError("model.sku", "unknown_sku", $"{model.Sku} is not stocked.")
+        ]));
+    }
+
+    return model.Sku;
+}
+```
+
+`ValidationModules.ValidationException` reaches the same response, so a handler calling that
+library's own `ValidateAndThrow` needs no adaptation.
+
+This envelope reports a field the caller got wrong. A refusal that is not about a field declares its
+own status instead. The built-in response types are plain records, so a handler throws one through
+`AsException()`. `[Throws<T>]` on the method puts that status in the published document.
+
+```csharp
+[Post("/todos")]
+[Throws<Conflict>]
+public Todo Create(NewTodo body) {
+    if (_store.Has(body.Title)) {
+        throw new Conflict($"A todo titled '{body.Title}' already exists.").AsException();
+    }
+
+    return _store.Add(body);
+}
+```
+
+`[Throws<Conflict>]` states no status, because `Conflict` carries `[HttpStatus(409)]`. The full set
+of response types is in [responses](/guide/responses).
+
+## Adding a validator by hand
+
+The filter resolves every `IValidatorFor<T>` registered for the validated type and runs them all
+into one collector. A hand-written validator adds to the generated checks. It cannot replace them or
+suppress them.
+
+An `IAsyncValidatorFor<T>` runs after the structural checks, and only when they passed. It is
+resolved per request, so it may be registered scoped.
+
+The filter is built on the first request and kept. The build throws `InvalidOperationException` when
+no validator is registered for the type. An empty set means the application was wired against
+another entry point. The filter refuses to read it as an absence of work.
+
+The filter also throws `InvalidOperationException` when the bound parameters are not the validated
+type. Continuing would answer the request with nothing validated.
+
+## Build properties
+
+| Property | Values | Effect |
+| --- | --- | --- |
+| `ValidationModules_FieldNaming` | `PascalCase`, `AsDeclared`, `SnakeCase` | The spelling of a field in an error. The default is camelCase. |
+| `ValidationModules_DataAnnotations` | `Ignore` | Stops compiling the DataAnnotations vocabulary. |
+| `ValidationModules_PatternPolicy` | `Error`, `Warn`, `Allow` | How an inline `[Pattern("...")]` is treated. |
+
+The pattern policy defaults to `Error` when the project sets `PublishAot` or `IsAotCompatible`, and
+to `Allow` otherwise. An inline pattern makes the generator construct a `Regex`, which roots the
+regex parser and interpreter in an AOT publish.
 
 ## Next
 
-- [The OpenAPI document](/guide/openapi-document): what publishes, including the synthesized 400
-- [Declared responses](/guide/responses): declaring the statuses a handler answers deliberately
-- [Parameter binding](/guide/parameter-binding): how values reach the validated model
+- [Parameter binding](/guide/parameter-binding)
+- [The execution pipeline](/guide/execution-pipeline)
+- [Generating from OpenAPI](/guide/openapi)
+- [Diagnostics](/reference/diagnostics)

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -133,7 +133,7 @@ See [Authorization](/guide/authorization).
 | `[Operation(id)]` | Method | The [`operationId`](/guide/openapi-document) the handler publishes, which a generated client names its method after. Defaults to the method name in camelCase. Two handlers declaring one id is `HRDOA004` |
 | `[Server(url, description?)]` | Class | A base URL the generated document lists under `servers`. Read off the `[HardenedModule]` class in the compilation that writes the document. The assembly target compiles and publishes nothing, and a described contract's own `servers` block wins over it |
 | `[CaseInsensitiveRoutes]` | Class | Matches this module's routes [without regard to case](/guide/routing#case-and-trailing-slashes) |
-| `[RouteConstraint(name)]` | Method | Declares a [route constraint](/guide/routing#declaring-your-own-constraint). `static bool(ReadOnlySpan<char>)` |
+| `[RouteConstraint(name)]` | Method | Declares a [route constraint](/guide/routing#declaring-a-constraint). `static bool(ReadOnlySpan<char>)` |
 
 `Hardened.Web.Runtime.Compression`
 
@@ -175,7 +175,7 @@ feature on for handlers it only references.
 The verb attributes also declare `SuccessStatus`, the status a successful response answers with
 and the document publishes; unset means 200. The `NullReturnStatus`, `ValidationErrorStatus` and
 `ErrorStatus` properties they once carried are gone. See
-[Returning `null`](/guide/routing#returning-null) for what decides those statuses.
+[Status codes](/guide/routing#status-codes) for what decides those statuses.
 
 ## Templates
 

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -73,7 +73,7 @@ front end only leaves a gap in the other.
 
 | Id | | Meaning |
 |---|---|---|
-| `HRDV001` | retired | Retired. It warned that a constraint on a handler parameter was not compiled; [they are compiled now](/guide/validation#declaring-constraints-in-code) |
+| `HRDV001` | retired | Retired. It warned that a constraint on a handler parameter was not compiled; [they are compiled now](/guide/validation#constraints-on-handler-parameters) |
 | `HRDV002` | warning | Two validators claimed the same generated file |
 | `HRDV003` | warning | A required member of a value type cannot be found missing, so `[Required]` there does nothing |
 | `HRDV004` | warning | Nested constraints are never reached |


### PR DESCRIPTION
A trial of a different way of rewriting a page. Three pages, one of them validation.

## The method

Each page was written by an agent that could not read the page it replaces. The prohibition covered
all of `docs/`: every other guide page, and the maintainer notes under `docs/design`. The existing
prose is the thing being replaced, so a writer that reads it echoes it. The notes are written in the
same voice and are stale in places, and `design/validation-usage.md` opens by saying parts of it
describe design that was never built.

The fact source was `src/` and the tests. Tests assert the exact status code, the exact JSON and the
exact diagnostic text, so they settle questions that prose cannot.

Each writer returned a fact ledger mapping every claim to a `file.cs:line`. That is what made
orchestration possible: I checked claims against the ledger and diffed each new page against the old
one for dropped facts, rather than re-deriving the framework three times. Two rounds, with the
second round handing back verified facts and letting the writer word them.

Simple Technical English here means 20 rules, the load-bearing ones being: one idea per sentence,
20 words at most, active voice, simple present, one term per concept taken from the code, no
em-dash, no metaphor, no epigram, and no sentence that only restates the code beneath it. On top of
that sits the existing content rule, that a fact earns a sentence only if a competent C# developer
could not predict it.

## Measured

|  | mean sentence | longest | over 25 words | em-dashes |
|---|---|---|---|---|
| validation | 17.9 → 11.1 | 67 → 20 | 16 → 0 | 10 → 0 |
| routing | 13.2 → 10.0 | 30 → 19 | 4 → 0 | 1 → 0 |
| response caching | 16.2 → 9.8 | 60 → 19 | 8 → 0 | 0 → 0 |

## The pages got longer

2090 → 2765 words, 1697 → 3043, 1749 → 2774. Not padding. The sentence count roughly doubles while
the prose gets shorter per sentence, and the rest is facts the pages did not have.

Validation gains `HRDV002`, `HRDV006`, the retirement of `HRDV001`, the
`Hardened.Validation.SourceGenerator` reference a project needs before any constraint is enforced,
the `System.ComponentModel.DataAnnotations` vocabulary and the alias a model using both needs, the
three `ValidationModules_` build properties including the pattern policy that changes under
`PublishAot`, `IValidatorFor<T>` and `IAsyncValidatorFor<T>`, and
`[Throws<RequestValidationError>(422)]`. That last one is the supported way to change the status of
a validation failure, and the page did not mention it. It taught a custom `IExceptionToModelConverter`
instead, which is the heavier answer.

Routing gains `HRDR002`, `HRDR003`, `HRDR005`, `HRDR006` and `HRDR013`, the seven parameterised
constraints (`length`, `minlength`, `maxlength`, `min`, `max`, `range`) which the constraint table
did not list at all, constraint chaining as a conjunction, and the rule that one path is one node so
a constraint declared under any verb constrains that position for every verb at it.

Response caching gains `HRDW005` and the fact that there is no stampede protection.

## Three things the pages stated wrongly

- `LinkConfiguration` was configured with `services.Configure<LinkConfiguration>`. That appears
  nowhere in the source. Hardened configures through `IConfigurationPackage` and an amender, the way
  `CompressionServiceCollectionExtensions` does.
- Two cached-handler samples bound a query parameter without `[FromQueryString]`.
- Routing said that where two constraints could match one segment the narrower is tried first, in
  the order of its table. `RouteConstraintFacts.Rank` is called only from tests, and
  `RoutingTableGenerator` orders wildcard nodes by continuation path. The page is now silent on it.

## Out of scope, worth a look

Three code questions the writers surfaced and were told not to touch:

- `ResponseCacheStoreDiagnostics.cs:61` still lists `LambdaWebModuleAttribute` in the attributes that
  make an entry point a web application. #346 renamed that attribute to `LambdaHttpModuleAttribute`
  yesterday, and nothing else in the repository declares the old name, so `HRDW005` no longer fires
  for a Lambda HTTP application.
- `RouteConstraintFacts.Rank` is dead, and its own doc comment says the numbers are "published in
  the routing guide". Either the wiring is missing or the contract is stale.
- `GetPathFromAttribute` takes `Arguments.FirstOrDefault()` without checking `NameEquals`, so
  `[Get(SuccessStatus = 201)]` with no path reads the named argument as the path.

## Verified

`npm run build` in `docs/` passes. Every heading changed, so the ten other files are inbound anchors
remapped to headings that exist.

The style brief is deliberately not in this PR. #344 tried to add one to `docs/design` and you closed
it, so it stayed in the scratchpad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
