### PR TITLE
Describe seven things the generated document was getting wrong

### DIFF
--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.NUnitTests/HarnessUnderNUnitTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.NUnitTests/HarnessUnderNUnitTests.cs
@@ -64,7 +64,7 @@ public class HarnessUnderNUnitTests {
     public async Task TwoParametersCarryTwoCredentials(
         [Grants("pets:read")] WebAppClient reader, [Anonymous] WebAppClient nobody) {
         var pets = await reader.Authorization.Pets.GetAsync(cancellationToken: Token);
-        var refused = Assert.ThrowsAsync<ApiException>(() => nobody.Authorization.Pets.GetAsync(cancellationToken: Token));
+        var refused = Assert.ThrowsAsync<ClientModels.ErrorModel>(() => nobody.Authorization.Pets.GetAsync(cancellationToken: Token));
 
         Assert.That(pets, Is.Not.Null);
         Assert.That(refused!.ResponseStatusCode, Is.EqualTo(401));

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/CompressionTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Controllers/CompressionTests.cs
@@ -58,7 +58,7 @@ public class CompressionTests {
         Assert.Equal("gzip", Coding(response));
         Assert.Contains("Accept-Encoding", response.Headers[KnownHeaders.Vary].ToString());
         Assert.True(LooksGzip(response));
-        Assert.Equal(20, response.Deserialize<List<CompressionController.Reading>>().Count);
+        Assert.Equal(20, response.Deserialize<List<CompressionController.Sample>>().Count);
     }
 
     [HardenedTest]
@@ -70,7 +70,7 @@ public class CompressionTests {
 
         Assert.Equal("", Coding(response));
         Assert.False(LooksGzip(response));
-        Assert.Equal(20, response.Deserialize<List<CompressionController.Reading>>().Count);
+        Assert.Equal(20, response.Deserialize<List<CompressionController.Sample>>().Count);
     }
 
     [HardenedTest]
@@ -81,7 +81,7 @@ public class CompressionTests {
         response.Assert.Ok();
 
         Assert.Equal("br", Coding(response));
-        Assert.Equal(20, response.Deserialize<List<CompressionController.Reading>>().Count);
+        Assert.Equal(20, response.Deserialize<List<CompressionController.Sample>>().Count);
     }
 
     [HardenedTest]
@@ -94,8 +94,8 @@ public class CompressionTests {
 
         Assert.Equal("", Coding(small));
         Assert.Equal("gzip", Coding(large));
-        Assert.Equal(2, small.Deserialize<List<CompressionController.Reading>>().Count);
-        Assert.Equal(5, large.Deserialize<List<CompressionController.Reading>>().Count);
+        Assert.Equal(2, small.Deserialize<List<CompressionController.Sample>>().Count);
+        Assert.Equal(5, large.Deserialize<List<CompressionController.Sample>>().Count);
     }
 
     [HardenedTest]
@@ -175,7 +175,7 @@ public class CompressionTests {
 
         response.Assert.Ok();
 
-        Assert.Equal(new CompressionController.Reading("north", 12), response.Deserialize<CompressionController.Reading>());
+        Assert.Equal(new CompressionController.Sample("north", 12), response.Deserialize<CompressionController.Sample>());
     }
 
     /// <summary>

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiDocumentTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/OpenApiDocumentTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Hardened.Web.Runtime.Responses;
 
 namespace Hardened.IntegrationTests.WebApp.SUT.Tests;
@@ -351,4 +351,89 @@ public class OpenApiDocumentTests {
     }
 
     #endregion
+
+    /// <summary>
+    /// A scheme an operation names reaches <c>components.securitySchemes</c>, keyed by the type.
+    /// </summary>
+    /// <remarks>
+    /// Declaring a scheme is declaring the type and using it anywhere. Nothing in this application
+    /// registers <c>PetsOAuth</c> or lists it; the four operations naming it are the whole of what
+    /// puts it here.
+    /// </remarks>
+    [HardenedTest]
+    public async Task ASchemeAnOperationNamesIsPublished(ITestWebApp testWebApp) {
+        using var document = await Fetch(testWebApp);
+
+        var scheme = document.RootElement
+            .GetProperty("components").GetProperty("securitySchemes").GetProperty("PetsOAuth");
+
+        Assert.Equal("oauth2", scheme.GetProperty("type").GetString());
+        Assert.Equal(
+            "https://example.invalid/token",
+            scheme.GetProperty("flows").GetProperty("clientCredentials")
+                .GetProperty("tokenUrl").GetString());
+    }
+
+    /// <summary>
+    /// Grants required beside an OAuth2 scheme are the requirement's scopes.
+    /// </summary>
+    /// <remarks>
+    /// The kind of scheme decides. OAuth2 carries scopes, so <c>[AuthorizeGrants]</c> beside it
+    /// names them; under an HTTP scheme the same operation would publish the scheme and nothing
+    /// more, which is the rule the OpenAPI reader applies coming the other way.
+    /// </remarks>
+    [HardenedTest]
+    public async Task GrantsRequiredBesideAnOAuth2SchemeArePublishedAsScopes(ITestWebApp testWebApp) {
+        using var document = await Fetch(testWebApp);
+
+        var requirement = document.RootElement
+            .GetProperty("paths").GetProperty("/authorization/pets-manage").GetProperty("get")
+            .GetProperty("security").EnumerateArray().Single();
+
+        var scopes = requirement.GetProperty("PetsOAuth").EnumerateArray()
+            .Select(scope => scope.GetString()).ToList();
+
+        Assert.Equal(new[] { "pets:read", "pets:write" }, scopes);
+    }
+
+    /// <summary>
+    /// An operation with a security requirement publishes the 401 that enforcing it produces, and
+    /// the challenge that comes with it.
+    /// </summary>
+    /// <remarks>
+    /// The status is what the filter answers, not what the handler declares, so nothing on the
+    /// handler says 401 and the document has to derive it from the requirement.
+    /// <c>AuthorizationTests</c> asserts the same refusal on the wire.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AnOperationWithARequirementPublishesItsChallenge(ITestWebApp testWebApp) {
+        using var document = await Fetch(testWebApp);
+
+        var unauthorized = document.RootElement
+            .GetProperty("paths").GetProperty("/authorization/pets").GetProperty("get")
+            .GetProperty("responses").GetProperty("401");
+
+        Assert.Equal("Authentication required.", unauthorized.GetProperty("description").GetString());
+        Assert.True(unauthorized.GetProperty("headers").TryGetProperty("WWW-Authenticate", out _));
+    }
+
+    /// <summary>
+    /// A grant with no scheme beside it publishes nothing, so its 401 stays underived.
+    /// </summary>
+    /// <remarks>
+    /// A requirement has to reference a declared scheme, and the generator cannot invent one. The
+    /// operation is guarded at run time exactly as its neighbour is; what separates them in the
+    /// document is that one of them said which scheme establishes its caller.
+    /// </remarks>
+    [HardenedTest]
+    public async Task AGrantWithNoSchemePublishesNoRequirement(ITestWebApp testWebApp) {
+        using var document = await Fetch(testWebApp);
+
+        var operation = document.RootElement
+            .GetProperty("paths").GetProperty("/authorization/pets-unstated").GetProperty("get");
+
+        Assert.False(operation.TryGetProperty("security", out _));
+        Assert.False(operation.GetProperty("responses").TryGetProperty("401", out _));
+        Assert.True(operation.GetProperty("responses").TryGetProperty("403", out _));
+    }
 }

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/AspNetCoreHostTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/AspNetCoreHostTests.cs
@@ -66,7 +66,7 @@ public class AspNetCoreHostTests {
     public async Task ThreeParametersCarryThreeCredentialsOverTheWire(
         [Grants("pets:read")] WebAppClient reader, [Anonymous] WebAppClient nobody, [Grants("pets:write")] WebAppClient writer) {
         var pets = await reader.Authorization.Pets.GetAsync(cancellationToken: Token);
-        var refused = await Assert.ThrowsAsync<ApiException>(() => nobody.Authorization.Pets.GetAsync(cancellationToken: Token));
+        var refused = await Assert.ThrowsAsync<ClientModels.ErrorModel>(() => nobody.Authorization.Pets.GetAsync(cancellationToken: Token));
         var forbidden = await Assert.ThrowsAsync<ClientModels.ErrorModel>(() => writer.Authorization.Pets.GetAsync(cancellationToken: Token));
 
         Assert.NotNull(pets);

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/GeneratedClientTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/GeneratedClientTests.cs
@@ -107,10 +107,31 @@ public class GeneratedClientTests {
     /// A refusal the document does not declare has no type to be: Kiota's base exception, with the
     /// status on it.
     /// </summary>
+    /// <remarks>
+    /// <c>/authorization/pets-unstated</c> rather than <c>/pets</c>, which used to be the example.
+    /// A 401 is published from the operation's security requirement, and <c>/pets</c> names a
+    /// scheme now, so its 401 is typed - see
+    /// <see cref="AnAuthenticationRefusalIsTypedWhereTheOperationNamesAScheme"/>. This handler
+    /// requires a grant and names no scheme, which the generator cannot describe, so the status
+    /// the runtime answers is still undeclared and this is still what a client sees.
+    /// </remarks>
     [HardenedTest]
     public async Task AnUndeclaredRefusalIsABareApiException(WebAppClient client) {
         var refusal = await Assert.ThrowsAsync<ApiException>(() =>
-            client.Authorization.Pets.GetAsync(cancellationToken: TestContext.Current.CancellationToken));
+            client.Authorization.PetsUnstated.GetAsync(cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(401, refusal.ResponseStatusCode);
+    }
+
+    /// <summary>
+    /// The other side of it: an operation naming a scheme publishes the 401 enforcing it, so the
+    /// refusal arrives as the generated envelope rather than as a status with nothing on it.
+    /// </summary>
+    [HardenedTest]
+    public async Task AnAuthenticationRefusalIsTypedWhereTheOperationNamesAScheme(
+        [Anonymous] WebAppClient nobody) {
+        var refusal = await Assert.ThrowsAsync<ClientModels.ErrorModel>(() =>
+            nobody.Authorization.Pets.GetAsync(cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Equal(401, refusal.ResponseStatusCode);
     }
@@ -126,11 +147,10 @@ public class GeneratedClientTests {
 
     /// <summary>Three parameters of the generated type with three credentials: three instances, three answers.</summary>
     /// <remarks>
-    /// The 403 arrives as the generated <c>ErrorModel</c> rather than as Kiota's base exception,
-    /// which is what publishing a declared filter's status buys: the document now says an
-    /// authorization attribute can answer 403 with that envelope, so the generator has a case for
-    /// it. The 401 is still bare here because this operation carries no security requirement for
-    /// the document to hang one on.
+    /// Both refusals arrive as the generated <c>ErrorModel</c> rather than as Kiota's base
+    /// exception, which is what publishing them buys: the document says an authorization attribute
+    /// can answer 403 with that envelope, and the operation's security requirement says it can
+    /// answer 401 with the same one. The 401 was bare until this operation named a scheme.
     /// </remarks>
     [HardenedTest]
     public async Task ThreeGeneratedClientsCarryThreeCredentials(
@@ -138,7 +158,8 @@ public class GeneratedClientTests {
         var token = TestContext.Current.CancellationToken;
 
         var pets = await reader.Authorization.Pets.GetAsync(cancellationToken: token);
-        var refused = await Assert.ThrowsAsync<ApiException>(() => nobody.Authorization.Pets.GetAsync(cancellationToken: token));
+        var refused = await Assert.ThrowsAsync<ClientModels.ErrorModel>(
+            () => nobody.Authorization.Pets.GetAsync(cancellationToken: token));
         var forbidden = await Assert.ThrowsAsync<ClientModels.ErrorModel>(
             () => writer.Authorization.Pets.GetAsync(cancellationToken: token));
 

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/KestrelHostTests.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT.Tests/Transport/KestrelHostTests.cs
@@ -94,7 +94,7 @@ public class KestrelHostTests {
     public async Task ThreeParametersCarryThreeCredentialsOverTheWire(
         [Grants("pets:read")] WebAppClient reader, [Anonymous] WebAppClient nobody, [Grants("pets:write")] WebAppClient writer) {
         var pets = await reader.Authorization.Pets.GetAsync(cancellationToken: Token);
-        var refused = await Assert.ThrowsAsync<ApiException>(() => nobody.Authorization.Pets.GetAsync(cancellationToken: Token));
+        var refused = await Assert.ThrowsAsync<ClientModels.ErrorModel>(() => nobody.Authorization.Pets.GetAsync(cancellationToken: Token));
         var forbidden = await Assert.ThrowsAsync<ClientModels.ErrorModel>(() => writer.Authorization.Pets.GetAsync(cancellationToken: Token));
 
         Assert.NotNull(pets);

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/AuthorizationController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/AuthorizationController.cs
@@ -1,3 +1,4 @@
+using Hardened.Requests.Abstract.Authorization;
 using Hardened.Requests.Runtime.Authorization;
 using Hardened.Web.Runtime.Attributes;
 
@@ -11,6 +12,14 @@ namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
 /// <remarks>
 /// Grants arrive via <c>X-Test-Grants</c>, which the test principal middleware turns into a
 /// principal. Nothing here validates a credential; that is a later phase.
+/// </para>
+/// <para>
+/// Half the handlers name <see cref="PetsOAuth"/> and half do not, which is the distinction the
+/// document turns on. A grant with no scheme beside it publishes nothing - a requirement has to
+/// reference a declared scheme - so <see cref="Pets"/> publishes <c>security</c>, a 401 and the
+/// challenge header, while <see cref="Unstated"/> requires the same grant at run time and
+/// publishes a 403 alone. Both are supported and only one is describable, and the suite covers
+/// each because the difference is invisible from the handler.
 /// </remarks>
 [BasePath("/authorization")]
 public class AuthorizationController {
@@ -25,11 +34,18 @@ public class AuthorizationController {
     public string Open() => "open";
 
     [Get("/pets")]
+    [Authorize<PetsOAuth>]
     [AuthorizeGrants("pets:read")]
     public string Pets() => "pets";
 
+    /// <summary>The same grant with no scheme named, which is guarded and undescribable.</summary>
+    [Get("/pets-unstated")]
+    [AuthorizeGrants("pets:read")]
+    public string Unstated() => "unstated";
+
     /// <summary>Both grants, which is what one requirement object in a specification means.</summary>
     [Get("/pets-manage")]
+    [Authorize<PetsOAuth>]
     [AuthorizeGrants("pets:read", "pets:write")]
     public string Manage() => "managed";
 
@@ -42,6 +58,7 @@ public class AuthorizationController {
     /// the handler info conjoining them, and the filter refusing a caller holding one.
     /// </remarks>
     [Get("/stacked")]
+    [Authorize<PetsOAuth>]
     [AuthorizeGrants("pets:read")]
     [AuthorizeGrants("admin:*")]
     public string Stacked() => "stacked";
@@ -55,6 +72,7 @@ public class AuthorizationController {
     /// name-matching build diagnostic used to warn about while the runtime guarded it correctly.
     /// </remarks>
     [Get("/derived")]
+    [Authorize<PetsOAuth>]
     [RequiresPetWrite]
     public string Derived() => "derived";
 }
@@ -65,3 +83,26 @@ public class AuthorizationController {
 public sealed class RequiresPetWriteAttribute : AuthorizeGrantsAttribute {
     public RequiresPetWriteAttribute() : base("pets:read", "pets:write") { }
 }
+
+/// <summary>
+/// The scheme this application's guarded operations name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// OAuth2 rather than bearer because it is the kind that carries scopes: grants required beside
+/// an OAuth2 scheme become the requirement's scope list, so <c>pets:read</c> reaches the document
+/// as something a reader can act on rather than as a 403 with no explanation. Under an HTTP
+/// scheme the same operations would publish "authenticated via this scheme" and nothing more.
+/// </para>
+/// <para>
+/// The transport does not match and is not meant to. Callers here send <c>X-Test-Grants</c> and
+/// nothing validates a token; what the type declares is the shape of the published contract, which
+/// is the whole of what a scheme is to the generator - it reads the attribute and cannot run the
+/// code that establishes a caller.
+/// </para>
+/// </remarks>
+[OAuth2AuthenticationScheme(
+    OAuth2Flow.ClientCredentials,
+    TokenUrl = "https://example.invalid/token",
+    Description = "The scheme the integration fixture's guarded operations name.")]
+public sealed class PetsOAuth : IAuthenticationScheme;

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/CompressionController.cs
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/Controllers/CompressionController.cs
@@ -12,28 +12,33 @@ namespace Hardened.IntegrationTests.WebApp.SUT.Controllers;
 [BasePath("/compression")]
 public class CompressionController {
 
-    public record Reading(string Sensor, int Value);
+    /// <summary>
+    /// Named apart from <c>MessagePackController.Reading</c> deliberately. A component is named by
+    /// the type's own name, so two <c>Reading</c> records in two controllers were published as one
+    /// schema and the last one written described both. HRDOA005 reports that now.
+    /// </summary>
+    public record Sample(string Sensor, int Value);
 
-    private static List<Reading> Readings(int count) =>
-        Enumerable.Range(0, count).Select(i => new Reading("sensor-" + i, i * 3)).ToList();
+    private static List<Sample> Readings(int count) =>
+        Enumerable.Range(0, count).Select(i => new Sample("sensor-" + i, i * 3)).ToList();
 
     /// <summary>Nothing declared, so the application-wide default applies.</summary>
     [Get("/readings")]
-    public List<Reading> Readings() => Readings(20);
+    public List<Sample> Readings() => Readings(20);
 
     /// <summary>Compressed only when the list is longer than three.</summary>
     [Get("/sized/{count}")]
     [Compress<ListLargerThan>(3)]
-    public List<Reading> Sized(int count) => Readings(count);
+    public List<Sample> Sized(int count) => Readings(count);
 
     [Get("/brotli")]
     [Compress(Favor = CompressionType.Br)]
-    public List<Reading> Brotli() => Readings(20);
+    public List<Sample> Brotli() => Readings(20);
 
     /// <summary>How an operation opts out of the application-wide default.</summary>
     [Get("/never")]
     [Compress<Never>]
-    public List<Reading> Never() => Readings(20);
+    public List<Sample> Never() => Readings(20);
 
     [Get("/text")]
     [Produces("text/plain")]
@@ -44,7 +49,7 @@ public class CompressionController {
     public byte[] Binary() => [1, 2, 3, 4, 5, 6, 7, 8];
 
     [Post("/echo")]
-    public Reading Echo([FromBody] Reading reading) => reading;
+    public Sample Echo([FromBody] Sample sample) => sample;
 }
 
 public sealed class ListLargerThan : ICompressionPredicate {

--- a/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
+++ b/src/IntegrationTests/Web/Hardened.IntegrationTests.WebApp.SUT/openapi/Application.json
@@ -115,6 +115,11 @@
         "operationId": "derived",
         "summary": "An attribute of the application's own, deriving from [AuthorizeGrants].",
         "description": "The hand-authored form. It reaches the pipeline the same way the framework's own attributes do - recognised by the interface it inherits rather than by its name - and it is the case a name-matching build diagnostic used to warn about while the runtime guarded it correctly.",
+        "security": [
+          {
+            "PetsOAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -122,6 +127,24 @@
               "application/json": {
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "headers": {
+              "WWW-Authenticate": {
+                "description": "The challenge naming the scheme to authenticate with.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -188,6 +211,13 @@
           "Authorization"
         ],
         "operationId": "pets",
+        "security": [
+          {
+            "PetsOAuth": [
+              "pets:read"
+            ]
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -195,6 +225,24 @@
               "application/json": {
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "headers": {
+              "WWW-Authenticate": {
+                "description": "The challenge naming the scheme to authenticate with.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -230,6 +278,74 @@
         ],
         "operationId": "manage",
         "summary": "Both grants, which is what one requirement object in a specification means.",
+        "security": [
+          {
+            "PetsOAuth": [
+              "pets:read",
+              "pets:write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "headers": {
+              "WWW-Authenticate": {
+                "description": "The challenge naming the scheme to authenticate with.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller does not hold what this operation requires.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "The operation did not finish inside its budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-hardened-timeout": 300000
+      }
+    },
+    "/authorization/pets-unstated": {
+      "get": {
+        "tags": [
+          "Authorization"
+        ],
+        "operationId": "unstated",
+        "summary": "The same grant with no scheme named, which is guarded and undescribable.",
         "responses": {
           "200": {
             "description": "OK",
@@ -273,6 +389,14 @@
         "operationId": "stacked",
         "summary": "Two attributes, which conjoin - so this needs everything both of them named.",
         "description": "Stacking narrows and never widens. Exercised end to end because the rule is only worth anything if it survives the whole path: the generator putting both attributes in metadata, the handler info conjoining them, and the filter refusing a caller holding one.",
+        "security": [
+          {
+            "PetsOAuth": [
+              "pets:read",
+              "admin:*"
+            ]
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -280,6 +404,24 @@
               "application/json": {
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "headers": {
+              "WWW-Authenticate": {
+                "description": "The challenge naming the scheme to authenticate with.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
                 }
               }
             }
@@ -486,6 +628,7 @@
             "name": "path",
             "in": "path",
             "required": true,
+            "x-hardened-catch-all": true,
             "schema": {
               "type": "string"
             }
@@ -1727,11 +1870,8 @@
             "content": {
               "application/octet-stream": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
@@ -1764,7 +1904,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Reading"
+                    "$ref": "#/components/schemas/Sample"
                   }
                 }
               }
@@ -1795,7 +1935,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Reading"
+                "$ref": "#/components/schemas/Sample"
               }
             }
           }
@@ -1806,7 +1946,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Reading"
+                  "$ref": "#/components/schemas/Sample"
                 }
               }
             }
@@ -1840,7 +1980,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Reading"
+                    "$ref": "#/components/schemas/Sample"
                   }
                 }
               }
@@ -1875,7 +2015,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Reading"
+                    "$ref": "#/components/schemas/Sample"
                   }
                 }
               }
@@ -1921,7 +2061,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Reading"
+                    "$ref": "#/components/schemas/Sample"
                   }
                 }
               }
@@ -2591,6 +2731,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "propertyNames": {
+                    "$ref": "#/components/schemas/Priority"
+                  },
                   "additionalProperties": {
                     "type": "integer",
                     "format": "int32"
@@ -2623,6 +2766,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "propertyNames": {
+                  "$ref": "#/components/schemas/Priority"
+                },
                 "additionalProperties": {
                   "type": "integer",
                   "format": "int32"
@@ -3077,11 +3223,8 @@
             "content": {
               "image/png": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
@@ -5591,14 +5734,7 @@
         "summary": "A declared 204, which also means the body is not written.",
         "responses": {
           "204": {
-            "description": "No Content",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
+            "description": "No Content"
           },
           "504": {
             "description": "The operation did not finish inside its budget.",
@@ -6090,7 +6226,14 @@
             "maximum": 120
           },
           "address": {
-            "$ref": "#/components/schemas/AddressModel"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AddressModel"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },
@@ -6152,6 +6295,23 @@
           }
         }
       },
+      "Sample": {
+        "type": "object",
+        "description": "Named apart from MessagePackController.Reading deliberately. A component is named by the type's own name, so two Reading records in two controllers were published as one schema and the last one written described both. HRDOA005 reports that now.",
+        "required": [
+          "sensor",
+          "value"
+        ],
+        "properties": {
+          "sensor": {
+            "type": "string"
+          },
+          "value": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
       "Shipping": {
         "type": "string",
         "enum": [
@@ -6185,6 +6345,18 @@
             "type": "string"
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "PetsOAuth": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://example.invalid/token",
+            "scopes": {}
+          }
+        },
+        "description": "The scheme the integration fixture's guarded operations name."
       }
     }
   }

--- a/src/SourceGenerators/Hardened.Generation.Shared/Document/OpenApiDocumentLowering.cs
+++ b/src/SourceGenerators/Hardened.Generation.Shared/Document/OpenApiDocumentLowering.cs
@@ -116,6 +116,8 @@ internal static class OpenApiDocumentLowering {
                 RewriteExclusiveBound(obj, "exclusiveMinimum", "minimum");
                 RewriteExclusiveBound(obj, "exclusiveMaximum", "maximum");
                 RewriteNullableTypeArray(obj);
+                RewriteNullableRef(obj);
+                obj.Remove("propertyNames");
 
                 foreach (var member in obj.Members) {
                     RewriteForThreeZero(member.Value);
@@ -145,6 +147,57 @@ internal static class OpenApiDocumentLowering {
 
             schema.Members[index] = new KeyValuePair<string, JsonNode>(boundKey, bound);
             schema.Members.Insert(index + 1, new KeyValuePair<string, JsonNode>(exclusiveKey, JsonBoolean.True));
+
+            return;
+        }
+    }
+
+    /// <summary>
+    /// <c>{"anyOf": [{"$ref": x}, {"type": "null"}]}</c> becomes
+    /// <c>{"allOf": [{"$ref": x}], "nullable": true}</c>.
+    /// </summary>
+    /// <remarks>
+    /// 3.0 has no null type, so a nullable reference cannot be spelled as a union. It also gives a
+    /// <c>$ref</c> no siblings, which is why the reference moves inside an <c>allOf</c> rather than
+    /// taking <c>nullable</c> beside it - the same wrapping <c>JsonSchemaWriter.Append</c> applies
+    /// for the same reason. Left alone, the lowered document carried a branch typed <c>null</c>
+    /// that a 3.0 reader has no rule for.
+    /// </remarks>
+    private static void RewriteNullableRef(JsonObject schema) {
+        for (var index = 0; index < schema.Members.Count; index++) {
+            var member = schema.Members[index];
+
+            if (!string.Equals(member.Key, "anyOf", StringComparison.Ordinal) ||
+                !(member.Value is JsonArray branches) || branches.Items.Count != 2) {
+                continue;
+            }
+
+            JsonNode? referenced = null;
+            var sawNull = false;
+
+            foreach (var branch in branches.Items) {
+                if (!(branch is JsonObject option)) {
+                    return;
+                }
+
+                if (option.Get("$ref") is { } _) {
+                    referenced = option;
+                }
+                else if (option.Get("type") is JsonString type && type.Value == "null") {
+                    sawNull = true;
+                }
+            }
+
+            if (!sawNull || referenced == null) {
+                return;
+            }
+
+            var wrapped = new JsonArray();
+
+            wrapped.Items.Add(referenced);
+
+            schema.Members[index] = new KeyValuePair<string, JsonNode>("allOf", wrapped);
+            schema.Members.Insert(index + 1, new KeyValuePair<string, JsonNode>("nullable", JsonBoolean.True));
 
             return;
         }

--- a/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator.Tests/OpenApiDocumentEmissionTests.cs
@@ -847,6 +847,232 @@ public class OpenApiDocumentEmissionTests {
 
     #endregion
 
+    #region shapes the document used to get wrong
+
+    /// <summary>
+    /// Every shape in this region, in one application, so the document is read once.
+    /// </summary>
+    private const string ShapeControllers = """
+        public enum Priority { Low, InProgress }
+
+        public sealed class Address { public string? City { get; set; } }
+
+        public class Registration {
+            public string? Name { get; set; }
+            public Address? Home { get; set; }
+        }
+
+        public class ShapeController {
+            [Get("/download")]
+            [Produces("application/octet-stream")]
+            public byte[] Download() => new byte[] { 1, 2, 3 };
+
+            [Delete("/item", SuccessStatus = 204)]
+            public string Remove() => "this body is not written";
+
+            [Post("/registrations")]
+            public string Register(Registration registration) => registration.Name ?? "";
+
+            [Get("/files/{*path}")]
+            public string File(string path) => path;
+
+            [Get("/item/{id}")]
+            public string Item(string id) => id;
+
+            [Get("/counts")]
+            public Dictionary<Priority, int> Counts() => new();
+        }
+        """;
+
+    private static JsonElement ShapeDocument() =>
+        JsonDocument.Parse(Extract(
+            RequestGeneratorHarness
+                .Generate(Application(ShapeControllers, Enable))
+                .AssertNoErrors()
+                .SourceContaining("OpenApiDocument"))).RootElement;
+
+    /// <summary>
+    /// A byte array is the payload, not a list of numbers.
+    /// </summary>
+    /// <remarks>
+    /// Every element type resolves through the primitive map and a byte maps to an int32, so the
+    /// array branch described an octet-stream body as a JSON array of integers. A generated client
+    /// built from that reads numbers off a body that is not JSON.
+    /// </remarks>
+    [Fact]
+    public void AByteArrayIsABinaryPayload() {
+        var schema = ShapeDocument()
+            .GetProperty("paths").GetProperty("/download").GetProperty("get")
+            .GetProperty("responses").GetProperty("200")
+            .GetProperty("content").GetProperty("application/octet-stream")
+            .GetProperty("schema");
+
+        Assert.Equal("string", schema.GetProperty("type").GetString());
+        Assert.Equal("binary", schema.GetProperty("format").GetString());
+    }
+
+    /// <summary>
+    /// A 204 describes no body, because there is not one to describe.
+    /// </summary>
+    /// <remarks>
+    /// The handler returns a string and declares 204, which means both things it says: the writer
+    /// does not send the value. The document said the response carried a JSON string, so a strict
+    /// client waited to read one off an empty body.
+    /// </remarks>
+    [Fact]
+    public void ADeclared204CarriesNoContent() {
+        var response = ShapeDocument()
+            .GetProperty("paths").GetProperty("/item").GetProperty("delete")
+            .GetProperty("responses").GetProperty("204");
+
+        Assert.False(response.TryGetProperty("content", out _));
+    }
+
+    /// <summary>
+    /// A nullable member pointing at a component says so, the way a nullable scalar does.
+    /// </summary>
+    /// <remarks>
+    /// A reference carries no type of its own, so the null goes beside it under <c>anyOf</c>. The
+    /// nullability was dropped entirely, which put two spellings of one annotation in one schema:
+    /// <c>["string","null"]</c> on a scalar and silence on a reference.
+    /// </remarks>
+    [Fact]
+    public void ANullableReferenceMemberDeclaresItsNull() {
+        var home = ShapeDocument()
+            .GetProperty("components").GetProperty("schemas").GetProperty("Registration")
+            .GetProperty("properties").GetProperty("home");
+
+        var branches = home.GetProperty("anyOf").EnumerateArray().ToList();
+
+        Assert.Equal(
+            "#/components/schemas/Address", branches[0].GetProperty("$ref").GetString());
+        Assert.Equal("null", branches[1].GetProperty("type").GetString());
+    }
+
+    /// <summary>
+    /// A catch-all token says it is one, since the template cannot.
+    /// </summary>
+    /// <remarks>
+    /// <c>{*path}</c> and <c>{path}</c> reduce to the same expression - a template expression is a
+    /// name and nothing else - so a reader given the template alone escapes the separators in the
+    /// value it sends and gets a 404 from a route built to accept them.
+    /// </remarks>
+    [Fact]
+    public void ACatchAllTokenIsMarked() {
+        var parameter = ShapeDocument()
+            .GetProperty("paths").GetProperty("/files/{path}").GetProperty("get")
+            .GetProperty("parameters").EnumerateArray().Single();
+
+        Assert.Equal("path", parameter.GetProperty("name").GetString());
+        Assert.True(parameter.GetProperty("x-hardened-catch-all").GetBoolean());
+    }
+
+    /// <summary>A single-segment token says nothing, which is the common case.</summary>
+    [Fact]
+    public void AnOrdinaryPathTokenIsNotMarked() {
+        var parameter = ShapeDocument()
+            .GetProperty("paths").GetProperty("/item/{id}").GetProperty("get")
+            .GetProperty("parameters").EnumerateArray().Single();
+
+        Assert.Equal("id", parameter.GetProperty("name").GetString());
+        Assert.False(parameter.TryGetProperty("x-hardened-catch-all", out _));
+    }
+
+    /// <summary>
+    /// An enum key names the vocabulary the map accepts.
+    /// </summary>
+    /// <remarks>
+    /// A JSON object's keys are strings whatever the C# key type is, so
+    /// <c>additionalProperties</c> alone describes a string-keyed map completely. An enum key is a
+    /// closed set the server refuses anything outside of, and dropping it published a map
+    /// accepting any key at all.
+    /// </remarks>
+    [Fact]
+    public void AnEnumDictionaryKeyPublishesItsVocabulary() {
+        var schema = ShapeDocument()
+            .GetProperty("paths").GetProperty("/counts").GetProperty("get")
+            .GetProperty("responses").GetProperty("200")
+            .GetProperty("content").GetProperty("application/json").GetProperty("schema");
+
+        Assert.Equal(
+            "#/components/schemas/Priority",
+            schema.GetProperty("propertyNames").GetProperty("$ref").GetString());
+        Assert.Equal(
+            "integer", schema.GetProperty("additionalProperties").GetProperty("type").GetString());
+    }
+
+    /// <summary>
+    /// Two types published under one component name are reported.
+    /// </summary>
+    /// <remarks>
+    /// A component is named by the type's own name, unqualified, which is the spelling client
+    /// generators produce. Two types with that name in different controllers therefore collide and
+    /// the merge keeps whichever arrived last, leaving one operation described with the other's
+    /// shape in a document that is still valid.
+    /// </remarks>
+    [Fact]
+    public void TwoTypesUnderOneComponentNameAreReported() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class FirstController {
+                public record Reading(string Sensor);
+
+                [Get("/first")]
+                public Reading Get() => new Reading("north");
+            }
+
+            public class SecondController {
+                public record Reading(int Value, bool Settled);
+
+                [Get("/second")]
+                public Reading Get() => new Reading(1, true);
+            }
+            """, Enable));
+
+        var diagnostic = Assert.Single(
+            result.GeneratorDiagnostics,
+            entry => entry.Id == Hardened.SourceGenerator.OpenApiDocument
+                .OpenApiDocumentDiagnostics.SchemaNameCollisionId);
+
+        var message = diagnostic.GetMessage();
+
+        Assert.Contains("\"Reading\"", message);
+        Assert.Contains("FirstController.Get", message);
+        Assert.Contains("SecondController.Get", message);
+    }
+
+    /// <summary>
+    /// Two types that write the same schema are not reported.
+    /// </summary>
+    /// <remarks>
+    /// The document is then correct whichever one the merge keeps, so reporting it would name a
+    /// defect no reader of the document can see.
+    /// </remarks>
+    [Fact]
+    public void TwoIdenticalTypesUnderOneNameAreNotReported() {
+        var result = RequestGeneratorHarness.Generate(Application("""
+            public class LeftController {
+                public record Reading(string Sensor);
+
+                [Get("/left")]
+                public Reading Get() => new Reading("north");
+            }
+
+            public class RightController {
+                public record Reading(string Sensor);
+
+                [Get("/right")]
+                public Reading Get() => new Reading("south");
+            }
+            """, Enable));
+
+        Assert.DoesNotContain(
+            result.GeneratorDiagnostics,
+            entry => entry.Id == Hardened.SourceGenerator.OpenApiDocument
+                .OpenApiDocumentDiagnostics.SchemaNameCollisionId);
+    }
+
+    #endregion
+
     #region prose with commas in it
 
     /// <summary>

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/JsonSchemaWriter.cs
@@ -107,6 +107,14 @@ public static class JsonSchemaWriter {
         }
 
         if (type is IArrayTypeSymbol array) {
+            // byte[] is the payload itself, not a sequence of numbers. Every element type below
+            // maps through Primitive, and byte maps to an int32 - so the array branch described an
+            // octet-stream body as a JSON array of integers, which a generated client reads with
+            // the wrong type against a body that is not JSON at all.
+            if (array.ElementType.SpecialType == SpecialType.System_Byte) {
+                return BinaryPayload;
+            }
+
             return "{\"type\":\"array\",\"items\":" +
                    SchemaFor(array.ElementType, components, inProgress, enums, compilationAssembly) + "}";
         }
@@ -147,11 +155,45 @@ public static class JsonSchemaWriter {
         }
 
         if (name is "Dictionary" or "IDictionary" or "IReadOnlyDictionary") {
-            return "{\"type\":\"object\",\"additionalProperties\":" +
-                   SchemaFor(named.TypeArguments[1], components, inProgress, enums, compilationAssembly) + "}";
+            var values = SchemaFor(
+                named.TypeArguments[1], components, inProgress, enums, compilationAssembly);
+
+            return "{\"type\":\"object\"" + PropertyNames(
+                       named.TypeArguments[0], components, enums, compilationAssembly) +
+                   ",\"additionalProperties\":" + values + "}";
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// A binary body: the bytes themselves, which is what <c>byte[]</c> means on the wire.
+    /// </summary>
+    private const string BinaryPayload = "{\"type\":\"string\",\"format\":\"binary\"}";
+
+    /// <summary>
+    /// What a dictionary's keys may be, where the key type says something a string does not.
+    /// </summary>
+    /// <remarks>
+    /// A JSON object's keys are strings whatever the C# key type is, so <c>additionalProperties</c>
+    /// alone describes <c>Dictionary&lt;string, int&gt;</c> completely. An enum key is different:
+    /// it names a closed vocabulary the server will refuse anything outside of, and dropping it
+    /// published a map accepting any key at all. <c>propertyNames</c> is where JSON Schema puts
+    /// that, and it takes the same component the enum is already written as, so the vocabulary is
+    /// stated once.
+    /// <para>
+    /// Only enums. A key constrained some other way is constrained by code this cannot read, and
+    /// guessing a pattern for it would describe a rule the server does not enforce.
+    /// </para>
+    /// </remarks>
+    private static string PropertyNames(
+        ITypeSymbol key, Dictionary<string, string> components,
+        Dictionary<string, EnumVocabulary> enums, IAssemblySymbol? compilationAssembly) {
+        if (key is not INamedTypeSymbol { TypeKind: TypeKind.Enum } enumeration) {
+            return "";
+        }
+
+        return ",\"propertyNames\":" + EnumRef(enumeration, components, enums, compilationAssembly);
     }
 
     /// <summary>
@@ -631,6 +673,14 @@ public static class JsonSchemaWriter {
     private static string Nullable(string schema, ITypeSymbol type) {
         if (type.NullableAnnotation != NullableAnnotation.Annotated && !IsNullableValueType(type)) {
             return schema;
+        }
+
+        // A reference cannot carry a type of its own, so the null goes beside it rather than
+        // inside it. Without this a nullable member pointing at a component was published as
+        // though it were always present, while a nullable scalar beside it said ["string","null"] -
+        // the same annotation described two different ways in one schema.
+        if (schema.StartsWith("{\"$ref\"", System.StringComparison.Ordinal)) {
+            return "{\"anyOf\":[" + schema + ",{\"type\":\"null\"}]}";
         }
 
         const string prefix = "{\"type\":\"";

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentDiagnostics.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentDiagnostics.cs
@@ -15,6 +15,9 @@ public static class OpenApiDocumentDiagnostics {
     /// <summary>Two handlers declare the same <c>[Operation]</c> id.</summary>
     public const string DuplicateOperationIdId = "HRDOA004";
 
+    /// <summary>Two types are published under one component name.</summary>
+    public const string SchemaNameCollisionId = "HRDOA005";
+
     internal static DiagnosticDescriptor DuplicateOperationIdDescriptor() => new(
         id: DuplicateOperationIdId,
         title: "Two handlers declare the same operation id",
@@ -58,6 +61,103 @@ public static class OpenApiDocumentDiagnostics {
                         Location.None,
                         pair.Key,
                         string.Join(" and ", pair.Value)));
+            }
+        }
+    }
+
+    internal static DiagnosticDescriptor SchemaNameCollisionDescriptor() => new(
+        id: SchemaNameCollisionId,
+        title: "Two types are published as one schema component",
+        messageFormat:
+        "Two different types are both published as \"{0}\", reached from {1}. A component name " +
+        "identifies one schema, so whichever is written last describes both - and a client " +
+        "generated from the document has one of these operations wrong. Rename one of the types.",
+        category: "Hardened.OpenApi",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports every component name that two different types were written under.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A component is named by the type's own name, unqualified. That is the spelling every client
+    /// generator produces and it is worth keeping, but it means two types with one name in
+    /// different namespaces - or in different controllers, which is where it actually happens -
+    /// collide, and the merge keeps whichever arrived last. The document stays valid and one
+    /// operation is described with another type's shape.
+    /// </para>
+    /// <para>
+    /// Compared by the schema each type produced rather than by the symbol, because the models
+    /// carry written JSON by the time the document is assembled. Two types that produce identical
+    /// JSON are not reported: the document is then correct whichever one wins, and reporting it
+    /// would name a defect the reader cannot see.
+    /// </para>
+    /// <para>
+    /// A warning rather than an error. The document is readable and an application shipping this
+    /// today still serves; the point is that it stops being silent. This repository builds with
+    /// warnings as errors in CI, so it is fatal where it needs to be.
+    /// </para>
+    /// </remarks>
+    public static void ReportSchemaNameCollisions(
+        SourceProductionContext context, IReadOnlyList<RequestHandlerModel> handlers) {
+        var byName = new Dictionary<string, Dictionary<string, SortedSet<string>>>(StringComparer.Ordinal);
+
+        foreach (var handler in handlers) {
+            var owner = handler.ControllerType.Name + "." + handler.HandlerMethod;
+
+            foreach (var schema in Schemas(handler)) {
+                foreach (var component in schema.Components) {
+                    if (!byName.TryGetValue(component.Name, out var shapes)) {
+                        shapes = new Dictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+                        byName[component.Name] = shapes;
+                    }
+
+                    if (!shapes.TryGetValue(component.Json, out var reachedFrom)) {
+                        reachedFrom = new SortedSet<string>(StringComparer.Ordinal);
+                        shapes[component.Json] = reachedFrom;
+                    }
+
+                    reachedFrom.Add(owner);
+                }
+            }
+        }
+
+        foreach (var pair in byName.OrderBy(entry => entry.Key, StringComparer.Ordinal)) {
+            if (pair.Value.Count < 2) {
+                continue;
+            }
+
+            var owners = new SortedSet<string>(StringComparer.Ordinal);
+
+            foreach (var shape in pair.Value.Values) {
+                foreach (var owner in shape) {
+                    owners.Add(owner);
+                }
+            }
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    SchemaNameCollisionDescriptor(),
+                    Location.None,
+                    pair.Key,
+                    string.Join(" and ", owners)));
+        }
+    }
+
+    /// <summary>Every schema a handler contributes to the document.</summary>
+    private static IEnumerable<HandlerSchema> Schemas(RequestHandlerModel handler) {
+        if (handler.RequestSchema != null) {
+            yield return handler.RequestSchema;
+        }
+
+        if (handler.ResponseSchema != null) {
+            yield return handler.ResponseSchema;
+        }
+
+        foreach (var response in handler.ResponseSchemas) {
+            if (response.Schema != null) {
+                yield return response.Schema;
             }
         }
     }

--- a/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/OpenApiDocument/OpenApiDocumentGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using CSharpAuthor;
@@ -613,8 +613,16 @@ public static class OpenApiDocumentGenerator {
 
             WriteText(builder, "description", parameter.Description);
 
-            builder.Append("")
-                .Append(",\"schema\":").Append(ParameterSchema(parameter, version, enums))
+            // The one thing the template cannot carry. RouteTemplate reduces {*path} to {path}
+            // because a template expression is a name and nothing else, so without this the
+            // document describes a segment-bounded token and a generated client escapes the
+            // separators the route exists to accept.
+            if (parameter.BindingType == ParameterBindType.Path &&
+                RouteTemplate.IsCatchAll(handler.Name.Path, name)) {
+                builder.Append(",\"x-hardened-catch-all\":true");
+            }
+
+            builder.Append(",\"schema\":").Append(ParameterSchema(parameter, version, enums))
                 .Append('}');
         }
 
@@ -906,7 +914,7 @@ public static class OpenApiDocumentGenerator {
         if (handler.ResponseInformation.IsAsyncEnumerable) {
             WriteStreamedResponse(builder, handler, components, version);
         }
-        else if (handler.ResponseSchema != null) {
+        else if (handler.ResponseSchema != null && CarriesBody(successStatus)) {
             Merge(components, handler.ResponseSchema);
 
             WriteContentMap(builder, ContentTypes(handler), handler.ResponseSchema.Schema);
@@ -971,7 +979,7 @@ public static class OpenApiDocumentGenerator {
             if (group.Key == streamedStatus) {
                 WriteStreamedResponse(builder, handler, components, version);
             }
-            else if (bodies.Count > 0) {
+            else if (bodies.Count > 0 && CarriesBody(group.Key)) {
                 string schema;
 
                 if (bodies.Count == 1) {
@@ -1407,6 +1415,22 @@ public static class OpenApiDocumentGenerator {
     /// <c>ProducedContentTypes</c> - so sorting here would make a round trip through the document
     /// change which representation the operation leads with.
     /// </remarks>
+    /// <summary>
+    /// Whether a response with this status may describe a body.
+    /// </summary>
+    /// <remarks>
+    /// A handler returning a value and declaring 204 means both things it says: the value is what
+    /// the method hands back, and the status is what the caller is told - and the writer does not
+    /// send the body. The document said otherwise, describing <c>DELETE /verbs/emptied</c> as
+    /// answering 204 with a JSON string, so a strict client waited to read one off an empty body.
+    /// <para>
+    /// 204 and 304 are the two a handler can reach. RFC 9110 gives both no content, and the
+    /// OpenAPI description of a response with no content is the <c>content</c> key absent rather
+    /// than present and empty. 1xx never reaches a handler here.
+    /// </para>
+    /// </remarks>
+    private static bool CarriesBody(int status) => status != 204 && status != 304;
+
     private static void WriteContentMap(
         StringBuilder builder, IReadOnlyList<string> contentTypes, string schema) {
         builder.Append(",\"content\":{");

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTemplate.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RouteTemplate.cs
@@ -109,6 +109,40 @@ internal static class RouteTemplate {
         return "";
     }
 
+    /// <summary>
+    /// Whether <paramref name="token"/> is declared in <paramref name="path"/> as a catch-all.
+    /// </summary>
+    /// <remarks>
+    /// The question the document writer asks so it can say the one thing a path template cannot.
+    /// <c>{*path}</c> and <c>{path}</c> reduce to the same expression, so a reader given the
+    /// template alone percent-encodes the separators in the value it sends and gets a 404 from a
+    /// route that was built to accept them.
+    /// </remarks>
+    public static bool IsCatchAll(string path, string token) {
+        var open = path.IndexOf('{');
+
+        while (open >= 0) {
+            var close = path.IndexOf('}', open);
+
+            if (close < 0) {
+                return false;
+            }
+
+            var start = TokenStart(path, open, close);
+            var colon = path.IndexOf(':', start);
+            var nameEnd = colon >= 0 && colon < close ? colon : close;
+
+            if (nameEnd - start == token.Length &&
+                string.CompareOrdinal(path, start, token, 0, token.Length) == 0) {
+                return start > open + 1;
+            }
+
+            open = path.IndexOf('{', close);
+        }
+
+        return false;
+    }
+
     /// <summary>Whether any token in <paramref name="path"/> carries a constraint.</summary>
     /// <remarks>
     /// The question the document writer asks before it says anything about a route constraint at

--- a/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
+++ b/src/SourceGenerators/Hardened.SourceGenerator/Web/Routing/RoutingTableGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
 using CSharpAuthor;
@@ -139,6 +139,7 @@ public static class RoutingTableGenerator {
         // the grounds that it cost one string, which understated it - see OpenApiDocumentSource -
         // and an application that does not serve one now does not carry one.
         OpenApiDocumentDiagnostics.ReportDuplicateOperationIds(context, routable);
+        OpenApiDocumentDiagnostics.ReportSchemaNameCollisions(context, routable);
 
         if (OpenApiDocumentFeature.Path(models.Left) is { } documentPath) {
             // An empty document is the one outcome that looks like success from every angle: the


### PR DESCRIPTION
An audit of the 137 operations the web fixture publishes, against the document it exports. Seven findings, each a shape the document stated incorrectly or did not state at all. A client generated from that document disagreed with the server on every one of them.

Full solution builds with `--configuration Release -p:ContinuousIntegrationBuild=true`. 9000 tests across 74 assemblies pass.

## What changed

**A byte array is the payload, not a list of numbers.** Every element type resolves through the primitive map and a byte maps to an int32, so an octet-stream body was described as a JSON array of integers. Two operations in the fixture, both declaring a binary media type. It is `{"type": "string", "format": "binary"}` now.

**A 204 describes no body.** A handler returning a value and declaring 204 means both things it says, and the writer does not send the value. The document said the response carried a JSON string, so a strict client waited to read one off an empty body. `HttpMethodTests` already asserted the body was empty. 304 goes the same way for the same reason.

**A nullable member pointing at a component says so.** A reference carries no type of its own, so the null goes beside it under `anyOf`. It was dropped entirely, which put two spellings of one annotation in one schema: `["string","null"]` on a scalar and silence on a reference.

**A dictionary's enum key names the vocabulary it accepts.** Keys are strings whatever the C# key type is, so `additionalProperties` describes a string-keyed map completely. An enum key is a closed set the server refuses anything outside of, and dropping it published a map accepting any key at all.

**A catch-all token says it is one.** `{*path}` and `{path}` reduce to the same expression, because a template expression is a name and nothing else. A reader given the template alone escapes the separators in the value it sends and gets a 404 from a route built to accept them. `x-hardened-catch-all` is the only place that can be said.

**Two types published under one component name are reported.** A component is named by the type's own name, unqualified. That is the spelling client generators produce and is worth keeping, but two types with that name in different controllers collide and the merge keeps whichever arrived last, leaving one operation described with the other's shape in a document that stays valid. HRDOA005 reports it, as a warning, and only where the two wrote different schemas.

The fixture had exactly this. `MessagePackController.Reading` and `CompressionController.Reading` were one component, and the compression operations were published carrying MessagePack key indices they do not have. The compression record is `Sample` now.

**The fixture's guarded operations name a scheme.** Nothing in this repository exercised the code-first security path. A requirement has to reference a declared scheme and no integration fixture declared one, so `components.securitySchemes`, per-operation `security` and the 401 the filter answers were emitted by unit tests alone. Four operations name `PetsOAuth`; `/authorization/pets-unstated` requires the same grant without a scheme, which is guarded identically and describable not at all. That difference is invisible from the handler and now has a test on each side.

No generator change was needed for this one. `WriteAuthenticationResponse` has always written the 401 and its `WWW-Authenticate` challenge from `SecurityRequirements`; nothing had ever given it any.

## The 3.0 lowering

Both new keywords needed a 3.0 spelling. `propertyNames` has none and is dropped. A nullable reference becomes `allOf` plus `nullable`, because 3.0 has no null type and gives a `$ref` no siblings. `ALoweredExportStillParses` caught the first of those.

## Tests that changed rather than broke

Four transport tests asserted `ApiException` for the 401 on `/authorization/pets`, and two of them said in their own remarks that the 401 was bare "because this operation carries no security requirement for the document to hang one on". It has one now, so Kiota generates a typed error and xUnit's exact-type `ThrowsAsync` no longer matches. They assert the envelope instead. `AnUndeclaredRefusalIsABareApiException` moved to `/authorization/pets-unstated`, which is still the case it was written for.

## Not in this PR

The audit's other findings. `[FromForm]` publishes no request body at all, `[CacheControl]` and `[CacheResponse]` declare no response header where `[AnswersHeader]` would give them one, and `Retry-After` has a writer that is unreachable from the attribute path because `TimeoutAttribute` declares its own status. Each is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
