### PR TITLE
Decode MessagePack in the reference page, and restore a nested case type's schema

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiUiTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiUiTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Hardened.Web.Runtime.Responses;
 
 namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
@@ -134,5 +134,34 @@ public class OpenApiUiTests {
 
         Assert.Contains("<title>Internal</title>", second);
         Assert.Contains("data-url=\"/internal.json\"", second);
+    }
+
+    /// <summary>
+    /// The page that installs the MessagePack plugin renders the other form, because a plugin is a
+    /// function and cannot travel in a <c>data-</c> attribute.
+    /// </summary>
+    [HardenedTest]
+    public async Task ThePluginPageInitialisesInScript(ITestWebApp testWebApp) {
+        var page = await (await testWebApp.Get("/docs/msgpack")).ReadTextAsync();
+
+        Assert.Contains("<title>MessagePack</title>", page);
+        Assert.Contains("Scalar.createApiReference('#app', {", page);
+        Assert.Contains("@msgpack/msgpack@", page);
+        Assert.Contains("mimeTypes: ['application/msgpack', 'application/x-msgpack']", page);
+    }
+
+    /// <summary>
+    /// And the pages beside it are unchanged, which is what makes the plugin opt-in rather than a
+    /// change to every reference page an application serves.
+    /// </summary>
+    [HardenedTest]
+    public async Task TheOtherPagesKeepTheAttributeForm(ITestWebApp testWebApp) {
+        foreach (var path in new[] { "/docs", "/docs/internal" }) {
+            var page = await (await testWebApp.Get(path)).ReadTextAsync();
+
+            Assert.Contains("<script id=\"api-reference\" data-url=\"", page);
+            Assert.DoesNotContain("createApiReference", page);
+            Assert.DoesNotContain("msgpack", page);
+        }
     }
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Application.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Application.cs
@@ -27,6 +27,12 @@ namespace Hardened.IntegrationTests.WebApp.SUT;
 /// several specifications gets a page for each, and nothing but a second install proves the module
 /// loads more than once.
 /// </para>
+/// <para>
+/// A third carries <c>DecodeMessagePack</c>, which renders a different page - the plugin cannot
+/// travel in a <c>data-</c> attribute, so that page initialises in script. Its own install rather
+/// than a flag on one of the two above, so both forms are served by this fixture at once and the
+/// tests that pin the attribute form keep pinning it.
+/// </para>
 /// </remarks>
 [HardenedModule]
 [WebLibrary(Test = "test")]
@@ -34,6 +40,7 @@ namespace Hardened.IntegrationTests.WebApp.SUT;
 [Enable<ResponseCompression>]
 [HardenedOpenApiUi(Title = "Integration Tests")]
 [HardenedOpenApiUi(Path = "/docs/internal", Title = "Internal", DocumentPath = "/internal.json")]
+[HardenedOpenApiUi(Path = "/docs/msgpack", Title = "MessagePack", DecodeMessagePack = true)]
 [HardenedMemoryResponseCache]
 [MessagePackSerializerLibrary]
 [AspNetCoreRuntime]

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -3591,7 +3591,19 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reading"
+                }
+              },
+              "application/x-msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reading"
+                }
+              }
+            }
           },
           "400": {
             "description": "The request failed validation.",

--- a/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
+++ b/src/PublicApi/Hardened.PublicApi.Tests/Approved/Hardened.Web.Runtime.approved.txt
@@ -499,14 +499,17 @@ namespace Hardened.Web.Runtime.OpenApi
     public class HardenedOpenApiUi : DependencyModules.Runtime.Interfaces.IDependencyModule, DependencyModules.Runtime.Interfaces.IEnvironmentServiceCollectionConfiguration
     {
         public const string DefaultDocumentPath = "/openapi.json";
+        public const string DefaultMessagePackScriptUrl = "https://cdn.jsdelivr.net/npm/@msgpack/msgpack@3.1.3/dist.umd/msgpack.min.js";
         public const string DefaultPath = "/docs";
         public const string DefaultScriptIntegrity = "sha384-G6dkutu2k5IYVyNESLoFIpgaHx38IJTZ/HhrwN0fecTle9te75y8Kru3rJEJ0ZJV";
         public const string DefaultScriptUrl = "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.65.1/dist/browser/standalone" +
             ".js";
         public const string DefaultTitle = "API Reference";
         public HardenedOpenApiUi() { }
+        public bool DecodeMessagePack { get; set; }
         public string? DocumentPath { get; set; }
         public string? Environments { get; set; }
+        public string? MessagePackScriptUrl { get; set; }
         public string? Path { get; set; }
         public string? ScriptIntegrity { get; set; }
         public string? ScriptUrl { get; set; }
@@ -521,8 +524,10 @@ namespace Hardened.Web.Runtime.OpenApi
     public class HardenedOpenApiUiAttribute : System.Attribute, DependencyModules.Runtime.Interfaces.IDependencyModuleProvider
     {
         public HardenedOpenApiUiAttribute() { }
+        public bool DecodeMessagePack { get; set; }
         public string DocumentPath { get; set; }
         public string Environments { get; set; }
+        public string MessagePackScriptUrl { get; set; }
         public string Path { get; set; }
         public string ScriptIntegrity { get; set; }
         public string ScriptUrl { get; set; }
@@ -532,6 +537,7 @@ namespace Hardened.Web.Runtime.OpenApi
     public interface IOpenApiUiConfiguration
     {
         string DocumentPath { get; }
+        string? MessagePackScriptUrl { get; }
         string Path { get; }
         string? ScriptIntegrity { get; }
         string ScriptUrl { get; }
@@ -561,8 +567,9 @@ namespace Hardened.Web.Runtime.OpenApi
     }
     public sealed class OpenApiUiConfiguration : Hardened.Web.Runtime.OpenApi.IOpenApiUiConfiguration
     {
-        public OpenApiUiConfiguration(string path, string title, string documentPath, string scriptUrl, string? scriptIntegrity) { }
+        public OpenApiUiConfiguration(string path, string title, string documentPath, string scriptUrl, string? scriptIntegrity, string? messagePackScriptUrl = null) { }
         public string DocumentPath { get; }
+        public string? MessagePackScriptUrl { get; }
         public string Path { get; }
         public string? ScriptIntegrity { get; }
         public string ScriptUrl { get; }
@@ -575,8 +582,9 @@ namespace Hardened.Web.Runtime.OpenApi
     }
     public sealed class OpenApiUiModel : System.IEquatable<Hardened.Web.Runtime.OpenApi.OpenApiUiModel>
     {
-        public OpenApiUiModel(string Title, string DocumentPath, string ScriptUrl, string? ScriptIntegrity) { }
+        public OpenApiUiModel(string Title, string DocumentPath, string ScriptUrl, string? ScriptIntegrity, string? MessagePackScriptUrl = null) { }
         public string DocumentPath { get; init; }
+        public string? MessagePackScriptUrl { get; init; }
         public string? ScriptIntegrity { get; init; }
         public string ScriptUrl { get; init; }
         public string Title { get; init; }

--- a/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Requests/BaseRequestModelGenerator.cs
@@ -217,8 +217,8 @@ public abstract class BaseRequestModelGenerator {
             // under a member, which no client ever receives.
             var described = unionCase.BodyTypeName ?? unionCase.TypeName;
 
-            var symbol = context.SemanticModel.Compilation.GetTypeByMetadataName(
-                described.Replace("global::", ""));
+            var symbol = Resolve(
+                context.SemanticModel.Compilation, described.Replace("global::", ""));
 
             var model = new ResponseSchemaModel(
                 unionCase.Status,
@@ -299,7 +299,39 @@ public abstract class BaseRequestModelGenerator {
                    arity.ToString(System.Globalization.CultureInfo.InvariantCulture);
         }
 
-        return context.SemanticModel.Compilation.GetTypeByMetadataName(name);
+        return Resolve(context.SemanticModel.Compilation, name);
+    }
+
+    /// <summary>
+    /// The type a case's name names, a nested one included.
+    /// </summary>
+    /// <remarks>
+    /// A display string separates a nested type from the type it is declared in with a dot, and
+    /// metadata separates it with a plus, so <see cref="Compilation.GetTypeByMetadataName"/>
+    /// answers null for every type declared inside another - a model declared in its controller
+    /// among them. That reached the document as a status with no content: the case has a body, the
+    /// symbol it would be written from is null, and the response goes out describing nothing.
+    ///
+    /// Each dot is tried as the nesting point in turn, from the right, because the rightmost
+    /// segment is the innermost type and every dot to its left is either another nesting or the
+    /// end of the namespace.
+    /// </remarks>
+    private static INamedTypeSymbol? Resolve(Compilation compilation, string metadataName) {
+        var name = metadataName;
+
+        while (true) {
+            if (compilation.GetTypeByMetadataName(name) is { } symbol) {
+                return symbol;
+            }
+
+            var dot = name.LastIndexOf('.');
+
+            if (dot < 0) {
+                return null;
+            }
+
+            name = name.Substring(0, dot) + "+" + name.Substring(dot + 1);
+        }
     }
 
     /// <summary>

--- a/src/Web/Hardened.Web.Runtime.Tests/OpenApi/OpenApiUiPageTests.cs
+++ b/src/Web/Hardened.Web.Runtime.Tests/OpenApi/OpenApiUiPageTests.cs
@@ -1,4 +1,5 @@
-using System.Text;
+﻿using System.Text;
+using System.Text.Json;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Runtime.QueryString;
@@ -150,4 +151,89 @@ public class OpenApiUiPageTests {
 
         Assert.Contains(nameof(OpenApiUiModel), exception.Message);
     }
+
+    #region the MessagePack plugin
+
+    private static readonly OpenApiUiModel WithPlugin = Model with {
+        MessagePackScriptUrl = "https://cdn.example.com/msgpack.min.js"
+    };
+
+    /// <summary>
+    /// A page installing no plugin is the page it has always been: the attribute form, and no
+    /// inline script anywhere on it.
+    /// </summary>
+    [Fact]
+    public async Task WriteOutput_WithoutThePluginThereIsNoInlineScript() {
+        var (page, _) = await Render(Model);
+
+        Assert.Contains("<script id=\"api-reference\" data-url=\"/openapi.json\"></script>", page);
+        Assert.DoesNotContain("createApiReference", page);
+        Assert.DoesNotContain("msgpack", page);
+    }
+
+    /// <summary>
+    /// A plugin is a function, so it cannot travel in a <c>data-</c> attribute. Installing one moves
+    /// the page to <c>createApiReference</c>, which is the form that takes one.
+    /// </summary>
+    [Fact]
+    public async Task WriteOutput_ThePluginFormInitialisesInScript() {
+        var (page, _) = await Render(WithPlugin);
+
+        Assert.Contains("<div id=\"app\"></div>", page);
+        Assert.Contains("Scalar.createApiReference('#app', {", page);
+        Assert.DoesNotContain("data-url", page);
+    }
+
+    /// <summary>The decoder, from wherever it was configured.</summary>
+    [Fact]
+    public async Task WriteOutput_ThePluginFormLoadsTheDecoder() {
+        var (page, _) = await Render(WithPlugin);
+
+        Assert.Contains("<script src=\"https://cdn.example.com/msgpack.min.js\"></script>", page);
+    }
+
+    /// <summary>
+    /// The two spellings in the wild, and nothing else - which is what lets a page installing this
+    /// keep Scalar's own rendering for every other media type.
+    /// </summary>
+    [Fact]
+    public async Task WriteOutput_ThePluginClaimsTheMessagePackMediaTypesOnly() {
+        var (page, _) = await Render(WithPlugin);
+
+        Assert.Contains("mimeTypes: ['application/msgpack', 'application/x-msgpack']", page);
+        Assert.DoesNotContain("'application/json'", page);
+    }
+
+    /// <summary>
+    /// The reference UI keeps its own script tag and its hash. The plugin changes how the page
+    /// initialises, not what it initialises from.
+    /// </summary>
+    [Fact]
+    public async Task WriteOutput_ThePluginFormKeepsTheIntegrityHash() {
+        var (page, _) = await Render(WithPlugin);
+
+        Assert.Contains("src=\"https://cdn.example.com/ui.js\"", page);
+        Assert.Contains("integrity=\"sha384-abc\"", page);
+        Assert.Contains("crossorigin=\"anonymous\"", page);
+    }
+
+    /// <summary>
+    /// The document URL now lands in a JavaScript string literal rather than an HTML attribute, so
+    /// it is escaped as one. Asserted by parsing it back, which is the only check that says the
+    /// value survived rather than that some escape sequence appeared.
+    /// </summary>
+    [Theory]
+    [InlineData("/openapi.json")]
+    [InlineData("/a\";globalThis.pwned=1;//")]
+    [InlineData("/a\\b</script>")]
+    public async Task WriteOutput_TheDocumentUrlCannotCloseTheScript(string documentPath) {
+        var (page, _) = await Render(WithPlugin with { DocumentPath = documentPath });
+
+        var start = page.IndexOf("url: ", StringComparison.Ordinal) + "url: ".Length;
+        var literal = page[start..page.IndexOf(",\n", start, StringComparison.Ordinal)];
+
+        Assert.Equal(documentPath, JsonSerializer.Deserialize<string>(literal));
+    }
+
+    #endregion
 }

--- a/src/Web/Hardened.Web.Runtime/OpenApi/HardenedOpenApiUi.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/HardenedOpenApiUi.cs
@@ -1,4 +1,4 @@
-using DependencyModules.Runtime.Interfaces;
+﻿using DependencyModules.Runtime.Interfaces;
 using DependencyModules.Runtime.Attributes;
 using Hardened.Web.Runtime.Handlers;
 using Microsoft.Extensions.DependencyInjection;
@@ -105,6 +105,39 @@ public partial class HardenedOpenApiUi : IEnvironmentServiceCollectionConfigurat
     /// </remarks>
     public string? ScriptIntegrity { get; set; } = DefaultScriptIntegrity;
 
+    /// <summary>
+    /// Decode MessagePack response bodies in the page's request panel.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The document already describes a MessagePack representation and Scalar renders what it says.
+    /// What the page cannot do unaided is show a MessagePack body it fetched: send the request and
+    /// the response arrives as bytes. This installs Scalar's plugin for the two MessagePack media
+    /// types, so the panel shows decoded JSON. It is keyed on the media type, so JSON keeps Scalar's
+    /// own rendering on the same page.
+    /// </para>
+    /// <para>
+    /// <b>It changes how the page initialises.</b> A plugin is a function, so it cannot travel in
+    /// the <c>data-</c> attribute the standalone bundle reads - a page that installs one calls
+    /// <c>Scalar.createApiReference</c> from an inline script instead, and loads the decoder from
+    /// <see cref="MessagePackScriptUrl"/>. A page that installs none is unchanged. That is the whole
+    /// reason this is opt-in rather than always on: a <c>script-src</c> policy naming no
+    /// <c>'unsafe-inline'</c> would notice, and a service that never answers MessagePack should not
+    /// be made to find out.
+    /// </para>
+    /// </remarks>
+    public bool DecodeMessagePack { get; set; }
+
+    /// <summary>
+    /// Where <see cref="DecodeMessagePack"/> loads the decoder from.
+    /// </summary>
+    /// <remarks>
+    /// The UMD build, which installs a global the plugin reads - so the script tag above it has
+    /// already done the loading by the time the plugin runs. Pinned for the reason
+    /// <see cref="ScriptUrl"/> is, and overridable for the same reason.
+    /// </remarks>
+    public string? MessagePackScriptUrl { get; set; } = DefaultMessagePackScriptUrl;
+
     public const string DefaultPath = "/docs";
 
     public const string DefaultTitle = "API Reference";
@@ -113,6 +146,9 @@ public partial class HardenedOpenApiUi : IEnvironmentServiceCollectionConfigurat
 
     public const string DefaultScriptUrl =
         "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.65.1/dist/browser/standalone.js";
+
+    public const string DefaultMessagePackScriptUrl =
+        "https://cdn.jsdelivr.net/npm/@msgpack/msgpack@3.1.3/dist.umd/msgpack.min.js";
 
     public const string DefaultScriptIntegrity =
         "sha384-G6dkutu2k5IYVyNESLoFIpgaHx38IJTZ/HhrwN0fecTle9te75y8Kru3rJEJ0ZJV";
@@ -187,7 +223,8 @@ public partial class HardenedOpenApiUi : IEnvironmentServiceCollectionConfigurat
             Title ?? DefaultTitle,
             DocumentPath ?? DefaultDocumentPath,
             ScriptUrl ?? DefaultScriptUrl,
-            ScriptIntegrity);
+            ScriptIntegrity,
+            DecodeMessagePack ? MessagePackScriptUrl ?? DefaultMessagePackScriptUrl : null);
 
         services.AddSingleton<IWebExecutionRequestHandlerProvider>(
             serviceProvider => new OpenApiUiProvider(configuration, serviceProvider));

--- a/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiConfiguration.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiConfiguration.cs
@@ -1,4 +1,4 @@
-namespace Hardened.Web.Runtime.OpenApi;
+﻿namespace Hardened.Web.Runtime.OpenApi;
 
 /// <summary>
 /// One reference page: where it is served, and what it renders.
@@ -26,17 +26,24 @@ public interface IOpenApiUiConfiguration {
     /// none to state.
     /// </summary>
     string? ScriptIntegrity { get; }
+
+    /// <summary>
+    /// Where the MessagePack decoder is loaded from, or null where the page installs no plugin.
+    /// </summary>
+    string? MessagePackScriptUrl { get; }
 }
 
 /// <inheritdoc />
 public sealed class OpenApiUiConfiguration : IOpenApiUiConfiguration {
     public OpenApiUiConfiguration(
-        string path, string title, string documentPath, string scriptUrl, string? scriptIntegrity) {
+        string path, string title, string documentPath, string scriptUrl, string? scriptIntegrity,
+        string? messagePackScriptUrl = null) {
         Path = path;
         Title = title;
         DocumentPath = documentPath;
         ScriptUrl = scriptUrl;
         ScriptIntegrity = scriptIntegrity;
+        MessagePackScriptUrl = messagePackScriptUrl;
     }
 
     public string Path { get; }
@@ -48,4 +55,6 @@ public sealed class OpenApiUiConfiguration : IOpenApiUiConfiguration {
     public string ScriptUrl { get; }
 
     public string? ScriptIntegrity { get; }
+
+    public string? MessagePackScriptUrl { get; }
 }

--- a/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiController.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiController.cs
@@ -1,4 +1,4 @@
-namespace Hardened.Web.Runtime.OpenApi;
+﻿namespace Hardened.Web.Runtime.OpenApi;
 
 /// <summary>
 /// Turns one page's configuration into its model.
@@ -22,5 +22,6 @@ public class OpenApiUiController {
         new(configuration.Title,
             configuration.DocumentPath,
             configuration.ScriptUrl,
-            configuration.ScriptIntegrity);
+            configuration.ScriptIntegrity,
+            configuration.MessagePackScriptUrl);
 }

--- a/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiModel.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiModel.cs
@@ -1,4 +1,4 @@
-namespace Hardened.Web.Runtime.OpenApi;
+﻿namespace Hardened.Web.Runtime.OpenApi;
 
 /// <summary>
 /// Everything the reference page needs, resolved from configuration before it is rendered.
@@ -13,4 +13,13 @@ public sealed record OpenApiUiModel(
     string Title,
     string DocumentPath,
     string ScriptUrl,
-    string? ScriptIntegrity);
+    string? ScriptIntegrity,
+    /// <summary>
+    /// Where the MessagePack decoder is loaded from, or null where the page installs no plugin.
+    /// </summary>
+    /// <remarks>
+    /// One nullable field rather than a flag beside a URL. The two could not usefully disagree, and
+    /// a page that is on with nowhere to load the decoder from is not a state worth being able to
+    /// express.
+    /// </remarks>
+    string? MessagePackScriptUrl = null);

--- a/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiPage.cs
+++ b/src/Web/Hardened.Web.Runtime/OpenApi/OpenApiUiPage.cs
@@ -1,6 +1,7 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using Hardened.Requests.Abstract.Execution;
 using Hardened.Requests.Abstract.Headers;
 using Hardened.Requests.Abstract.Outputs;
@@ -68,11 +69,21 @@ public sealed class OpenApiUiPage : IHardenedResponseOutput<OpenApiUiModel> {
             .Append("<meta charset=\"utf-8\">\n")
             .Append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n")
             .Append("<title>").Append(Encode(model.Title)).Append("</title>\n")
-            .Append("</head>\n<body>\n")
-            .Append("<script id=\"api-reference\" data-url=\"")
-            .Append(Encode(model.DocumentPath))
-            .Append("\"></script>\n")
-            .Append("<script src=\"").Append(Encode(model.ScriptUrl)).Append('"');
+            .Append("</head>\n<body>\n");
+
+        // The mount point the initialiser names. Only the plugin form needs one: the standalone
+        // bundle finds its own script tag and renders in place.
+        if (model.MessagePackScriptUrl != null) {
+            builder.Append("<div id=\"app\"></div>\n");
+        }
+        else {
+            builder
+                .Append("<script id=\"api-reference\" data-url=\"")
+                .Append(Encode(model.DocumentPath))
+                .Append("\"></script>\n");
+        }
+
+        builder.Append("<script src=\"").Append(Encode(model.ScriptUrl)).Append('"');
 
         // Only when there is one to state. A same-origin script does not need integrity, and an
         // empty attribute is not "no integrity" - it is a hash nothing matches, which fails the
@@ -83,8 +94,160 @@ public sealed class OpenApiUiPage : IHardenedResponseOutput<OpenApiUiModel> {
                 .Append(" crossorigin=\"anonymous\"");
         }
 
-        return builder.Append("></script>\n</body>\n</html>\n").ToString();
+        builder.Append("></script>\n");
+
+        if (model.MessagePackScriptUrl != null) {
+            builder
+                .Append("<script src=\"").Append(Encode(model.MessagePackScriptUrl)).Append("\"></script>\n")
+                .Append(Initialiser(model.DocumentPath));
+        }
+
+        return builder.Append("</body>\n</html>\n").ToString();
     }
+
+    /// <summary>
+    /// The <c>createApiReference</c> call, which is the only form that takes a plugin.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Written only for a page that asked for the plugin.</b> A plugin is a function, and a
+    /// function does not fit in the <c>data-</c> attribute the standalone bundle reads - so
+    /// installing one means initialising in script. A page that installs none keeps the attribute
+    /// form it has always had, and with it the property that every value it substitutes is an HTML
+    /// attribute and nothing on the page is inline script. Opting in is opting into that too, which
+    /// is what a <c>script-src</c> policy naming no <c>'unsafe-inline'</c> would notice.
+    /// </para>
+    /// <para>
+    /// The document URL goes through <see cref="JsonEncodedText"/>, which is the JavaScript half of
+    /// what <see cref="WebUtility.HtmlEncode"/> is above: a JSON string is a JavaScript string, so
+    /// one function covers the whole of what a configured value can do to the syntax around it.
+    /// Not <c>JsonSerializer</c>, which carries the trimming and AOT annotations this assembly is
+    /// built to keep clear of, and would be reflection over a string.
+    /// </para>
+    /// <para>
+    /// The decoder is the global the MessagePack UMD build installs, rather than a dynamic import,
+    /// because the script tag above has already loaded it by the time this runs.
+    /// </para>
+    /// </remarks>
+    private static string Initialiser(string documentPath) =>
+        $$"""
+          <script>
+          Scalar.createApiReference('#app', {
+            url: "{{JsonEncodedText.Encode(documentPath)}}",
+            plugins: [
+              () => {
+                // What the operation declares for the body about to be decoded, recorded as the
+                // response arrives: decode() is handed the bytes and a media type and nothing else.
+                let declared = null;
+
+                const deref = (node, document) => {
+                  for (let hop = 0; node && node.$ref && hop < 10; hop++) {
+                    node = node.$ref.replace(/^#\//, '').split('/').reduce(
+                      (at, key) => at && at[key.replace(/~1/g, '/').replace(/~0/g, '~')], document);
+                  }
+
+                  return node;
+                };
+
+                // A keyed member is a position on the wire and a name in the document, so this
+                // walks the decoded value beside the schema and puts the names back. A named member
+                // arrives as one already, and is walked for the keyed types underneath it.
+                const name = (value, node, document) => {
+                  const schema = deref(node, document);
+
+                  if (!schema) {
+                    return value;
+                  }
+
+                  if (Array.isArray(value) && schema.items) {
+                    return value.map((item) => name(item, schema.items, document));
+                  }
+
+                  const properties = schema.properties;
+
+                  if (!properties) {
+                    return value;
+                  }
+
+                  if (Array.isArray(value)) {
+                    const object = {};
+
+                    for (const [member, property] of Object.entries(properties)) {
+                      const index = property['x-message-pack-index'];
+
+                      // One member without an index and the positions are not the document's to
+                      // read. The array is answered as it arrived rather than half named.
+                      if (index === undefined || index >= value.length) {
+                        return value;
+                      }
+
+                      object[member] = name(value[index], property, document);
+                    }
+
+                    return object;
+                  }
+
+                  if (value && typeof value === 'object') {
+                    return Object.fromEntries(Object.entries(value).map(
+                      ([member, item]) => [member, name(item, properties[member], document)]));
+                  }
+
+                  return value;
+                };
+
+                return {
+                  name: 'hardened-messagepack',
+                  extensions: [],
+                  apiClientPlugins: [
+                    {
+                      hooks: {
+                        // Before the request goes out, not after the response arrives. decode()
+                        // runs first of those two, so a schema recorded on the way back is always
+                        // one response late - the first body renders unnamed and every one after it
+                        // is named from the previous operation's schema.
+                        //
+                        // Which status answered is not known this early, so every representation
+                        // the operation declares is recorded and decode() takes the one that fits.
+                        // An operation declaring one - which is all of them until a refusal carries
+                        // a different shape - has nothing to choose between.
+                        beforeRequest: ({ operation, document }) => {
+                          const content = Object.values(operation?.responses ?? {}).map(
+                            (response) => deref(response, document)?.content ?? {});
+
+                          declared = {
+                            document,
+                            schemas: content.map(
+                              (media) => (media['application/x-msgpack']
+                                ?? media['application/msgpack'])?.schema).filter(Boolean),
+                          };
+                        },
+                      },
+                      responseBody: [
+                        {
+                          mimeTypes: ['application/msgpack', 'application/x-msgpack'],
+                          decode: async (buffer) => {
+                            const value = MessagePack.decode(new Uint8Array(buffer));
+
+                            // name() hands back what it was given when the schema does not describe
+                            // the value, so identity is what says a candidate fitted.
+                            const named = (declared?.schemas ?? []).map(
+                              (schema) => name(value, schema, declared.document)).find(
+                                (candidate) => candidate !== value);
+
+                            return JSON.stringify(named ?? value, null, 2);
+                          },
+                          language: 'json',
+                        },
+                      ],
+                    },
+                  ],
+                };
+              },
+            ],
+          });
+          </script>
+
+          """;
 
     private static string Encode(string value) => WebUtility.HtmlEncode(value);
 }


### PR DESCRIPTION
Two changes. The second is independent of the first and is the one that matters outside the reference page.

## Decode MessagePack in the reference page

`[HardenedOpenApiUi(DecodeMessagePack = true)]` loads the MessagePack UMD build from jsDelivr beside the Scalar bundle and registers Scalar's documented `responseBody` plugin for `application/msgpack` and `application/x-msgpack`. Send a request from the page and the body renders decoded instead of "Binary file".

A keyed member is a position on the wire, so the decoded body is an array. The plugin reads the schema the operation declares, walks the value beside it, and turns each `x-message-pack-index` back into the property it names. `["sensor-5", 15]` renders as `{ "sensor": "sensor-5", "value": 15 }`. A list goes through `items`, a nested keyed object recurses, and a named-mode body is an object already.

The schema is recorded in `beforeRequest`, not `responseReceived`. `decode` runs before `responseReceived`, so recording it on the way back names every body from the previous operation's schema and leaves the first one raw.

It is opt-in because a Scalar plugin is a function. A function does not fit in the `data-` attribute the standalone bundle reads, so a page that installs one initialises with `Scalar.createApiReference` from an inline script. A page that installs none renders exactly as before, with no inline script on it.

## Restore a nested case type's schema

`DeclaredResponses` looked a response case's body type up by handing `Compilation.GetTypeByMetadataName` a fully qualified display string. A display string separates a nested type from the type it is declared in with a dot. Metadata separates it with a plus. So any model declared inside its controller resolved to nothing, and the status reached the document with a description and no content.

This is not MessagePack's. A handler returning `Response<Reading, NotFound>` with `Reading` declared in the controller published a 200 carrying no `application/json` either, so a generated client had no body type for the success of that operation.

`CaseSymbol` read a case's declared headers through the same lookup, so a nested case type would have dropped its `Location` the same way. Both now go through one `Resolve`.

The SUT's committed document gains the content that 200 has always answered, which is what holds it.

## Verified

Release build with `-p:ContinuousIntegrationBuild=true` is clean. 8993 tests pass across 75 projects. Both pages were driven in a browser against the integration SUT: `/docs` unchanged, `/docs/msgpack` decoding and naming `GET /msgpack/packed/{id}` and `GET /msgpack/declared/{id}`.

## Not done

No generator test for the nested case. The committed document pins the behaviour, but a test in `Hardened.SourceGenerator.Tests` would say why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
